### PR TITLE
refactor: extract SQLAlchemy models to standalone module

### DIFF
--- a/docs/content/docs/documentation/sql_migration.mdx
+++ b/docs/content/docs/documentation/sql_migration.mdx
@@ -74,6 +74,14 @@ DATABASE_URL=postgresql://user:pass@localhost:5432/openrag \
     uv run alembic -c openrag/scripts/migrations/alembic/alembic.ini upgrade head
 ```
 
+:::tip[Quick alternative: run inside a running container]
+If your stack is already running, you can apply migrations directly without rebuilding:
+```bash title="Apply migrations via exec"
+docker compose exec -w /app/openrag openrag \
+  /app/.venv/bin/alembic -c scripts/migrations/alembic/alembic.ini upgrade head
+```
+:::
+
 :::tip[Automatic Migrations on Code Update]
 When you pull the latest changes to your local code, check if a new migration script has been added. If so, make sure to apply the migration before restarting the service.
 :::

--- a/openrag/components/indexer/vectordb/models.py
+++ b/openrag/components/indexer/vectordb/models.py
@@ -143,6 +143,7 @@ class Workspace(Base):
         String,
         ForeignKey("partitions.partition", ondelete="CASCADE"),
         nullable=False,
+        index=True,
     )
     created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     display_name = Column(String, nullable=True)

--- a/openrag/components/indexer/vectordb/models.py
+++ b/openrag/components/indexer/vectordb/models.py
@@ -1,0 +1,166 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import (
+    declarative_base,
+    relationship,
+)
+
+Base = declarative_base()
+
+
+class File(Base):
+    __tablename__ = "files"
+
+    id = Column(Integer, primary_key=True)
+    file_id = Column(String, nullable=False, index=True)  # Added index for file_id lookups
+    # Foreign key points directly to the partition string
+    partition_name = Column(String, ForeignKey("partitions.partition"), nullable=False, index=True)  # Added index
+    file_metadata = Column(JSON, nullable=True, default=dict)
+
+    created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+
+    # Document relationship fields
+    relationship_id = Column(
+        String, nullable=True, index=True
+    )  # Groups related documents (e.g., email thread ID, folder path)
+    parent_id = Column(
+        String, nullable=True, index=True
+    )  # Hierarchical parent reference (e.g., parent email, parent folder)
+
+    # relationship to the Partition object
+    partition = relationship("Partition", back_populates="files")
+
+    # Enforce uniqueness of (file_id, partition_name) - this also creates an index
+    __table_args__ = (
+        UniqueConstraint("file_id", "partition_name", name="uix_file_id_partition"),
+        # Additional composite index for common query patterns (partition first for better selectivity)
+        Index("ix_partition_file", "partition_name", "file_id"),
+        # Indexes for relationship queries
+        Index("ix_relationship_partition", "relationship_id", "partition_name"),
+        Index("ix_parent_partition", "parent_id", "partition_name"),
+    )
+
+    def to_dict(self):
+        metadata = self.file_metadata or {}
+        d = {
+            "partition": self.partition_name,
+            "file_id": self.file_id,
+            "relationship_id": self.relationship_id,
+            "parent_id": self.parent_id,
+            **metadata,
+        }
+        return d
+
+    def __repr__(self):
+        return f"<File(id={self.id}, file_id='{self.file_id}', partition='{self.partition_name}')>"
+
+
+class Partition(Base):
+    __tablename__ = "partitions"
+
+    id = Column(Integer, primary_key=True)
+    partition = Column(String, unique=True, nullable=False, index=True)  # Index already exists due to unique constraint
+    created_at = Column(
+        DateTime, default=datetime.now, nullable=False, index=True
+    )  # Added index for time-based queries
+    files = relationship("File", back_populates="partition", cascade="all, delete-orphan")
+    memberships = relationship("PartitionMembership", back_populates="partition", cascade="all, delete-orphan")
+    workspaces = relationship(
+        "Workspace",
+        cascade="all, delete-orphan",
+        backref="partition_ref",
+        foreign_keys="Workspace.partition_name",
+        primaryjoin="Partition.partition == Workspace.partition_name",
+    )
+
+    def to_dict(self):
+        d = {
+            "partition": self.partition,
+            "created_at": self.created_at.isoformat(),
+        }
+        return d
+
+    def __repr__(self):
+        return f"<Partition(key='{self.partition}', created_at='{self.created_at}')>"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    external_user_id = Column(String, unique=True, nullable=True, index=True)
+    display_name = Column(String, nullable=True)
+    token = Column(String, unique=True, nullable=True, index=True)
+    is_admin = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+    file_quota = Column(Integer, nullable=True, default=None)
+    file_count = Column(Integer, nullable=False, default=0)
+    memberships = relationship("PartitionMembership", back_populates="user", cascade="all, delete-orphan")
+
+
+class PartitionMembership(Base):
+    __tablename__ = "partition_memberships"
+
+    id = Column(Integer, primary_key=True)
+    partition_name = Column(
+        String,
+        ForeignKey("partitions.partition", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    role = Column(String, nullable=False)  # 'owner' | 'editor' | 'viewer'
+    added_at = Column(DateTime, default=datetime.now, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("partition_name", "user_id", name="uix_partition_user"),
+        CheckConstraint("role IN ('owner','editor','viewer')", name="ck_membership_role"),
+        Index("ix_user_partition", "user_id", "partition_name"),
+    )
+
+    partition = relationship("Partition", back_populates="memberships")
+    user = relationship("User", back_populates="memberships")
+
+
+class Workspace(Base):
+    __tablename__ = "workspaces"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String, unique=True, nullable=False, index=True)
+    partition_name = Column(
+        String,
+        ForeignKey("partitions.partition", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    display_name = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.now)
+
+    files = relationship("WorkspaceFile", cascade="all, delete-orphan", backref="workspace")
+
+
+class WorkspaceFile(Base):
+    __tablename__ = "workspace_files"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(
+        String,
+        ForeignKey("workspaces.workspace_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    file_id = Column(String, nullable=False, index=True)
+
+    __table_args__ = (UniqueConstraint("workspace_id", "file_id", name="uix_workspace_file"),)

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -1,32 +1,11 @@
 import hashlib
 import os
 import secrets
-from datetime import datetime
 
 from config import load_config
-from sqlalchemy import (
-    JSON,
-    Boolean,
-    CheckConstraint,
-    Column,
-    DateTime,
-    ForeignKey,
-    Index,
-    Integer,
-    String,
-    UniqueConstraint,
-    create_engine,
-    delete,
-    func,
-    select,
-    text,
-)
+from sqlalchemy import create_engine, delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import (
-    declarative_base,
-    relationship,
-    sessionmaker,
-)
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import (
     create_database,
     database_exists,
@@ -34,159 +13,12 @@ from sqlalchemy_utils import (
 from utils.exceptions.vectordb import *
 from utils.logger import get_logger
 
+from .models import Base, File, Partition, PartitionMembership, User, Workspace, WorkspaceFile
+
 logger = get_logger()
 config = load_config()
 
 DEFAULT_FILE_QUOTA = config.rdb.get("default_file_quota", -1)
-
-Base = declarative_base()
-
-
-class File(Base):
-    __tablename__ = "files"
-
-    id = Column(Integer, primary_key=True)
-    file_id = Column(String, nullable=False, index=True)  # Added index for file_id lookups
-    # Foreign key points directly to the partition string
-    partition_name = Column(String, ForeignKey("partitions.partition"), nullable=False, index=True)  # Added index
-    file_metadata = Column(JSON, nullable=True, default={})
-
-    created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
-
-    # Document relationship fields
-    relationship_id = Column(
-        String, nullable=True, index=True
-    )  # Groups related documents (e.g., email thread ID, folder path)
-    parent_id = Column(
-        String, nullable=True, index=True
-    )  # Hierarchical parent reference (e.g., parent email, parent folder)
-
-    # relationship to the Partition object
-    partition = relationship("Partition", back_populates="files")
-
-    # Enforce uniqueness of (file_id, partition_name) - this also creates an index
-    __table_args__ = (
-        UniqueConstraint("file_id", "partition_name", name="uix_file_id_partition"),
-        # Additional composite index for common query patterns (partition first for better selectivity)
-        Index("ix_partition_file", "partition_name", "file_id"),
-        # Indexes for relationship queries
-        Index("ix_relationship_partition", "relationship_id", "partition_name"),
-        Index("ix_parent_partition", "parent_id", "partition_name"),
-    )
-
-    def to_dict(self):
-        metadata = self.file_metadata or {}
-        d = {
-            "partition": self.partition_name,
-            "file_id": self.file_id,
-            "relationship_id": self.relationship_id,
-            "parent_id": self.parent_id,
-            **metadata,
-        }
-        return d
-
-    def __repr__(self):
-        return f"<File(id={self.id}, file_id='{self.file_id}', partition='{self.partition}')>"
-
-
-# In the Partition model
-class Partition(Base):
-    __tablename__ = "partitions"
-
-    id = Column(Integer, primary_key=True)
-    partition = Column(String, unique=True, nullable=False, index=True)  # Index already exists due to unique constraint
-    created_at = Column(
-        DateTime, default=datetime.now, nullable=False, index=True
-    )  # Added index for time-based queries
-    files = relationship("File", back_populates="partition", cascade="all, delete-orphan")
-    memberships = relationship("PartitionMembership", back_populates="partition", cascade="all, delete-orphan")
-    workspaces = relationship(
-        "Workspace",
-        cascade="all, delete-orphan",
-        backref="partition_ref",
-        foreign_keys="Workspace.partition_name",
-        primaryjoin="Partition.partition == Workspace.partition_name",
-    )
-
-    def to_dict(self):
-        d = {
-            "partition": self.partition,
-            "created_at": self.created_at.isoformat(),
-        }
-        return d
-
-    def __repr__(self):
-        return f"<Partition(key='{self.partition}', created_at='{self.created_at}')>"
-
-
-class User(Base):
-    __tablename__ = "users"
-
-    id = Column(Integer, primary_key=True)
-    external_user_id = Column(String, unique=True, nullable=True, index=True)
-    display_name = Column(String, nullable=True)
-    token = Column(String, unique=True, nullable=True, index=True)
-    is_admin = Column(Boolean, default=False, nullable=False)
-    created_at = Column(DateTime, default=datetime.now, nullable=False)
-    file_quota = Column(Integer, nullable=True, default=None)
-    file_count = Column(Integer, nullable=False, default=0)
-    memberships = relationship("PartitionMembership", back_populates="user", cascade="all, delete-orphan")
-
-
-class PartitionMembership(Base):
-    __tablename__ = "partition_memberships"
-
-    id = Column(Integer, primary_key=True)
-    partition_name = Column(
-        String,
-        ForeignKey("partitions.partition", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    role = Column(String, nullable=False)  # 'owner' | 'editor' | 'viewer'
-    added_at = Column(DateTime, default=datetime.now, nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("partition_name", "user_id", name="uix_partition_user"),
-        CheckConstraint("role IN ('owner','editor','viewer')", name="ck_membership_role"),
-        Index("ix_user_partition", "user_id", "partition_name"),
-    )
-
-    partition = relationship("Partition", back_populates="memberships")
-    user = relationship("User", back_populates="memberships")
-
-
-class Workspace(Base):
-    __tablename__ = "workspaces"
-
-    id = Column(Integer, primary_key=True)
-    workspace_id = Column(String, unique=True, nullable=False, index=True)
-    partition_name = Column(
-        String,
-        ForeignKey("partitions.partition", ondelete="CASCADE"),
-        nullable=False,
-    )
-    created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    display_name = Column(String, nullable=True)
-    created_at = Column(DateTime, default=datetime.now)
-
-    files = relationship("WorkspaceFile", cascade="all, delete-orphan", backref="workspace")
-
-
-class WorkspaceFile(Base):
-    __tablename__ = "workspace_files"
-
-    id = Column(Integer, primary_key=True)
-    workspace_id = Column(
-        String,
-        ForeignKey("workspaces.workspace_id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    file_id = Column(String, nullable=False, index=True)
-
-    __table_args__ = (UniqueConstraint("workspace_id", "file_id", name="uix_workspace_file"),)
 
 
 class PartitionFileManager:
@@ -761,7 +593,7 @@ class PartitionFileManager:
             List of file_id strings ordered from root to the specified file
         """
         ancestors = self.get_file_ancestors(partition, file_id, max_ancestor_depth)
-        return [a["file_id"] for a in ancestors if a["file_id"] != file_id]
+        return [a["file_id"] for a in ancestors]
 
     # --- Workspace methods ---
 

--- a/openrag/scripts/migrations/alembic/env.py
+++ b/openrag/scripts/migrations/alembic/env.py
@@ -1,7 +1,7 @@
 from logging.config import fileConfig
 
 from alembic import context
-from components.indexer.vectordb.utils import Base
+from components.indexer.vectordb.models import Base
 from config import load_config
 from sqlalchemy import URL, engine_from_config, pool
 


### PR DESCRIPTION
Alembic's env.py imported Base from vectordb/utils.py, which transitively pulled in the entire app: utils.py -> logger -> config -> Hydra, and
via Python's package init chain: components.indexer.__init__ -> indexer ->
chunker -> prompts -> file I/O. This meant `alembic upgrade head` failed unless run from the exact working directory with all config and prompt files accessible.

Extract the pure data definitions (Base, File, Partition, User, PartitionMembership) into a new vectordb/models.py that only depends on sqlalchemy and datetime. Alembic's env.py now imports Base from models.py instead of utils.py, and utils.py re-imports the models so all existing code continues to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a quick tip showing how to apply SQL migrations inside a running container without rebuilding.

* **Backend Improvements**
  * Centralized and expanded database schemas to support partitions, users, memberships, workspaces, and file indexing with richer constraints and indexes.
  * Refactored model definitions into a single module and updated migration tooling to use the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->