### PR TITLE
Fix: OpenAI endpoints blocked due to LLM/VLM availability check

### DIFF
--- a/openrag/api.py
+++ b/openrag/api.py
@@ -214,8 +214,8 @@ app.include_router(users_router, prefix="/users", tags=[Tags.USERS])
 
 app.include_router(tools_router, prefix="/v1", tags=[Tags.TOOLS])
 
-if WITH_OPENAI_API:
-    # Mount the openai router
+# Mount openai router if either OpenAI API or Chainlit UI is enabled (chainlit uses openai api endpoints)
+if WITH_OPENAI_API or WITH_CHAINLIT_UI:
     app.include_router(openai_router, prefix="/v1", tags=[Tags.OPENAI])
 
 if WITH_CHAINLIT_UI:
@@ -223,7 +223,6 @@ if WITH_CHAINLIT_UI:
     from chainlit.utils import mount_chainlit
 
     mount_chainlit(app, "./app_front.py", path="/chainlit")
-    app.include_router(openai_router, prefix="/v1", tags=[Tags.OPENAI])  # cause chainlit uses openai api endpoints
 
 if __name__ == "__main__":
     if config.ray.serve.enable:

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -52,7 +52,6 @@ Returns models in OpenAI-compatible format with:
     response_description="A list of available models in OpenAI format",
 )
 async def list_models(
-    _: None = Depends(check_llm_model_availability),
     vectordb=Depends(get_vectordb),
     user_partitions=Depends(current_user_or_admin_partitions),
 ):
@@ -144,9 +143,9 @@ Set `stream: true` for Server-Sent Events (SSE) streaming responses.
 async def openai_chat_completion(
     request2: Request,
     request: OpenAIChatCompletionRequest = Body(...),
-    _: None = Depends(check_llm_model_availability),
     user=Depends(current_user),
     user_partitions=Depends(current_user_or_admin_partitions_list),
+    _: None = Depends(check_llm_model_availability),
 ):
     model_name = request.model or config.llm.get("model")
     log = logger.bind(model=model_name, endpoint="/chat/completions")
@@ -264,9 +263,9 @@ Returns OpenAI-compatible response with additional `extra` field containing:
 async def openai_completion(
     request2: Request,
     request: OpenAICompletionRequest,
-    _: None = Depends(check_llm_model_availability),
     user=Depends(current_user),
     user_partitions=Depends(current_user_or_admin_partitions_list),
+    _: None = Depends(check_llm_model_availability),
 ):
     model_name = request.model or config.llm.get("model")
     log = logger.bind(model=model_name, endpoint="/completions")

--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -244,9 +244,9 @@ async def check_llm_model_availability(request: Request):
     api_key = llm_param.get("api_key")
     timeout = 30
 
-    log = logger.bind(base_url=llm_param["base_url"], model=llm_param["model"], model_type="LLM")
+    log = logger.bind(base_url=llm_param["base_url"], model=llm_param["model"])
     try:
-        log.info("Validating model")
+        log.debug("Validating model")
         client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
         openai_models = await client.models.list(timeout=timeout)
         available_models = {m.id for m in openai_models.data}
@@ -256,9 +256,10 @@ async def check_llm_model_availability(request: Request):
                 detail=f"The underlying model '{model}' is not available via this endpoint.",
             )
     except openai.APIError as e:
-        log.exception("API Endpoint error while validating model", error=str(e))
+        log.error("API Endpoint error while validating model", error=str(e))
+        status_code = getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status_code,
             detail=f"OpenAI API Endpoint error: {str(e)}",
         )
 

--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import consts
+import openai
 from config import load_config
 from fastapi import Depends, Form, HTTPException, Request, UploadFile, status
 from openai import AsyncOpenAI
@@ -237,25 +238,38 @@ def get_app_state(request: Request):
 
 
 async def check_llm_model_availability(request: Request):
-    models = {"LLM": config.llm, "VLM": config.vlm}
-    for model_type, param in models.items():
-        try:
-            client = AsyncOpenAI(api_key=param["api_key"], base_url=param["base_url"])
-            openai_models = await client.models.list()
-            available_models = {m.id for m in openai_models.data}
-            if param["model"] not in available_models:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Only these models ({available_models}) are available for your `{model_type}`. Please check your configuration file.",
-                )
-        except Exception as e:
-            logger.exception("Failed to validate model", model=model_type, error=str(e))
-            if isinstance(e, HTTPException):
-                raise
+    llm_param = config.llm
+    base_url = llm_param.get("base_url")
+    model = llm_param.get("model")
+    api_key = llm_param.get("api_key")
+    timeout = 30
+
+    log = logger.bind(base_url=llm_param["base_url"], model=llm_param["model"], model_type="LLM")
+    try:
+        log.info("Validating model")
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+        openai_models = await client.models.list(timeout=timeout)
+        available_models = {m.id for m in openai_models.data}
+        if model not in available_models:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Error while checking the `{model_type}` endpoint, it seems not available at this moment",
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"The underlying model '{model}' is not available via this endpoint.",
             )
+    except openai.APIError as e:
+        log.exception("API Endpoint error while validating model", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"OpenAI API Endpoint error: {str(e)}",
+        )
+
+    except Exception as e:
+        log.exception("Failed to validate model", error=str(e))
+        if isinstance(e, HTTPException):
+            raise
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Internal Error : {str(e)}",
+        )
 
 
 async def get_partition_name(model_name, user_partitions, is_admin=False):


### PR DESCRIPTION
**Fix OpenAI endpoint failures due to LLM availability checks**

OpenAI endpoints are failing when the underlying LLM or VLM in openrag is unavailable, caused by the `check_llm_model_availability` dependency blocking requests.

**Changes**

* **v1/models endpoint**: Removed the `check_llm_model_availability` dependency since this endpoint doesn't require model availability to function

* **v1/chat/completions and v1/completions endpoints**: These endpoints depend only on the LLM availability (for answer generation). 
  * The VLM check is removed as these endpoints do not  require the VLM to work
  * When checking, clients weren't receiving timely feedback about availability issues because the health check lacks a timeout, causing requests to hang indefinitely. Added timeout handling (30s) to provide immediate feedback to clients.

* **Additional fix**: Corrected the OpenAI endpoint duplication warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model availability checks now return clearer HTTP status codes and messages (missing models yield explicit 404; API errors map to appropriate error responses). External LLM calls use a 30s timeout to avoid hangs.

* **Refactor**
  * Router mounting logic consolidated to remove duplication and ensure consistent behavior.
  * Model validation simplified to a single-flow with improved contextual logging for easier diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->