### PR TITLE
Phase 4: Async Infrastructure

### DIFF
--- a/openrag/api.py
+++ b/openrag/api.py
@@ -167,6 +167,16 @@ async def openrag_exception_handler(request: Request, exc: OpenRAGError):
     return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
 
 
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger = get_logger()
+    logger.exception("Unhandled exception", error=str(exc))
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "[UNEXPECTED_ERROR]: An unexpected error occurred", "extra": {}},
+    )
+
+
 # Add CORS middleware
 allow_origins = [
     "http://localhost:3042",

--- a/openrag/components/indexer/chunker/chunker.py
+++ b/openrag/components/indexer/chunker/chunker.py
@@ -68,18 +68,20 @@ class ChunkContextualizer:
                 ]
                 output = await self.context_generator.ainvoke(messages)
                 return output.content
+
             except openai.APITimeoutError:
-                logger.warning(
-                    f"OpenAI API timeout contextualizing chunk after {CONTEXTUALIZATION_TIMEOUT}s",
-                    filename=filename,
-                )
+                # VLM timeout - graceful degradation
+                logger.warning("VLM context generation timeout", timeout=CONTEXTUALIZATION_TIMEOUT)
                 return ""
+
+            except openai.APIError as e:
+                # Other VLM API errors - log but don't fail chunking
+                logger.error("VLM context generation failed", error=str(e))
+                return ""
+
             except Exception as e:
-                logger.warning(
-                    "Error contextualizing chunk of document",
-                    filename=filename,
-                    error=str(e),
-                )
+                # Unexpected errors - log but still gracefully degrade
+                logger.exception("Unexpected error during context generation")
                 return ""
 
     async def contextualize_chunks(
@@ -131,7 +133,7 @@ class ChunkContextualizer:
             ]
 
         except Exception as e:
-            logger.warning(f"Error contextualizing chunks from `{filename}`: {e}")
+            logger.exception("Error contextualizing chunks", filename=filename)
             return chunks
 
 

--- a/openrag/components/indexer/chunker/chunker.py
+++ b/openrag/components/indexer/chunker/chunker.py
@@ -79,7 +79,7 @@ class ChunkContextualizer:
                 logger.error("VLM context generation failed", error=str(e))
                 return ""
 
-            except Exception as e:
+            except Exception:
                 # Unexpected errors - log but still gracefully degrade
                 logger.exception("Unexpected error during context generation")
                 return ""
@@ -132,7 +132,7 @@ class ChunkContextualizer:
                 for chunk, context in zip(chunks, contexts, strict=True)
             ]
 
-        except Exception as e:
+        except Exception:
             logger.exception("Error contextualizing chunks", filename=filename)
             return chunks
 

--- a/openrag/components/indexer/embeddings/openai.py
+++ b/openrag/components/indexer/embeddings/openai.py
@@ -23,8 +23,18 @@ class OpenAIEmbedding(BaseEmbedding):
             # Test call to get embedding dimension
             output = self.embed_documents([Document(page_content="test")])
             return len(output[0])
-        except Exception:
-            raise
+
+        except openai.APIError as e:
+            logger.error("Failed to get embedding dimension", error=str(e))
+            raise EmbeddingAPIError(f"API error: {e}", model_name=self.embedding_model)
+
+        except (IndexError, AttributeError) as e:
+            logger.error("Invalid embedding response format", error=str(e))
+            raise EmbeddingResponseError("Unexpected response format", error=str(e))
+
+        except Exception as e:
+            logger.exception("Unexpected error getting embedding dimension")
+            raise UnexpectedEmbeddingError("An unexpected error occurred")
 
     def embed_documents(self, texts: list[str | Document]) -> list[list[float]]:
         """
@@ -62,7 +72,7 @@ class OpenAIEmbedding(BaseEmbedding):
         except Exception as e:
             logger.exception("Unexpected error while embedding documents", error=str(e))
             raise UnexpectedEmbeddingError(
-                f"Failed to embed documents: {e!s}",
+                "An unexpected error occurred during document embedding",
                 model_name=self.embedding_model,
                 base_url=self.base_url,
                 error=str(e),

--- a/openrag/components/indexer/embeddings/openai.py
+++ b/openrag/components/indexer/embeddings/openai.py
@@ -32,7 +32,7 @@ class OpenAIEmbedding(BaseEmbedding):
             logger.error("Invalid embedding response format", error=str(e))
             raise EmbeddingResponseError("Unexpected response format", error=str(e))
 
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error getting embedding dimension")
             raise UnexpectedEmbeddingError("An unexpected error occurred")
 

--- a/openrag/components/indexer/indexer.py
+++ b/openrag/components/indexer/indexer.py
@@ -10,6 +10,8 @@ import ray
 import torch
 from config import load_config
 from langchain_core.documents.base import Document
+from utils.exceptions.embeddings import EmbeddingError
+from utils.exceptions.vectordb import VDBError
 
 from .chunker import BaseChunker, ChunkerFactory
 from .utils import serialize_file
@@ -119,25 +121,51 @@ class Indexer:
             # Mark task as completed
             await task_state_manager.set_state.remote(task_id, "COMPLETED")
 
-        except Exception as e:
-            log.exception(f"Task {task_id} failed in add_file")
+        except OSError as e:
+            # File I/O errors (FileNotFoundError, PermissionError, etc.)
+            log.error("File operation failed", path=path, error=str(e))
             tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
             await task_state_manager.set_state.remote(task_id, "FAILED")
             await task_state_manager.set_error.remote(task_id, tb)
             raise
 
+        except VDBError as e:
+            # Database errors (already typed from vectordb)
+            log.error("Database operation failed", error=str(e))
+            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+            await task_state_manager.set_state.remote(task_id, "FAILED")
+            await task_state_manager.set_error.remote(task_id, tb)
+            raise
+
+        except EmbeddingError as e:
+            # Embedding errors (already typed from embeddings)
+            log.error("Embedding generation failed", error=str(e))
+            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+            await task_state_manager.set_state.remote(task_id, "FAILED")
+            await task_state_manager.set_error.remote(task_id, tb)
+            raise
+
+        except Exception as e:
+            # Truly unexpected errors
+            log.exception("Unexpected error during file ingestion", task_id=task_id)
+            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+            await task_state_manager.set_state.remote(task_id, "FAILED")
+            await task_state_manager.set_error.remote(task_id, tb)
+            raise RuntimeError("An unexpected error occurred during file processing")
+
         finally:
+            # GPU cleanup
             if torch.cuda.is_available():
                 gc.collect()
                 torch.cuda.empty_cache()
                 torch.cuda.ipc_collect()
+
+            # File cleanup - nest try/except per Phase 2 decision
             try:
-                # Cleanup input file
                 if not save_uploaded_files:
                     Path(path).unlink(missing_ok=True)
-                    log.debug(f"Deleted input file: {path}")
             except Exception as cleanup_err:
-                log.warning(f"Failed to delete input file {path}: {cleanup_err}")
+                log.warning("Failed to delete input file", path=path, error=str(cleanup_err))
         return True
 
     @ray.method(concurrency_group="insert")
@@ -157,9 +185,15 @@ class Indexer:
             await vectordb.delete_file.remote(file_id, partition)
             log.info("Deleted file from partition.", file_id=file_id, partition=partition)
 
-        except Exception as e:
-            log.exception("Error in delete_file", error=str(e))
+        except VDBError as e:
+            # Database errors (already typed from vectordb)
+            log.error("Database operation failed in delete_file", error=str(e))
             raise
+
+        except Exception as e:
+            # Unexpected errors
+            log.exception("Unexpected error in delete_file")
+            raise RuntimeError("An unexpected error occurred during file deletion")
 
     @ray.method(concurrency_group="update")
     async def update_file_metadata(
@@ -184,9 +218,16 @@ class Indexer:
             await vectordb.async_add_documents.remote(docs, user=user)
 
             log.info("Metadata updated for file.")
-        except Exception as e:
-            log.exception("Error in update_file_metadata", error=str(e))
+
+        except VDBError as e:
+            # Database errors (already typed from vectordb)
+            log.error("Database operation failed in update_file_metadata", error=str(e))
             raise
+
+        except Exception as e:
+            # Unexpected errors
+            log.exception("Unexpected error in update_file_metadata")
+            raise RuntimeError("An unexpected error occurred during metadata update")
 
     @ray.method(concurrency_group="update")
     async def copy_file(
@@ -216,9 +257,16 @@ class Indexer:
                 new_file_id=metadata.get("file_id"),
                 new_partition=metadata.get("partition"),
             )
-        except Exception as e:
-            log.exception("Error in copy_file", error=str(e))
+
+        except VDBError as e:
+            # Database errors (already typed from vectordb)
+            log.error("Database operation failed in copy_file", error=str(e))
             raise
+
+        except Exception as e:
+            # Unexpected errors
+            log.exception("Unexpected error in copy_file")
+            raise RuntimeError("An unexpected error occurred during file copy")
 
     @ray.method(concurrency_group="search")
     async def asearch(

--- a/openrag/components/indexer/indexer.py
+++ b/openrag/components/indexer/indexer.py
@@ -10,8 +10,8 @@ import ray
 import torch
 from config import load_config
 from langchain_core.documents.base import Document
-from utils.exceptions.embeddings import EmbeddingError
-from utils.exceptions.vectordb import VDBError
+from utils.exceptions.base import OpenRAGError
+from utils.exceptions.common import UnexpectedError
 
 from .chunker import BaseChunker, ChunkerFactory
 from .utils import serialize_file
@@ -121,25 +121,8 @@ class Indexer:
             # Mark task as completed
             await task_state_manager.set_state.remote(task_id, "COMPLETED")
 
-        except OSError as e:
-            # File I/O errors (FileNotFoundError, PermissionError, etc.)
-            log.error("File operation failed", path=path, error=str(e))
-            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            await task_state_manager.set_state.remote(task_id, "FAILED")
-            await task_state_manager.set_error.remote(task_id, tb)
-            raise
-
-        except VDBError as e:
-            # Database errors (already typed from vectordb)
-            log.error("Database operation failed", error=str(e))
-            tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            await task_state_manager.set_state.remote(task_id, "FAILED")
-            await task_state_manager.set_error.remote(task_id, tb)
-            raise
-
-        except EmbeddingError as e:
-            # Embedding errors (already typed from embeddings)
-            log.error("Embedding generation failed", error=str(e))
+        except OpenRAGError as e:
+            log.error("Operation failed during file ingestion", code=e.code, error=e.message)
             tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
             await task_state_manager.set_state.remote(task_id, "FAILED")
             await task_state_manager.set_error.remote(task_id, tb)
@@ -151,7 +134,7 @@ class Indexer:
             tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
             await task_state_manager.set_state.remote(task_id, "FAILED")
             await task_state_manager.set_error.remote(task_id, tb)
-            raise RuntimeError("An unexpected error occurred during file processing")
+            raise UnexpectedError("An unexpected error occurred during file processing") from e
 
         finally:
             # GPU cleanup
@@ -185,15 +168,12 @@ class Indexer:
             await vectordb.delete_file.remote(file_id, partition)
             log.info("Deleted file from partition.", file_id=file_id, partition=partition)
 
-        except VDBError as e:
-            # Database errors (already typed from vectordb)
-            log.error("Database operation failed in delete_file", error=str(e))
+        except OpenRAGError:
             raise
 
         except Exception as e:
-            # Unexpected errors
             log.exception("Unexpected error in delete_file")
-            raise RuntimeError("An unexpected error occurred during file deletion")
+            raise UnexpectedError("An unexpected error occurred during file deletion") from e
 
     @ray.method(concurrency_group="update")
     async def update_file_metadata(
@@ -219,15 +199,12 @@ class Indexer:
 
             log.info("Metadata updated for file.")
 
-        except VDBError as e:
-            # Database errors (already typed from vectordb)
-            log.error("Database operation failed in update_file_metadata", error=str(e))
+        except OpenRAGError:
             raise
 
         except Exception as e:
-            # Unexpected errors
             log.exception("Unexpected error in update_file_metadata")
-            raise RuntimeError("An unexpected error occurred during metadata update")
+            raise UnexpectedError("An unexpected error occurred during metadata update") from e
 
     @ray.method(concurrency_group="update")
     async def copy_file(
@@ -258,15 +235,12 @@ class Indexer:
                 new_partition=metadata.get("partition"),
             )
 
-        except VDBError as e:
-            # Database errors (already typed from vectordb)
-            log.error("Database operation failed in copy_file", error=str(e))
+        except OpenRAGError:
             raise
 
         except Exception as e:
-            # Unexpected errors
             log.exception("Unexpected error in copy_file")
-            raise RuntimeError("An unexpected error occurred during file copy")
+            raise UnexpectedError("An unexpected error occurred during file copy") from e
 
     @ray.method(concurrency_group="search")
     async def asearch(

--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import binascii
 import re
 from abc import ABC, abstractmethod
 from io import BytesIO

--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -50,10 +50,14 @@ class BaseLoader(ABC):
     ):
         pass
 
-    def save_content(self, text_content: str, path: str):
-        path = re.sub(r"\..*", ".md", path)
+    def _write_file(self, path: str, content: str):
+        """Synchronous helper for file writing."""
         with open(path, "w", encoding="utf-8") as f:
-            f.write(text_content)
+            f.write(content)
+
+    async def save_content(self, text_content: str, path: str):
+        path = re.sub(r"\..*", ".md", path)
+        await asyncio.to_thread(self._write_file, path, text_content)
         logger.debug(f"Document saved to {path}")
 
     def _pil_image_to_base64(self, image: Image.Image) -> str:
@@ -116,7 +120,7 @@ class BaseLoader(ABC):
                             base64.b64decode(image_data)
                             image_url = f"data:image/png;base64,{image_data}"
                             logger.debug("Processing raw base64 string")
-                        except (ValueError, base64.binascii.Error) as e:
+                        except (ValueError, binascii.Error) as e:
                             # Invalid base64 data
                             logger.warning("Failed to decode base64 image", error=str(e)[:100])
                             return """\n<image_description>\nInvalid image data format\n</image_description>\n"""

--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import binascii
 import re
 from abc import ABC, abstractmethod
 from io import BytesIO

--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import binascii
 import re
 from abc import ABC, abstractmethod
 from io import BytesIO
@@ -116,8 +117,13 @@ class BaseLoader(ABC):
                             base64.b64decode(image_data)
                             image_url = f"data:image/png;base64,{image_data}"
                             logger.debug("Processing raw base64 string")
-                        except Exception:
-                            logger.error(f"Invalid image data type or format: {type(image_data)}")
+                        except (ValueError, base64.binascii.Error) as e:
+                            # Invalid base64 data
+                            logger.warning("Failed to decode base64 image", error=str(e)[:100])
+                            return """\n<image_description>\nInvalid image data format\n</image_description>\n"""
+                        except Exception as e:
+                            # PIL image opening errors or other unexpected issues
+                            logger.warning("Failed to process image data", error=str(e)[:100])
                             return """\n<image_description>\nInvalid image data format\n</image_description>\n"""
                     else:
                         logger.error(f"Unsupported image data type: {type(image_data)}")

--- a/openrag/components/indexer/loaders/doc.py
+++ b/openrag/components/indexer/loaders/doc.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import tempfile
 
@@ -14,16 +15,22 @@ class DocLoader(BaseLoader):
         super().__init__(**kwargs)
         self.MDLoader = DocxLoader(**kwargs)
 
+    def _convert_doc_to_docx(self, file_path):
+        """Convert .doc to .docx using Spire.Doc (blocking operations in thread pool)."""
+        document = Document()
+        document.LoadFromFile(str(file_path))
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as temp_file:
+            temp_path = temp_file.name
+            document.SaveToFile(temp_path, FileFormat.Docx2016)
+        return document, temp_path
+
     async def aload_document(self, file_path, metadata, save_markdown=False):
         """Here we convert the document to docx format, save it in local and then use the MarkItDownLoader
         to convert it to markdown."""
-        document = Document()
-        document.LoadFromFile(str(file_path))
-        # file_path = "converted/sample2.docx"
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as temp_file:
-            file_path = temp_file.name
-            document.SaveToFile(file_path, FileFormat.Docx2016)
-        result_string = await self.MDLoader.aload_document(file_path, metadata, save_markdown)
-        os.remove(file_path)
-        document.Close()
+        document, temp_path = await asyncio.to_thread(self._convert_doc_to_docx, file_path)
+        try:
+            result_string = await self.MDLoader.aload_document(temp_path, metadata, save_markdown)
+        finally:
+            await asyncio.to_thread(os.remove, temp_path)
+            document.Close()
         return result_string

--- a/openrag/components/indexer/loaders/docx.py
+++ b/openrag/components/indexer/loaders/docx.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import zipfile
 from io import BytesIO
@@ -28,11 +29,12 @@ class DocxLoader(BaseLoader):
         self.converter = MarkItDown()
 
     async def aload_document(self, file_path, metadata, save_markdown=False):
-        result = self.converter.convert(file_path).text_content
+        convert_result = await asyncio.to_thread(self.converter.convert, file_path)
+        result = convert_result.text_content
 
         if self.image_captioning:
             # Handle embedded images (extracted from docx zip)
-            images = self.get_images_from_zip(file_path)
+            images = await asyncio.to_thread(self.get_images_from_zip, file_path)
             captions = await self.caption_images(images, desc="Captioning embedded images")
             for caption in captions:
                 result = re.sub(
@@ -54,7 +56,7 @@ class DocxLoader(BaseLoader):
 
         doc = Document(page_content=result, metadata=metadata)
         if save_markdown:
-            self.save_content(result, str(file_path))
+            await self.save_content(result, str(file_path))
         return doc
 
     def get_images_from_zip(self, input_file):

--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -1,5 +1,6 @@
 import datetime
 import email
+import email.errors
 import io
 import os
 import tempfile
@@ -7,7 +8,7 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 from langchain_core.documents.base import Document
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 from . import get_loader_classes
 from .base import BaseLoader
@@ -52,7 +53,8 @@ class EmlLoader(BaseLoader):
             if email_data["header"]["date"]:
                 try:
                     email_data["header"]["date"] = parsedate_to_datetime(email_data["header"]["date"]).isoformat()
-                except Exception:
+                except (ValueError, TypeError, email.errors.MessageError):
+                    # Invalid date format - keep original string
                     pass
 
             # Extract body content and attachments
@@ -98,7 +100,8 @@ class EmlLoader(BaseLoader):
                                 # Use plain text as primary body content
                                 if content_type == "text/plain" or not body_content:
                                     body_content = text_content
-                            except Exception as e:
+                            except (UnicodeDecodeError, email.errors.MessageError) as e:
+                                # Failed to decode email text part - skip this part
                                 print(f"Failed to decode text content: {e}")
 
             # Extract body content
@@ -140,7 +143,11 @@ class EmlLoader(BaseLoader):
                                         metadata={"source": f"attachment:{filename}"},
                                     )
                                     attachments_text += f"Content:\n{attachment_doc.page_content}\n"
+                                except OSError as e:
+                                    # File I/O error - skip this attachment
+                                    attachments_text += f"Cannot read attachment file: {str(e)[:200]}...\n"
                                 except Exception as e:
+                                    # Loader-specific errors - try fallback loaders
                                     attachments_text += f"Failed to process attachment with loader ({loader_cls.__name__}): {str(e)[:200]}...\n"
 
                                     # Special fallback handling for PDFs with alternative loaders
@@ -179,7 +186,11 @@ class EmlLoader(BaseLoader):
                                                         attachments_text += f"Content (via {fallback_loader_name}):\n{attachment_doc.page_content}\n"
                                                         fallback_success = True
                                                         break
+                                                except OSError as fallback_e:
+                                                    # File I/O error - skip fallback
+                                                    attachments_text += f"Fallback {fallback_loader_name} file error: {str(fallback_e)[:100]}...\n"
                                                 except Exception as fallback_e:
+                                                    # Fallback loader failed - try next
                                                     attachments_text += f"Fallback {fallback_loader_name} also failed: {str(fallback_e)[:100]}...\n"
 
                                         if not fallback_success:
@@ -197,7 +208,11 @@ class EmlLoader(BaseLoader):
                                                 attachments_text += (
                                                     "Image attachment present but image captioning disabled\n"
                                                 )
+                                        except (OSError, UnidentifiedImageError) as img_e:
+                                            # Invalid or unreadable image
+                                            attachments_text += f"Image fallback failed (invalid image): {str(img_e)[:100]}...\n"
                                         except Exception as img_e:
+                                            # Unexpected image processing error
                                             attachments_text += f"Image fallback also failed: {str(img_e)[:100]}...\n"
 
                                     # Try text fallback for other text-based formats
@@ -213,7 +228,11 @@ class EmlLoader(BaseLoader):
                                                 )
                                             else:
                                                 attachments_text += "No readable text found in attachment\n"
+                                        except UnicodeDecodeError as text_e:
+                                            # Text decoding failed
+                                            attachments_text += f"Text fallback failed (encoding error): {str(text_e)[:100]}...\n"
                                         except Exception as text_e:
+                                            # Unexpected text extraction error
                                             attachments_text += f"Text fallback failed: {str(text_e)[:100]}...\n"
                                 finally:
                                     # Clean up temporary file
@@ -237,8 +256,9 @@ class EmlLoader(BaseLoader):
                                     # Generate caption using the base loader's method
                                     caption = await self.get_image_description(image_data=image)
                                     attachments_text += f"Image Description:\n{caption}\n"
-                                except Exception as e:
-                                    attachments_text += f"Failed to generate image caption: {str(e)[:200]}...\n"
+                                except (OSError, UnidentifiedImageError) as e:
+                                    # Invalid or corrupted image
+                                    attachments_text += f"Failed to generate image caption (invalid image): {str(e)[:200]}...\n"
                                     # Try to show basic image info if available
                                     try:
                                         size_info = f"Image size: {len(attachment['raw'])} bytes"
@@ -247,6 +267,9 @@ class EmlLoader(BaseLoader):
                                         )
                                     except Exception:
                                         attachments_text += "Image attachment present but corrupted or unreadable\n"
+                                except Exception as e:
+                                    # Unexpected image captioning error (VLM errors handled in base.py)
+                                    attachments_text += f"Failed to generate image caption: {str(e)[:200]}...\n"
 
                             elif content_type.startswith("text/"):
                                 # For text attachments, decode directly
@@ -255,7 +278,11 @@ class EmlLoader(BaseLoader):
                             else:
                                 # For other binary content, just show metadata
                                 attachments_text += f"Binary content (size: {len(attachment['raw'])} bytes)\n"
+                        except OSError as e:
+                            # File I/O error creating temp file
+                            attachments_text += f"Cannot create temp file for attachment: {e}\n"
                         except Exception as e:
+                            # Unexpected error processing attachment
                             attachments_text += f"Content could not be processed: {e}\n"
                     attachments_text += "---\n"
 
@@ -298,7 +325,14 @@ class EmlLoader(BaseLoader):
                 with open(markdown_path, "w", encoding="utf-8") as md_file:
                     md_file.write(content_body)
                 metadata["markdown_path"] = str(markdown_path)
+        except OSError as e:
+            # File I/O error reading email file
+            raise ValueError(f"Cannot read email file: {e}")
+        except email.errors.MessageError as e:
+            # Email parsing error
+            raise ValueError(f"Invalid email format: {e}")
         except Exception as e:
+            # Unexpected error
             raise ValueError(f"Failed to parse the EML file {file_path}: {e}")
 
         document = Document(page_content=content_body, metadata=metadata)

--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import email
 import email.errors
@@ -28,10 +29,20 @@ class EmlLoader(BaseLoader):
         # Get available loaders for processing attachments
         self.loader_classes = get_loader_classes(config=self.config)
 
+    def _read_file_bytes(self, file_path):
+        """Read file bytes (blocking operation for thread pool)."""
+        with open(file_path, "rb") as fhdl:
+            return fhdl.read()
+
+    def _write_temp_file(self, suffix, data):
+        """Write temp file (blocking operation for thread pool)."""
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+            temp_file.write(data)
+            return temp_file.name
+
     async def aload_document(self, file_path, metadata: dict | None = None, save_markdown: bool = False):
         try:
-            with open(file_path, "rb") as fhdl:
-                raw_email = fhdl.read()
+            raw_email = await asyncio.to_thread(self._read_file_bytes, file_path)
 
             # Parse email using standard email library
             email_msg = email.message_from_bytes(raw_email)
@@ -131,9 +142,9 @@ class EmlLoader(BaseLoader):
 
                             if loader_cls:
                                 # Save attachment to temporary file
-                                with tempfile.NamedTemporaryFile(suffix=file_ext, delete=False) as temp_file:
-                                    temp_file.write(attachment["raw"])
-                                    temp_file_path = temp_file.name
+                                temp_file_path = await asyncio.to_thread(
+                                    self._write_temp_file, file_ext, attachment["raw"]
+                                )
 
                                 try:
                                     # Use appropriate loader to process attachment
@@ -236,8 +247,8 @@ class EmlLoader(BaseLoader):
                                             attachments_text += f"Text fallback failed: {str(text_e)[:100]}...\n"
                                 finally:
                                     # Clean up temporary file
-                                    if os.path.exists(temp_file_path):
-                                        os.unlink(temp_file_path)
+                                    if await asyncio.to_thread(os.path.exists, temp_file_path):
+                                        await asyncio.to_thread(os.unlink, temp_file_path)
 
                             # Special handling for images with captioning if no specific loader or captioning is enabled
                             elif file_ext in [
@@ -321,10 +332,8 @@ class EmlLoader(BaseLoader):
 
             # Save content body to a file if requested
             if save_markdown:
-                markdown_path = Path(file_path).with_suffix(".md")
-                with open(markdown_path, "w", encoding="utf-8") as md_file:
-                    md_file.write(content_body)
-                metadata["markdown_path"] = str(markdown_path)
+                await self.save_content(content_body, str(file_path))
+                metadata["markdown_path"] = str(Path(file_path).with_suffix(".md"))
         except OSError as e:
             # File I/O error reading email file
             raise ValueError(f"Cannot read email file: {e}")

--- a/openrag/components/indexer/loaders/image.py
+++ b/openrag/components/indexer/loaders/image.py
@@ -1,3 +1,4 @@
+import asyncio
 from io import BytesIO
 from pathlib import Path
 
@@ -19,16 +20,19 @@ class ImageLoader(BaseLoader):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+    def _load_image(self, path: Path):
+        """Load image file, converting SVG to PNG if needed."""
+        if path.suffix.lower() == ".svg":
+            png_data = cairosvg.svg2png(url=str(path))
+            return Image.open(BytesIO(png_data))
+        else:
+            return Image.open(path)
+
     async def aload_document(self, file_path, metadata=None, save_markdown=False):
         path = Path(file_path)
 
         try:
-            # Handle SVG files by converting to PNG first
-            if path.suffix.lower() == ".svg":
-                png_data = cairosvg.svg2png(url=str(path))
-                img = Image.open(BytesIO(png_data))
-            else:
-                img = Image.open(path)
+            img = await asyncio.to_thread(self._load_image, path)
         except OSError as e:
             # File not found, permission denied, etc.
             log.error("Cannot read image file", file_path=str(path), error=str(e))
@@ -50,5 +54,5 @@ class ImageLoader(BaseLoader):
         description = await self.get_image_description(image_data=img)
         doc = Document(page_content=description, metadata=metadata)
         if save_markdown:
-            self.save_content(description, str(path))
+            await self.save_content(description, str(path))
         return doc

--- a/openrag/components/indexer/loaders/image.py
+++ b/openrag/components/indexer/loaders/image.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import cairosvg
 from langchain_core.documents import Document
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from utils.logger import get_logger
 
 from .base import BaseLoader
@@ -29,7 +29,16 @@ class ImageLoader(BaseLoader):
                 img = Image.open(BytesIO(png_data))
             else:
                 img = Image.open(path)
+        except OSError as e:
+            # File not found, permission denied, etc.
+            log.error("Cannot read image file", file_path=str(path), error=str(e))
+            raise ImageLoadError(f"Cannot read image file: {e}") from e
+        except UnidentifiedImageError as e:
+            # Invalid image format
+            log.error("Invalid image format", file_path=str(path), error=str(e))
+            raise ImageLoadError(f"Invalid image format: {e}") from e
         except Exception as e:
+            # SVG conversion errors or other unexpected issues
             log.error(
                 "Failed to load image file",
                 file_path=str(path),

--- a/openrag/components/indexer/loaders/media_loader.py
+++ b/openrag/components/indexer/loaders/media_loader.py
@@ -7,7 +7,7 @@ import librosa
 import numpy as np
 from components.utils import get_audio_semaphore
 from langchain_core.documents.base import Document
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, APIError
 from pydub import AudioSegment, silence
 from tqdm.asyncio import tqdm
 from utils.logger import get_logger
@@ -58,8 +58,13 @@ class AudioTranscriber:
             try:
                 result = await self._transcribe_chunk(tmp_path, language)
                 return result
+            except APIError as e:
+                # OpenAI API errors - gracefully degrade by returning empty transcript
+                logger.warning("Audio transcription API error", chunk=tmp_path.name, error=str(e)[:200])
+                return ""
             except Exception as e:
-                logger.exception(f"Error transcribing chunk {tmp_path.name}", error=str(e))
+                # Unexpected errors - log and return empty transcript for graceful degradation
+                logger.exception("Error transcribing chunk", chunk=tmp_path.name, error=str(e))
                 return ""
             finally:
                 tmp_path.unlink(missing_ok=True)
@@ -77,8 +82,13 @@ class AudioTranscriber:
                 kwargs["language"] = language
             result = await self.client.audio.transcriptions.create(**kwargs)
             return result.text.strip()
+        except APIError as e:
+            # OpenAI API errors - gracefully degrade by returning empty transcript
+            logger.warning("Audio transcription API error", chunk=wav_path.name, error=str(e)[:200])
+            return ""
         except Exception as e:
-            logger.exception(f"Error transcribing chunk {wav_path.name}", error=str(e))
+            # Unexpected errors - log and return empty transcript for graceful degradation
+            logger.exception("Error transcribing chunk", chunk=wav_path.name, error=str(e))
             return ""
 
     async def _get_audio_chunks(self, sound: AudioSegment) -> list[AudioSegment]:
@@ -122,7 +132,12 @@ class AudioTranscriber:
             return fallback_language  # Fallback to English
         try:
             return langdetect.detect(text)
+        except langdetect.LangDetectException as e:
+            # Expected failure for non-textual content or too-short text
+            logger.warning("Language detection failed", error=str(e))
+            return fallback_language
         except Exception as e:
+            # Unexpected language detection errors
             logger.exception("Language detection failed", error=str(e))
             return fallback_language
         finally:

--- a/openrag/components/indexer/loaders/media_loader.py
+++ b/openrag/components/indexer/loaders/media_loader.py
@@ -228,5 +228,5 @@ class VideoAudioLoader(BaseLoader):
             await asyncio.to_thread(os.remove, audio_path_wav)
         doc = Document(page_content=content, metadata=metadata)
         if save_markdown:
-            self.save_content(content, str(file_path))
+            await self.save_content(content, str(file_path))
         return doc

--- a/openrag/components/indexer/loaders/media_loader.py
+++ b/openrag/components/indexer/loaders/media_loader.py
@@ -7,7 +7,7 @@ import librosa
 import numpy as np
 from components.utils import get_audio_semaphore
 from langchain_core.documents.base import Document
-from openai import AsyncOpenAI, APIError
+from openai import APIError, AsyncOpenAI
 from pydub import AudioSegment, silence
 from tqdm.asyncio import tqdm
 from utils.logger import get_logger

--- a/openrag/components/indexer/loaders/pdf_loaders/docling.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/docling.py
@@ -80,5 +80,5 @@ class DoclingLoader(BaseLoader):
 
         doc = Document(page_content=enriched_content, metadata=metadata)
         if save_markdown:
-            self.save_content(enriched_content, str(file_path))
+            await self.save_content(enriched_content, str(file_path))
         return doc

--- a/openrag/components/indexer/loaders/pdf_loaders/marker.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/marker.py
@@ -259,7 +259,7 @@ class MarkerLoader(BaseLoader):
             doc = Document(page_content=markdown, metadata=metadata)
 
             if save_markdown:
-                self.save_content(markdown, file_path_str)
+                await self.save_content(markdown, file_path_str)
 
             duration = time.time() - start
             logger.info(f"Processed {file_path_str} in {duration:.2f}s")

--- a/openrag/components/indexer/loaders/pdf_loaders/marker.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/marker.py
@@ -102,9 +102,18 @@ class MarkerWorker:
             )
             render = converter(file_path)
             return render
-        except Exception as e:
-            logger.exception("Error processing PDF", path=file_path, error=str(e))
+        except asyncio.CancelledError:
+            # Cancellation request - propagate immediately
+            logger.info("PDF processing cancelled", path=file_path)
             raise
+        except OSError as e:
+            # File I/O error
+            logger.error("Cannot read PDF file", path=file_path, error=str(e))
+            raise RuntimeError(f"Cannot read PDF file: {e}")
+        except Exception as e:
+            # Marker library errors or unexpected failures
+            logger.exception("Error processing PDF", path=file_path, error=str(e))
+            raise RuntimeError("Failed to process PDF document")
         finally:
             gc.collect()
             if torch.cuda.is_available():
@@ -124,6 +133,10 @@ class MarkerWorker:
                 return result
             except MPTimeoutError:
                 self.logger.exception("MarkerWorker child process timed out", path=file_path)
+                raise RuntimeError(f"PDF processing timed out")
+            except asyncio.CancelledError:
+                # Cancellation - propagate
+                self.logger.info("PDF processing cancelled", path=file_path)
                 raise
             except Exception:
                 self.logger.exception("Error processing with MarkerWorker", path=file_path)
@@ -253,6 +266,15 @@ class MarkerLoader(BaseLoader):
             logger.info(f"Processed {file_path_str} in {duration:.2f}s")
             return doc
 
+        except asyncio.CancelledError:
+            # Cancellation - propagate immediately (MUST be first)
+            logger.info("PDF loading cancelled", path=file_path_str)
+            raise
+        except OSError as e:
+            # File I/O error
+            logger.error("Cannot read PDF file", path=file_path_str, error=str(e))
+            raise RuntimeError(f"Cannot read PDF file: {e}")
         except Exception:
+            # Ray actor errors or PDF processing failures
             logger.exception("Error in aload_document", path=file_path_str)
             raise

--- a/openrag/components/indexer/loaders/pdf_loaders/marker.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/marker.py
@@ -9,6 +9,7 @@ import torch
 from config import load_config
 from langchain_core.documents.base import Document
 from marker.converters.pdf import PdfConverter
+from utils.exceptions.common import FileStorageError, UnexpectedError
 from utils.logger import get_logger
 
 from ..base import BaseLoader
@@ -107,13 +108,11 @@ class MarkerWorker:
             logger.info("PDF processing cancelled", path=file_path)
             raise
         except OSError as e:
-            # File I/O error
             logger.error("Cannot read PDF file", path=file_path, error=str(e))
-            raise RuntimeError(f"Cannot read PDF file: {e}")
+            raise FileStorageError(f"Cannot read PDF file: {e}") from e
         except Exception as e:
-            # Marker library errors or unexpected failures
             logger.exception("Error processing PDF", path=file_path, error=str(e))
-            raise RuntimeError("Failed to process PDF document")
+            raise UnexpectedError("Failed to process PDF document") from e
         finally:
             gc.collect()
             if torch.cuda.is_available():
@@ -133,7 +132,7 @@ class MarkerWorker:
                 return result
             except MPTimeoutError:
                 self.logger.exception("MarkerWorker child process timed out", path=file_path)
-                raise RuntimeError(f"PDF processing timed out")
+                raise UnexpectedError("PDF processing timed out")
             except asyncio.CancelledError:
                 # Cancellation - propagate
                 self.logger.info("PDF processing cancelled", path=file_path)
@@ -242,7 +241,7 @@ class MarkerLoader(BaseLoader):
             )
 
             if not markdown:
-                raise RuntimeError(f"Conversion failed for {file_path_str}")
+                raise UnexpectedError(f"Conversion failed for {file_path_str}")
 
             if self.image_captioning:
                 keys = list(images.keys())
@@ -271,9 +270,8 @@ class MarkerLoader(BaseLoader):
             logger.info("PDF loading cancelled", path=file_path_str)
             raise
         except OSError as e:
-            # File I/O error
             logger.error("Cannot read PDF file", path=file_path_str, error=str(e))
-            raise RuntimeError(f"Cannot read PDF file: {e}")
+            raise FileStorageError(f"Cannot read PDF file: {e}") from e
         except Exception:
             # Ray actor errors or PDF processing failures
             logger.exception("Error in aload_document", path=file_path_str)

--- a/openrag/components/indexer/loaders/pdf_loaders/openai.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/openai.py
@@ -58,7 +58,7 @@ class OpenAILoader(BaseLoader, ABC):
             markdown = await self._assemble_markdown(pages, ocr_results)
 
             if save_markdown:
-                self.save_content(markdown, file_path)
+                await self.save_content(markdown, file_path)
 
             duration = time.time() - start_time
             logger.info(f"Processed {file_path} in {duration:.2f}s")

--- a/openrag/components/indexer/loaders/pdf_loaders/pymupdf.py
+++ b/openrag/components/indexer/loaders/pdf_loaders/pymupdf.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import pymupdf4llm
@@ -23,7 +24,7 @@ class PyMuPDFLoader(BaseLoader):
 
         doc = Document(page_content=s, metadata=metadata)
         if save_markdown:
-            self.save_content(s, str(file_path))
+            await self.save_content(s, str(file_path))
         return doc
 
 
@@ -32,7 +33,9 @@ class PyMuPDF4LLMLoader(BaseLoader):
         super().__init__(**kwargs)
 
     async def aload_document(self, file_path, metadata: dict = None, save_markdown=False):
-        pages = pymupdf4llm.to_markdown(file_path, write_images=False, page_chunks=True)
+        pages = await asyncio.to_thread(
+            pymupdf4llm.to_markdown, file_path, write_images=False, page_chunks=True
+        )
 
         s = ""
         for page_num, segment in enumerate(pages, start=1):
@@ -40,5 +43,5 @@ class PyMuPDF4LLMLoader(BaseLoader):
 
         doc = Document(page_content=s, metadata=metadata)
         if save_markdown:
-            self.save_content(s, str(file_path))
+            await self.save_content(s, str(file_path))
         return doc

--- a/openrag/components/indexer/loaders/pptx_loader.py
+++ b/openrag/components/indexer/loaders/pptx_loader.py
@@ -1,3 +1,4 @@
+import asyncio
 import html
 import re
 from io import BytesIO
@@ -149,7 +150,7 @@ class PPTXLoader(BaseLoader):
         self.converter = PPTXConverter(image_placeholder=self.image_placeholder, page_separator=self.page_sep)
 
     async def aload_document(self, file_path, metadata=None, save_markdown=False):
-        md_content, imgs = self.converter.convert(local_path=file_path)
+        md_content, imgs = await asyncio.to_thread(self.converter.convert, local_path=file_path)
 
         if self.image_captioning:
             images_captions = await self.caption_images(imgs, desc="Generating captions")
@@ -168,5 +169,5 @@ class PPTXLoader(BaseLoader):
 
         doc = Document(page_content=md_content, metadata=metadata)
         if save_markdown:
-            self.save_content(md_content, str(file_path))
+            await self.save_content(md_content, str(file_path))
         return doc

--- a/openrag/components/indexer/loaders/pptx_loader.py
+++ b/openrag/components/indexer/loaders/pptx_loader.py
@@ -125,11 +125,20 @@ class PPTXConverter:
             separator = "|" + "|".join(["---"] * len(data[0])) + "|"
             return md + "\n".join([header, separator] + markdown_table[1:])
         except ValueError as e:
-            # Handle the specific error for unsupported chart types
+            # Handle unsupported chart types (expected error)
             if "unsupported plot type" in str(e):
+                logger.debug("Unsupported chart type encountered")
                 return "\n\n[unsupported chart]\n\n"
-        except Exception:
-            # Catch any other exceptions that might occur
+            # Other ValueError - log and return placeholder
+            logger.warning("Chart conversion value error", error=str(e))
+            return "\n\n[unsupported chart]\n\n"
+        except (AttributeError, IndexError) as e:
+            # Missing chart data or unexpected structure
+            logger.warning("Chart structure error", error=str(e))
+            return "\n\n[unsupported chart]\n\n"
+        except Exception as e:
+            # Unexpected errors - log and gracefully degrade
+            logger.warning("Chart conversion failed", error=str(e))
             return "\n\n[unsupported chart]\n\n"
 
 

--- a/openrag/components/indexer/loaders/serializer.py
+++ b/openrag/components/indexer/loaders/serializer.py
@@ -84,6 +84,11 @@ class DocSerializer:
                 torch.cuda.ipc_collect()
             log.info("Document serialized successfully")
             return doc
+        except OSError as e:
+            # File operation failed (file not found, permission denied, etc.)
+            log.error("File operation failed during serialization", path=str(path), error=str(e))
+            raise RuntimeError(f"Cannot read file: {e}")
         except Exception as e:
-            log.exception("Failed to serialize document", error=str(e))
-            raise
+            # Loader-specific errors or unexpected failures
+            log.exception("Failed to serialize document", path=str(path), file_type=file_ext, error=str(e))
+            raise RuntimeError("Failed to serialize document: unsupported format or corrupted file")

--- a/openrag/components/indexer/loaders/serializer.py
+++ b/openrag/components/indexer/loaders/serializer.py
@@ -5,6 +5,7 @@ import ray
 import torch
 from config import load_config
 from langchain_core.documents.base import Document
+from utils.exceptions.common import FileStorageError, UnexpectedError
 
 from . import get_loader_classes
 
@@ -85,10 +86,8 @@ class DocSerializer:
             log.info("Document serialized successfully")
             return doc
         except OSError as e:
-            # File operation failed (file not found, permission denied, etc.)
             log.error("File operation failed during serialization", path=str(path), error=str(e))
-            raise RuntimeError(f"Cannot read file: {e}")
+            raise FileStorageError(f"Cannot read file: {e}") from e
         except Exception as e:
-            # Loader-specific errors or unexpected failures
             log.exception("Failed to serialize document", path=str(path), file_type=file_ext, error=str(e))
-            raise RuntimeError("Failed to serialize document: unsupported format or corrupted file")
+            raise UnexpectedError("Failed to serialize document: unsupported format or corrupted file") from e

--- a/openrag/components/indexer/loaders/txt_loader.py
+++ b/openrag/components/indexer/loaders/txt_loader.py
@@ -40,7 +40,7 @@ class TextLoader(BaseLoader):
 
         doc = Document(page_content=content, metadata=metadata)
         if save_markdown:
-            self.save_content(content, str(path))
+            await self.save_content(content, str(path))
 
         return doc
 
@@ -76,5 +76,5 @@ class MarkdownLoader(BaseLoader):
 
         doc = Document(page_content=content, metadata=metadata)
         if save_markdown:
-            self.save_content(text_content=content, path=str(path))
+            await self.save_content(text_content=content, path=str(path))
         return doc

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -97,6 +97,24 @@ class User(Base):
     memberships = relationship("PartitionMembership", back_populates="user", cascade="all, delete-orphan")
 
 
+class FileDomain(Base):
+    __tablename__ = "file_domains"
+
+    id = Column(Integer, primary_key=True)
+    file_id = Column(String, nullable=False)
+    partition_name = Column(
+        String,
+        ForeignKey("partitions.partition", ondelete="CASCADE"),
+        nullable=False,
+    )
+    domain = Column(String, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("file_id", "partition_name", "domain", name="uix_file_domain"),
+        Index("ix_partition_domain", "partition_name", "domain"),
+    )
+
+
 class PartitionMembership(Base):
     __tablename__ = "partition_memberships"
 
@@ -136,8 +154,8 @@ class PartitionFileManager:
 
         except Exception as e:
             raise VDBConnectionError(
-                f"Failed to connect to database: {e!s}",
-                db_url=database_url,
+                "An unexpected database error occurred",
+                db_url=str(database_url),
                 db_type="SQLAlchemy",
             )
 
@@ -225,10 +243,14 @@ class PartitionFileManager:
                 session.commit()
                 log.info("Added file successfully")
                 return True
-            except Exception:
+            except Exception as e:
                 session.rollback()
-                log.exception("Error adding file to partition")
-                raise
+                log.exception("Error adding file to partition", error=str(e))
+                raise VDBInsertError(
+                    "An unexpected database error occurred",
+                    file_id=file_id,
+                    partition=partition,
+                )
 
     def remove_file_from_partition(self, file_id: str, partition: str):
         """Remove a file from its partition - Optimized without join"""
@@ -246,8 +268,12 @@ class PartitionFileManager:
                 return False
             except Exception as e:
                 session.rollback()
-                log.error(f"Error removing file: {e}")
-                raise e
+                log.exception("Error removing file", error=str(e))
+                raise VDBDeleteError(
+                    "An unexpected database error occurred",
+                    file_id=file_id,
+                    partition=partition,
+                )
 
     def delete_partition(self, partition: str):
         """Delete a partition and all its files"""
@@ -292,6 +318,58 @@ class PartitionFileManager:
             return session.query(
                 session.query(File).filter(File.file_id == file_id, File.partition_name == partition).exists()
             ).scalar()
+
+    # Domains
+
+    def get_file_ids_by_domains(self, partition: str | None, domains: list[str]) -> list[str]:
+        """Get file_ids matching ANY of the given domains in a partition (or all partitions if None)."""
+        with self.Session() as session:
+            query = session.query(FileDomain.file_id).filter(FileDomain.domain.in_(domains))
+            if partition is not None:
+                query = query.filter(FileDomain.partition_name == partition)
+            rows = query.distinct().all()
+            return [row[0] for row in rows]
+
+    def set_file_domains(self, file_id: str, partition: str, domains: list[str]):
+        """Replace all domains for a file with the given list."""
+        with self.Session() as session:
+            try:
+                session.query(FileDomain).filter(
+                    FileDomain.file_id == file_id,
+                    FileDomain.partition_name == partition,
+                ).delete()
+                for domain in domains:
+                    session.add(FileDomain(file_id=file_id, partition_name=partition, domain=domain))
+                session.commit()
+            except Exception as e:
+                session.rollback()
+                self.logger.exception("Error setting file domains", error=str(e))
+                raise VDBInsertError(
+                    "An unexpected database error occurred",
+                    file_id=file_id,
+                    partition=partition,
+                )
+
+    def get_file_domains(self, file_id: str, partition: str) -> list[str]:
+        """Get domains for a file in a partition."""
+        with self.Session() as session:
+            rows = (
+                session.query(FileDomain.domain)
+                .filter(FileDomain.file_id == file_id, FileDomain.partition_name == partition)
+                .all()
+            )
+            return [row[0] for row in rows]
+
+    def list_partition_domains(self, partition: str) -> list[str]:
+        """List all unique domains in a partition."""
+        with self.Session() as session:
+            rows = (
+                session.query(FileDomain.domain)
+                .filter(FileDomain.partition_name == partition)
+                .distinct()
+                .all()
+            )
+            return [row[0] for row in rows]
 
     # Users
 

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -152,7 +152,7 @@ class PartitionFileManager:
             AUTH_TOKEN = os.getenv("AUTH_TOKEN")
             self._ensure_admin_user(AUTH_TOKEN)
 
-        except Exception as e:
+        except Exception:
             raise VDBConnectionError(
                 "An unexpected database error occurred",
                 db_url=str(database_url),

--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -178,7 +178,7 @@ class MilvusDB(BaseVectorDB):
         except Exception as e:
             self.logger.exception("Unexpected error initializing Milvus clients", error=str(e))
             raise VDBConnectionError(
-                f"Unexpected error initializing Milvus clients: {e!s}",
+                "An unexpected database error occurred",
                 db_url=uri,
                 db_type="Milvus",
             )
@@ -247,7 +247,7 @@ class MilvusDB(BaseVectorDB):
                     error=str(e),
                 )
                 raise UnexpectedVDBError(
-                    f"Unexpected error setting collection name `{self.collection_name}`: {e!s}",
+                    "An unexpected database error occurred",
                     collection_name=self.collection_name,
                 )
 
@@ -410,10 +410,16 @@ class MilvusDB(BaseVectorDB):
             self.logger.exception("VectorDB operation failed", error=str(e))
             raise
 
+        except MilvusException as e:
+            self.logger.exception("Milvus insert operation failed", error=str(e))
+            raise VDBInsertError(
+                "Failed to insert document into collection",
+                collection_name=self.collection_name,
+            )
         except Exception as e:
             self.logger.exception("Unexpected error while adding a document", error=str(e))
             raise UnexpectedVDBError(
-                f"Unexpected error while adding a document: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
             )
 
@@ -587,7 +593,7 @@ class MilvusDB(BaseVectorDB):
         except Exception as e:
             self.logger.exception("Unexpected error occurred", error=str(e))
             raise UnexpectedVDBError(
-                f"Unexpected error occurred: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
             )
@@ -661,7 +667,7 @@ class MilvusDB(BaseVectorDB):
         except Exception as e:
             log.exception("Unexpected error while deleting file chunks", error=str(e))
             raise UnexpectedVDBError(
-                f"Unexpected error while deleting file chunks {file_id}: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
                 file_id=file_id,
@@ -718,8 +724,8 @@ class MilvusDB(BaseVectorDB):
 
         except Exception as e:
             log.exception("Unexpected error while getting file chunks", error=str(e))
-            raise VDBSearchError(
-                f"Unexpected error while getting file chunks {file_id}: {e!s}",
+            raise UnexpectedVDBError(
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
                 file_id=file_id,
@@ -763,7 +769,7 @@ class MilvusDB(BaseVectorDB):
         except Exception as e:
             log.exception("Unexpected error while retrieving chunk", error=str(e))
             raise UnexpectedVDBError(
-                f"Unexpected error while retrieving chunk {chunk_id}: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
             )
 
@@ -773,6 +779,8 @@ class MilvusDB(BaseVectorDB):
         """
         try:
             return self.partition_file_manager.file_exists_in_partition(file_id=file_id, partition=partition)
+        except VDBError:
+            raise
         except Exception as e:
             self.logger.exception(
                 "File existence check failed.",
@@ -780,7 +788,12 @@ class MilvusDB(BaseVectorDB):
                 partition=partition,
                 error=str(e),
             )
-            return False
+            raise UnexpectedVDBError(
+                "An unexpected database error occurred",
+                collection_name=self.collection_name,
+                partition=partition,
+                file_id=file_id,
+            )
 
     def list_partition_files(self, partition: str, limit: int | None = None):
         try:
@@ -796,7 +809,7 @@ class MilvusDB(BaseVectorDB):
                 error=str(e),
             )
             raise UnexpectedVDBError(
-                f"Unexpected error while listing files in partition {partition}: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
             )
@@ -804,9 +817,14 @@ class MilvusDB(BaseVectorDB):
     def list_partitions(self):
         try:
             return self.partition_file_manager.list_partitions()
+        except VDBError:
+            raise
         except Exception as e:
             self.logger.exception("Failed to list partitions", error=str(e))
-            raise
+            raise UnexpectedVDBError(
+                "An unexpected database error occurred",
+                collection_name=self.collection_name,
+            )
 
     def collection_exists(self, collection_name: str):
         """
@@ -840,7 +858,7 @@ class MilvusDB(BaseVectorDB):
         except Exception as e:
             log.exception("Unexpected error while deleting partition", error=str(e))
             raise UnexpectedVDBError(
-                f"Unexpected error while deleting partition {partition}: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
             )
@@ -852,9 +870,15 @@ class MilvusDB(BaseVectorDB):
         log = self.logger.bind(partition=partition)
         try:
             return self.partition_file_manager.partition_exists(partition=partition)
+        except VDBError:
+            raise
         except Exception as e:
             log.exception("Partition existence check failed.", error=str(e))
-            return False
+            raise UnexpectedVDBError(
+                "An unexpected database error occurred",
+                collection_name=self.collection_name,
+                partition=partition,
+            )
 
     async def list_all_chunk(self, partition: str, include_embedding: bool = True):
         """
@@ -922,7 +946,7 @@ class MilvusDB(BaseVectorDB):
                 error=str(e),
             )
             raise UnexpectedVDBError(
-                f"Unexpected error while listing all chunks in partition {partition}: {e!s}",
+                "An unexpected database error occurred",
                 collection_name=self.collection_name,
                 partition=partition,
             )

--- a/openrag/components/llm.py
+++ b/openrag/components/llm.py
@@ -3,6 +3,7 @@ import copy
 import json
 
 import httpx
+from utils.exceptions.common import UnexpectedError
 from utils.logger import get_logger
 
 logger = get_logger()
@@ -79,9 +80,8 @@ class LLM:
                     raise
 
                 except Exception as e:
-                    # Truly unexpected errors
                     logger.exception("Unexpected error during LLM streaming")
-                    raise RuntimeError("An unexpected error occurred during streaming")
+                    raise UnexpectedError("An unexpected error occurred during streaming") from e
 
             else:  # Handle non-streaming response
                 try:

--- a/openrag/components/llm.py
+++ b/openrag/components/llm.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 
@@ -58,17 +59,29 @@ class LLM:
                         headers=self.headers,
                         json=payload,
                     ) as response:
-                        if response.status_code >= 400:
-                            await response.aread()
-                            error_detail = response.text
-                            raise ValueError(f"LLM API error ({response.status_code}): {error_detail}")
+                        response.raise_for_status()
                         async for line in response.aiter_lines():
                             yield line
-                except ValueError:
+
+                except asyncio.CancelledError:
+                    # MUST be first per Phase 2 decision
+                    logger.info("LLM streaming cancelled by client")
                     raise
+
+                except httpx.HTTPStatusError as e:
+                    # 4xx/5xx responses
+                    logger.error("LLM API returned error", status_code=e.response.status_code)
+                    raise
+
+                except httpx.RequestError as e:
+                    # Network/connection failures
+                    logger.error("Network error during LLM streaming", error=str(e))
+                    raise
+
                 except Exception as e:
-                    logger.error(f"Error while streaming chat completion: {str(e)}")
-                    raise
+                    # Truly unexpected errors
+                    logger.exception("Unexpected error during LLM streaming")
+                    raise RuntimeError("An unexpected error occurred during streaming")
 
             else:  # Handle non-streaming response
                 try:

--- a/openrag/components/map_reduce.py
+++ b/openrag/components/map_reduce.py
@@ -80,7 +80,8 @@ class RAGMapReduce:
                 )
                 return output_chunk
             except Exception as e:
-                logger.error("Error during chunk relevancy inference", error=str(e))
+                # Graceful degradation - mark chunk as irrelevant on error
+                logger.warning("Failed to infer chunk relevancy", chunk_id=chunk.metadata.get("id"), error=str(e)[:200])
                 return SummarizedChunk(relevancy=False, summary="")
 
     async def map_batch(

--- a/openrag/components/pipeline.py
+++ b/openrag/components/pipeline.py
@@ -44,8 +44,10 @@ class RetrieverPipeline:
         if self.reranker_enabled:
             self.reranker = Reranker(logger, config)
 
-    async def retrieve_docs(self, partition: list[str], query: str, use_map_reduce: bool = False) -> list[Document]:
-        docs = await self.retriever.retrieve(partition=partition, query=query)
+    async def retrieve_docs(
+        self, partition: list[str], query: str, use_map_reduce: bool = False, filter: dict | None = None
+    ) -> list[Document]:
+        docs = await self.retriever.retrieve(partition=partition, query=query, filter=filter)
         top_k = max(self.map_reduce_max_docs, self.reranker_top_k) if use_map_reduce else self.reranker_top_k
         logger.debug("Documents retreived", document_count=len(docs))
         if docs:
@@ -117,20 +119,25 @@ class RagPipeline:
         query = await self.generate_query(messages)
         logger.debug("Prepared query for chat completion", query=query)
 
-        metadata = payload.get("metadata", {})
+        metadata = payload.get("metadata", {}) or {}
 
         use_map_reduce = metadata.get("use_map_reduce", False)
         spoken_style_answer = metadata.get("spoken_style_answer", False)
+        domains = metadata.get("domains")
 
         logger.debug(
             "Metadata parameters",
             use_map_reduce=use_map_reduce,
             spoken_style_answer=spoken_style_answer,
+            domains=domains,
         )
+
+        # Build filter from metadata
+        search_filter = {"domains": domains} if domains else None
 
         # 2. get docs
         docs = await self.retriever_pipeline.retrieve_docs(
-            partition=partition, query=query, use_map_reduce=use_map_reduce
+            partition=partition, query=query, use_map_reduce=use_map_reduce, filter=search_filter
         )
 
         if use_map_reduce and docs:
@@ -157,11 +164,14 @@ class RagPipeline:
 
     async def _prepare_for_completions(self, partition: list[str], payload: dict):
         prompt = payload["prompt"]
+        metadata = payload.get("metadata", {}) or {}
+        domains = metadata.get("domains")
+        search_filter = {"domains": domains} if domains else None
 
         # 1. get the query
         query = await self.generate_query(messages=[{"role": "user", "content": prompt}])
         # 2. get docs
-        docs = await self.retriever_pipeline.retrieve_docs(partition=partition, query=query)
+        docs = await self.retriever_pipeline.retrieve_docs(partition=partition, query=query, filter=search_filter)
 
         # 3. Format the retrieved docs
         context = format_context(docs, max_context_tokens=self.max_context_tokens)

--- a/openrag/components/pipeline.py
+++ b/openrag/components/pipeline.py
@@ -178,25 +178,17 @@ class RagPipeline:
         return payload, docs
 
     async def completions(self, partition: list[str], payload: dict):
-        try:
-            if partition is None:
-                docs = []
-            else:
-                payload, docs = await self._prepare_for_completions(partition=partition, payload=payload)
-            llm_output = self.llm_client.completions(request=payload)
-            return llm_output, docs
-        except Exception as e:
-            logger.error(f"Error during chat completion: {e!s}")
-            raise e
+        if partition is None:
+            docs = []
+        else:
+            payload, docs = await self._prepare_for_completions(partition=partition, payload=payload)
+        llm_output = self.llm_client.completions(request=payload)
+        return llm_output, docs
 
     async def chat_completion(self, partition: list[str] | None, payload: dict):
-        try:
-            if partition is None:
-                docs = []
-            else:
-                payload, docs = await self._prepare_for_chat_completion(partition=partition, payload=payload)
-            llm_output = self.llm_client.chat_completion(request=payload)
-            return llm_output, docs
-        except Exception as e:
-            logger.error(f"Error during chat completion: {e!s}")
-            raise e
+        if partition is None:
+            docs = []
+        else:
+            payload, docs = await self._prepare_for_chat_completion(partition=partition, payload=payload)
+        llm_output = self.llm_client.chat_completion(request=payload)
+        return llm_output, docs

--- a/openrag/components/ray_utils.py
+++ b/openrag/components/ray_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import ray
 from ray.exceptions import RayTaskError, TaskCancelledError
+from utils.exceptions.common import RayActorError
 from utils.logger import get_logger
 
 logger = get_logger()
@@ -33,7 +34,7 @@ async def call_ray_actor_with_timeout(
         TimeoutError: If the task exceeds the timeout
         asyncio.CancelledError: If the calling coroutine is cancelled
         TaskCancelledError: If the Ray task was cancelled
-        RuntimeError: If the Ray task failed with an error
+        RayActorError: If the Ray task failed with an error
     """
     try:
         result = await asyncio.wait_for(asyncio.gather(future), timeout=timeout)
@@ -54,4 +55,4 @@ async def call_ray_actor_with_timeout(
         raise
 
     except RayTaskError as e:
-        raise RuntimeError(f"{task_description} failed") from e
+        raise RayActorError(f"{task_description} failed") from e

--- a/openrag/components/reranker.py
+++ b/openrag/components/reranker.py
@@ -4,6 +4,7 @@ from infinity_client import Client
 from infinity_client.api.default import rerank
 from infinity_client.models import RerankInput, ReRankResult
 from langchain_core.documents.base import Document
+from utils.exceptions.common import UnexpectedError
 
 
 class Reranker:
@@ -38,6 +39,5 @@ class Reranker:
                 return output
 
             except Exception as e:
-                # Model-specific errors (depends on reranker implementation)
                 self.logger.exception("Reranking failed", query=query[:100], doc_count=len(documents))
-                raise RuntimeError("An unexpected error occurred during reranking")
+                raise UnexpectedError("An unexpected error occurred during reranking") from e

--- a/openrag/components/reranker.py
+++ b/openrag/components/reranker.py
@@ -38,10 +38,6 @@ class Reranker:
                 return output
 
             except Exception as e:
-                self.logger.error(
-                    "Reranking failed",
-                    error=str(e),
-                    model_name=self.model_name,
-                    documents_count=len(documents),
-                )
-                raise e
+                # Model-specific errors (depends on reranker implementation)
+                self.logger.exception("Reranking failed", query=query[:100], doc_count=len(documents))
+                raise RuntimeError("An unexpected error occurred during reranking")

--- a/openrag/routers/actors.py
+++ b/openrag/routers/actors.py
@@ -51,24 +51,17 @@ Returns list of all Ray actors with:
 )
 async def list_ray_actors():
     """List all known Ray actors and their status."""
-    try:
-        actors = [
-            {
-                "actor_id": a.actor_id,
-                "name": a.name,
-                "class_name": a.class_name,
-                "state": a.state,
-                "namespace": a.ray_namespace,
-            }
-            for a in list_actors()
-        ]
-        return JSONResponse(status_code=status.HTTP_200_OK, content={"actors": actors})
-    except Exception:
-        logger.exception("Error getting actor summaries")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve actor summaries.",
-        )
+    actors = [
+        {
+            "actor_id": a.actor_id,
+            "name": a.name,
+            "class_name": a.class_name,
+            "state": a.state,
+            "namespace": a.ray_namespace,
+        }
+        for a in list_actors()
+    ]
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"actors": actors})
 
 
 @router.post(
@@ -116,29 +109,16 @@ async def restart_actor(
         logger.info(f"Killed actor: {actor_name}")
     except ValueError:
         logger.warning("Actor not found. Creating new instance.", actor=actor_name)
-    except Exception as e:
-        logger.exception("Failed to kill actor", actor=actor_name)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to kill actor {actor_name}: {e!s}",
-        )
 
-    try:
-        new_actor = actor_creation_map[actor_name]()
-        if "Semaphore" in actor_name:
-            new_actor = new_actor._actor
-        logger.info(f"Restarted actor: {actor_name}")
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={
-                "message": f"Actor {actor_name} restarted successfully.",
-                "actor_name": actor_name,
-                "actor_id": new_actor._actor_id.hex(),
-            },
-        )
-    except Exception as e:
-        logger.exception("Failed to restart actor", actor=actor_name)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to restart actor {actor_name}: {e!s}",
-        )
+    new_actor = actor_creation_map[actor_name]()
+    if "Semaphore" in actor_name:
+        new_actor = new_actor._actor
+    logger.info(f"Restarted actor: {actor_name}")
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={
+            "message": f"Actor {actor_name} restarted successfully.",
+            "actor_name": actor_name,
+            "actor_id": new_actor._actor_id.hex(),
+        },
+    )

--- a/openrag/routers/extract.py
+++ b/openrag/routers/extract.py
@@ -48,31 +48,23 @@ async def get_extract(
     user_partitions=Depends(current_user_or_admin_partitions_list),
 ):
     log = logger.bind(extract_id=extract_id)
-    try:
-        chunk = await vectordb.get_chunk_by_id.remote(extract_id)
-        if chunk is None:
-            log.warning("Extract not found.")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Extract '{extract_id}' not found.",
-            )
-        chunk_partition = chunk.metadata["partition"]
-        log.info(f"User partitions: {user_partitions}, Chunk partition: {chunk_partition}")
-        if chunk_partition not in user_partitions and user_partitions != ["all"]:
-            log.warning("User does not have access to this extract.")
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"User does not have access to extract '{extract_id}'.",
-            )
-        log.info("Extract successfully retrieved.")
-    except HTTPException:
-        raise
-    except Exception as e:
-        log.exception("Failed to retrieve extract.", error=str(e))
+
+    chunk = await vectordb.get_chunk_by_id.remote(extract_id)
+    if chunk is None:
+        log.warning("Extract not found.")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve extract: {e!s}",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Extract '{extract_id}' not found.",
         )
+    chunk_partition = chunk.metadata["partition"]
+    log.info(f"User partitions: {user_partitions}, Chunk partition: {chunk_partition}")
+    if chunk_partition not in user_partitions and user_partitions != ["all"]:
+        log.warning("User does not have access to this extract.")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User does not have access to extract '{extract_id}'.",
+        )
+    log.info("Extract successfully retrieved.")
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,

--- a/openrag/routers/indexer.py
+++ b/openrag/routers/indexer.py
@@ -123,13 +123,6 @@ async def add_file(
     vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),
 ):
-    log = logger.bind(
-        file_id=file_id,
-        partition=partition,
-        filename=file.filename,
-        user=user.get("display_name"),
-    )
-
     if await vectordb.file_exists.remote(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -137,16 +130,9 @@ async def add_file(
         )
 
     save_dir = Path(DATA_DIR)
-    try:
-        original_filename = file.filename
-        file.filename = sanitize_filename(file.filename)
-        file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
-    except Exception as e:
-        log.exception("Failed to save file to disk.", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        )
+    original_filename = file.filename
+    file.filename = sanitize_filename(file.filename)
+    file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
 
     metadata.update(
         {
@@ -240,8 +226,6 @@ async def put_file(
     vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),
 ):
-    log = logger.bind(file_id=file_id, partition=partition, filename=file.filename)
-
     if not await vectordb.file_exists.remote(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -252,16 +236,9 @@ async def put_file(
     await indexer.delete_file.remote(file_id, partition)
 
     save_dir = Path(DATA_DIR)
-    try:
-        original_filename = file.filename
-        file.filename = sanitize_filename(file.filename)
-        file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
-    except Exception:
-        log.exception("Failed to save file to disk.")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to save uploaded file.",
-        )
+    original_filename = file.filename
+    file.filename = sanitize_filename(file.filename)
+    file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
 
     metadata.update(
         {
@@ -441,21 +418,13 @@ async def get_task_error(
     task_state_manager=Depends(get_task_state_manager),
     task_details=Depends(require_task_owner),
 ):
-    try:
-        error = await task_state_manager.get_error.remote(task_id)
-        if error is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"No error found for task '{task_id}'.",
-            )
-        return {"task_id": task_id, "traceback": error.splitlines()}
-    except HTTPException:
-        raise
-    except Exception:
+    error = await task_state_manager.get_error.remote(task_id)
+    if error is None:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve task error.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No error found for task '{task_id}'.",
         )
+    return {"task_id": task_id, "traceback": error.splitlines()}
 
 
 @router.get(
@@ -475,32 +444,27 @@ Returns task logs including:
 """,
 )
 async def get_task_logs(task_id: str, max_lines: int = 100, task_details=Depends(require_task_owner)):
-    try:
-        if not LOG_FILE.exists():
-            raise HTTPException(status_code=500, detail="Log file not found.")
+    if not LOG_FILE.exists():
+        raise HTTPException(status_code=500, detail="Log file not found.")
 
-        logs = []
-        with open(LOG_FILE, errors="replace") as f:
-            for line in reversed(list(f)):
-                try:
-                    record = json.loads(line).get("record", {})
-                    if record.get("extra", {}).get("task_id") == task_id:
-                        logs.append(
-                            f"{record['time']['repr']} - {record['level']['name']} - {record['message']} - {(record['extra'])}"
-                        )
-                        if len(logs) >= max_lines:
-                            break
-                except json.JSONDecodeError:
-                    continue
+    logs = []
+    with open(LOG_FILE, errors="replace") as f:
+        for line in reversed(list(f)):
+            try:
+                record = json.loads(line).get("record", {})
+                if record.get("extra", {}).get("task_id") == task_id:
+                    logs.append(
+                        f"{record['time']['repr']} - {record['level']['name']} - {record['message']} - {(record['extra'])}"
+                    )
+                    if len(logs) >= max_lines:
+                        break
+            except json.JSONDecodeError:
+                continue
 
-        if not logs:
-            raise HTTPException(status_code=404, detail=f"No logs found for task '{task_id}'")
+    if not logs:
+        raise HTTPException(status_code=404, detail=f"No logs found for task '{task_id}'")
 
-        return JSONResponse(content={"task_id": task_id, "logs": logs[::-1]})  # restore order
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to fetch logs: {e!s}")
+    return JSONResponse(content={"task_id": task_id, "logs": logs[::-1]})  # restore order
 
 
 @router.delete(
@@ -525,13 +489,9 @@ async def cancel_task(
     task_state_manager=Depends(get_task_state_manager),
     task_details=Depends(require_task_owner),
 ):
-    try:
-        obj_ref = await task_state_manager.get_object_ref.remote(task_id)
-        if obj_ref is None:
-            raise HTTPException(404, f"No ObjectRef stored for task {task_id}")
+    obj_ref = await task_state_manager.get_object_ref.remote(task_id)
+    if obj_ref is None:
+        raise HTTPException(404, f"No ObjectRef stored for task {task_id}")
 
-        ray.cancel(obj_ref["ref"], recursive=True)
-        return {"message": f"Cancellation signal sent for task {task_id}"}
-    except Exception as e:
-        logger.exception("Failed to cancel task.")
-        raise HTTPException(status_code=500, detail=str(e))
+    ray.cancel(obj_ref["ref"], recursive=True)
+    return {"message": f"Cancellation signal sent for task {task_id}"}

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from urllib.parse import quote
@@ -13,6 +14,7 @@ from models.openai import (
     OpenAICompletionRequest,
 )
 from utils.dependencies import get_vectordb
+from utils.exceptions.base import OpenRAGError
 from utils.logger import get_logger
 
 from .utils import (
@@ -29,6 +31,19 @@ config = load_config()
 router = APIRouter()
 
 ragpipe = RagPipeline(config=config)
+
+
+def _make_sse_error(message: str, code: str) -> str:
+    """Format an error as an SSE data chunk for streaming responses."""
+    chunk = {
+        "error": {
+            "message": message,
+            "type": "error",
+            "param": None,
+            "code": code,
+        }
+    }
+    return f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n"
 
 
 @router.get(
@@ -163,25 +178,14 @@ async def openai_chat_completion(
         truncate(str(request.messages)),
     )
 
-    try:
-        if is_direct_llm_model(request):
-            partitions = None
-        else:
-            partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
-            log.debug(f"Using partitions: {partitions}")
-    except Exception as e:
-        log.warning("Invalid model or partition", error=str(e))
-        raise
+    if is_direct_llm_model(request):
+        partitions = None
+    else:
+        partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
+        log.debug(f"Using partitions: {partitions}")
 
-    try:
-        llm_output, docs = await ragpipe.chat_completion(partition=partitions, payload=request.model_dump())
-        log.debug("RAG chat completion pipeline executed.")
-    except Exception as e:
-        log.exception("Chat completion failed.", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Chat completion failed: {e!s}",
-        )
+    llm_output, docs = await ragpipe.chat_completion(partition=partitions, payload=request.model_dump())
+    log.debug("RAG chat completion pipeline executed.")
 
     metadata = __prepare_sources(request2, docs)
     metadata_json = json.dumps({"sources": metadata})
@@ -204,33 +208,23 @@ async def openai_chat_completion(
                             except json.JSONDecodeError as e:
                                 log.error("Failed to decode streamed chunk.", error=str(e))
                                 raise
+            except asyncio.CancelledError:
+                log.info("Client disconnected during streaming")
+                return
+            except OpenRAGError as e:
+                log.warning("OpenRAG error during streaming", code=e.code, error=e.message)
+                yield _make_sse_error(e.message, e.code)
             except Exception as e:
-                log.warning("Error while generating streaming answer", error=str(e))
-                error_chunk = {
-                    "error": {
-                        "message": f"Error while generating answer: {str(e)}",
-                        "type": "error",
-                        "param": None,
-                        "code": "ERROR_ANSWER_GENERATION",
-                    }
-                }
-                yield f"data: {json.dumps(error_chunk)}\n\n"
-                yield "data: [DONE]\n\n"
+                log.warning("Error during streaming", error=str(e))
+                yield _make_sse_error("An unexpected error occurred during streaming", "UNEXPECTED_ERROR")
 
         return StreamingResponse(stream_response(), media_type="text/event-stream")
     else:
-        try:
-            chunk = await llm_output.__anext__()
-            chunk["model"] = model_name
-            chunk["extra"] = metadata_json
-            log.debug("Returning non-streaming completion chunk.")
-            return JSONResponse(content=chunk)
-        except Exception as e:
-            log.warning("Error while generating answer", error=str(e))
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Error while generating answer: {e!s}",
-            )
+        chunk = await llm_output.__anext__()
+        chunk["model"] = model_name
+        chunk["extra"] = metadata_json
+        log.debug("Returning non-streaming completion chunk.")
+        return JSONResponse(content=chunk)
 
 
 @router.post(
@@ -285,37 +279,18 @@ async def openai_completion(
             detail="Streaming is not supported for this endpoint",
         )
 
-    try:
-        if is_direct_llm_model(request):
-            partitions = None
-        else:
-            partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
+    if is_direct_llm_model(request):
+        partitions = None
+    else:
+        partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
 
-    except Exception as e:
-        log.warning(f"Invalid model or partition: {e}")
-        raise
-
-    try:
-        llm_output, docs = await ragpipe.completions(partition=partitions, payload=request.model_dump())
-        log.debug("RAG completion pipeline executed.")
-    except Exception as e:
-        log.exception("Completion request failed.", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Completion failed: {e!s}",
-        )
+    llm_output, docs = await ragpipe.completions(partition=partitions, payload=request.model_dump())
+    log.debug("RAG completion pipeline executed.")
 
     metadata = __prepare_sources(request2, docs)
     metadata_json = json.dumps({"sources": metadata})
 
-    try:
-        complete_response = await llm_output.__anext__()
-        complete_response["extra"] = metadata_json
-        log.debug("Returning completion response.")
-        return JSONResponse(content=complete_response)
-    except Exception as e:
-        log.warning("No response from LLM.", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"No response from LLM: {e!s}",
-        )
+    complete_response = await llm_output.__anext__()
+    complete_response["extra"] = metadata_json
+    log.debug("Returning completion response.")
+    return JSONResponse(content=complete_response)

--- a/openrag/routers/tools.py
+++ b/openrag/routers/tools.py
@@ -118,15 +118,6 @@ async def execute_tool(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Tool {tool['name']} not found",
             )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception("Failed during tool execution.", extra={"error": str(e)})
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Tool execution failed due to an internal error.",
-        )
     finally:
         # Cleanup of the temporary file
         if file_path is not None:

--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import consts
+import httpx
 from config import load_config
 from fastapi import Depends, Form, HTTPException, Request, UploadFile, status
 from models.indexer import FileMetadataSchema
@@ -258,13 +259,25 @@ async def check_llm_model_availability(request: Request):
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=f"Only these models ({available_models}) are available for your `{model_type}`. Please check your configuration file.",
                 )
+        except HTTPException:
+            raise
+        except httpx.TimeoutException:
+            logger.warning("LLM model availability check timed out", model=model_type)
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="LLM service timed out",
+            )
+        except httpx.HTTPError as e:
+            logger.warning("LLM model availability check failed", model=model_type, error=str(e))
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="LLM service is unavailable",
+            )
         except Exception as e:
-            logger.exception("Failed to validate model", model=model_type, error=str(e))
-            if isinstance(e, HTTPException):
-                raise
+            logger.exception("Failed to check LLM model availability", model=model_type, error=str(e))
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Error while checking the `{model_type}` endpoint, it seems not available at this moment",
+                detail="Failed to check LLM model availability",
             )
 
 

--- a/openrag/scripts/restore.py
+++ b/openrag/scripts/restore.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+import asyncio
 import json
 import sys
 import time
 from typing import IO, Any
 
-import ray
 from components.indexer.vectordb import MilvusDB
 from components.indexer.vectordb.utils import PartitionFileManager
 from pymilvus import MilvusClient
@@ -190,7 +190,7 @@ def open_backup_file(file_name: str, logger: Any) -> IO[str]:
         raise
 
 
-def main():
+async def main():
     """
     Main entry point:
       - Parses CLI arguments.
@@ -258,9 +258,7 @@ def main():
         # It will create a the Milvus collection if it doesn't exist
         vdb_tmp = MilvusDB.options(name="Vectordb", namespace="openrag", lifetime="detached").remote()
 
-        ray.get(
-            vdb_tmp.__ray_ready__.remote()
-        )  # ensure the actor is fully initialized and ready: collection and all created if nont existing
+        await vdb_tmp.__ray_ready__.remote()  # ensure the actor is fully initialized and ready: collection and all created if nont existing
         print("VectorDB (Milvus) actor fully initialized")
     except Exception as e:
         logger.exception(f"Failed while trying to create Milvus collection: {e}")
@@ -332,4 +330,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(asyncio.run(main()))

--- a/openrag/utils/exceptions/__init__.py
+++ b/openrag/utils/exceptions/__init__.py
@@ -1,1 +1,2 @@
 from .base import *
+from .common import *

--- a/openrag/utils/exceptions/common.py
+++ b/openrag/utils/exceptions/common.py
@@ -1,0 +1,29 @@
+from .base import OpenRAGError
+
+
+class FileStorageError(OpenRAGError):
+    """Raised when file I/O operations fail (save, read, delete)."""
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message=message, code="FILE_STORAGE_ERROR", status_code=500, **kwargs)
+
+
+class RayActorError(OpenRAGError):
+    """Raised when a Ray actor operation fails."""
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message=message, code="RAY_ACTOR_ERROR", status_code=500, **kwargs)
+
+
+class ToolExecutionError(OpenRAGError):
+    """Raised when tool execution fails."""
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message=message, code="TOOL_EXECUTION_ERROR", status_code=500, **kwargs)
+
+
+class UnexpectedError(OpenRAGError):
+    """Raised for unexpected errors that don't match any specific category."""
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message=message, code="UNEXPECTED_ERROR", status_code=500, **kwargs)


### PR DESCRIPTION
## Summary
- Eliminate blocking I/O operations in async contexts using `asyncio.to_thread`
- Convert restore script from blocking `ray.get()` to async Ray actor calls

## Changes
- `loaders/base.py`: Convert `save_content` to async with `_write_file` sync helper
- 5 simple loaders (`txt`, `media`, `marker`, `openai`, `docling`): `await self.save_content()`
- 6 complex loaders (`eml`, `docx`, `doc`, `image`, `pymupdf`, `pptx`): Wrap blocking ops with `asyncio.to_thread`
- `scripts/restore.py`: `async main()`, replace `ray.get()` with `await`, `asyncio.run(main())`

## Test plan
- [ ] All 98 existing tests pass
- [ ] `ruff check openrag/` passes
- [ ] No blocking file operations in async request handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)