### PR TITLE
fix: Add explicit network name to fix docker compose down issue

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -151,3 +151,7 @@ services:
     # For details see https://github.com/vllm-project/vllm/issues/21179
     profiles:
       - "cpu"
+
+networks:
+  default:
+    name: openrag_default


### PR DESCRIPTION
When using profiles, `docker compose down` would fail with "Network openrag_default Resource is still in use" because the network wasn't explicitly named and managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration with a named default network for container orchestration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->