### PR TITLE
**Added:** VLLM Docker container for audio loading

### DIFF
--- a/.hydra_config/config.yaml
+++ b/.hydra_config/config.yaml
@@ -126,9 +126,9 @@ loader:
   marker_num_gpus: ${oc.decode:${oc.env:MARKER_NUM_GPUS, 0.01}}
   marker_timeout: ${oc.decode:${oc.env:MARKER_TIMEOUT, 3600}}
   transcriber:
-    base_url: ${oc.env:TRANSCRIBER_BASE_URL, http://vllm:8000/v1}
+    base_url: ${oc.env:TRANSCRIBER_BASE_URL, http://transcriber:8000/v1}
     api_key: ${oc.env:TRANSCRIBER_API_KEY, EMPTY}
-    model_name: ${oc.env:TRANSCRIBER_MODEL_NAME, whisper-large-v3-turbo}
+    model_name: ${oc.env:TRANSCRIBER_MODEL, openai/whisper-large-v3-turbo}
     max_chunk_ms: ${oc.decode:${oc.env:TRANSCRIBER_MAX_CHUNK_MS, 30000}}
     silence_thresh_db: ${oc.decode:${oc.env:TRANSCRIBER_SILENCE_THRESH_DB, -40}}
     min_silence_len_ms: ${oc.decode:${oc.env:TRANSCRIBER_MIN_SILENCE_LEN_MS, 500}}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ include:
   - vdb/milvus.yaml
   - ${CHAINLIT_DATALAYER_COMPOSE:-extern/dummy.yaml}
   - extern/infinity.yaml
+  - ${TRANSCRIBER_COMPOSE:-extern/dummy.yaml}
 
 x-openrag: &openrag_template
   image: ghcr.io/linagora/openrag:dev-latest

--- a/docs/content/docs/documentation/features_in_details.md
+++ b/docs/content/docs/documentation/features_in_details.md
@@ -12,6 +12,16 @@ title: ✨ Key Features
 
 All files are intelligently converted to **Markdown format** with images replaced by AI-generated captions, ensuring consistent processing across all document types.
 
+### 🎵 Audio File Processing
+Audio files are processed using Whisper deployed with vLLM for reliable transcription. To enable audio file indexing, configure the transcriber service:
+
+```bash
+# .env
+TRANSCRIBER_COMPOSE=extern/transcriber.yaml
+```
+
+
+
 ### 🎛️ Native Web-Based Indexer UI
 Experience intuitive document management through our built-in web interface.
 

--- a/extern/transcriber.yaml
+++ b/extern/transcriber.yaml
@@ -1,0 +1,26 @@
+services:
+  transcriber:
+    build:
+      context: .
+      dockerfile: ./vllm/Dockerfile.transcriber
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - HUGGING_FACE_HUB_TOKEN
+      - VLLM_MAX_AUDIO_CLIP_FILESIZE_MB=10000
+    ipc: "host"
+    volumes:
+      - ${VLLM_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface
+    command: >
+      --model ${TRANSCRIBER_MODEL:-openai/whisper-large-v3-turbo}
+      --trust-remote-code
+      --async-scheduling
+      --gpu_memory_utilization 0.3
+    # ports:
+    #   - ${TRANSCRIBER_PORT:-8002}:8000

--- a/extern/vllm/Dockerfile.transcriber
+++ b/extern/vllm/Dockerfile.transcriber
@@ -1,0 +1,3 @@
+FROM vllm/vllm-openai:v0.11.0
+# FROM vllm/vllm-openai:v0.9.2
+RUN pip install --no-cache-dir "vllm[audio]"


### PR DESCRIPTION
 **Added:** VLLM Docker container for audio loading

**Breaking change:**
Audio transcription has been moved to a dedicated VLLM container. To enable audio processing, set the following variable in your `.env` file:

```bash
TRANSCRIBER_COMPOSE=extern/transcriber.yaml
```

Note:
This audio pipeline is imperfect — occasional mismatches may occur between the language of the audio content and that of the transcription. This happens because VLLM’s current implementation does not fully leverage Whisper’s language detection feature during transcription. An issue will be opened in the VLLM repository to address this problem.
