### PR TITLE
fix: downgrade auth failure log from exception to info level

### DIFF
--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -84,8 +84,11 @@ if AUTH_TOKEN:
                 },
             )
 
+        except httpx.HTTPStatusError:
+            logger.info("Authentication failed", username=username)
+            return None
         except Exception as e:
-            logger.exception("Authentication failed", error=str(e))
+            logger.exception("Unexpected error during authentication", error=str(e))
             return None
 
 


### PR DESCRIPTION
Failed login attempts are expected events, not errors. Split the exception handler so HTTP status errors log at info level while unexpected errors still get full tracebacks.