### PR TITLE
Fix event loop blocking by using asyncio.gather instead of ray.get

### DIFF
--- a/openrag/components/ray_utils.py
+++ b/openrag/components/ray_utils.py
@@ -36,11 +36,13 @@ async def call_ray_actor_with_timeout(
         RuntimeError: If the Ray task failed with an error
     """
     try:
-        ready, pending = await asyncio.to_thread(ray.wait, [future], num_returns=1, timeout=timeout)
-        if not ready:
-            ray.cancel(future, recursive=True)
-            raise TimeoutError(f"{task_description} timed out after {timeout}s")
-        return await asyncio.to_thread(ray.get, ready[0])
+        result = await asyncio.wait_for(asyncio.gather(future), timeout=timeout)
+        return result[0]  # gather returns a list
+
+    except TimeoutError:
+        logger.warning(f"{task_description} timed out, cancelling Ray task")
+        ray.cancel(future, recursive=True)
+        raise
 
     except asyncio.CancelledError:
         logger.warning(f"{task_description} cancelled, cancelling Ray task")


### PR DESCRIPTION
### Description

When indexing files for the first time after starting **OpenRAG**, the following warnings appear. They occur only once and do not repeat in subsequent indexing operations:

```bash
(MarkerPool pid=6129) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.

(DocSerializer pid=6134) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.

(Indexer pid=6126) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
```

We suspect that the issue originates from the `call_ray_actor_with_timeout` function, which internally calls `ray.get`:

* [https://github.com/linagora/openrag/blob/dev/openrag/components/ray_utils.py#L11](https://github.com/linagora/openrag/blob/dev/openrag/components/ray_utils.py#L11)

### Call stack analysis

The execution flow leading to the warning is the following:

1. A file is uploaded
2. The **Indexer** Ray actor processes the file
3. The Indexer calls `serialize_file`, which uses the **DocSerializer** actor
[https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/indexer/indexer.py#L57-L66](https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/indexer/indexer.py#L57-L66)

5. `serialize_file` calls `call_ray_actor_with_timeout`
  [https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/indexer/utils/files.py#L73](https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/indexer/utils/files.py#L73)

7. `call_ray_actor_with_timeout` uses `ray.get`, which blocks inside an async actor
  [https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/ray_utils.py#L39-L43](https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/components/ray_utils.py#L39-L43)

As a result, the Indexer Ray actor ends up calling `ray.get` within an async context, which blocks the event loop.

---

### Impact analysis

To evaluate the impact, we benchmarked the indexing of 200 files before and after applying the proposed modifications.

* **Execution time** remained unchanged overall.
* However, during the experiment, we closely monitored:

  * Application logs
  * The `/queue/info` endpoint
    [https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/routers/queue.py#L28-L30](https://github.com/linagora/openrag/blob/8e273d7ccc1217e1c8c4481e95fcd6f74a012292/openrag/routers/queue.py#L28-L30)

Observed behavior:

* The metrics exposed by `/queue/info` did not update smoothly. The number of indexed files would sometimes jump abruptly, instead of progressing gradually, indicating temporary blocking or lag.
* Log output showed similar behavior: From a blink, a bursts of log lines can suddenly appear.

These observations confirm that the use of `ray.get` inside async actors introduces blocking behavior, even if the overall execution time is not visibly impacted. The impact is observed in logs and in one monitored endpoint but other endpoints might be impacted as well. This simple PR solves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and cancellation handling for asynchronous background operations: tasks that exceed time limits are now detected and cancelled, timeouts are logged, and error propagation has been preserved to maintain stability and responsiveness during interrupted or long-running background work.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->