### PR TITLE
Upgrade vllm + fix arm64 issues

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,6 +102,17 @@ services:
       target: vllm-openai
     image: openrag-vllm-openai-cpu
     deploy: {}
+    command: >
+      --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
+      --trust-remote-code
+      --gpu_memory_utilization 0.3
+      --task embed
+      --max-model-len 2048
+      --dtype float32
+# These two flags are required only for arm64:
+# --max-model-len 2048  https://github.com/vllm-project/vllm/issues/21179
+# --dtype float32       https://github.com/vllm-project/vllm/issues/11327
+
     profiles:
       - 'cpu'
 

--- a/extern/vllm/Dockerfile.cpu
+++ b/extern/vllm/Dockerfile.cpu
@@ -42,7 +42,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 ENV UV_HTTP_TIMEOUT=500
 
-RUN git clone https://github.com/vllm-project/vllm/ . && git checkout v0.9.2
+RUN git clone https://github.com/vllm-project/vllm/ . && git checkout v0.10.1.1
 
 # Install Python dependencies 
 ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
@@ -51,7 +51,7 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE="copy"
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --upgrade pip && \
-    uv pip install -r requirements/cpu.txt --torch-backend auto
+    uv pip install -r requirements/cpu.txt
 
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:/opt/venv/lib/libiomp5.so:$LD_PRELOAD"
 


### PR DESCRIPTION
* upgrade vllm from 0.9.2 to 0.10.1.1
* workarounds for vllm bugs on arm64:
  * https://github.com/vllm-project/vllm/issues/21179
  * "reshape_and_cache_cpu_impl not implemented for bfloat16" (similar to https://github.com/vllm-project/vllm/issues/11327)