### PR TITLE
feat: Allow model in openAI completion routes

### DIFF
--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -224,7 +224,10 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 ```
 
 You can also direclty use this endpoint with no RAG pipeline, i.e. to directly use the LLM.
-For that, simply do not specify any model: 
+For that, instead of using the `openrag` prefix for the model, you can:
+- Specify no model
+- Specify an empty model
+- Specify the openRAG configured model, e.g. `Mistral-Small-3.1-24B-Instruct-2503`.
 
 **Request Body:**
 ```bash frame="none" title="Testing the openai OpenRAG chat completions endpoint with curl"
@@ -232,13 +235,14 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_AUTH_TOKEN" \
   -d '{
+    "model": "",
     "messages": [
       {
         "role": "user",
         "content": "Your question here"
       }
     ],
-    "temperature": 0.7,
+    "temperature": 0.1max,
     "stream": false
   }'
 ```


### PR DESCRIPTION
Some openai-compatible libs make the `model` parameter mandatory, to query chat completions API.
Thus, we now allow providing empty model, or actual LLM model defined in the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI-compatible endpoints accept three ways to request direct LLM usage: omit the model, set the model to an empty string, or specify a model name. Empty or omitted model values will be routed as direct LLM calls where applicable.

* **Documentation**
  * API docs updated to show all three model-specification options, include an example JSON with "model": "", and set example temperature to 0.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->