### PR TITLE
feat: Add mimetypes to supported list of types

### DIFF
--- a/openrag/routers/indexer.py
+++ b/openrag/routers/indexer.py
@@ -109,7 +109,9 @@ def _human_readable_size(size_bytes: int) -> str:
 @router.get("/supported/types")
 async def get_supported_types():
     list_extensions = list(ACCEPTED_FILE_FORMATS)
-    return JSONResponse(content={"supported_types": list_extensions})
+    list_mimetypes = list(DICT_MIMETYPES)
+    resp = {"extensions": list_extensions, "mimetypes": list_mimetypes}
+    return JSONResponse(content=resp)
 
 
 @router.post(

--- a/openrag/routers/indexer.py
+++ b/openrag/routers/indexer.py
@@ -106,8 +106,19 @@ def _human_readable_size(size_bytes: int) -> str:
     return f"{size_bytes:.2f} PB"
 
 
-@router.get("/supported/types")
+@router.get(
+    "/supported/types",
+    description="Returns the list of supported file extensions and MIME types.",
+)
 async def get_supported_types():
+    """
+    Get a list of supported types for indexing.
+
+    Returns:
+        JSON object containing:
+        - `extensions`: List of supported file extensions.
+        - `mimetypes`: List of supported MIME types.
+    """
     list_extensions = list(ACCEPTED_FILE_FORMATS)
     list_mimetypes = list(DICT_MIMETYPES)
     resp = {"extensions": list_extensions, "mimetypes": list_mimetypes}


### PR DESCRIPTION
In addition to file extensions, let's add mimetypes to `indexer/supported/types` API,
which can be useful for clients.

BREAKING CHANGE: the API no longer lists file types as `supported_types`,
but with `extension`.