### PR TITLE
fix: Improve error logging for external resource access failures

### DIFF
--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -12,6 +12,8 @@ from langchain_openai import ChatOpenAI
 from PIL import Image
 from utils.logger import get_logger
 
+from utils.external_resource_errors import is_external_resource_error
+
 logger = get_logger()
 config = load_config()
 
@@ -145,9 +147,23 @@ class BaseLoader(ABC):
                 image_description = response.content
 
             except Exception as e:
-                logger.exception(
-                    "Error while generating image description", error=str(e)
-                )
+                is_external, status_code, url = is_external_resource_error(e)
+                if is_external:
+                    # Log external resource errors as warnings, not exceptions
+                    # These are expected when VLM cannot fetch external URLs
+                    log_msg = "Failed to fetch external image resource"
+                    log_extra = {"error": str(e)}
+                    if status_code:
+                        log_extra["http_status"] = status_code
+                    if url:
+                        log_extra["url"] = url
+                    elif self._is_http_url(str(image_data)):
+                        log_extra["url"] = str(image_data)
+                    logger.warning(log_msg, **log_extra)
+                else:
+                    logger.exception(
+                        "Error while generating image description", error=str(e)
+                    )
                 image_description = ""
 
             return f"""<image_description>\n\n{image_description}\n\n</image_description>"""

--- a/openrag/utils/external_resource_errors.py
+++ b/openrag/utils/external_resource_errors.py
@@ -1,0 +1,55 @@
+"""
+Utilities for detecting external resource access errors.
+
+When VLM models fetch external image URLs, HTTP errors (403, 404, etc.) from
+remote servers get wrapped in InternalServerError, which is misleading.
+This module detects such errors for better logging.
+"""
+
+import re
+
+# HTTP error codes indicating external resource issues
+EXTERNAL_ERROR_CODES = frozenset(
+    {
+        # 4xx client errors
+        "400", "401", "403", "404", "405", "408", "410", "429", "451",
+        # 5xx gateway errors
+        "502", "503", "504",
+    }
+)
+
+# Error type indicators for external fetch failures
+EXTERNAL_ERROR_INDICATORS = (
+    "ClientResponseError",
+    "HTTPError",
+    "ConnectionError",
+    "TimeoutError",
+    "SSLError",
+)
+
+
+def is_external_resource_error(error: Exception) -> tuple[bool, str, str]:
+    """
+    Check if an error is caused by an external resource access issue.
+
+    Returns:
+        (is_external_error, status_code, url) - status_code and url are empty
+        strings if not detected.
+    """
+    error_str = str(error)
+
+    # Find HTTP 4xx/5xx status code (first one that's in our allowed set)
+    status_code = ""
+    for match in re.finditer(r"\b([45]\d{2})\b", error_str):
+        if match.group(1) in EXTERNAL_ERROR_CODES:
+            status_code = match.group(1)
+            break
+
+    # Extract URL
+    url_match = re.search(r"https?://[^\s'\"\)>]+", error_str)
+    url = url_match.group(0) if url_match else ""
+
+    # Check for error type indicators
+    has_indicator = any(ind in error_str for ind in EXTERNAL_ERROR_INDICATORS)
+
+    return bool(status_code) or has_indicator, status_code, url

--- a/openrag/utils/test_external_resource_errors.py
+++ b/openrag/utils/test_external_resource_errors.py
@@ -1,0 +1,130 @@
+"""
+Tests for external resource error detection utilities.
+Related to: https://github.com/linagora/openrag/issues/182
+"""
+
+import pytest
+
+from utils.external_resource_errors import is_external_resource_error
+
+
+class TestIsExternalResourceError:
+    """Test suite for is_external_resource_error function."""
+
+    @pytest.mark.parametrize(
+        "error_msg,expected_code,url_contains",
+        [
+            # Issue #182
+            (
+                "aiohttp.client_exceptions.ClientResponseError: 403, message='Forbidden', "
+                "url='https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Logo.png'",
+                "403",
+                "upload.wikimedia.org",
+            ),
+            # Other HTTP status codes
+            (
+                "ClientResponseError: 404, url='https://example.com/missing.png'",
+                "404",
+                "example.com",
+            ),
+            (
+                "HTTPError: 401 Unauthorized for url: https://api.example.com/image.jpg",
+                "401",
+                "api.example.com",
+            ),
+            (
+                "ClientResponseError: 429 Too Many Requests - https://cdn.example.com/img.png",
+                "429",
+                "cdn.example.com",
+            ),
+            # 5xx gateway errors
+            (
+                "502 Bad Gateway: https://api.example.com/image.png",
+                "502",
+                "api.example.com",
+            ),
+            (
+                "ClientResponseError: 503 Service Unavailable - https://cdn.example.com/img.png",
+                "503",
+                "cdn.example.com",
+            ),
+            # vLLM wrapped error (the real-world scenario)
+            (
+                "openai.InternalServerError: Error code: 500 - {'error': {'message': "
+                "'litellm.InternalServerError: aiohttp.client_exceptions.ClientResponseError: "
+                "403, message=Forbidden, url=https://example.com/path/to/image.png'}}",
+                "403",
+                "example.com/path/to/image.png",
+            ),
+        ],
+    )
+    def test_detects_http_errors_with_urls(self, error_msg, expected_code, url_contains):
+        """Test detection of HTTP errors with URL extraction."""
+        is_external, status_code, url = is_external_resource_error(Exception(error_msg))
+
+        assert is_external is True
+        assert status_code == expected_code
+        assert url_contains in url
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "TimeoutError: Connection timed out while fetching resource",
+            "SSLError: Certificate verification failed",
+            "ConnectionError: Failed to connect to server",
+            "aiohttp.client_exceptions.ClientResponseError: some error",
+            "requests.exceptions.HTTPError: 500 Server Error",
+        ],
+    )
+    def test_detects_error_indicators(self, error_msg):
+        """Test detection via error type indicators."""
+        is_external, _, _ = is_external_resource_error(Exception(error_msg))
+        assert is_external is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            Exception("ValueError: Invalid input parameter"),
+            Exception("Something went wrong during processing"),
+            TypeError("'NoneType' object is not subscriptable"),
+            AttributeError("'dict' object has no attribute 'content'"),
+            Exception(""),
+            # vLLM error without external cause details
+            Exception(
+                "openai.InternalServerError: Error code: 500 - {'error': {'message': "
+                "'litellm.InternalServerError: InternalServerError: OpenAIException'}}"
+            ),
+        ],
+    )
+    def test_does_not_flag_internal_errors(self, error):
+        """Test that internal/generic errors are not flagged as external."""
+        is_external, status_code, url = is_external_resource_error(error)
+
+        assert is_external is False
+        assert status_code == ""
+        assert url == ""
+
+    def test_extracts_url_with_query_params(self):
+        """Test URL extraction with query parameters."""
+        error = Exception("403 Forbidden: https://api.example.com/image?id=123&size=large")
+        _, _, url = is_external_resource_error(error)
+
+        assert "api.example.com/image?id=123" in url
+
+    def test_indicator_substring_causes_false_positive(self):
+        """Document known limitation: indicator substrings cause false positives.
+
+        This test documents that internal errors mentioning HTTP error class names
+        will be incorrectly classified as external. This is accepted because:
+        1. Real error messages use these as exception class names, not prose
+        2. Stricter matching (word boundaries) would break legitimate matches
+           like 'aiohttp.client_exceptions.ClientResponseError'
+        3. This scenario is unlikely in practice
+        """
+        error = Exception("InternalServerError: Failed to handle ClientResponseError in retry logic")
+        is_external, status_code, url = is_external_resource_error(error)
+
+        # This IS classified as external (false positive) due to substring match
+        assert is_external is True
+        assert status_code == ""  # No HTTP status code
+        assert url == ""  # No URL


### PR DESCRIPTION
## Summary

Fixes #182

When VLM models try to fetch external image URLs during indexing, they may encounter HTTP errors (403 Forbidden, 404 Not Found, etc.) from remote servers. These errors were being wrapped and logged as 500 Internal Server Errors, which is misleading and makes debugging difficult.

**Changes:**
- Add `_is_external_resource_error()` helper function that detects external resource errors by analyzing error messages for HTTP status codes (400, 401, 403, 404, etc.) and common error indicators (ClientResponseError, HTTPError, etc.)
- Update `get_image_description()` error handling to log external resource errors as warnings with proper context (HTTP status, URL) instead of exception stack traces
- Preserve exception logging for genuine internal errors

**Before:**
```
openai.InternalServerError: Error code: 500 - {'error': {'message': 'litellm.InternalServerError...'}}
```

**After:**
```
WARNING: Failed to fetch external image resource | http_status=403 | url=https://example.com/image.png
```

## Test plan

- [ ] Verify that external URL fetch failures (403, 404) are logged as warnings, not exceptions
- [ ] Verify that genuine internal errors still produce exception logs with stack traces
- [ ] Verify indexing continues gracefully when external images fail to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external-resource detection to classify network/HTTP fetch failures separately from internal errors.

* **Bug Fixes**
  * Improved handling of external image fetch failures (timeouts, SSL, HTTP 4xx/5xx, connection issues) to log warnings with context (status, URL) and avoid raising, reducing unexpected failures.

* **Tests**
  * Added comprehensive tests for external error detection and URL/status extraction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->