### PR TITLE
fix: only enforce token limit in direct LLM mode

### DIFF
--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -320,14 +320,13 @@ async def openai_chat_completion(
             detail="The last message must be a non-empty user message",
         )
 
-    check_tokens_limit(request, log)
-
     log.debug(
         "Received chat completion request with messages: {}",
         truncate(str(request.messages)),
     )
 
     if is_direct_llm_model(request):
+        check_tokens_limit(request, log)
         partitions = None
     else:
         partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
@@ -421,9 +420,8 @@ async def openai_completion(
             detail="Streaming is not supported for this endpoint",
         )
 
-    check_tokens_limit(request, log)
-
     if is_direct_llm_model(request):
+        check_tokens_limit(request, log)
         partitions = None
     else:
         partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])


### PR DESCRIPTION
Move the token-limit check so it only runs in direct LLM mode. In RAG mode the pipeline trims chat history to `chat_history_depth` (default 4) before calling the LLM, so the pre-trim check was falsely rejecting long conversations that would fit once truncated. Direct LLM mode still enforces the limit since no trimming happens there.