### PR TITLE
update starlight documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 // https://astro.build/config
 export default defineConfig({
   srcDir: './docs',
+  base: '/openrag/',
   integrations: [
       starlight({
           title: 'Docs',

--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -185,7 +185,7 @@ Retrieve specific document extract (chunk) by ID.
 
 ### 💬 OpenAI-Compatible Chat
 
-These endpoints provide full OpenAI API compatibility for seamless integration with existing tools and workflows. For detailed example of openai usage [see this section](#openai-client-integration)
+These endpoints provide full OpenAI API compatibility for seamless integration with existing tools and workflows. For detailed example of openai usage [see this section](#example-openai-client-usage)
 
 * List Available Models
 ```http
@@ -232,9 +232,9 @@ OpenAI-compatible text completion endpoint.
 
 ## 💡 Usage Examples
 
-### Bulk File Indexing
+#### Bulk File Indexing
 
-For indexing multiple files programmatically, you can use this script [`data_indexer.py`](../utility/data_indexer.py) utility script in the [`📁 utility`](../utility/) folder or simply use **`indexer ui`**.
+For indexing multiple files programmatically, you can use this script [`data_indexer.py`](http://github.com/linagora/openrag/blob/main/utility/data_indexer.py) utility script in the [`📁 utility`](https://github.com/linagora/openrag/tree/main/utility) folder or simply use **`indexer ui`**.
 
 #### Example OpenAI Client Usage
 

--- a/docs/content/docs/documentation/chainlit_data_persistency.md
+++ b/docs/content/docs/documentation/chainlit_data_persistency.md
@@ -8,7 +8,7 @@ This project uses a [dockerized fork](https://github.com/Chainlit/chainlit-datal
 In OpenRAG, one can activate **`Chainlit data layer`** following these steps:
 
 ### Step 1: Set up authentication
-In fact, chainlit authentication is necessary for data persistency. Set chainlit authentication if not already done (refer to the [chainlit auth guide](/documentation/setup_chainlit_ui_auth))
+In fact, chainlit authentication is necessary for data persistency. Set chainlit authentication if not already done (refer to the [chainlit auth guide](/openrag/documentation/api/#-authentication)
 
 ### Step 2: Add the following variables
 To deploy the Chainlit data layer service, add the following variable:

--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -73,7 +73,7 @@ If other GPU-intensive services are running on your nodes (e.g. vLLM, the RAG AP
 All nodes need to access shared configuration and data folders.  
 We recommend using **GlusterFS** for this.
 
-➡ Follow the [GlusterFS Setup Guide](/documentation/setup_glusterfs/) to configure:
+➡ Follow the [GlusterFS Setup Guide](/openrag/documentation/setup_glusterfs/) to configure:
 
 - Shared access to:
   - `.env`

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -1,0 +1,5 @@
+---
+title: Environment Variables
+---
+
+# A comprehensive list of environment variables used in the application.

--- a/docs/content/docs/documentation/features_in_details.md
+++ b/docs/content/docs/documentation/features_in_details.md
@@ -45,7 +45,7 @@ Engage with your documents through our sophisticated chat interface:
 
 
 ### 🔌 OpenAI API Compatibility
-[OpenRag](https://open-rag.ai/) API is tailored to be compatible with the OpenAI format (see the [openai-compatibility section](/documentation/api/#-openai-compatible-chat) for more details), enabling seamless integration of your deployed RAG into popular frontends and workflows such as OpenWebUI, LangChain, N8N, and more. This ensures flexibility and ease of adoption without requiring custom adapters.
+[OpenRag](https://open-rag.ai/) API is tailored to be compatible with the OpenAI format (see the [openai-compatibility section](/openrag/documentation/api/#-openai-compatible-chat) for more details), enabling seamless integration of your deployed RAG into popular frontends and workflows such as OpenWebUI, LangChain, N8N, and more. This ensures flexibility and ease of adoption without requiring custom adapters.
 
 <details>
 

--- a/docs/content/docs/documentation/setup_chainlit_ui_auth.mdx
+++ b/docs/content/docs/documentation/setup_chainlit_ui_auth.mdx
@@ -6,7 +6,7 @@ import { Image } from 'astro:assets';
 import myImage from "../../../assets/Chainlit_Login.png";
 
 
-Chainlit's password-based authentication is now integrated with the [User Model](/documentation/data_model/#-users). When [API authentication](/documentation/api/#-authentication) is enabled, Chainlit authentication is also enabled. Disabling API authentication will disable Chainlit's password-based authentication as well.
+Chainlit's password-based authentication is now integrated with the [User Model](/openrag/documentation/data_model/#-users). When [API authentication](/openrag/documentation/api/#-authentication) is enabled, Chainlit authentication is also enabled. Disabling API authentication will disable Chainlit's password-based authentication as well.
 
 ## How to authentication
 * Go to **`/chainlit`** and provide your credentials

--- a/docs/content/docs/documentation/setup_glusterfs.md
+++ b/docs/content/docs/documentation/setup_glusterfs.md
@@ -17,7 +17,7 @@ This includes:
 ## 1️⃣ Setup VPN (if required)
 
 If your Ray nodes are **not on the same local network**, set up a VPN between them first.  
-➡ Refer to the dedicated [VPN setup guide](/documentation/setup_vpn/).  
+➡ Refer to the dedicated [VPN setup guide](/openrag/documentation/setup_vpn/).  
 You can skip this step if your nodes are already on the same LAN.
 
 ---

--- a/docs/content/docs/documentation/update_embeddings.md
+++ b/docs/content/docs/documentation/update_embeddings.md
@@ -5,7 +5,7 @@ title: How to update embeddings?
 
 ## How to update embeddings?
 A command-line utility for generating text embeddings using any **OpenAI-compatible embedding endpoint**.  
-It supports adaptive batching for optimal performance and handles both plain and `.xz` compressed [backup files](README-backup.md).
+It supports adaptive batching for optimal performance and handles both plain and `.xz` compressed [backup files](/openrag/documentation/backup_restore/#backup-dump-format).
 
 ```bash
 python3 openrag/scripts/embed.py \

--- a/docs/content/docs/getting_started/quickstart.mdx
+++ b/docs/content/docs/getting_started/quickstart.mdx
@@ -11,7 +11,7 @@ OpenRAG is an open source Retrieval Augmented Generation (RAG) solution. This gu
 ### Prerequisites
 - [Docker](https://www.docker.com/get-started) and **Docker Compose**
 - Your hardware should meet these specifications:
-  - **CPU deployment**: Minimum **13 GiB** RAM for light PDF parsers (**`PyMuPDF4LLMLoader`, `PyMuPDFLoader`**), or **23 GiB** RAM for heavier parsers like **`MarkerLoader`** (refer to [this section](/getting_started/quickstart/#3-file-parser-configuration) for details)
+  - **CPU deployment**: Minimum **13 GiB** RAM for light PDF parsers (**`PyMuPDF4LLMLoader`, `PyMuPDFLoader`**), or **23 GiB** RAM for heavier parsers like **`MarkerLoader`** (refer to [this section](/openrag/getting_started/quickstart/#3-file-parser-configuration) for details)
   - **GPU deployment**: **16 GB** GPU memory recommended (for systems with separate CPU and GPU memory)
 
 ### Installation and Configuration

--- a/docs/content/docs/getting_started/usage.mdx
+++ b/docs/content/docs/getting_started/usage.mdx
@@ -10,7 +10,7 @@ By default, OpenRAG services are exposed on the following ports:
 
 | Service           | Port           | Description                                                    |
 |-------------------|----------------|----------------------------------------------------------------|
-| API Documentation | 8080/docs      | Main FastAPI’s for document ingestion and querying. See [this](/documentation/api)|
+| API Documentation | 8080/docs      | Main FastAPI’s for document ingestion and querying. See [this](/openrag/documentation/api)|
 | Chainlit UI       | 8080/chainlit  | User interface for interacting with the RAG system             |
 | Ray Dashboard     | 8265           | Ray dashboard for monitoring and managing tasks                |
 | Indexer UI        | 3042/          | Main user interface for indexing and viewing indexed documents |


### PR DESCRIPTION
Fix: Correct documentation URL routing for GitHub Pages deployment

**Problem:**
When the site is deployed to `https://linagora.github.io/openrag/` (Githup Pages), absolute paths starting with `/` (e.g., `/documentation/api`) incorrectly resolve to `https://linagora.github.io/documentation/api`, which omits the `/openrag` segment and results in 404 errors.

**Solution:**
This PR addresses the GitHub Pages routing issue by:
1. Setting the correct base URL for the website
2. Prepending relative paths with `/openrag` to ensure proper resolution