### PR TITLE
feat: add user update endpoints.

### DIFF
--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -3,6 +3,7 @@ import os
 import secrets
 
 from config import load_config
+from models.user import UserCreate, UserUpdate
 from sqlalchemy import create_engine, delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import sessionmaker
@@ -233,26 +234,20 @@ class PartitionFileManager:
 
     # Users
 
-    def create_user(
-        self,
-        display_name: str | None = None,
-        external_user_id: str | None = None,
-        is_admin: bool = False,
-        file_quota: int | None = None,
-    ) -> dict:
+    def create_user(self, body: UserCreate) -> dict:
         """Create a user and generate an API token for them."""
         with self.Session() as s:
             token = f"or-{secrets.token_hex(16)}"
             hashed_token = self.hash_token(token)
-
+            file_quota = body.file_quota
             if self.file_quota_per_user > 0 and file_quota is None:
                 file_quota = self.file_quota_per_user  # default to default quota
 
             user = User(
-                display_name=display_name,
-                external_user_id=external_user_id,
+                display_name=body.display_name,
+                external_user_id=body.external_user_id,
                 token=hashed_token,
-                is_admin=is_admin,
+                is_admin=body.is_admin,
                 file_quota=file_quota,
             )
             s.add(user)
@@ -453,25 +448,21 @@ class PartitionFileManager:
         with self.Session() as s:
             return s.query(PartitionMembership).filter_by(user_id=user_id, partition_name=partition).first() is not None
 
-    def update_user_quota(self, user_id: int, file_quota: int | None) -> dict:
-        """
-        Update a user's file quota.
-        - None: Use global default (DEFAULT_FILE_QUOTA env var)
-        - <0: Unlimited
-        - >=0: Specific limit
-        """
+    def update_user(self, user_id: int, body: UserUpdate) -> dict:
+        """Update user's profile fields. Only provided (non-None) fields are updated."""
         with self.Session() as s:
             user = s.query(User).filter(User.id == user_id).first()
-            user.file_quota = file_quota
-            s.commit()
-            self.logger.info(f"Updated file_quota for user {user_id} to {file_quota}")
-            s.refresh(user)
+            for field, value in body.model_dump(exclude_unset=True).items():
+                setattr(user, field, value)
 
+            s.commit()
+            s.refresh(user)
             return {
                 "id": user.id,
                 "display_name": user.display_name,
                 "external_user_id": user.external_user_id,
                 "is_admin": user.is_admin,
+                "created_at": user.created_at.isoformat(),
                 "file_quota": user.file_quota,
                 "file_count": user.file_count,
             }

--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -6,6 +6,7 @@ import numpy as np
 import ray
 from config import load_config
 from langchain_core.documents.base import Document
+from models.user import UserCreate, UserUpdate
 from pymilvus import (
     AnnSearchRequest,
     AsyncMilvusClient,
@@ -925,14 +926,8 @@ class MilvusDB(BaseVectorDB):
                 partition=partition,
             )
 
-    async def create_user(
-        self,
-        display_name: str | None = None,
-        external_user_id: str | None = None,
-        is_admin: bool = False,
-        file_quota: int | None = None,
-    ):
-        return self.partition_file_manager.create_user(display_name, external_user_id, is_admin, file_quota)
+    async def create_user(self, body: UserCreate):
+        return self.partition_file_manager.create_user(body)
 
     async def get_user(self, user_id: int):
         self._check_user_exists(user_id)
@@ -957,9 +952,9 @@ class MilvusDB(BaseVectorDB):
         self._check_user_exists(user_id)
         return self.partition_file_manager.regenerate_user_token(user_id)
 
-    def update_user_quota(self, user_id: int, file_quota: int | None):
+    async def update_user(self, user_id: int, body: UserUpdate):
         self._check_user_exists(user_id)
-        return self.partition_file_manager.update_user_quota(user_id, file_quota)
+        return self.partition_file_manager.update_user(user_id, body)
 
     async def list_user_partitions(self, user_id: int):
         self._check_user_exists(user_id)

--- a/openrag/models/user.py
+++ b/openrag/models/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UserBase(BaseModel):
@@ -9,11 +9,11 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    pass
+    model_config = ConfigDict(extra="allow")
 
 
 class UserUpdate(UserBase):
-    pass
+    model_config = ConfigDict(extra="allow")
 
 
 class UserPublic(UserBase):

--- a/openrag/models/user.py
+++ b/openrag/models/user.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, Field
+
+
+class UserBase(BaseModel):
+    display_name: str | None = None
+    external_user_id: str | None = None
+    is_admin: bool = False
+    file_quota: int | None = Field(default=10)
+
+
+class UserCreate(UserBase):
+    pass
+
+
+class UserUpdate(UserBase):
+    pass
+
+
+class UserPublic(UserBase):
+    id: int
+    created_at: str | None
+    file_quota: int | None = None
+    file_count: int | None = None

--- a/openrag/routers/users.py
+++ b/openrag/routers/users.py
@@ -271,7 +271,8 @@ async def update_user(
     """
     Update a user's profile fields.
     """
-    if user_id == 1:
+    # Only block if is_admin was explicitly set to False in the request
+    if user_id == 1 and "is_admin" in body.model_fields_set and body.is_admin is False:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot revoke admin privileges from the default admin user.",

--- a/openrag/routers/users.py
+++ b/openrag/routers/users.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends, Form, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
+from models.user import UserCreate, UserPublic, UserUpdate
 from utils.dependencies import get_task_state_manager, get_vectordb
 from utils.logger import get_logger
 
@@ -123,22 +124,14 @@ Returns created user including:
 """,
 )
 async def create_user(
-    display_name: str | None = Form(None),
-    external_user_id: str | None = Form(None),
-    is_admin: bool = Form(False),
+    body: UserCreate,
     vectordb=Depends(get_vectordb),
-    file_quota: int | None = Form(None),
     admin_user=Depends(require_admin),
 ):
     """
     Create a new user and generate a token.
     """
-    user = await vectordb.create_user.remote(
-        display_name=display_name,
-        external_user_id=external_user_id,
-        is_admin=is_admin,
-        file_quota=file_quota,
-    )
+    user = await vectordb.create_user.remote(body)
     logger.info("Created new user", user_id=user["id"])
     return JSONResponse(status_code=status.HTTP_201_CREATED, content=user)
 
@@ -240,38 +233,49 @@ async def regenerate_user_token(user_id: int, vectordb=Depends(get_vectordb)):
 
 
 @router.patch(
-    "/{user_id}/quota",
-    description="""Update a user's file quota.
+    "/{user_id}",
+    description="""Update a user's profile information.
 
 **Parameters:**
 - `user_id`: User identifier
-- `file_quota`: New file quota value (form data)
-    * `None` or not provided: Use global default (`DEFAULT_FILE_QUOTA` env var)
-    * `<0`: Unlimited
-    * `>=0`: Specific limit for this user
+- `display_name`: New display name (optional)
+- `external_user_id`: New external system user ID (optional)
+- `is_admin`: Grant or revoke admin privileges (optional)
+- `file_quota`: File quota override (optional)
+    * `None` or omitted: field is not changed
+    * `< 0`: Unlimited
+    * `>= 0`: Specific file limit for this user
+
+Only fields explicitly provided in the request body are updated.
 
 **Permissions:**
 - Requires admin role
 
 **Response:**
-Returns 200 OK with success message.
-
-**Note:** Admins always have unlimited quota regardless of this setting.
+Returns updated user details including:
+- `id`: User identifier
+- `display_name`: Updated display name
+- `external_user_id`: Updated external ID
+- `is_admin`: Updated admin status
+- `created_at`: Account creation timestamp
+- `file_quota`: File quota setting (`null` = use global default, `< 0` = unlimited)
+- `file_count`: Number of indexed files
 """,
 )
-async def update_user_quota(
+async def update_user(
     user_id: int,
-    file_quota: int | None = Form(None),
+    body: UserUpdate,
     vectordb=Depends(get_vectordb),
     admin_user=Depends(require_admin),
-):
+) -> UserPublic:
     """
-    Update a user's file quota.
+    Update a user's profile fields.
     """
-    await vectordb.update_user_quota.remote(user_id, file_quota)
-
-    logger.debug("Updated user quota", user_id=user_id, file_quota=file_quota)
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content={"message": f"Quota for user {user_id} updated to {file_quota}"},
-    )
+    if user_id == 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot revoke admin privileges from the default admin user.",
+        )
+    user = await vectordb.update_user.remote(user_id, body)
+    logger.info("Updated user info", user_id=user_id)
+    return user

--- a/tests/api_tests/conftest.py
+++ b/tests/api_tests/conftest.py
@@ -41,7 +41,7 @@ def created_user(api_client):
 
     response = api_client.post(
         "/users/",
-        data={"display_name": display_name, "external_user_id": external_id},
+        json={"display_name": display_name, "external_user_id": external_id},
     )
     assert response.status_code == 201, f"Failed to create user: {response.text}"
     user = response.json()

--- a/tests/api_tests/test_indexer.py
+++ b/tests/api_tests/test_indexer.py
@@ -380,7 +380,7 @@ class TestUserQuotaEnforcement:
         data = {"display_name": display_name}
         if file_quota is not None:
             data["file_quota"] = file_quota
-        response = api_client.post("/users/", data=data)
+        response = api_client.post("/users/", json=data)
         assert response.status_code == 201, f"Failed to create user: {response.text}"
         return response.json()
 

--- a/tests/api_tests/test_users.py
+++ b/tests/api_tests/test_users.py
@@ -183,18 +183,21 @@ class TestUserManagement:
         """Test that other fields can be updated on user 1 (default admin)."""
         # Get current display_name
         get_response = api_client.get("/users/1")
+        assert get_response.status_code == 200
         original_name = get_response.json().get("display_name")
 
-        # Update display_name (not is_admin)
-        response = api_client.patch(
-            "/users/1",
-            json={"display_name": "updated_admin_name"},
-        )
-        assert response.status_code == 200
-        assert response.json()["display_name"] == "updated_admin_name"
-
-        # Restore original name
-        api_client.patch("/users/1", json={"display_name": original_name})
+        try:
+            # Update display_name (not is_admin)
+            response = api_client.patch(
+                "/users/1",
+                json={"display_name": "updated_admin_name"},
+            )
+            assert response.status_code == 200
+            assert response.json()["display_name"] == "updated_admin_name"
+        finally:
+            # Restore original name
+            restore_response = api_client.patch("/users/1", json={"display_name": original_name})
+            assert restore_response.status_code == 200
 
     def test_user_default_quota(self, api_client):
         """Test that user created with None quota gets default value (10)."""

--- a/tests/api_tests/test_users.py
+++ b/tests/api_tests/test_users.py
@@ -38,7 +38,7 @@ class TestUserManagement:
         # Create a new user with quota 10
         create_response = api_client.post(
             "/users/",
-            data={"display_name": "quota_test_user", "file_quota": 10},
+            json={"display_name": "quota_test_user", "file_quota": 10},
         )
         assert create_response.status_code == 201
         user_data = create_response.json()
@@ -47,16 +47,14 @@ class TestUserManagement:
         try:
             # Update the user's quota to 12
             update_response = api_client.patch(
-                f"/users/{user_id}/quota",
-                data={"file_quota": 12},
+                f"/users/{user_id}",
+                json={"file_quota": 12},
             )
             assert update_response.status_code == 200
             update_data = update_response.json()
-            assert "message" in update_data
-            assert str(user_id) in update_data["message"]
-            assert "12" in update_data["message"]
+            assert update_data["file_quota"] == 12
 
-            # check that user user has quota 12
+            # check that user has quota 12
             get_response = api_client.get(f"/users/{user_id}")
             assert get_response.status_code == 200
             get_data = get_response.json()
@@ -70,7 +68,7 @@ class TestUserManagement:
         # Create a user without specifying quota (None)
         create_response = api_client.post(
             "/users/",
-            data={"display_name": "default_quota_user"},
+            json={"display_name": "default_quota_user"},
         )
         assert create_response.status_code == 201
         user_data = create_response.json()

--- a/tests/api_tests/test_users.py
+++ b/tests/api_tests/test_users.py
@@ -63,6 +63,139 @@ class TestUserManagement:
             # Clean up: delete the test user
             api_client.delete(f"/users/{user_id}")
 
+    def test_update_user_display_name(self, api_client):
+        """Test updating user display_name."""
+        create_response = api_client.post(
+            "/users/",
+            json={"display_name": "original_name"},
+        )
+        assert create_response.status_code == 201
+        user_id = create_response.json()["id"]
+
+        try:
+            update_response = api_client.patch(
+                f"/users/{user_id}",
+                json={"display_name": "updated_name"},
+            )
+            assert update_response.status_code == 200
+            assert update_response.json()["display_name"] == "updated_name"
+
+            # Verify persistence
+            get_response = api_client.get(f"/users/{user_id}")
+            assert get_response.json()["display_name"] == "updated_name"
+        finally:
+            api_client.delete(f"/users/{user_id}")
+
+    def test_update_user_multiple_fields(self, api_client):
+        """Test updating multiple user fields at once."""
+        create_response = api_client.post(
+            "/users/",
+            json={"display_name": "multi_test", "file_quota": 5},
+        )
+        assert create_response.status_code == 201
+        user_id = create_response.json()["id"]
+
+        try:
+            update_response = api_client.patch(
+                f"/users/{user_id}",
+                json={
+                    "display_name": "multi_updated",
+                    "external_user_id": "ext-123",
+                    "file_quota": 20,
+                },
+            )
+            assert update_response.status_code == 200
+            data = update_response.json()
+            assert data["display_name"] == "multi_updated"
+            assert data["external_user_id"] == "ext-123"
+            assert data["file_quota"] == 20
+        finally:
+            api_client.delete(f"/users/{user_id}")
+
+    def test_update_user_partial_preserves_other_fields(self, api_client):
+        """Test that partial update preserves fields not in request."""
+        create_response = api_client.post(
+            "/users/",
+            json={
+                "display_name": "partial_test",
+                "external_user_id": "ext-preserve",
+                "file_quota": 15,
+            },
+        )
+        assert create_response.status_code == 201
+        user_id = create_response.json()["id"]
+
+        try:
+            # Update only display_name
+            update_response = api_client.patch(
+                f"/users/{user_id}",
+                json={"display_name": "partial_updated"},
+            )
+            assert update_response.status_code == 200
+            data = update_response.json()
+            # Updated field should change
+            assert data["display_name"] == "partial_updated"
+            # Other fields should be preserved
+            assert data["external_user_id"] == "ext-preserve"
+            assert data["file_quota"] == 15
+        finally:
+            api_client.delete(f"/users/{user_id}")
+
+    def test_update_user_is_admin(self, api_client):
+        """Test granting and revoking admin privileges."""
+        create_response = api_client.post(
+            "/users/",
+            json={"display_name": "admin_test", "is_admin": False},
+        )
+        assert create_response.status_code == 201
+        user_id = create_response.json()["id"]
+
+        try:
+            # Grant admin
+            update_response = api_client.patch(
+                f"/users/{user_id}",
+                json={"is_admin": True},
+            )
+            assert update_response.status_code == 200
+            assert update_response.json()["is_admin"] is True
+
+            # Revoke admin
+            update_response = api_client.patch(
+                f"/users/{user_id}",
+                json={"is_admin": False},
+            )
+            assert update_response.status_code == 200
+            assert update_response.json()["is_admin"] is False
+        finally:
+            api_client.delete(f"/users/{user_id}")
+
+    def test_cannot_revoke_admin_from_default_user(self, api_client):
+        """Test that admin cannot be revoked from user 1 (default admin)."""
+        # Attempt to revoke admin from user 1
+        response = api_client.patch(
+            "/users/1",
+            json={"is_admin": False},
+        )
+        assert response.status_code == 400
+        assert "Cannot revoke admin" in response.json()["detail"]
+
+    def test_can_update_other_fields_on_default_user(self, api_client):
+        """Test that other fields can be updated on user 1 (default admin)."""
+        # Get current display_name
+        get_response = api_client.get("/users/1")
+        original_name = get_response.json().get("display_name")
+
+        # Update display_name (not is_admin)
+        response = api_client.patch(
+            "/users/1",
+            json={"display_name": "updated_admin_name"},
+        )
+        assert response.status_code == 200
+        assert response.json()["display_name"] == "updated_admin_name"
+
+        # Restore original name
+        api_client.patch("/users/1", json={"display_name": original_name})
+
     def test_user_default_quota(self, api_client):
         """Test that user created with None quota gets default value (10)."""
         # Create a user without specifying quota (None)


### PR DESCRIPTION
**Refactor user creation and update flows to use Pydantic models**

Replaces manual form parsing with typed Pydantic models (`UserCreate`, `UserUpdate`, `UserPublic`) across the user API, backend logic, and tests.

**Changes:**
- Added Pydantic models in `openrag/models/user.py` for user creation, update, and serialization
- Refactored user endpoints to accept JSON bodies and support updating all profile fields (not just quota)
- Updated `vectordb/utils.py` and `vectordb/vectordb.py` to use the new models; generalized update logic for multiple fields
- Updated tests to use JSON request bodies and validate updated fields
- Simplified workspace file association by using direct file IDs, removing unnecessary PK resolution

* This solves this issue #121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed user schemas and safeguard preventing removal of admin privileges from the primary admin account.
  * Patch supports partial updates to multiple profile fields in one request; responses include created_at.

* **API Changes**
  * User create/update now accept JSON bodies with typed schemas.
  * Patch endpoint moved from quota-specific route to a general user PATCH and returns the updated user.

* **Tests**
  * Tests updated to send JSON payloads and cover multi-field updates and admin-protection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->