### PR TITLE
Remove `max_tokens` default value to avoid cutting mid-generation.

### DIFF
--- a/openrag/models/openai.py
+++ b/openrag/models/openai.py
@@ -19,7 +19,7 @@ class OpenAIChatCompletionRequest(BaseModel):
     temperature: Optional[float] = Field(0.3)
     top_p: Optional[float] = Field(1.0)
     stream: Optional[bool] = Field(False)
-    max_tokens: Optional[int] = Field(1024)
+    max_tokens: Optional[int] = Field(None)
     logprobs: Optional[int] = Field(None)
     metadata: Optional[Dict[str, Any]] = Field(
         {


### PR DESCRIPTION
The default value for `max_tokens` was 1024. In rare cases, the generated text could reach this limit, causing the output to be truncated, since `max_tokens` defines the maximum number of tokens that can be generated in a chat completion.

To prevent responses from being cut off mid-generation, we no longer set a default value. The generation will continue until it reaches the available limit (`llms_context_size - context_size`). Clients can still provide a `max_tokens` value if they wish to explicitly control the length of the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI Chat Completion: Updated default token limit behavior to use API-level defaults when not explicitly configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->