### PR TITLE
fix: improve LLM API error messages for better debugging

### DIFF
--- a/openrag/components/llm.py
+++ b/openrag/components/llm.py
@@ -1,7 +1,7 @@
+import copy
 import json
 
 import httpx
-import copy
 from utils.logger import get_logger
 
 logger = get_logger()

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -102,10 +102,10 @@ def __prepare_sources(request: Request, docs: list[Document]):
 
 
 def is_direct_llm_model(
-    request: OpenAIChatCompletionRequest | OpenAICompletionRequest
+    request: OpenAIChatCompletionRequest | OpenAICompletionRequest,
 ) -> bool:
     """Check if request should use direct LLM (no RAG partition).
-    
+
     Returns True if model is None, empty, or matches the configured default model.
     """
     return (
@@ -197,22 +197,35 @@ async def openai_chat_completion(
     if request.stream:
 
         async def stream_response():
-            async for line in llm_output:
-                if line.startswith("data:"):
-                    if "[DONE]" in line:
-                        yield f"{line}\n\n"
-                    else:
-                        try:
-                            data_str = line[len("data: ") :]
-                            data = json.loads(data_str)
-                            data["model"] = model_name
-                            data["extra"] = metadata_json
-                            yield f"data: {json.dumps(data)}\n\n"
-                        except json.JSONDecodeError as e:
-                            log.exception(
-                                "Failed to decode streamed chunk.", error=str(e)
-                            )
-                            raise
+            try:
+                async for line in llm_output:
+                    if line.startswith("data:"):
+                        if "[DONE]" in line:
+                            yield f"{line}\n\n"
+                        else:
+                            try:
+                                data_str = line[len("data: ") :]
+                                data = json.loads(data_str)
+                                data["model"] = model_name
+                                data["extra"] = metadata_json
+                                yield f"data: {json.dumps(data)}\n\n"
+                            except json.JSONDecodeError as e:
+                                log.error(
+                                    "Failed to decode streamed chunk.", error=str(e)
+                                )
+                                raise
+            except Exception as e:
+                log.warning("Error while generating streaming answer", error=str(e))
+                error_chunk = {
+                    "error": {
+                        "message": f"Error while generating answer: {str(e)}",
+                        "type": "error",
+                        "param": None,
+                        "code": "ERROR_ANSWER_GENERATION",
+                    }
+                }
+                yield f"data: {json.dumps(error_chunk)}\n\n"
+                yield "data: [DONE]\n\n"
 
         return StreamingResponse(stream_response(), media_type="text/event-stream")
     else:


### PR DESCRIPTION
Extract error details from LLM API responses instead of showing generic "Invalid JSON in API response" for all failures. Now displays the actual error response from the LLM provider.

Fixes #197

:information_source: An additional integration test could be added after https://github.com/linagora/openrag/pull/194 is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable preferred URL scheme for generated links.
  * Added a lightweight mock service and CI workflow to run API integration tests.
  * Runtime settings to control contextualization timeouts and concurrency.

* **Bug Fixes**
  * Improved LLM/API streaming and non-streaming error handling with clearer user-facing error payloads.
  * Better handling of external resource errors to avoid noisy failures.

* **Documentation**
  * New usage guide for a Claude-compatible backend and env var docs.

* **Tests**
  * Extensive new API integration test suite and fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->