### PR TITLE
fix: update serialize_file call to use handle for remote execution

### DIFF
--- a/openrag/components/indexer/indexer.py
+++ b/openrag/components/indexer/indexer.py
@@ -96,7 +96,7 @@ class Indexer:
             metadata = {**metadata, "partition": partition}
 
             # Serialize
-            doc = await self.serialize_file(path=path, metadata=metadata, task_id=task_id)
+            doc = await self.handle.serialize_file.remote(path=path, metadata=metadata, task_id=task_id)
 
             # Chunk
             if doc:


### PR DESCRIPTION
This pull request fixes a small bug in the `add_file` method of `indexer.py` by using the existing `handle` for file serialization.

The serialization now goes through `self.handle.serialize_file.remote` for consistency with the rest of the `Indexer`, instead of calling the local method directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal document serialization handling in the indexer component to use a distributed processing approach, improving efficiency without affecting the public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->