### PR TITLE
feat: Better error handling for LLM failure

### DIFF
--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -248,7 +248,7 @@ def get_app_state(request: Request):
 
 
 async def check_llm_model_availability(request: Request):
-    models = {"VLM": config.vlm, "LLM": config.llm}
+    models = {"LLM": config.llm, "VLM": config.vlm}
     for model_type, param in models.items():
         try:
             client = AsyncOpenAI(api_key=param["api_key"], base_url=param["base_url"])
@@ -260,10 +260,12 @@ async def check_llm_model_availability(request: Request):
                     detail=f"Only these models ({available_models}) are available for your `{model_type}`. Please check your configuration file.",
                 )
         except Exception as e:
-            logger.exception("Failed to validate model", model=model_type)
+            logger.exception("Failed to validate model", model=model_type, error=str(e))
+            if isinstance(e, HTTPException):
+                raise
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Error while checking the `{model_type}` endpoint: {str(e)}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error while checking the `{model_type}` endpoint, it seems not available at this moment",
             )
 
 


### PR DESCRIPTION
If the LLM endpoint is down, we used to return to the client a 404 saying: Error while checking the `VLM` endpoint:
`<html>\r\n<head><title>502 Bad
Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx/1.29.4</center>\r\n</body>\r\n</html>`

This is not ideal because:
- It is not a 404, since the LLM endpoint is down, it should be a 500
- The error message is full of useless HTML, let's answer a generic error
- As the VLM was checked before the LLM, the error mentioned VLM while the client asks for LLM for the vast majority of cases, which is confusing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for model endpoint validation with more detailed diagnostic information.
  * Standardized unexpected validation failures to return a 500 with a clear, user-facing availability message while preserving specific HTTP error responses.
  * Adjusted validation order for model checks, which may change which model is probed first during availability checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->