### PR TITLE
fix: Make nvidia GPU available from openrag container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,10 @@ x-openrag: &openrag_template
     - ${SHARED_ENV:-.env}
   shm_size: 10.24gb
 
+x-vllm-env: &vllm_env
+  HUGGING_FACE_HUB_TOKEN:
+  VLLM_SLEEP_WHEN_IDLE: 1  # Avoid 100% CPU usage when idle
+
 x-vllm: &vllm_template
   networks:
     default:
@@ -35,8 +39,7 @@ x-vllm: &vllm_template
         - vllm
   restart: on-failure
   environment:
-    - HUGGING_FACE_HUB_TOKEN
-    - VLLM_SLEEP_WHEN_IDLE=1  # Avoid 100% CPU usage when idle
+    <<: *vllm_env
   ipc: "host"
   volumes:
     - ${VLLM_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface # put ./vllm_cache if you want to have the weights on the vllm_cache folder in your project
@@ -125,8 +128,9 @@ services:
     image: vllm/vllm-openai:v0.9.2
     gpus: all
     environment:
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      <<: *vllm_env
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
     runtime: nvidia
     deploy:
       resources:
@@ -147,7 +151,8 @@ services:
     image: openrag-vllm-openai-cpu
     deploy: {}
     environment:
-      - VLLM_CPU_KVCACHE_SPACE=8
+      <<: *vllm_env
+      VLLM_CPU_KVCACHE_SPACE: 8
     # Default value isn't sufficient for full context length
     command: >
       --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}


### PR DESCRIPTION
We noticed slow treatment in some environements. We find out that GPU were not used in the openrag container. The `nvidia-smi` returning an error `Failed to initialize NVML: Unknown Error`

Following nvidia doc: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html

And docker: https://docs.docker.com/compose/how-tos/gpu-support/

Those changes made the GPU correctly available in openrag container. A text extraction from a PDF that was taking +7s now takes 1-2s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit GPU-enabled deployments so services can leverage available NVIDIA GPUs.
  * Introduced separate GPU and CPU variants for the model-serving component to optimize resource usage.

* **Chores**
  * Centralized vllm-related environment configuration for consistent settings across CPU/GPU services.
  * Ensured GPU-aware service startup and resource reservations for smoother deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->