### PR TITLE
feat: implement query decomposition for search and enhance reranking …

### DIFF
--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -276,4 +276,4 @@ async def on_message(message: cl.Message):
                 await msg.update()
         except Exception as e:
             logger.exception("Error during chat completion", error=str(e))
-            await cl.Message(content=f"An error occurred: {e!s}").send()
+            await cl.Message(content=f"An error occurred: {e}").send()

--- a/openrag/components/pipeline.py
+++ b/openrag/components/pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+from datetime import datetime
 from enum import Enum
 
 import ray
@@ -9,17 +10,19 @@ from components.prompts import (
     SYS_PROMPT_TMPLT,
 )
 from components.ray_utils import call_ray_actor_with_timeout
+from components.utils import detect_language, format_context, format_web_context
 from components.websearch import WebSearchFactory
 from config import load_config
 from langchain_core.documents.base import Document
-from openai import AsyncOpenAI
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
 from utils.logger import get_logger
 
 from .llm import LLM
 from .map_reduce import RAGMapReduce
 from .reranker import Reranker
 from .retriever import BaseRetriever, RetrieverFactory
-from .utils import SOURCE_SEPARATOR, format_context, format_web_context
+from .utils import SOURCE_SEPARATOR
 
 logger = get_logger()
 config = load_config()
@@ -29,6 +32,15 @@ VECTORDB_TIMEOUT = config.ray.indexer.get("vectordb_timeout", 30)
 class RAGMODE(Enum):
     SIMPLERAG = "SimpleRag"
     CHATBOTRAG = "ChatBotRag"
+
+
+class SearchQueries(BaseModel):
+    """Search queries for semantic retrieval."""
+
+    query_list: list[str] = Field(..., description="Search sub-queries to retrieve relevant documents.")
+
+    def __str__(self) -> str:
+        return " -- ".join(f"Query: {q}" for q in self.query_list)
 
 
 class RetrieverPipeline:
@@ -51,7 +63,7 @@ class RetrieverPipeline:
         if docs:
             # 1. rerank all the docs
             if self.reranker_enabled:
-                docs = await self.reranker.rerank(query, documents=docs, top_k=None)
+                docs = await self.reranker.rerank(query=query, documents=docs, top_k=None)
                 logger.debug("Documents reranked", document_count=len(docs))
 
             # 2. expand the docs with related documents
@@ -61,22 +73,37 @@ class RetrieverPipeline:
                 docs2expand = copy.deepcopy(docs[:top_k])
 
                 logger.debug("Documents to expand", document_count=len(docs2expand))
-
                 expanded_docs = await self.retriever.expand_search_results(results=docs2expand)
-
-                logger.debug("Documents expanded", document_count=len(expanded_docs))
-
                 if len(docs2expand) == len(expanded_docs):  # no expansion found, keep the original docs
                     return docs
 
+                logger.debug("Documents expanded", document_count=len(expanded_docs))
                 docs = expanded_docs
 
                 # rerank again after expansion if reranker is enabled
                 if self.reranker_enabled:
-                    docs = await self.reranker.rerank(query, documents=docs, top_k=None)
+                    docs = await self.reranker.rerank(query=query, documents=docs, top_k=None)
                     logger.debug("Documents after expansion and reranking", document_count=len(docs))
 
         return docs
+
+    async def get_relevant_docs(
+        self,
+        partition: list[str],
+        search_queries: SearchQueries,
+        top_k: int | None = None,
+        filter: dict | None = None,
+    ) -> list[Document]:
+        tasks = [
+            self.retrieve_docs(partition=partition, query=q, top_k=top_k, filter=filter)
+            for q in search_queries.query_list
+        ]
+        results = await asyncio.gather(*tasks)
+        results = self.reranker.rrf_reranking(doc_lists=results)
+        if top_k is not None:
+            results = results[:top_k]
+        logger.debug("Final relevant documents after RRF reranking", document_count=len(results))
+        return results
 
 
 class RagPipeline:
@@ -90,7 +117,13 @@ class RagPipeline:
         self.max_context_tokens = config.reranker.get("top_k", 10) * config.chunker.get("chunk_size", 512)
 
         self.llm_client = LLM(config.llm, logger)
-        self.contextualizer = AsyncOpenAI(base_url=config.llm["base_url"], api_key=config.llm["api_key"])
+        self.query_generator = ChatOpenAI(
+            base_url=config.llm.get("base_url"),
+            api_key=config.llm.get("api_key"),
+            model=config.llm.get("model"),
+            temperature=config.llm.get("temperature", 0.3),
+        ).with_structured_output(SearchQueries, method="function_calling")
+
         self.max_contextualized_query_len = config.rag["max_contextualized_query_len"]
 
         # map reduce
@@ -103,12 +136,12 @@ class RagPipeline:
         else:
             logger.info("Web search disabled (WEBSEARCH_API_TOKEN not set)")
 
-    async def generate_query(self, messages: list[dict]) -> str:
+    async def generate_query(self, messages: list[dict]) -> SearchQueries:
         match RAGMODE(self.rag_mode):
             case RAGMODE.SIMPLERAG:
                 # For SimpleRag, we don't need to contextualize the query as the chat history is not taken into account
                 last_msg = messages[-1]
-                return last_msg["content"]
+                return SearchQueries(query_list=[last_msg["content"]])
 
             case RAGMODE.CHATBOTRAG:
                 # Contextualize the query based on the chat history
@@ -116,32 +149,39 @@ class RagPipeline:
                 for m in messages:
                     chat_history += f"{m['role']}: {m['content']}\n"
 
-                params = dict(config.llm_params)
-                params.pop("max_retries")
-                params["max_completion_tokens"] = self.max_contextualized_query_len
-                params["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
+                query_language = detect_language(messages[-1]["content"])
 
-                response = await self.contextualizer.chat.completions.create(
-                    model=config.llm["model"],
-                    messages=[
-                        {"role": "system", "content": QUERY_CONTEXTUALIZER_PROMPT},
-                        {
-                            "role": "user",
-                            "content": f"Given the following chat, generate a query. \n{chat_history}\n",
-                        },
-                    ],
-                    **params,
+                model_kwargs = {
+                    "max_completion_tokens": self.max_contextualized_query_len,
+                    "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+                }
+                prompt = QUERY_CONTEXTUALIZER_PROMPT.format(
+                    query_language=query_language,
+                    current_date=datetime.now().strftime("%Y-%m-%d"),
                 )
-                contextualized_query = response.choices[0].message.content
-                return contextualized_query
+
+                messages = [
+                    {
+                        "role": "system",
+                        "content": prompt,
+                    },
+                    {
+                        "role": "user",
+                        "content": f"Here is the chat history: \n{chat_history}\n",
+                    },
+                ]
+
+                # generate queries based on the chat history
+                output: SearchQueries = await self.query_generator.bind(**model_kwargs).ainvoke(messages)
+                return output
 
     async def _prepare_for_chat_completion(self, partition: list[str] | None, payload: dict):
         messages = payload["messages"]
         messages = messages[-self.chat_history_depth :]  # limit history depth
 
         # 1. get the query
-        query = await self.generate_query(messages)
-        logger.debug("Prepared query for chat completion", query=query)
+        queries: SearchQueries = await self.generate_query(messages)
+        logger.debug("Prepared query for chat completion", queries=str(queries))
 
         metadata = payload.get("metadata") or {}
 
@@ -175,29 +215,52 @@ class RagPipeline:
                 )
                 workspace = None
         filter_dict = {"workspace_id": workspace} if workspace else None
+
         if partition is not None and use_websearch:
-            docs, web_results = await asyncio.gather(
-                self.retriever_pipeline.retrieve_docs(
-                    partition=partition, query=query, top_k=top_k, filter=filter_dict
-                ),
-                self.web_search_service.search(query),
-            )
+            # Run one retrieval and one web search per sub-query, all concurrently (Option C).
+            # Web results from different sub-queries are deduplicated by URL, preserving order.
+            rag_tasks = [
+                self.retriever_pipeline.retrieve_docs(partition=partition, query=q, top_k=top_k, filter=filter_dict)
+                for q in queries.query_list
+            ]
+            web_tasks = [self.web_search_service.search(q) for q in queries.query_list]
+            all_results = await asyncio.gather(*rag_tasks, *web_tasks)
+            n = len(queries.query_list)
+            raw_doc_lists = list(all_results[:n])
+            raw_web_lists = list(all_results[n:])
+            docs = self.retriever_pipeline.reranker.rrf_reranking(doc_lists=raw_doc_lists)
+            if top_k is not None:
+                docs = docs[:top_k]
+            # Deduplicate web results by URL, preserving first-seen order
+            seen_urls: set[str] = set()
+            web_results = []
+            for result in (r for web_list in raw_web_lists for r in web_list):
+                if result.url not in seen_urls:
+                    seen_urls.add(result.url)
+                    web_results.append(result)
         elif partition is not None:
-            docs = await self.retriever_pipeline.retrieve_docs(
-                partition=partition, query=query, top_k=top_k, filter=filter_dict
+            docs = await self.retriever_pipeline.get_relevant_docs(
+                partition=partition, search_queries=queries, top_k=top_k, filter=filter_dict
             )
             web_results = []
         else:
-            # Web-only mode (partition is None): no RAG retrieval
+            # Web-only mode (partition is None): no RAG retrieval.
+            # Run one web search per sub-query concurrently and deduplicate by URL.
+            raw_web_lists = await asyncio.gather(*[self.web_search_service.search(q) for q in queries.query_list])
+            seen_urls = set()
+            web_results = []
+            for result in (r for web_list in raw_web_lists for r in web_list):
+                if result.url not in seen_urls:
+                    seen_urls.add(result.url)
+                    web_results.append(result)
             docs = []
-            web_results = await self.web_search_service.search(query)
 
         # Web-only with no results: fall back to plain direct LLM mode
         if not docs and not web_results and partition is None:
             return payload, [], []
 
         if use_map_reduce and docs:
-            docs = await self.map_reduce.map(query=query, chunks=docs)
+            docs = await self.map_reduce.map(query=" ".join(queries.query_list), chunks=docs)
 
         # 3. Format web results first to know actual token usage, then allocate remaining budget to RAG
         web_formatted = ""
@@ -246,9 +309,9 @@ class RagPipeline:
         prompt = payload["prompt"]
 
         # 1. get the query
-        query = await self.generate_query(messages=[{"role": "user", "content": prompt}])
+        queries: SearchQueries = await self.generate_query(messages=[{"role": "user", "content": prompt}])
         # 2. get docs
-        docs = await self.retriever_pipeline.retrieve_docs(partition=partition, query=query)
+        docs = await self.retriever_pipeline.get_relevant_docs(partition=partition, search_queries=queries)
 
         # 3. Format the retrieved docs
         context, included_indices = format_context(docs, max_context_tokens=self.max_context_tokens)

--- a/openrag/components/reranker.py
+++ b/openrag/components/reranker.py
@@ -6,12 +6,47 @@ from infinity_client.models import RerankInput, ReRankResult
 from langchain_core.documents.base import Document
 
 
-class Reranker:
+class BaseReranker:
+    async def rerank(self, query: str, documents: list[Document], top_k: int | None = None) -> list[Document]:
+        """Rerank a list of documents based on a query and an optional top_k parameter"""
+        raise NotImplementedError("Rerank method must be implemented by subclasses")
+
+    @staticmethod
+    def rrf_reranking(doc_lists: list[list], k: int = 60) -> list[Document]:
+        """Reciprocal_rank_fusion that takes multiple lists of ranked documents
+        and an optional parameter k used in the RRF formula
+        RRF formula: \\sum_{i=1}^{n} \frac{1}{k + rank_i}
+        where rank_i is the rank of the document in the i-th list and n is the number of lists.
+
+        k small: High sensitivity to top ranks
+        k large: More balanced sensitivity across ranks
+        k = 60 a common and balanced choice in practice.
+        """
+
+        if len(doc_lists) == 1:
+            return doc_lists[0]
+
+        fused_scores = {}
+        for doc_list in doc_lists:
+            doc_list: list[Document]
+            for rank, doc in enumerate(doc_list, start=1):
+                doc_id = doc.metadata.get("_id")
+
+                score, d = fused_scores.get(doc_id, (0, doc))
+                fused_scores[doc_id] = (score + (1 / (rank + k)), d)
+
+        # sort the docs
+        reranked_docs = [doc for score, doc in sorted(fused_scores.values(), key=lambda x: x[0], reverse=True)]
+        return reranked_docs
+
+
+class Reranker(BaseReranker):
     def __init__(self, logger, config):
         self.model_name = config.reranker["model_name"]
         self.client = Client(base_url=config.reranker["base_url"])
         self.logger = logger
         self.semaphore = asyncio.Semaphore(5)  # Only allow 5 reranking operation at a time
+        self.temporal_reranking = config.reranker.get("temporal_reranking", False)
         self.logger.debug("Reranker initialized", model_name=self.model_name)
 
     async def rerank(self, query: str, documents: list[Document], top_k: int | None = None) -> list[Document]:
@@ -25,7 +60,7 @@ class Reranker:
                     "documents": [doc.page_content for doc in documents],
                     "top_n": top_k,
                     "return_documents": True,
-                    "raw_scores": True,
+                    "raw_scores": True,  # Normalized score between 0 and 1
                 }
             )
             try:

--- a/openrag/components/test_rrf_reranking.py
+++ b/openrag/components/test_rrf_reranking.py
@@ -1,0 +1,73 @@
+"""Tests for BaseReranker.rrf_reranking static method."""
+
+from components.reranker import BaseReranker
+from langchain_core.documents.base import Document
+
+
+def make_doc(doc_id: str, content: str = "", **metadata) -> Document:
+    return Document(page_content=content, metadata={"_id": doc_id, **metadata})
+
+
+class TestRrfRerankingSingleList:
+    def test_single_list_returned_as_is(self):
+        docs = [make_doc("a"), make_doc("b"), make_doc("c")]
+        result = BaseReranker.rrf_reranking([docs])
+        assert result is docs
+
+
+class TestRrfRerankingMultipleLists:
+    def test_two_lists_no_overlap_all_docs_present(self):
+        list1 = [make_doc("a"), make_doc("b")]
+        list2 = [make_doc("c"), make_doc("d")]
+        result = BaseReranker.rrf_reranking([list1, list2])
+        assert {d.metadata["_id"] for d in result} == {"a", "b", "c", "d"}
+
+    def test_document_in_multiple_lists_ranked_higher(self):
+        # doc_shared appears rank 1 in both lists
+        # doc_only_list1 appears rank 2 in list1 only
+        doc_shared = make_doc("shared")
+        doc_only = make_doc("only")
+        list1 = [doc_shared, doc_only]
+        list2 = [doc_shared]
+        result = BaseReranker.rrf_reranking([list1, list2])
+        ids = [d.metadata["_id"] for d in result]
+        assert ids[0] == "shared"
+
+    def test_overlapping_docs_deduped(self):
+        doc = make_doc("dup")
+        list1 = [doc, make_doc("a")]
+        list2 = [doc, make_doc("b")]
+        result = BaseReranker.rrf_reranking([list1, list2])
+        ids = [d.metadata["_id"] for d in result]
+        assert ids.count("dup") == 1
+
+    def test_sorted_descending_by_rrf_score(self):
+        # doc_a: rank 1 in both → score = 2/(1+60) ≈ 0.0328
+        # doc_b: rank 2 in both → score = 2/(2+60) ≈ 0.0323
+        # doc_c: rank 3 in both → score = 2/(3+60) ≈ 0.0317
+        doc_a, doc_b, doc_c = make_doc("a"), make_doc("b"), make_doc("c")
+        list1 = [doc_a, doc_b, doc_c]
+        list2 = [doc_a, doc_b, doc_c]
+        result = BaseReranker.rrf_reranking([list1, list2])
+        assert [d.metadata["_id"] for d in result] == ["a", "b", "c"]
+
+    def test_higher_rank_in_one_list_can_outweigh_single_appearance(self):
+        # doc_top: rank 1 in list1 only → score = 1/61
+        # doc_bottom: rank 3 in list1, rank 3 in list2 → score = 2/63
+        # 2/63 ≈ 0.0317 > 1/61 ≈ 0.0164, so doc_bottom wins
+        doc_top = make_doc("top")
+        doc_bottom = make_doc("bottom")
+        list1 = [doc_top, make_doc("x"), doc_bottom]
+        list2 = [make_doc("y"), make_doc("z"), doc_bottom]
+        result = BaseReranker.rrf_reranking([list1, list2])
+        ids = [d.metadata["_id"] for d in result]
+        assert ids.index("bottom") < ids.index("top")
+
+
+class TestRrfRerankingDocumentPreservation:
+    def test_preserves_page_content_and_metadata(self):
+        doc = make_doc("doc1", content="hello world", source="file.pdf", score=0.9)
+        result = BaseReranker.rrf_reranking([[doc], [doc]])
+        assert result[0].page_content == "hello world"
+        assert result[0].metadata["source"] == "file.pdf"
+        assert result[0].metadata["score"] == 0.9

--- a/prompts/example1/query_contextualizer_tmpl.txt
+++ b/prompts/example1/query_contextualizer_tmpl.txt
@@ -1,21 +1,36 @@
-From a chat history, reformulate the user's last message into an autonomous search query by integrating relevant context from previous conversations.
+From a chat history, reformulate the user's last message into one or more autonomous search queries by integrating relevant context from previous conversations.
 
 # Task:
 - For follow-up questions: Reformulate by replacing pronouns with corresponding nouns and add relevant keywords
 - For independent questions: Apply only minimal corrections (grammar, keywords)
 - For simple thank you messages: No reformulation necessary
+- Enrich queries with prior conversation context only when relevant to the query.
+
+## Query decomposition guidelines
+- Use full, descriptive sentences (not isolated keywords) to improve semantic retrieval.
+- Inject previous chat history only when it is directly relevant to the current query, as unnecessary context can degrade search quality.
+- Split complex queries into independent sub-queries, especially for comparisons or multi-dimensional questions.
+  - Distinct time periods 
+    - "What are the sales figures for Product A in Q1 and Q2?" should give two sub-queries (one per quarter).
+    - "Evolution of carbone footprint in the last 2" should give two sub-queries (one per year).
+
+  - Distinct entities
+    - "What are the sales figures for Product A and Product B?" should give two sub-queries (one per product).
+    
+  - Unrelated dimensions
+    - "What are the sales figures for Product A in the US and in Europe?" should give two sub-queries (one per region).
+
+# additional information
+- Current date: {current_date}
 
 # Requirements:
 - Preserve the original tone and intention
 - Do not add information beyond necessary context
 - Do not answer the questions, only reformulate them
-- Respond in the language of the user's last message
+- Respond in the language of the user's last message : {query_language}
 
 # Examples:
 - User: I'm planning a trip to Italy and I'm interested in historical monuments and local cuisine.
 - Assistant: Italy offers a wealth of history and culinary delights.
 - User: What are the must-see sites?
 Reformulated query: What are the must-see historical monuments and local cuisine restaurants in Italy?
-
-# Response format: 
-Return only the reformulated query in plain text, without additional formatting.

--- a/prompts/example1/query_contextualizer_tmpl.txt
+++ b/prompts/example1/query_contextualizer_tmpl.txt
@@ -12,7 +12,7 @@ From a chat history, reformulate the user's last message into one or more autono
 - Split complex queries into independent sub-queries, especially for comparisons or multi-dimensional questions.
   - Distinct time periods 
     - "What are the sales figures for Product A in Q1 and Q2?" should give two sub-queries (one per quarter).
-    - "Evolution of carbone footprint in the last 2" should give two sub-queries (one per year).
+    - "Evolution of carbon footprint in the last 2 years" should give two sub-queries (one per year).
 
   - Distinct entities
     - "What are the sales figures for Product A and Product B?" should give two sub-queries (one per product).

--- a/tests/api_tests/api_run/mock_vllm.py
+++ b/tests/api_tests/api_run/mock_vllm.py
@@ -54,6 +54,8 @@ class ChatCompletionRequest(BaseModel):
     top_p: float | None = 1.0
     n: int | None = 1
     stop: str | list[str] | None = None
+    tools: list[Any] | None = None
+    tool_choice: Any | None = None
 
 
 class ChatCompletionChoice(BaseModel):
@@ -222,9 +224,66 @@ async def stream_chat_completion(request: ChatCompletionRequest):
     yield "data: [DONE]\n\n"
 
 
+def generate_tool_call_response(request: ChatCompletionRequest) -> dict:
+    """Generate a mock tool_calls response for structured output requests."""
+    tool = request.tools[0]
+    fn = tool.get("function", tool)
+    fn_name = fn.get("name", "unknown")
+    parameters = fn.get("parameters", {})
+    properties = parameters.get("properties", {})
+
+    # Build mock arguments based on property types
+    last_user_msg = next((m for m in reversed(request.messages) if m.role == "user"), None)
+    user_text = str(last_user_msg.content)[:100] if last_user_msg else "mock query"
+
+    mock_args: dict = {}
+    for prop_name, prop_schema in properties.items():
+        if prop_schema.get("type") == "array":
+            mock_args[prop_name] = [user_text]
+        elif prop_schema.get("type") == "string":
+            mock_args[prop_name] = user_text
+        else:
+            mock_args[prop_name] = None
+
+    prompt_tokens = sum(count_tokens(str(msg.content)) for msg in request.messages)
+    args_json = json.dumps(mock_args)
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": request.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": f"call_{uuid.uuid4().hex[:8]}",
+                            "type": "function",
+                            "function": {"name": fn_name, "arguments": args_json},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": count_tokens(args_json),
+            "total_tokens": prompt_tokens + count_tokens(args_json),
+        },
+    }
+
+
 @app.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest):
     """Mock chat completion endpoint for LLM/VLM requests."""
+    # Handle function/tool calling (used by structured output)
+    if request.tools:
+        return generate_tool_call_response(request)
+
     if request.stream:
         return StreamingResponse(
             stream_chat_completion(request),


### PR DESCRIPTION
This PR Improves retrieval quality and reranking by adding multi-query generation and RRF-based result fusion.

* Added `SearchQueries` model to generate multiple sub-queries from chat history when needed to handle advances queries that requires decomposition.
  * Query like "difference between US, China and EU approach concerning personal data governance" produces subqueries
    * Query 1: What is the approach of the United States concerning personal data governance?
    * Query 2: What is the approach of China concerning personal data governance?
    * Query 3: What is the approach of the European Union concerning personal data governance?

* Updated pipeline to retrieve with multiple queries and merge results using Reciprocal Rank Fusion (RRF).
* Added tests for RRF logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-query decomposition: breaks complex questions into multiple autonomous search queries.
  * Batch retrieval & aggregation: fetches and deduplicates web results across sub-queries and joins them for map-reduce.
  * New reranking fusion: Reciprocal Rank Fusion improves aggregated ranking and supports temporal reranking.

* **Documentation**
  * Expanded query-generation guidelines with decomposition rules and contextual enrichment examples.

* **Tests**
  * Added unit tests for RRF reranking and mock tool-call responses for chat completion.

* **Bug Fixes**
  * Minor error-message formatting tweak in messaging path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->