### PR TITLE
Fixed typo on embedding config name

### DIFF
--- a/openrag/components/indexer/embeddings/openai.py
+++ b/openrag/components/indexer/embeddings/openai.py
@@ -11,7 +11,7 @@ logger = get_logger()
 
 class OpenAIEmbedding(BaseEmbedding):
     def __init__(self, embeddings_config: dict):
-        self.embedding_model = embeddings_config.get("model")
+        self.embedding_model = embeddings_config.get("model_name")
         self.base_url = embeddings_config.get("base_url")
         self.api_key = embeddings_config.get("api_key")
 


### PR DESCRIPTION
Fixed typo introduced in 0d42900744242fdc406145909cbffe476ad31d39 where embedder's "model_name" was erroneously changed to "model"

https://github.com/linagora/openrag/blob/0d42900744242fdc406145909cbffe476ad31d39/openrag/components/indexer/embeddings/openai.py#L12-L16