### PR TITLE
Fix: Not raising exception when the get_captions method fails

### DIFF
--- a/openrag/components/indexer/loaders/pdf_loaders/marker.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/marker.py
@@ -262,13 +262,14 @@ class MarkerLoader(BaseLoader):
         try:
             results = await tqdm.gather(*tasks, desc="Captioning images")
             assert len(keys) == len(results), "Mismatch between keys and results count"
+            result_dict = dict(zip(keys, results))
+            return result_dict
+
         except asyncio.CancelledError:
             logger.warning("Image captioning tasks cancelled")
             for task in tasks:
                 task.cancel()
             raise
-        except Exception:
-            logger.exception("Error during image captioning")
-            raise
-        result_dict = dict(zip(keys, results))
-        return result_dict
+        except Exception as e:
+            logger.exception("Error during image captioning", error=str(e))
+            return {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during PDF processing to gracefully manage captioning errors through logging instead of failures
  * Enhanced result collection and mapping for PDF content extraction operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->