### PR TITLE
chore: Restart vllm only on failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ x-vllm: &vllm_template
     default:
       aliases:
         - vllm
-  restart: always
+  restart: on-failure
   environment:
     - HUGGING_FACE_HUB_TOKEN
   ipc: "host"


### PR DESCRIPTION
The "always" restart option makes the container systematically restart, even at machine reboot. 
This is not ideal for developers, especially since vllm is quite hungry for ressources