### PR TITLE
fix: Replace multiprocessing.Pool with ProcessPoolExecutor in MarkerW…

### DIFF
--- a/.hydra_config/config.yaml
+++ b/.hydra_config/config.yaml
@@ -129,6 +129,8 @@ loader:
   marker_min_processes: ${oc.decode:${oc.env:MARKER_MIN_PROCESSES, 1}}
   marker_num_gpus: ${oc.decode:${oc.env:MARKER_NUM_GPUS, 0.01}} # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/gpu.html
   marker_timeout: ${oc.decode:${oc.env:MARKER_TIMEOUT, 3600}}
+  marker_pdftext_workers: ${oc.decode:${oc.env:MARKER_PDFTEXT_WORKERS, 2}}
+  
   transcriber:
     base_url: ${oc.env:TRANSCRIBER_BASE_URL, http://transcriber:8000/v1}
     api_key: ${oc.env:TRANSCRIBER_API_KEY, EMPTY}

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -38,6 +38,7 @@ The `MarkerLoader` is the default PDF parsing engine. It can be configured using
 | `MARKER_MAX_TASKS_PER_CHILD` | int | 10 | Number of tasks a child (PDF worker) has to process before it gets restarted to clean up memory leaks |
 | `MARKER_MIN_PROCESSES` | int | 1 | Minimum number of subprocesses available before triggering a process pool reset |
 | `MARKER_TIMEOUT` | int | 3600 | Timeout in seconds for marker processes |
+| `MARKER_PDFTEXT_WORKERS` | int | 2 | Number of PDF text extractor workers inside marker. |
 
 
 

--- a/openrag/components/indexer/loaders/pdf_loaders/marker.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/marker.py
@@ -41,8 +41,8 @@ class MarkerWorker:
             "output_format": "markdown",
             "paginate_output": True,
             "page_separator": self.page_sep,
-            "pdftext_workers": 1,
-            "disable_multiprocessing": True,
+            "pdftext_workers": self.config.loader.get("marker_pdftext_workers"),
+            "disable_multiprocessing": False,
         }
         os.environ["RAY_ADDRESS"] = "auto"
 
@@ -90,6 +90,7 @@ class MarkerWorker:
             initializer=self._worker_init,
             initargs=(self.model_dict,),
             mp_context=mp.get_context("spawn"),
+            max_tasks_per_child=self.config.loader.get("marker_max_tasks_per_child", 5),
         )
         self.logger.info("MarkerWorker initialized with ProcessPoolExecutor")
 
@@ -134,7 +135,6 @@ class MarkerWorker:
                 return result
             except FuturesTimeoutError:
                 self.logger.exception("MarkerWorker child process timed out", path=file_path)
-                future.cancel()
                 raise
             except Exception:
                 self.logger.exception("Error processing with MarkerWorker", path=file_path)


### PR DESCRIPTION
We met an error in staging looking like this: 
```
logs/app.2026-01-12_12-14-58_071032.json:{"text": "2026-01-17 08:34:16.447 | ERROR    | components.indexer.loaders.pdf_loaders.marker:run_with_timeout:159 - Error processing with MarkerWorker\nmultiprocessing.pool.RemoteTraceback: \n\"\"\"\nTraceback (most recent call last):\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/multiprocessing/pool.py\", line 125, in worker\n    result = (True, func(*args, **kwds))\n                    ^^^^^^^^^^^^^^^^^^^\n  File \"/app/openrag/components/indexer/loaders/pdf_loaders/marker.py\", line 129, in _process_pdf\n    render = converter(file_path)\n             ^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/marker/converters/pdf.py\", line 193, in __call__\n    document = self.build_document(temp_path)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/marker/converters/pdf.py\", line 179, in build_document\n    provider = provider_cls(filepath, self.config)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/marker/providers/pdf.py\", line 107, in __init__\n    self.page_lines = self.pdftext_extraction(doc)\n                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/marker/providers/pdf.py\", line 204, in pdftext_extraction\n    page_char_blocks = dictionary_output(\n                       ^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/pdftext/extraction.py\", line 103, in dictionary_output\n    pages: Pages = _get_pages(pdf_path, page_range, workers=workers, flatten_pdf=flatten_pdf, quote_loosebox=quote_loosebox)\n                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/pdftext/extraction.py\", line 64, in _get_pages\n    pages = list(executor.map(_get_page_range, page_range_chunks, repeat(flatten_pdf), repeat(quote_loosebox)))\n                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/process.py\", line 859, in map\n    results = super().map(partial(_process_chunk, fn),\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py\", line 608, in map\n    fs = [self.submit(fn, *args) for args in zip(*iterables)]\n          ^^^^^^^^^^^^^^^^^^^^^^\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/process.py\", line 830, in submit\n    self._adjust_process_count()\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/process.py\", line 789, in _adjust_process_count\n    self._spawn_process()\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/process.py\", line 807, in _spawn_process\n    p.start()\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py\", line 118, in start\n    assert not _current_process._config.get('daemon'), \\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nAssertionError: daemonic processes are not allowed to have children\n\"\"\"\n\n\nThe above exception was the direct cause of the following exception:\n\n\nTraceback (most recent call last):\n\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/threading.py\", line 1032, in _bootstrap\n    self._bootstrap_inner()\n    │    └ <function Thread._bootstrap_inner at 0x7f077ce6e520>\n    └ <Thread(asyncio_1, started 139647388735168)>\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/threading.py\", line 1075, in _bootstrap_inner\n    self.run()\n    │    └ <function Thread.run at 0x7f077ce6e200>\n    └ <Thread(asyncio_1, started 139647388735168)>\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/threading.py\", line 1012, in run\n    self._target(*self._args, **self._kwargs)\n    │    │        │    │        │    └ {}\n    │    │        │    │        └ <Thread(asyncio_1, started 139647388735168)>\n    │    │        │    └ (<weakref at 0x7f02c23effb0; to 'ThreadPoolExecutor' at 0x7f02c234c710>, <_queue.SimpleQueue object at 0x7f02c23eeb10>, None,...\n    │    │        └ <Thread(asyncio_1, started 139647388735168)>\n    │    └ <function _worker at 0x7f0434734cc0>\n    └ <Thread(asyncio_1, started 139647388735168)>\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/thread.py\", line 92, in _worker\n    work_item.run()\n    │         └ <function _WorkItem.run at 0x7f0434734e00>\n    └ <concurrent.futures.thread._WorkItem object at 0x7f02e9415a90>\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/concurrent/futures/thread.py\", line 58, in run\n    result = self.fn(*self.args, **self.kwargs)\n             │    │   │    │       │    └ {}\n             │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x7f02e9415a90>\n             │    │   │    └ ()\n             │    │   └ <concurrent.futures.thread._WorkItem object at 0x7f02e9415a90>\n             │    └ <function MarkerWorker.process_pdf.<locals>.run_with_timeout at 0x7f02602dfb00>\n             └ <concurrent.futures.thread._WorkItem object at 0x7f02e9415a90>\n\n> File \"/app/openrag/components/indexer/loaders/pdf_loaders/marker.py\", line 149, in run_with_timeout\n    result = async_result.get(\n             │            └ <function ApplyResult.get at 0x7f06f81bb6a0>\n             └ <multiprocessing.pool.ApplyResult object at 0x7f02e9417cb0>\n\n  File \"/root/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/multiprocessing/pool.py\", line 774, in get\n    raise self._value\n          │    └ AssertionError('daemonic processes are not allowed to have children')\n          └ <multiprocessing.pool.ApplyResult object at 0x7f02e9417cb0>\n\nAssertionError: daemonic processes are not allowed to have children\n", "record": {"elapsed": {"repr": "17:47:41.266505", "seconds": 64061.266505}, "exception": {"type": "AssertionError", "value": "daemonic processes are not allowed to have children", "traceback": true}, "extra": {"path": "/app/data/test.pdf"}, "file": {"name": "marker.py", "path": "/app/openrag/components/indexer/loaders/pdf_loaders/marker.py"}, "function": "run_with_timeout", "level": {"icon": "❌", "name": "ERROR", "no": 40}, "line": 159, "message": "Error processing with MarkerWorker", "module": "marker", "name": "components.indexer.loaders.pdf_loaders.marker", "process": {"id": 868, "name": "MainProcess"}, "thread": {"id": 139647388735168, "name": "asyncio_1"}, "time": {"repr": "2026-01-17 08:34:16.447879+00:00", "timestamp": 1768638856.447879}}}

```

Use ProcessPoolExecutor instead of multiprocessing.Pool because:
- Ray actors run as daemon processes
- Pool workers are daemonic by default and cannot spawn children
- The pdftext library (used by Marker) internally spawns processes
- ProcessPoolExecutor workers are non-daemon, allowing nested process creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized PDF processing for better efficiency, stability, timeout handling, task cancellation, and GPU compatibility; improved graceful shutdown of background workers.
* **New Features**
  * Added a configurable worker count for PDF text extraction.
* **Documentation**
  * Documented a new environment variable to control the PDF extractor worker count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->