### PR TITLE
feat: Allow using openAI routes without partition

### DIFF
--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -223,6 +223,27 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   }'
 ```
 
+You can also direclty use this endpoint with no RAG pipeline, i.e. to directly use the LLM.
+For that, simply do not specify any model: 
+
+**Request Body:**
+```bash frame="none" title="Testing the openai OpenRAG chat completions endpoint with curl"
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_AUTH_TOKEN" \
+  -d '{
+    "messages": [
+      {
+        "role": "user",
+        "content": "Your question here"
+      }
+    ],
+    "temperature": 0.7,
+    "stream": false
+  }'
+```
+
+
 * Text Completions
 ```http
 POST /v1/completions

--- a/openrag/components/pipeline.py
+++ b/openrag/components/pipeline.py
@@ -178,17 +178,27 @@ class RagPipeline:
         return payload, docs
 
     async def completions(self, partition: list[str], payload: dict):
-        payload, docs = await self._prepare_for_completions(
-            partition=partition, payload=payload
-        )
-        llm_output = self.llm_client.completions(request=payload)
-        return llm_output, docs
-
-    async def chat_completion(self, partition: list[str], payload: dict):
         try:
-            payload, docs = await self._prepare_for_chat_completion(
-                partition=partition, payload=payload
-            )
+            if partition is None:
+                docs = []
+            else:
+                payload, docs = await self._prepare_for_completions(
+                    partition=partition, payload=payload
+                )
+            llm_output = self.llm_client.completions(request=payload)
+            return llm_output, docs
+        except Exception as e:
+            logger.error(f"Error during chat completion: {str(e)}")
+            raise e
+
+    async def chat_completion(self, partition: list[str] | None, payload: dict):
+        try:
+            if partition is None:
+                docs = []
+            else:
+                payload, docs = await self._prepare_for_chat_completion(
+                    partition=partition, payload=payload
+                )
             llm_output = self.llm_client.chat_completion(request=payload)
             return llm_output, docs
         except Exception as e:

--- a/openrag/models/openai.py
+++ b/openrag/models/openai.py
@@ -14,7 +14,7 @@ class OpenAIMessage(BaseModel):
 class OpenAIChatCompletionRequest(BaseModel):
     """Modèle représentant une requête de complétion chat pour l'API OpenAI."""
 
-    model: str = Field(..., description="model name")
+    model: Optional[str] = Field(None, description="model name")
     messages: List[OpenAIMessage]
     temperature: Optional[float] = Field(0.3)
     top_p: Optional[float] = Field(1.0)
@@ -74,7 +74,7 @@ class OpenAICompletionChoice(BaseModel):
 class OpenAICompletionRequest(BaseModel):
     """Legacy OpenAI completion API"""
 
-    model: str = Field(..., description="model name")
+    model: Optional[str] = Field(None, description="model name")
     prompt: str
     best_of: Optional[int] = Field(1)
     echo: Optional[bool] = Field(False)


### PR DESCRIPTION
We now allow to directly request the LLM through the openAI endpoints. This is useful when we want to interact with the LLM without relying on documents, e.g. for translation, rephrasing, etc.
To use it, the client must simply not specify the `model`.

Note that is this approach, no system prompt will be used, it is entirely up to the client.