### PR TITLE
feat(auth): add OpenID Connect authentication mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,27 @@ LOG_LEVEL=DEBUG # See possible values https://loguru.readthedocs.io/en/stable/ap
 # SERVER
 # Set the preferred URL scheme for generated URLs (e.g., task_status_url).
 PREFERRED_URL_SCHEME=https
+
+# ============================================================================
+# Authentication
+# ============================================================================
+# AUTH_MODE controls how users authenticate.
+#   - token (default): Bearer AUTH_TOKEN-based auth (legacy).
+#   - oidc:           OpenID Connect flow (auth code + PKCE).
+# AUTH_MODE=token
+
+# --- OIDC (only required when AUTH_MODE=oidc) ---
+# Issuer URL — MUST match EXACTLY the "issuer" field returned by the IdP's
+# /.well-known/openid-configuration (trailing slash matters, per OIDC spec).
+# Keycloak typically returns no trailing slash; LemonLDAP::NG and Auth0 return one.
+# Check with: curl -s <endpoint>/.well-known/openid-configuration | jq -r .issuer
+# OIDC_ENDPOINT=https://idp.example.com/realms/openrag
+# OIDC_CLIENT_ID=openrag
+# OIDC_CLIENT_SECRET=change-me
+# OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+# OIDC_EMAIL_SOURCE=id_token    # 'id_token' (default) or 'userinfo'
+# OIDC_SCOPES=openid email profile offline_access  # include offline_access for refresh tokens (persistent sessions)
+# Generate a Fernet key once: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# OIDC_TOKEN_ENCRYPTION_KEY=
+# OIDC_POST_LOGOUT_REDIRECT_URI=/
+# OIDC_ALLOWED_EMAIL_DOMAINS=    # Optional CSV whitelist, e.g. "example.com,partner.org"

--- a/.env.example
+++ b/.env.example
@@ -84,9 +84,16 @@ PREFERRED_URL_SCHEME=https
 # OIDC_CLIENT_ID=openrag
 # OIDC_CLIENT_SECRET=change-me
 # OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
-# OIDC_EMAIL_SOURCE=id_token    # 'id_token' (default) or 'userinfo'
 # OIDC_SCOPES=openid email profile offline_access  # include offline_access for refresh tokens (persistent sessions)
 # Generate a Fernet key once: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # OIDC_TOKEN_ENCRYPTION_KEY=
 # OIDC_POST_LOGOUT_REDIRECT_URI=/
-# OIDC_ALLOWED_EMAIL_DOMAINS=    # Optional CSV whitelist, e.g. "example.com,partner.org"
+# --- Optional claim mapping ---
+# Where to read claims from when OIDC_CLAIM_MAPPING is set.
+#   'id_token'  (default) — read from the verified ID-token claims (no extra HTTP).
+#   'userinfo'            — fetch the IdP /userinfo endpoint (more complete, non-standard claims).
+# OIDC_CLAIM_SOURCE=id_token
+# CSV of `db_field:claim` pairs to sync into the users row on every login.
+# Writable fields whitelist: display_name, email (never is_admin / external_user_id / file_quota / token).
+# Leave unset to keep user rows untouched after login.
+# OIDC_CLAIM_MAPPING=display_name:name,email:email

--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,10 @@ PREFERRED_URL_SCHEME=https
 # OIDC_SCOPES=openid email profile offline_access  # include offline_access for refresh tokens (persistent sessions)
 # Generate a Fernet key once: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # OIDC_TOKEN_ENCRYPTION_KEY=
-# OIDC_POST_LOGOUT_REDIRECT_URI=/
+# Where the IdP sends the user after RP-initiated logout. No default —
+# pointing this to an OpenRag URL causes an instant re-auth loop. Prefer
+# a URL OUTSIDE OpenRag (corporate intranet, static 'bye' page, IdP home).
+# OIDC_POST_LOGOUT_REDIRECT_URI=https://intranet.example.com/
 # --- Optional claim mapping ---
 # Where to read claims from when OIDC_CLAIM_MAPPING is set.
 #   'id_token'  (default) — read from the verified ID-token claims (no extra HTTP).

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ docs/plans/
 
 # Build artifacts
 *.egg-info/
+
+# Local developer overrides (not committed)
+docker-compose.override.yaml
+docker-compose.override.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,3 +323,94 @@ from config import load_config
 # Avoid relative imports across packages
 # from .ray_utils import ...  # Only within same package
 ```
+
+### OIDC Authentication (OpenID Connect)
+
+OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environment variable:
+
+**Token Mode** (`AUTH_MODE=token`, default):
+- Bearer token authentication via `Authorization: Bearer <AUTH_TOKEN>` header
+- Existing behavior unchanged
+- Suitable for programmatic access, CI/CD, and testing
+- Admin user (id=1) created with `AUTH_TOKEN` env var or random token on bootstrap
+
+**OIDC Mode** (`AUTH_MODE=oidc`):
+- OpenID Connect Authorization Code + PKCE flow
+- Users authenticate via an external IdP (Keycloak, LemonLDAP::NG, etc.)
+- Browser UI (Chainlit, Indexer) redirects to IdP login
+- Opaque session tokens stored in `openrag_session` httpOnly cookie
+- Bearer `users.token` still accepted for programmatic access
+
+**Env Variables** (required when `AUTH_MODE=oidc`):
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `OIDC_ENDPOINT` | Issuer URL for auto-discovery | `https://idp.example.com/realms/openrag` |
+| `OIDC_CLIENT_ID` | Client registered at IdP | `openrag` |
+| `OIDC_CLIENT_SECRET` | Client secret | (provided by IdP) |
+| `OIDC_REDIRECT_URI` | Callback URL (must match IdP config) | `https://openrag.example.com/auth/callback` |
+| `OIDC_TOKEN_ENCRYPTION_KEY` | Fernet key for token encryption | (generate via: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`) |
+
+**Optional Env Variables**:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OIDC_EMAIL_SOURCE` | `id_token` | Claim source: `id_token` or `userinfo` |
+| `OIDC_SCOPES` | `openid email profile offline_access` | Space-separated scope list (include `offline_access` for refresh tokens) |
+| `OIDC_POST_LOGOUT_REDIRECT_URI` | `/` | URL to redirect after RP-initiated logout |
+| `OIDC_ALLOWED_EMAIL_DOMAINS` | (none) | CSV whitelist of email domains (e.g., `example.com,partner.org`) |
+
+**User Matching & Provisioning**:
+
+When a user logs in via OIDC:
+1. Lookup by `users.external_user_id = sub` (OIDC claim, stable identifier)
+2. Fallback: lookup by `users.email = email` claim
+3. On email match, backfill `external_user_id = sub` (first login only)
+4. If neither matches: reject with 403 (no auto-provisioning)
+
+**Admin Pre-provisioning**: Admins must create users in the database with matching email (and optionally `external_user_id` if known). Example:
+```bash
+curl -X POST http://localhost:8080/users/ \
+  -H "Authorization: Bearer <AUTH_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"display_name": "Alice", "email": "alice@example.com", "is_admin": false}'
+```
+
+**Database Schema**:
+
+New columns on `users` table:
+- `email` (String, unique, nullable): Email matching the `email` OIDC claim
+
+New table `oidc_sessions`:
+- `session_token_hash` (unique): SHA-256 of the opaque session token
+- `user_id` (FK): User this session belongs to
+- `sid` (nullable): OIDC session identifier (used for back-channel logout)
+- `sub` (required): OIDC `sub` claim (stable user identifier)
+- `id_token_encrypted`, `access_token_encrypted`, `refresh_token_encrypted`: Fernet-encrypted IdP tokens
+- `access_token_expires_at`, `session_expires_at`: Token expiry times
+- `revoked_at` (nullable): Set on back-channel logout or manual revocation
+
+**Auth Endpoints** (all bypass the normal middleware):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/auth/login` | Start Authorization Code + PKCE flow; redirects to IdP |
+| GET | `/auth/callback` | IdP callback; creates session, sets cookie; redirects to `next_url` |
+| POST | `/auth/backchannel-logout` | IdP-driven logout (OIDC spec); revokes sessions by `sid` |
+| GET | `/auth/logout` | RP-initiated logout; invalidates session + redirects to IdP |
+| GET | `/auth/me` | (debug) Returns current user and session expiry |
+
+**Session Management**:
+
+- Session token: 32-byte hex opaque token, hashed (SHA-256) before storage
+- Cookie: `openrag_session` (httpOnly, Secure if HTTPS, SameSite=Lax, Path=/, no Domain=)
+- TTL: Aligned with `access_token_expires_at`; auto-refresh if `refresh_token` available (<60s before expiry)
+- Revocation: Via back-channel logout or manual invalidation
+
+**Middleware Behavior**:
+
+- UI paths (`/`, `/chainlit`, `/static`) without auth → 302 redirect to `/auth/login?next=...`
+- API paths (`/v1`, `/indexer`, `/search`, etc.) without auth → 401 JSON response
+- Programmtic access: Bearer `users.token` accepted in both modes
+
+**See Also**: Full configuration and troubleshooting guide at `docs/oidc.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,7 +401,7 @@ New table `oidc_sessions`:
 
 **Session Management**:
 
-- Session token: 32-byte hex opaque token, hashed (SHA-256) before storage
+- Session token: URL-safe opaque token (`secrets.token_urlsafe(32)` — ~43 chars from 32 bytes of randomness), hashed (SHA-256) before storage
 - Cookie: `openrag_session` (httpOnly, Secure if HTTPS, SameSite=Lax, Path=/, no Domain=)
 - TTL: Aligned with `access_token_expires_at`; auto-refresh if `refresh_token` available (<60s before expiry)
 - Revocation: Via back-channel logout or manual invalidation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,31 +355,30 @@ OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environ
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `OIDC_EMAIL_SOURCE` | `id_token` | Claim source: `id_token` or `userinfo` |
+| `OIDC_CLAIM_SOURCE` | `id_token` | Where to read claims for claim mapping: `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
+| `OIDC_CLAIM_MAPPING` | (none) | CSV of `db_field:claim` pairs to sync IdP claims into the users row on every login (whitelist: `display_name`, `email`). Unset = no post-login update. |
 | `OIDC_SCOPES` | `openid email profile offline_access` | Space-separated scope list (include `offline_access` for refresh tokens) |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | `/` | URL to redirect after RP-initiated logout |
-| `OIDC_ALLOWED_EMAIL_DOMAINS` | (none) | CSV whitelist of email domains (e.g., `example.com,partner.org`) |
 
 **User Matching & Provisioning**:
 
-When a user logs in via OIDC:
-1. Lookup by `users.external_user_id = sub` (OIDC claim, stable identifier)
-2. Fallback: lookup by `users.email = email` claim
-3. On email match, backfill `external_user_id = sub` (first login only)
-4. If neither matches: reject with 403 (no auto-provisioning)
+When a user logs in via OIDC, matching is **exclusively** by `users.external_user_id == sub` (the stable OIDC claim). There is no email fallback and no auto-provisioning: if the `sub` is unknown, the callback returns `403 "User not registered"`. Admins MUST pre-create every user with the expected `external_user_id`.
 
-**Admin Pre-provisioning**: Admins must create users in the database with matching email (and optionally `external_user_id` if known). Example:
+Optionally, if `OIDC_CLAIM_MAPPING` is set, after a successful match the callback reads the configured claims (from the ID token or `/userinfo`, per `OIDC_CLAIM_SOURCE`) and updates the user row. The writable whitelist is strict — only `display_name` and `email` are allowed; `is_admin`, `external_user_id`, `file_quota`, `token` are never writable via claim mapping.
+
+**Admin Pre-provisioning**: Admins create users with the `external_user_id` matching the IdP's `sub` claim for that user. Example:
 ```bash
 curl -X POST http://localhost:8080/users/ \
   -H "Authorization: Bearer <AUTH_TOKEN>" \
   -H "Content-Type: application/json" \
-  -d '{"display_name": "Alice", "email": "alice@example.com", "is_admin": false}'
+  -d '{"display_name": "Alice", "external_user_id": "kc-alice-uuid", "is_admin": false}'
 ```
 
 **Database Schema**:
 
-New columns on `users` table:
-- `email` (String, unique, nullable): Email matching the `email` OIDC claim
+Columns on `users` table relevant to OIDC:
+- `external_user_id` (String, unique, nullable): Must equal the IdP's `sub` for OIDC matching
+- `email` (String, unique, nullable): Pure metadata; populated manually or via claim mapping. Not used for matching.
 
 New table `oidc_sessions`:
 - `session_token_hash` (unique): SHA-256 of the opaque session token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environ
 | `OIDC_CLAIM_SOURCE` | `id_token` | Where to read claims for claim mapping: `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
 | `OIDC_CLAIM_MAPPING` | (none) | CSV of `db_field:claim` pairs to sync IdP claims into the users row on every login (whitelist: `display_name`, `email`). Unset = no post-login update. |
 | `OIDC_SCOPES` | `openid email profile offline_access` | Space-separated scope list (include `offline_access` for refresh tokens) |
-| `OIDC_POST_LOGOUT_REDIRECT_URI` | `/` | URL to redirect after RP-initiated logout |
+| `OIDC_POST_LOGOUT_REDIRECT_URI` | — | URL the IdP sends the user to after RP-initiated logout. No default (an OpenRag URL would re-trigger OIDC login) |
 
 **User Matching & Provisioning**:
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ Once the app is up and running, visit `http://localhost:APP_PORT` or `http:X.X.X
 >[!NOTE]
 > Chainlit UI has no authentication by default. To enable it, follow the [dedicated guide](./docs/setup_chainlit_ui_auth.md). The same goes for chat data persistancy, enable it with this [guide](docs/chainlit_data_persistency.md)
 
+#### Authentication Modes
+
+OpenRag supports two authentication modes:
+
+- **Token Mode** (`AUTH_MODE=token`, default): Bearer token authentication via `Authorization: Bearer <AUTH_TOKEN>` header. Suitable for development and programmatic access.
+- **OIDC Mode** (`AUTH_MODE=oidc`): OpenID Connect flow with an external identity provider (Keycloak, LemonLDAP::NG, etc.). Users authenticate via browser redirect to the IdP.
+
+To enable OIDC, set `AUTH_MODE=oidc` and configure the required OIDC variables (see [`.env.example`](./.env.example) for the full list).
+
+For comprehensive OIDC setup and configuration, see the [OIDC Authentication Guide](./docs/oidc.md).
+
 3. `http://localhost:INDEXERUI_PORT` to access the indexer ui for easy document ingestion, indexing, and management
 
 #### 5. Distributed deployment in a Ray cluster

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,10 +10,14 @@ x-openrag: &openrag_template
     context: .
     dockerfile: Dockerfile
   extra_hosts:
-    # Let containers resolve hostnames defined in the host's /etc/hosts
-    # (e.g. auth.example.com for a local OIDC provider running on the host).
+    # Let containers reach services running on the Docker host via
+    # ``host.docker.internal`` (Linux Docker >= 20.10). Useful when an OIDC
+    # provider runs on the host in AUTH_MODE=oidc. If the IdP is behind a
+    # custom hostname resolved only in the host's /etc/hosts, add your own
+    # mapping via a ``docker-compose.override.yaml`` rather than editing this
+    # list — otherwise real external domains with the same name would be
+    # shadowed for other users.
     - "host.docker.internal:host-gateway"
-    - "auth.example.com:host-gateway"
   volumes:
     - ${DATA_VOLUME:-./data}:/app/data
     - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights # Model weights for RAG
@@ -100,8 +104,8 @@ services:
         condition: service_started
       milvus:
         condition: service_healthy
-      #vllm-gpu:
-      #  condition: service_healthy
+      vllm-gpu:
+        condition: service_healthy
 
   # No GPU
   openrag-cpu:
@@ -114,8 +118,8 @@ services:
         condition: service_started
       milvus:
         condition: service_healthy
-      #vllm-cpu:
-      #  condition: service_healthy
+      vllm-cpu:
+        condition: service_healthy
 
   rdb:
     image: postgres:15
@@ -127,48 +131,48 @@ services:
     expose:
       - 5432
 
-  #vllm-gpu:
-  #  <<: *vllm_template
-  #  image: vllm/vllm-openai:v0.9.2
-  #  environment:
-  #    <<: *vllm_env
-  #    NVIDIA_VISIBLE_DEVICES: all
-  #    NVIDIA_DRIVER_CAPABILITIES: compute,utility
-  #  runtime: nvidia
-  #  deploy:
-  #    resources:
-  #      reservations:
-  #        devices:
-  #          - driver: nvidia
-  #            count: all
-  #            capabilities: [gpu]
-  #  profiles:
-  #    - "" # Empty string gives default behavior (but does not run when cpu requested)
+  vllm-gpu:
+    <<: *vllm_template
+    image: vllm/vllm-openai:v0.9.2
+    environment:
+      <<: *vllm_env
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    profiles:
+      - "" # Empty string gives default behavior (but does not run when cpu requested)
 
-  #vllm-cpu:
-  #  <<: *vllm_template
-  #  build:
-  #    context: extern/vllm
-  #    dockerfile: Dockerfile.cpu
-  #    target: vllm-openai
-  #  image: openrag-vllm-openai-cpu
-  #  deploy: {}
-  #  environment:
-  #    <<: *vllm_env
-  #    VLLM_CPU_KVCACHE_SPACE: 8
-  #  # Default value isn't sufficient for full context length
-  #  command: >
-  #    --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
-  #    --trust-remote-code
-  #    --dtype float32
-  #    --max-model-len ${MAX_MODEL_LEN:-8192}
-  #  #  --max-num-batched-tokens 32768
-  #  # dtype is required for aarch64 (https://github.com/vllm-project/vllm/issues/11327) and improves speed on amd64.
-  #  # max-num-batched-tokens is required for aarch64 because chunked prefill isn't supported by V1 vllm backend
-  #  # for aarch64 yet. On aarch64 max-num-batched-tokens must be equal max-model-len for now (without chunked prefill).
-  #  # For details see https://github.com/vllm-project/vllm/issues/21179
-  #  profiles:
-  #    - "cpu"
+  vllm-cpu:
+    <<: *vllm_template
+    build:
+      context: extern/vllm
+      dockerfile: Dockerfile.cpu
+      target: vllm-openai
+    image: openrag-vllm-openai-cpu
+    deploy: {}
+    environment:
+      <<: *vllm_env
+      VLLM_CPU_KVCACHE_SPACE: 8
+    # Default value isn't sufficient for full context length
+    command: >
+      --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
+      --trust-remote-code
+      --dtype float32
+      --max-model-len ${MAX_MODEL_LEN:-8192}
+    #  --max-num-batched-tokens 32768
+    # dtype is required for aarch64 (https://github.com/vllm-project/vllm/issues/11327) and improves speed on amd64.
+    # max-num-batched-tokens is required for aarch64 because chunked prefill isn't supported by V1 vllm backend
+    # for aarch64 yet. On aarch64 max-num-batched-tokens must be equal max-model-len for now (without chunked prefill).
+    # For details see https://github.com/vllm-project/vllm/issues/21179
+    profiles:
+      - "cpu"
 
 networks:
   default:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,11 @@ x-openrag: &openrag_template
   build:
     context: .
     dockerfile: Dockerfile
+  extra_hosts:
+    # Let containers resolve hostnames defined in the host's /etc/hosts
+    # (e.g. auth.example.com for a local OIDC provider running on the host).
+    - "host.docker.internal:host-gateway"
+    - "auth.example.com:host-gateway"
   volumes:
     - ${DATA_VOLUME:-./data}:/app/data
     - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights # Model weights for RAG
@@ -69,6 +74,7 @@ services:
     environment:
       - API_BASE_URL=${API_BASE_URL:-http://localhost:${APP_PORT:-8080}}
       - INCLUDE_CREDENTIALS=${INCLUDE_CREDENTIALS:-false}
+      - AUTH_MODE=${AUTH_MODE:-token}
     ports:
       - "${INDEXERUI_PORT:-3042}:3000"
     restart: unless-stopped
@@ -94,8 +100,8 @@ services:
         condition: service_started
       milvus:
         condition: service_healthy
-      vllm-gpu:
-        condition: service_healthy
+      #vllm-gpu:
+      #  condition: service_healthy
 
   # No GPU
   openrag-cpu:
@@ -108,8 +114,8 @@ services:
         condition: service_started
       milvus:
         condition: service_healthy
-      vllm-cpu:
-        condition: service_healthy
+      #vllm-cpu:
+      #  condition: service_healthy
 
   rdb:
     image: postgres:15
@@ -121,48 +127,48 @@ services:
     expose:
       - 5432
 
-  vllm-gpu:
-    <<: *vllm_template
-    image: vllm/vllm-openai:v0.9.2
-    environment:
-      <<: *vllm_env
-      NVIDIA_VISIBLE_DEVICES: all
-      NVIDIA_DRIVER_CAPABILITIES: compute,utility
-    runtime: nvidia
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-    profiles:
-      - "" # Empty string gives default behavior (but does not run when cpu requested)
+  #vllm-gpu:
+  #  <<: *vllm_template
+  #  image: vllm/vllm-openai:v0.9.2
+  #  environment:
+  #    <<: *vllm_env
+  #    NVIDIA_VISIBLE_DEVICES: all
+  #    NVIDIA_DRIVER_CAPABILITIES: compute,utility
+  #  runtime: nvidia
+  #  deploy:
+  #    resources:
+  #      reservations:
+  #        devices:
+  #          - driver: nvidia
+  #            count: all
+  #            capabilities: [gpu]
+  #  profiles:
+  #    - "" # Empty string gives default behavior (but does not run when cpu requested)
 
-  vllm-cpu:
-    <<: *vllm_template
-    build:
-      context: extern/vllm
-      dockerfile: Dockerfile.cpu
-      target: vllm-openai
-    image: openrag-vllm-openai-cpu
-    deploy: {}
-    environment:
-      <<: *vllm_env
-      VLLM_CPU_KVCACHE_SPACE: 8
-    # Default value isn't sufficient for full context length
-    command: >
-      --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
-      --trust-remote-code
-      --dtype float32
-      --max-model-len ${MAX_MODEL_LEN:-8192}
-    #  --max-num-batched-tokens 32768
-    # dtype is required for aarch64 (https://github.com/vllm-project/vllm/issues/11327) and improves speed on amd64.
-    # max-num-batched-tokens is required for aarch64 because chunked prefill isn't supported by V1 vllm backend
-    # for aarch64 yet. On aarch64 max-num-batched-tokens must be equal max-model-len for now (without chunked prefill).
-    # For details see https://github.com/vllm-project/vllm/issues/21179
-    profiles:
-      - "cpu"
+  #vllm-cpu:
+  #  <<: *vllm_template
+  #  build:
+  #    context: extern/vllm
+  #    dockerfile: Dockerfile.cpu
+  #    target: vllm-openai
+  #  image: openrag-vllm-openai-cpu
+  #  deploy: {}
+  #  environment:
+  #    <<: *vllm_env
+  #    VLLM_CPU_KVCACHE_SPACE: 8
+  #  # Default value isn't sufficient for full context length
+  #  command: >
+  #    --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
+  #    --trust-remote-code
+  #    --dtype float32
+  #    --max-model-len ${MAX_MODEL_LEN:-8192}
+  #  #  --max-num-batched-tokens 32768
+  #  # dtype is required for aarch64 (https://github.com/vllm-project/vllm/issues/11327) and improves speed on amd64.
+  #  # max-num-batched-tokens is required for aarch64 because chunked prefill isn't supported by V1 vllm backend
+  #  # for aarch64 yet. On aarch64 max-num-batched-tokens must be equal max-model-len for now (without chunked prefill).
+  #  # For details see https://github.com/vllm-project/vllm/issues/21179
+  #  profiles:
+  #    - "cpu"
 
 networks:
   default:

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -110,7 +110,7 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_CLAIM_SOURCE` | No | `id_token` | Where to read claims for [Claim Mapping](#claim-mapping-optional): `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
 | `OIDC_CLAIM_MAPPING` | No | — | Optional CSV of `db_field:claim` pairs to copy claims into user fields on every login (e.g., `display_name:name,email:email`). See [Claim Mapping](#claim-mapping-optional). |
 | `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
-| `OIDC_POST_LOGOUT_REDIRECT_URI` | No | `/` | URL to redirect to after RP-initiated logout |
+| `OIDC_POST_LOGOUT_REDIRECT_URI` | No | — | URL the IdP sends the user to after RP-initiated logout. **No default**: if unset AND the IdP doesn't have an `end_session_endpoint`, `/auth/logout` returns a plain 200 confirming the logout. Avoid pointing this to an OpenRag URL (triggers re-auth — silent SSO loop). |
 
 \* Required when `AUTH_MODE=oidc`
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,0 +1,739 @@
+# OpenID Connect (OIDC) Authentication Guide
+
+This guide walks you through configuring and using OpenRag's OIDC authentication mode.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Configuration](#configuration)
+4. [User Pre-provisioning](#user-pre-provisioning)
+5. [Keycloak Setup](#keycloak-setup)
+6. [LemonLDAP::NG Setup](#lemonldapng-setup)
+7. [Programmatic Access](#programmatic-access)
+8. [Back-Channel Logout](#back-channel-logout)
+9. [Troubleshooting](#troubleshooting)
+10. [Security Considerations](#security-considerations)
+
+---
+
+## Overview
+
+OpenRag supports two authentication modes:
+
+- **Token Mode** (`AUTH_MODE=token`, default): Traditional Bearer token authentication. Suitable for development and programmatic access.
+- **OIDC Mode** (`AUTH_MODE=oidc`): OpenID Connect Authorization Code + PKCE flow. Users authenticate via an external identity provider (IdP), and the UI receives a browser-managed session cookie.
+
+### When to Use OIDC
+
+Use OIDC when:
+- Your organization uses a centralized identity provider (Keycloak, Azure AD, Okta, LemonLDAP::NG, etc.)
+- You want users to authenticate through a familiar corporate login
+- You need federated identity and single sign-on (SSO) across multiple systems
+- You want to leverage existing user directories (LDAP, Active Directory, SAML)
+
+Use Token Mode when:
+- Running in development or testing
+- Your application is purely backend/programmatic
+- You prefer simplicity without external dependencies
+- You're integrating with headless tools (CI/CD, SDKs, etc.)
+
+---
+
+## Architecture
+
+### Authentication Flow Diagram
+
+```
+Browser              OpenRag           IdP (Keycloak)
+   |                   |                    |
+   |-- GET /chainlit -->|                   |
+   |<- 302 /auth/login  |                   |
+   |-- GET /auth/login->|                   |
+   |                    | [gen state/nonce/PKCE,
+   |                    |  pose cookie (5 min)]
+   |<-302 authorize-----|                   |
+   |----------- authorize?client_id=&state=&code_challenge=-------->|
+   |<------ login form --------------------------------|
+   |------- username/password ----------------------->|
+   |<------ 302 /auth/callback?code=&state=----------|
+   |-- GET /auth/callback->|                   |
+   |                    |---token exchange --->|
+   |                    |<-- id_token, access_token, refresh_token --|
+   |                    | [verify signature, nonce, claims;
+   |                    |  extract email; match user;
+   |                    |  create oidc_sessions row;
+   |                    |  set openrag_session cookie]
+   |<--302 next_url-----|                   |
+   |-- GET /chainlit --->|                   |
+   |                    | [session OK]
+   |<-- 200 Chainlit UI--|                   |
+```
+
+### Key Components
+
+**`openrag/components/auth/` package:**
+- `oidc_client.py` — Authlib-based OIDC client (discovery, JWKS, token exchange, verification)
+- `session_tokens.py` — Session token generation and Fernet encryption/decryption
+- `state_cookie.py` — Temporary cookie (5 min TTL) for transporting `state`, `nonce`, `code_verifier`
+- `middleware.py` — Modified `AuthMiddleware` supporting cookie + bearer + lazy refresh
+- `refresh.py` — Lazy access token refresh logic
+
+**`openrag/routers/auth.py`:**
+- `/auth/login` — Start Authorization Code + PKCE flow
+- `/auth/callback` — Handle IdP redirect, create session
+- `/auth/backchannel-logout` — IdP-driven revocation (OIDC spec)
+- `/auth/logout` — RP-initiated logout (local + IdP)
+- `/auth/me` — Debug endpoint (returns current user + session expiry)
+
+**Database:**
+- New `oidc_sessions` table: stores encrypted IdP tokens, session metadata, revocation status
+- New `email` column on `users` table: unique index for matching users by email claim
+
+---
+
+## Configuration
+
+### Environment Variables
+
+All variables must be set when `AUTH_MODE=oidc`. If any required variable is missing, the application refuses to start.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AUTH_MODE` | No | `token` | Set to `oidc` to enable OIDC authentication |
+| `OIDC_ENDPOINT` | Yes* | — | Issuer URL (auto-discovery via `/.well-known/openid-configuration`) |
+| `OIDC_CLIENT_ID` | Yes* | — | Client ID registered at the IdP |
+| `OIDC_CLIENT_SECRET` | Yes* | — | Client secret (confidential clients only) |
+| `OIDC_REDIRECT_URI` | Yes* | — | Callback URL, must match IdP configuration (e.g., `https://openrag.example.com/auth/callback`) |
+| `OIDC_TOKEN_ENCRYPTION_KEY` | Yes* | — | Fernet key for encrypting tokens at rest (see [Generating the Fernet Key](#generating-the-fernet-key)) |
+| `OIDC_EMAIL_SOURCE` | No | `id_token` | Where to extract the `email` claim: `id_token` (from JWT) or `userinfo` (from `/userinfo` endpoint) |
+| `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
+| `OIDC_POST_LOGOUT_REDIRECT_URI` | No | `/` | URL to redirect to after RP-initiated logout |
+| `OIDC_ALLOWED_EMAIL_DOMAINS` | No | — | Optional CSV list of email domain whitelist (e.g., `example.com,partner.org`) |
+
+\* Required when `AUTH_MODE=oidc`
+
+### Generating the Fernet Key
+
+Generate a cryptographically secure key for token encryption:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Output example:
+```
+XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
+```
+
+Store this key securely (e.g., in a secrets manager). Never commit it to version control.
+
+### Example Configuration
+
+Create a `.env` file (or set these environment variables):
+
+```bash
+# Token mode (default)
+AUTH_MODE=token
+AUTH_TOKEN=sk-or-change-me
+
+# OR, OIDC mode
+AUTH_MODE=oidc
+
+# OIDC configuration (Keycloak example)
+OIDC_ENDPOINT=https://idp.example.com/realms/openrag
+OIDC_CLIENT_ID=openrag
+OIDC_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxx
+OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+OIDC_TOKEN_ENCRYPTION_KEY=XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
+OIDC_EMAIL_SOURCE=id_token
+OIDC_SCOPES=openid email profile offline_access
+OIDC_POST_LOGOUT_REDIRECT_URI=/
+# OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
+```
+
+---
+
+## User Pre-provisioning
+
+OIDC requires users to be pre-provisioned in OpenRag's database. There is **no automatic user creation** on login.
+
+### Admin Pre-provisioning
+
+Admins must create users with email matching the OIDC `email` claim **before** users attempt to log in.
+
+**Create a user via API:**
+
+```bash
+curl -X POST http://localhost:8080/users/ \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Alice Cooper",
+    "email": "alice@example.com",
+    "is_admin": false
+  }'
+```
+
+**Response** (returns the token once):
+```json
+{
+  "id": 42,
+  "display_name": "Alice Cooper",
+  "email": "alice@example.com",
+  "external_user_id": null,
+  "is_admin": false,
+  "token": "or-xxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+**Pre-fill `external_user_id` (optional):**
+
+If you know the user's OIDC `sub` claim in advance (e.g., from a Keycloak export or LDAP directory), you can set `external_user_id` directly:
+
+```bash
+curl -X POST http://localhost:8080/users/ \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Bob Smith",
+    "email": "bob@example.com",
+    "external_user_id": "550e8400-e29b-41d4-a716-446655440000",
+    "is_admin": false
+  }'
+```
+
+This skips the email-matching step on first login; the OIDC `sub` claim is checked directly.
+
+### Bulk User Provisioning
+
+For bulk imports, write a script that calls `/users/` in a loop:
+
+```python
+import requests
+import json
+
+auth_token = "sk-your-token"
+headers = {
+    "Authorization": f"Bearer {auth_token}",
+    "Content-Type": "application/json"
+}
+
+users = [
+    {"display_name": "Alice", "email": "alice@example.com"},
+    {"display_name": "Bob", "email": "bob@example.com"},
+    {"display_name": "Charlie", "email": "charlie@example.com"},
+]
+
+base_url = "http://localhost:8080"
+
+for user in users:
+    response = requests.post(f"{base_url}/users/", headers=headers, json=user)
+    print(f"Created {user['display_name']}: {response.json()}")
+```
+
+---
+
+## Keycloak Setup
+
+[Keycloak](https://www.keycloak.org/) is a popular open-source identity provider. This section walks through a typical Keycloak configuration.
+
+### Prerequisites
+
+- Keycloak 20+ (or latest)
+- Network connectivity between OpenRag and Keycloak
+- Admin access to Keycloak
+
+### Step 1: Create a Realm
+
+1. Log into Keycloak Admin Console (e.g., `http://localhost:8081/admin`)
+2. Click **Create Realm** (top left)
+3. Enter realm name: `openrag`
+4. Click **Create**
+
+### Step 2: Create a Client (Confidential)
+
+1. In the realm `openrag`, navigate to **Clients** (left sidebar)
+2. Click **Create client**
+3. Set **Client ID**: `openrag`
+4. Leave **Client Type**: `OpenID Connect`
+5. Click **Next**
+6. Enable:
+   - **Client authentication**: ON (confidential client)
+   - **Authorization**: ON
+7. Click **Next**
+8. **Valid redirect URIs**: Add `https://openrag.example.com/auth/callback` (replace with your actual URL)
+9. **Valid post logout redirect URIs**: Add `https://openrag.example.com/` (or your home page)
+10. **Backchannel logout URL**: Add `https://openrag.example.com/auth/backchannel-logout`
+11. **Backchannel logout session required**: ON
+12. Click **Save**
+
+### Step 3: Configure Scopes
+
+1. Navigate to **Clients** → `openrag` → **Client scopes**
+2. Ensure these default scopes are assigned:
+   - `email` — includes email claim
+   - `profile` — includes name claims
+   - `offline_access` — allows refresh tokens
+3. Click **Save**
+
+### Step 4: Get Client Credentials
+
+1. Navigate to **Clients** → `openrag` → **Credentials** tab
+2. Copy **Client secret**
+3. Use this in `OIDC_CLIENT_SECRET` env var
+
+### Step 5: Configure OpenRag
+
+In `.env`:
+
+```bash
+AUTH_MODE=oidc
+OIDC_ENDPOINT=http://keycloak.example.com/realms/openrag
+OIDC_CLIENT_ID=openrag
+OIDC_CLIENT_SECRET=<paste-secret-from-step-4>
+OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+OIDC_TOKEN_ENCRYPTION_KEY=<generate-via-python-script>
+OIDC_EMAIL_SOURCE=id_token
+OIDC_SCOPES=openid email profile offline_access
+```
+
+### Step 6: Create Test User in Keycloak
+
+1. Navigate to **Users** (left sidebar)
+2. Click **Create new user**
+3. **Username**: `testuser`
+4. **Email**: `testuser@example.com`
+5. **First name**: `Test`
+6. **Last name**: `User`
+7. Click **Create**
+8. Go to **Credentials** tab, set a password for testing
+9. Ensure **Temporary** is OFF (so user can log in immediately)
+
+### Step 7: Pre-provision User in OpenRag
+
+```bash
+curl -X POST http://localhost:8080/users/ \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Test User",
+    "email": "testuser@example.com",
+    "is_admin": false
+  }'
+```
+
+### Step 8: Test the Flow
+
+1. Navigate to `http://localhost:8080/chainlit` (or your app URL)
+2. Expect: 302 redirect to `/auth/login`
+3. Expect: 302 redirect to Keycloak (`http://keycloak.example.com/realms/openrag/protocol/openid-connect/auth?...`)
+4. Log in with `testuser` / `<password>`
+5. Expect: 302 redirect back to `/auth/callback?code=...`
+6. Expect: 302 redirect to `/chainlit` or `next_url`
+7. Should be authenticated
+
+**Troubleshooting Keycloak**:
+
+- **"Invalid redirect URI"**: Ensure `OIDC_REDIRECT_URI` exactly matches what's configured in Keycloak **Clients** → **Valid redirect URIs**.
+- **"Client secret mismatch"**: Copy the secret again from **Credentials** tab.
+- **"Invalid scope"**: Ensure `email` and `offline_access` are in the client's scope mappings.
+
+---
+
+## LemonLDAP::NG Setup
+
+[LemonLDAP::NG](https://www.lemonldap-ng.org/) is another OIDC provider, often used in enterprise environments with LDAP/AD integration.
+
+### Configuration Mapping
+
+LemonLDAP::NG uses different terminology. Map these OpenRag variables to LLNG config:
+
+| OpenRag Variable | LLNG Parameter | Example |
+|---|---|---|
+| `OIDC_ENDPOINT` | `OIDCServiceMetaDataIssuer` | `https://llng.example.com` |
+| `OIDC_CLIENT_ID` | `OIDCServiceMetaDataClientID` | `openrag` |
+| `OIDC_CLIENT_SECRET` | `OIDCServiceMetaDataClientSecret` | (from LLNG admin) |
+| `OIDC_REDIRECT_URI` | `OIDCServiceMetaDataRedirectUris` | `https://openrag.example.com/auth/callback` |
+
+### Steps
+
+1. **Create an OIDC relying party in LLNG admin**:
+   - Go to LLNG admin console
+   - Navigate to **Applications** → **OpenID Connect Relying Parties**
+   - Create a new relying party named `openrag`
+   - Set **Client ID**: `openrag`
+   - Set **Redirect URI**: `https://openrag.example.com/auth/callback`
+   - Set **Post-logout URI**: `https://openrag.example.com/`
+   - Generate/retrieve the client secret
+
+2. **Configure OpenRag .env**:
+
+```bash
+AUTH_MODE=oidc
+OIDC_ENDPOINT=https://llng.example.com
+OIDC_CLIENT_ID=openrag
+OIDC_CLIENT_SECRET=<secret-from-llng>
+OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+OIDC_TOKEN_ENCRYPTION_KEY=<generate-via-python>
+OIDC_EMAIL_SOURCE=id_token
+OIDC_SCOPES=openid email profile offline_access
+```
+
+3. **Pre-provision users** (via `/users/` API, same as Keycloak)
+
+4. **Test**: Navigate to OpenRag, should redirect to LLNG login
+
+For LLNG-specific questions, consult the [LLNG documentation](https://www.lemonldap-ng.org/documentation).
+
+---
+
+## Programmatic Access
+
+Even in OIDC mode, **Bearer token authentication is still supported** for programmatic access (CI/CD, SDKs, scripts, tests).
+
+### Using `users.token` in OIDC Mode
+
+Each user has a `users.token` column (same as token mode). Clients can use this for programmatic access:
+
+```bash
+curl -H "Authorization: Bearer or-xxxxxxxxxxxxxxxxxxxxxxxx" \
+  http://openrag.example.com/v1/models
+```
+
+This bypasses the OIDC/session cookie flow entirely, suitable for:
+- CI/CD pipelines uploading documents
+- Python/JavaScript SDK clients
+- Test automation
+- Headless microservices
+
+### Getting a User's API Token
+
+Admin retrieves a user's token:
+
+```bash
+curl -X GET http://localhost:8080/users/42 \
+  -H "Authorization: Bearer ${AUTH_TOKEN}"
+```
+
+**Note**: The token is hidden in normal responses (security). To get it, use:
+
+```bash
+curl -X POST http://localhost:8080/users/42/regenerate_token \
+  -H "Authorization: Bearer ${AUTH_TOKEN}"
+```
+
+This returns a fresh token (old one invalidated).
+
+### Example: Upload Documents via CI/CD
+
+```bash
+#!/bin/bash
+OPENRAG_URL="https://openrag.example.com"
+API_TOKEN="or-xxxxxxxxxxxxxxxxxxxxxxxx"
+PARTITION_NAME="documents"
+
+curl -X POST "${OPENRAG_URL}/indexer/add_file" \
+  -H "Authorization: Bearer ${API_TOKEN}" \
+  -F "file=@document.pdf" \
+  -F "partition=${PARTITION_NAME}"
+```
+
+---
+
+## Back-Channel Logout
+
+Back-channel logout is part of the OIDC standard. When a user logs out from the IdP or an admin terminates their session, the IdP can notify OpenRag to revoke the session.
+
+### How It Works
+
+1. User logs out from Keycloak (or is logged out by admin)
+2. Keycloak sends a `POST` request to `https://openrag.example.com/auth/backchannel-logout` with a signed JWT `logout_token`
+3. OpenRag verifies the JWT signature and extracts the `sid` claim
+4. All `oidc_sessions` rows with matching `sid` are marked `revoked_at = now()`
+5. OpenRag responds with `200 OK`
+6. Next time the user tries to use an old session cookie, the middleware sees `revoked_at` is set and redirects to login
+
+### IdP Configuration
+
+**Keycloak:**
+
+1. **Clients** → `openrag` → **Settings**
+2. Enable **Backchannel logout session required**: ON
+3. Set **Backchannel logout URL**: `https://openrag.example.com/auth/backchannel-logout`
+4. Click **Save**
+
+**LemonLDAP::NG:**
+
+1. Set the backchannel logout URL in the relying party configuration
+2. Consult LLNG docs for exact steps
+
+### Request Format
+
+The IdP sends:
+
+```
+POST /auth/backchannel-logout HTTP/1.1
+Host: openrag.example.com
+Content-Type: application/x-www-form-urlencoded
+
+logout_token=eyJhbGc...
+```
+
+**`logout_token`** is a signed JWT with claims:
+```json
+{
+  "iss": "https://idp.example.com/realms/openrag",
+  "sub": "user-sub",
+  "sid": "session-id",
+  "aud": "openrag",
+  "iat": 1234567890,
+  "exp": 1234571490,
+  "events": {
+    "http://schemas.openid.net/event/backchannel-logout": {}
+  }
+}
+```
+
+OpenRag:
+1. Fetches the IdP's JWKS (via auto-discovery)
+2. Verifies the JWT signature, `iss`, `aud`, `exp`, `iat`
+3. Checks the `events` claim contains the logout event
+4. Extracts `sid` and revokes matching sessions
+5. Returns `200 OK` or `400 Bad Request` if validation fails
+
+### Testing Back-Channel Logout
+
+Create a signed logout token manually (advanced):
+
+```python
+import jwt
+import json
+from datetime import datetime, timedelta
+
+# Keycloak realm public key (from /.well-known/openid-configuration -> jwks_uri)
+# For testing, sign with a private key
+
+payload = {
+    "iss": "https://idp.example.com/realms/openrag",
+    "sub": "user-sub",
+    "sid": "session-id-from-openrag",
+    "aud": "openrag",
+    "iat": int(datetime.utcnow().timestamp()),
+    "exp": int((datetime.utcnow() + timedelta(minutes=5)).timestamp()),
+    "events": {
+        "http://schemas.openid.net/event/backchannel-logout": {}
+    }
+}
+
+token = jwt.encode(payload, "your-private-key", algorithm="RS256")
+print(token)
+```
+
+Then send:
+
+```bash
+curl -X POST http://localhost:8080/auth/backchannel-logout \
+  -d "logout_token=${token}" \
+  -H "Content-Type: application/x-www-form-urlencoded"
+```
+
+Expect `200 OK`.
+
+---
+
+## Troubleshooting
+
+### 1. "OIDC_TOKEN_ENCRYPTION_KEY is not set"
+
+**Error**: Application refuses to start when `AUTH_MODE=oidc`.
+
+**Solution**: Generate and set the key:
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+export OIDC_TOKEN_ENCRYPTION_KEY=<paste-key>
+```
+
+### 2. "Issuer mismatch" at discovery
+
+**Error**: Backend logs show `Issuer mismatch: configured '…', got '…'` and `/auth/login` returns 500 "OIDC discovery failed".
+
+**Cause**: OpenRag enforces **byte-for-byte equality** between `OIDC_ENDPOINT`, the `issuer` field returned by the IdP's discovery document, and the `iss` claim in tokens — per OIDC Core §2. The most common culprit is a **trailing slash mismatch**:
+
+| IdP | Typical issuer form |
+|-----|---------------------|
+| Keycloak | `https://kc.example.com/realms/myrealm` (no trailing slash) |
+| LemonLDAP::NG | `https://llng.example.com/` (WITH trailing slash) |
+| Auth0 | `https://tenant.auth0.com/` (WITH trailing slash) |
+| Google | `https://accounts.google.com` (no trailing slash) |
+
+**Solution**: Configure `OIDC_ENDPOINT` to match the IdP's advertised issuer **exactly**. To check what the IdP actually returns:
+
+```bash
+curl -s http://your-idp/.well-known/openid-configuration | jq -r .issuer
+```
+
+Copy that string verbatim (including or excluding the trailing `/`) into `.env`:
+
+```
+OIDC_ENDPOINT=<exact string from jq output>
+```
+
+OpenRag builds the discovery URL by stripping any trailing slash internally, so both forms work for discovery — but the subsequent token-claim validation is strict.
+
+### 3. "Invalid redirect URI"
+
+**Error**: IdP rejects the callback with "Invalid redirect URI" or similar.
+
+**Solution**: 
+- Ensure `OIDC_REDIRECT_URI` matches exactly what's configured in the IdP (case-sensitive, trailing slashes matter)
+- Example: `https://openrag.example.com/auth/callback` (NOT `https://openrag.example.com/auth/callback/`)
+- Keycloak: **Clients** → **Valid redirect URIs**
+
+### 4. "email claim not found"
+
+**Error**: User logs in successfully, but OpenRag responds with 403 "email not found in claims".
+
+**Solution**:
+- Set `OIDC_EMAIL_SOURCE=userinfo` if `email` is not in the ID token
+- Or, ask IdP admin to include `email` scope in the token
+- Verify the IdP is returning `email` claim via OIDC `/userinfo` endpoint:
+```bash
+curl -H "Authorization: Bearer <access_token>" \
+  https://idp.example.com/realms/openrag/protocol/openid-connect/userinfo
+```
+
+### 5. "external_user_id mismatch"
+
+**Error**: User with `external_user_id=A` tries to log in, but OIDC `sub=B`.
+
+**Cause**: The user's `external_user_id` was set to one value, but the IdP's `sub` claim changed (e.g., user was re-imported or IdP was reconfigured).
+
+**Solution**:
+- If intentional (user switched IdPs), clear the old `external_user_id`:
+```bash
+curl -X PATCH http://localhost:8080/users/42 \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"external_user_id": null}'
+```
+- Then log in again; the new `sub` will be backfilled
+
+### 6. "email domain not whitelisted"
+
+**Error**: User logs in, but OpenRag responds with 403 "email domain not whitelisted".
+
+**Solution**:
+- Set `OIDC_ALLOWED_EMAIL_DOMAINS` to allow the user's domain:
+```bash
+export OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
+```
+- Or, empty it to allow any domain
+
+### 6. "session not found" or "session expired"
+
+**Error**: User can log in once, but subsequent requests show "unauthenticated".
+
+**Cause**: Session cookie was lost or expired.
+
+**Solution**:
+- Ensure cookies are enabled in browser
+- Check `openrag_session` cookie exists and is not marked `revoked_at` in DB
+- Increase `access_token_expires_at` via OIDC scopes (`offline_access` + longer TTL in IdP)
+
+### 7. "clock skew" or "token not yet valid"
+
+**Error**: "iat claim is in the future" or "exp claim is in the past".
+
+**Solution**:
+- Sync system clocks between OpenRag and IdP servers
+- Check NTP is running: `ntpq -p`
+
+### 8. "invalid scope: offline_access"
+
+**Error**: OIDC client redirect fails with "Invalid scope requested: offline_access".
+
+**Solution**:
+- Keycloak: Ensure `offline_access` scope is mapped to the client
+  - **Clients** → `openrag` → **Client scopes** → Verify `offline_access` is in the assigned scopes
+- LemonLDAP::NG: Check the OIDC relying party configuration includes `offline_access`
+
+---
+
+## Security Considerations
+
+### Cookie Security
+
+- **httpOnly**: Cookies are marked `httpOnly`, preventing JavaScript access (XSS mitigation)
+- **Secure**: In production (HTTPS), cookies are marked `Secure` (only sent over HTTPS)
+- **SameSite=Lax**: CSRF protection; allows top-level navigation but not cross-site subresource requests
+- **Path=/**: Cookies sent for all paths
+- **No Domain**: Host-only (not shared with subdomains)
+
+### Token Encryption at Rest
+
+- Access tokens and refresh tokens are encrypted using **Fernet** (symmetric encryption) before storage in the database
+- The key (`OIDC_TOKEN_ENCRYPTION_KEY`) must be kept secret
+- If the key is compromised, regenerate it and re-encrypt all sessions (manual process in v1; planned for v2)
+
+### Token Rotation
+
+- Access tokens have a short expiry (typically 5-15 minutes)
+- Refresh tokens have a longer expiry (typically hours or days, configured in IdP)
+- Middleware automatically refreshes access tokens when <60 seconds remain before expiry (lazy refresh)
+- No extra API calls for users; happens transparently
+
+### CSRF Mitigation
+
+- Authorization requests use a server-generated `state` parameter
+- The `state` is stored in a temporary, signed cookie (`idp_state`, 5-minute TTL)
+- The callback validates that the returned `state` matches the cookie
+- Prevents CSRF attacks on the callback endpoint
+
+### Replay Protection
+
+- **PKCE** (Proof Key for Code Exchange):
+  - Client generates a `code_verifier` (43-128 character random string)
+  - Client computes `code_challenge = BASE64URL(SHA256(code_verifier))`
+  - Client sends `code_challenge` in the authorization request
+  - Callback sends `code_verifier` in the token exchange request
+  - IdP verifies they match, preventing authorization code interception
+- **Nonce**:
+  - Client generates a random `nonce`
+  - Included in the authorization request and returned in the ID token
+  - Callback verifies the nonce matches, preventing token replay
+
+### Breach Scenarios
+
+| Breach | Impact | Mitigation |
+|--------|--------|-----------|
+| OIDC_TOKEN_ENCRYPTION_KEY leaked | All encrypted tokens (access, refresh) decryptable | Rotate key + re-encrypt sessions (v2 feature) |
+| Authorization code intercepted | Code is single-use + PKCE prevents exchange without code_verifier | PKCE enforced |
+| Session cookie stolen (XSS) | Attacker can impersonate user in browser | httpOnly prevents JavaScript access; SameSite limits scope; session revocation via back-channel logout |
+| IdP tokens (access/refresh) leaked | Attacker can call IdP on behalf of user | Refresh tokens are short-lived; access tokens are encrypted at rest |
+| `state` cookie stolen | Attacker can forge authorization requests | `state` is signed (itsdangerous); 5-minute TTL |
+
+### Best Practices
+
+1. **Use HTTPS in production** — Secure and httpOnly cookies require HTTPS
+2. **Rotate encryption keys periodically** (v2 feature; manual rotation needed in v1)
+3. **Monitor back-channel logout requests** — Ensure IdP is sending them
+4. **Set reasonable token lifetimes** in the IdP (e.g., 15-minute access tokens, 7-day refresh tokens)
+5. **Use strong OIDC scopes** — Request only what you need (e.g., `openid email` vs. `openid email profile`)
+6. **Audit user access** — Log all authentication and authorization events
+7. **Implement a password policy** in the IdP
+8. **Enforce MFA** in the IdP for sensitive users
+
+---
+
+## Additional Resources
+
+- [OpenID Connect Core 1.0 Specification](https://openid.net/specs/openid-connect-core-1_0.html)
+- [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html)
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [LemonLDAP::NG Documentation](https://www.lemonldap-ng.org/documentation)
+- [Authlib Documentation](https://docs.authlib.org/)
+
+---
+
+**Last Updated**: 2026-04-17

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -721,7 +721,7 @@ Server logs record the attempted `sub` at `WARNING` level so admins can copy it 
 ### CSRF Mitigation
 
 - Authorization requests use a server-generated `state` parameter
-- The `state` is stored in a temporary, signed cookie (`idp_state`, 5-minute TTL)
+- The `state` is stored in a temporary, itsdangerous-signed cookie (`openrag_oidc_state`, 10-minute TTL)
 - The callback validates that the returned `state` matches the cookie
 - Prevents CSRF attacks on the callback endpoint
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -60,8 +60,9 @@ Browser              OpenRag           IdP (Keycloak)
    |-- GET /auth/callback->|                   |
    |                    |---token exchange --->|
    |                    |<-- id_token, access_token, refresh_token --|
-   |                    | [verify signature, nonce, claims;
-   |                    |  extract email; match user;
+   |                    | [verify signature, nonce, iss, aud;
+   |                    |  match user by external_user_id=sub;
+   |                    |  (optional) apply OIDC_CLAIM_MAPPING;
    |                    |  create oidc_sessions row;
    |                    |  set openrag_session cookie]
    |<--302 next_url-----|                   |
@@ -88,7 +89,7 @@ Browser              OpenRag           IdP (Keycloak)
 
 **Database:**
 - New `oidc_sessions` table: stores encrypted IdP tokens, session metadata, revocation status
-- New `email` column on `users` table: unique index for matching users by email claim
+- `email` column on `users` table: optional metadata, NOT used for matching (matching is exclusively by `external_user_id == sub`)
 
 ---
 
@@ -106,10 +107,10 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_CLIENT_SECRET` | Yes* | — | Client secret (confidential clients only) |
 | `OIDC_REDIRECT_URI` | Yes* | — | Callback URL, must match IdP configuration (e.g., `https://openrag.example.com/auth/callback`) |
 | `OIDC_TOKEN_ENCRYPTION_KEY` | Yes* | — | Fernet key for encrypting tokens at rest (see [Generating the Fernet Key](#generating-the-fernet-key)) |
-| `OIDC_EMAIL_SOURCE` | No | `id_token` | Where to extract the `email` claim: `id_token` (from JWT) or `userinfo` (from `/userinfo` endpoint) |
+| `OIDC_CLAIM_SOURCE` | No | `id_token` | Where to read claims for [Claim Mapping](#claim-mapping-optional): `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
+| `OIDC_CLAIM_MAPPING` | No | — | Optional CSV of `db_field:claim` pairs to copy claims into user fields on every login (e.g., `display_name:name,email:email`). See [Claim Mapping](#claim-mapping-optional). |
 | `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | No | `/` | URL to redirect to after RP-initiated logout |
-| `OIDC_ALLOWED_EMAIL_DOMAINS` | No | — | Optional CSV list of email domain whitelist (e.g., `example.com,partner.org`) |
 
 \* Required when `AUTH_MODE=oidc`
 
@@ -146,23 +147,22 @@ OIDC_CLIENT_ID=openrag
 OIDC_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxx
 OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
 OIDC_TOKEN_ENCRYPTION_KEY=XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
-OIDC_EMAIL_SOURCE=id_token
 OIDC_SCOPES=openid email profile offline_access
 OIDC_POST_LOGOUT_REDIRECT_URI=/
-# OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
+# Optional — sync display name and email from IdP on every login:
+# OIDC_CLAIM_SOURCE=id_token      # or 'userinfo'
+# OIDC_CLAIM_MAPPING=display_name:name,email:email
 ```
 
 ---
 
 ## User Pre-provisioning
 
-OIDC requires users to be pre-provisioned in OpenRag's database. There is **no automatic user creation** on login.
+OIDC requires users to be pre-provisioned in OpenRag's database. There is **no automatic user creation** on login. User matching is performed **exclusively** by `external_user_id == sub`: the admin MUST set each user's `external_user_id` to the exact OIDC `sub` claim the IdP will emit for that user.
 
 ### Admin Pre-provisioning
 
-Admins must create users with email matching the OIDC `email` claim **before** users attempt to log in.
-
-**Create a user via API:**
+**Create a user with `external_user_id`:**
 
 ```bash
 curl -X POST http://localhost:8080/users/ \
@@ -170,59 +170,44 @@ curl -X POST http://localhost:8080/users/ \
   -H "Content-Type: application/json" \
   -d '{
     "display_name": "Alice Cooper",
-    "email": "alice@example.com",
-    "is_admin": false
-  }'
-```
-
-**Response** (returns the token once):
-```json
-{
-  "id": 42,
-  "display_name": "Alice Cooper",
-  "email": "alice@example.com",
-  "external_user_id": null,
-  "is_admin": false,
-  "token": "or-xxxxxxxxxxxxxxxxxxxxxxxx"
-}
-```
-
-**Pre-fill `external_user_id` (optional):**
-
-If you know the user's OIDC `sub` claim in advance (e.g., from a Keycloak export or LDAP directory), you can set `external_user_id` directly:
-
-```bash
-curl -X POST http://localhost:8080/users/ \
-  -H "Authorization: Bearer ${AUTH_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "display_name": "Bob Smith",
-    "email": "bob@example.com",
     "external_user_id": "550e8400-e29b-41d4-a716-446655440000",
     "is_admin": false
   }'
 ```
 
-This skips the email-matching step on first login; the OIDC `sub` claim is checked directly.
+**Response** (returns the API token once):
+```json
+{
+  "id": 42,
+  "display_name": "Alice Cooper",
+  "external_user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "email": null,
+  "is_admin": false,
+  "token": "or-xxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+**Where does `external_user_id` come from?** It is whatever string the IdP puts in the `sub` claim for that user — an opaque stable identifier. Look it up in the IdP admin console (Keycloak: **Users** → open a user → copy the `ID` field) or via the IdP's own API.
+
+**`email` is OPTIONAL metadata.** It is not used for matching. You may set it at creation time for human-readable admin listings, or let it be populated automatically via [Claim Mapping](#claim-mapping-optional).
 
 ### Bulk User Provisioning
 
-For bulk imports, write a script that calls `/users/` in a loop:
+For bulk imports, write a script that calls `/users/` with the users' `external_user_id` values from your IdP export:
 
 ```python
 import requests
-import json
 
 auth_token = "sk-your-token"
 headers = {
     "Authorization": f"Bearer {auth_token}",
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
 }
 
 users = [
-    {"display_name": "Alice", "email": "alice@example.com"},
-    {"display_name": "Bob", "email": "bob@example.com"},
-    {"display_name": "Charlie", "email": "charlie@example.com"},
+    {"display_name": "Alice", "external_user_id": "kc-uuid-alice"},
+    {"display_name": "Bob", "external_user_id": "kc-uuid-bob"},
+    {"display_name": "Charlie", "external_user_id": "kc-uuid-charlie"},
 ]
 
 base_url = "http://localhost:8080"
@@ -231,6 +216,65 @@ for user in users:
     response = requests.post(f"{base_url}/users/", headers=headers, json=user)
     print(f"Created {user['display_name']}: {response.json()}")
 ```
+
+---
+
+## Claim Mapping (optional)
+
+By default, the callback only verifies the user's `sub` claim and issues a session — nothing else is read from the IdP. If you want OpenRag to keep selected columns on the `users` table in sync with IdP claims (display name, email, …) **on every login**, set `OIDC_CLAIM_MAPPING`.
+
+### When to Use It
+
+- You want `users.display_name` to reflect the IdP's current value (e.g., user renamed themselves).
+- You're migrating from an email-based matching scheme and want to populate `users.email` automatically without a manual script.
+- Your LDAP directory is the source of truth for user attributes.
+
+### Configuration
+
+Format: comma-separated pairs `db_field:claim`.
+
+```bash
+OIDC_CLAIM_MAPPING=display_name:name,email:email
+```
+
+Each pair means *"copy the value of the OIDC claim `claim` into `users.db_field`".* Spaces around the separator are tolerated.
+
+**Where the claim is read from** is controlled by `OIDC_CLAIM_SOURCE`:
+
+| Value | Source |
+|-------|--------|
+| `id_token` (default) | Verified ID-token claims |
+| `userinfo` | `/userinfo` endpoint fetched with the user's access token |
+
+### Writable Fields Whitelist
+
+Only these columns may appear on the left-hand side of a mapping:
+
+| DB field | Purpose |
+|----------|---------|
+| `display_name` | Human-readable name |
+| `email` | Email metadata (NOT used for matching) |
+
+Any other field (`is_admin`, `external_user_id`, `file_quota`, `token`, …) is rejected at startup — this is a hard security boundary, preventing an IdP that returns an `is_admin: true` claim from privilege-escalating existing users.
+
+### Behavior
+
+- If `OIDC_CLAIM_MAPPING` is empty or unset: no user field is updated on login.
+- If a mapped claim is missing from the source, that field is skipped (but the login still succeeds).
+- If the claim value matches what's already stored, no DB write happens (no-op).
+- If `OIDC_CLAIM_SOURCE=userinfo` and the `/userinfo` fetch fails, the login fails with `400 "Failed to fetch userinfo from IdP"`.
+- Email values are normalized (trimmed + lowercased) before being written.
+
+### Example
+
+With `OIDC_CLAIM_MAPPING=display_name:name,email:email` and `OIDC_CLAIM_SOURCE=id_token`:
+
+| ID token claim | `users` column updated to |
+|----------------|---------------------------|
+| `name: "Alice Cooper"` | `display_name = "Alice Cooper"` |
+| `email: "alice@example.com"` | `email = "alice@example.com"` |
+| `sub: "kc-alice-uuid"` | (used for matching only, never written) |
+| `is_admin: true` | ignored (not in whitelist) |
 
 ---
 
@@ -294,7 +338,6 @@ OIDC_CLIENT_ID=openrag
 OIDC_CLIENT_SECRET=<paste-secret-from-step-4>
 OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
 OIDC_TOKEN_ENCRYPTION_KEY=<generate-via-python-script>
-OIDC_EMAIL_SOURCE=id_token
 OIDC_SCOPES=openid email profile offline_access
 ```
 
@@ -307,10 +350,13 @@ OIDC_SCOPES=openid email profile offline_access
 5. **First name**: `Test`
 6. **Last name**: `User`
 7. Click **Create**
-8. Go to **Credentials** tab, set a password for testing
-9. Ensure **Temporary** is OFF (so user can log in immediately)
+8. Copy the user's `ID` from the detail view — this is the `sub` claim the IdP will emit
+9. Go to **Credentials** tab, set a password for testing
+10. Ensure **Temporary** is OFF (so user can log in immediately)
 
 ### Step 7: Pre-provision User in OpenRag
+
+Use the Keycloak user ID from the previous step as `external_user_id`:
 
 ```bash
 curl -X POST http://localhost:8080/users/ \
@@ -318,7 +364,7 @@ curl -X POST http://localhost:8080/users/ \
   -H "Content-Type: application/json" \
   -d '{
     "display_name": "Test User",
-    "email": "testuser@example.com",
+    "external_user_id": "<paste-keycloak-user-id>",
     "is_admin": false
   }'
 ```
@@ -376,11 +422,10 @@ OIDC_CLIENT_ID=openrag
 OIDC_CLIENT_SECRET=<secret-from-llng>
 OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
 OIDC_TOKEN_ENCRYPTION_KEY=<generate-via-python>
-OIDC_EMAIL_SOURCE=id_token
 OIDC_SCOPES=openid email profile offline_access
 ```
 
-3. **Pre-provision users** (via `/users/` API, same as Keycloak)
+3. **Pre-provision users** via `/users/` API, same as Keycloak — set `external_user_id` to whatever value LLNG emits as the `sub` claim (typically the uid).
 
 4. **Test**: Navigate to OpenRag, should redirect to LLNG login
 
@@ -590,47 +635,37 @@ OpenRag builds the discovery URL by stripping any trailing slash internally, so 
 - Example: `https://openrag.example.com/auth/callback` (NOT `https://openrag.example.com/auth/callback/`)
 - Keycloak: **Clients** → **Valid redirect URIs**
 
-### 4. "email claim not found"
+### 4. "User not registered" (403 at callback)
 
-**Error**: User logs in successfully, but OpenRag responds with 403 "email not found in claims".
+**Error**: After a successful IdP login, OpenRag responds with `403 {"detail": "User not registered"}` at `/auth/callback`.
 
-**Solution**:
-- Set `OIDC_EMAIL_SOURCE=userinfo` if `email` is not in the ID token
-- Or, ask IdP admin to include `email` scope in the token
-- Verify the IdP is returning `email` claim via OIDC `/userinfo` endpoint:
+**Cause**: User matching is now performed **exclusively** by `users.external_user_id == sub`. There is no email fallback and no auto-provisioning. The user either doesn't exist yet, or their `external_user_id` column is not set (or does not match the IdP's `sub`).
+
+**Solution**: The admin must pre-provision the user with the *exact* `sub` the IdP emits. Discover the IdP's `sub` for the user (e.g., Keycloak: **Users** → open the user → copy the `ID` field; or decode an ID token for that user with <https://jwt.io> and read the `sub` claim).
+
+Create the user:
 ```bash
-curl -H "Authorization: Bearer <access_token>" \
-  https://idp.example.com/realms/openrag/protocol/openid-connect/userinfo
+curl -X POST http://localhost:8080/users/ \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Alice Cooper",
+    "external_user_id": "<paste-the-sub-value-here>",
+    "is_admin": false
+  }'
 ```
 
-### 5. "external_user_id mismatch"
-
-**Error**: User with `external_user_id=A` tries to log in, but OIDC `sub=B`.
-
-**Cause**: The user's `external_user_id` was set to one value, but the IdP's `sub` claim changed (e.g., user was re-imported or IdP was reconfigured).
-
-**Solution**:
-- If intentional (user switched IdPs), clear the old `external_user_id`:
+Or, if the user already exists with a wrong `external_user_id`:
 ```bash
 curl -X PATCH http://localhost:8080/users/42 \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d '{"external_user_id": null}'
+  -d '{"external_user_id": "<new-sub-value>"}'
 ```
-- Then log in again; the new `sub` will be backfilled
 
-### 6. "email domain not whitelisted"
+Server logs record the attempted `sub` at `WARNING` level so admins can copy it over without having to decode the token themselves.
 
-**Error**: User logs in, but OpenRag responds with 403 "email domain not whitelisted".
-
-**Solution**:
-- Set `OIDC_ALLOWED_EMAIL_DOMAINS` to allow the user's domain:
-```bash
-export OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
-```
-- Or, empty it to allow any domain
-
-### 6. "session not found" or "session expired"
+### 5. "session not found" or "session expired"
 
 **Error**: User can log in once, but subsequent requests show "unauthenticated".
 
@@ -641,7 +676,7 @@ export OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
 - Check `openrag_session` cookie exists and is not marked `revoked_at` in DB
 - Increase `access_token_expires_at` via OIDC scopes (`offline_access` + longer TTL in IdP)
 
-### 7. "clock skew" or "token not yet valid"
+### 6. "clock skew" or "token not yet valid"
 
 **Error**: "iat claim is in the future" or "exp claim is in the past".
 
@@ -649,7 +684,7 @@ export OIDC_ALLOWED_EMAIL_DOMAINS=example.com,partner.org
 - Sync system clocks between OpenRag and IdP servers
 - Check NTP is running: `ntpq -p`
 
-### 8. "invalid scope: offline_access"
+### 7. "invalid scope: offline_access"
 
 **Error**: OIDC client redirect fails with "Invalid scope requested: offline_access".
 

--- a/docs/sso-quickstart.md
+++ b/docs/sso-quickstart.md
@@ -1,0 +1,168 @@
+# SSO Quick Start (OIDC)
+
+Configure OpenRag to delegate authentication to your corporate SSO (LemonLDAP::NG, Keycloak, Auth0, Azure AD, Okta…) in five steps.
+
+> **New to OIDC?** You just need to coordinate with your SSO admin and set six `.env` variables. No code to change.
+
+---
+
+## Step 1 — Ask your SSO admin to register a client
+
+Give them the following information (replace `<openrag-host>` with the public URL of your OpenRag instance, e.g. `https://rag.mycorp.com` or `http://localhost:8080`):
+
+| Field                         | Value to give                                              |
+| ----------------------------- | ---------------------------------------------------------- |
+| **Client type**               | `confidential` (server-to-server token exchange)           |
+| **Grant type**                | `authorization_code`                                       |
+| **Response type**             | `code`                                                     |
+| **PKCE**                      | `S256` required                                            |
+| **Valid redirect URIs**       | `<openrag-host>/auth/callback`                             |
+| **Back-channel logout URI**   | `<openrag-host>/auth/backchannel-logout`                   |
+| **Post-logout redirect URIs** | `<openrag-host>/`                                          |
+| **Allowed scopes**            | `openid`, `email`, `profile`, `offline_access`             |
+| **Include `sid` in tokens**   | ✅ enabled (required for back-channel logout)              |
+| **Send refresh token**        | ✅ enabled (so the session doesn't drop every few minutes) |
+
+Then ask the admin for **three pieces of information**:
+
+1. **`client_id`** — a public identifier, typically `openrag` or similar.
+2. **`client_secret`** — a long random string, shown **only once** by most IdPs. Store it in a password manager.
+3. **The IdP issuer URL** — e.g. `https://sso.mycorp.com/` or `https://keycloak.mycorp.com/realms/mycorp`.
+
+---
+
+## Step 2 — Verify the **exact** issuer string
+
+This is the most common setup mistake. The issuer value you put in `.env` **MUST** match byte-for-byte what the IdP's discovery document advertises (including trailing slash, per OIDC Core §2). Keycloak usually has no trailing slash; LemonLDAP::NG and Auth0 usually have one.
+
+Run this command against your IdP:
+
+```bash
+curl -s https://sso.mycorp.com/.well-known/openid-configuration | jq -r .issuer
+```
+
+Copy the output verbatim. If you get:
+
+- `https://sso.mycorp.com/` → use that with the slash.
+- `https://keycloak.mycorp.com/realms/mycorp` → use that without a slash.
+
+Any mismatch and OpenRag refuses the login with `Issuer mismatch` in the logs.
+
+---
+
+## Step 3 — Generate a Fernet encryption key
+
+Access tokens and refresh tokens returned by the IdP are stored encrypted at rest. Generate a dedicated key for your deployment:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+Output example: `XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=` (44 chars, url-safe base64).
+
+Store this in your secrets manager — **losing it invalidates every stored session**.
+
+---
+
+## Step 4 — Populate `.env`
+
+Copy this block at the end of your `.env` and fill in your values:
+
+```env
+AUTH_MODE=oidc
+
+# Issuer URL — EXACT match with the curl|jq output from Step 2.
+OIDC_ENDPOINT=https://sso.mycorp.com/
+
+OIDC_CLIENT_ID=openrag
+OIDC_CLIENT_SECRET=change-me-the-secret-from-step-1
+
+# Must match EXACTLY the "Valid redirect URI" registered in Step 1.
+OIDC_REDIRECT_URI=https://rag.mycorp.com/auth/callback
+
+# From Step 3.
+OIDC_TOKEN_ENCRYPTION_KEY=XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
+
+# --- Optional ---
+# OIDC_SCOPES="openid email profile offline_access"   # default
+# OIDC_CLAIM_SOURCE=id_token                          # default ; alternative: userinfo
+# OIDC_CLAIM_MAPPING=                                 # default: empty (no sync of display_name/email from IdP)
+# OIDC_POST_LOGOUT_REDIRECT_URI=/                     # default
+```
+
+> **Tip — values with spaces (like `OIDC_SCOPES`)**: quote them to stay safe across dotenv parsers:
+> `OIDC_SCOPES="openid email profile offline_access"`.
+> Quotes are stripped on read.
+
+### Optional: sync `display_name` / `email` from the IdP
+
+By default, OpenRag never modifies a user's `display_name` or `email` after login. If you want the IdP to be the source of truth (useful when HR changes a user's name), set:
+
+```env
+OIDC_CLAIM_MAPPING=display_name:name,email:email
+```
+
+Each pair is `db_field:oidc_claim`. Only `display_name` and `email` are writable — `is_admin`, `external_user_id`, `file_quota`, and `token` can **never** be changed via the IdP.
+
+By default OpenRag reads the claims from the verified ID token (`OIDC_CLAIM_SOURCE=id_token`, no extra HTTP call). Switch to `userinfo` if your IdP only exposes certain claims via the `/userinfo` endpoint.
+
+---
+
+## Step 5 — Pre-provision users
+
+OpenRag **does not auto-create users** on first login. Each user must exist in the database with their OIDC `sub` stored in `external_user_id`.
+
+Ask the IdP admin for each user's `sub` claim value (stable identifier, NOT the username). Then create the user via the OpenRag admin API — you'll need an admin `AUTH_TOKEN` for this:
+
+```bash
+# Boot once with AUTH_MODE=token and AUTH_TOKEN=sk-... to create users,
+# OR keep AUTH_TOKEN in .env alongside AUTH_MODE=oidc — in that mode the
+# bearer is still accepted for programmatic admin calls.
+
+curl -X POST https://rag.mycorp.com/users/ \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "Alice Cooper",
+    "external_user_id": "alice@mycorp.com",
+    "email": "alice@mycorp.com",
+    "is_admin": false
+  }'
+```
+
+- `external_user_id` **must equal** the user's OIDC `sub`. If you don't know it, ask the admin to check with a test login (the `sub` is the `.sub` claim in the ID token).
+- `email` is optional metadata; not used for matching.
+- `is_admin: true` grants full admin rights inside OpenRag.
+
+If a user tries to log in and their `sub` isn't pre-provisioned, OpenRag returns `403 User not registered` and logs the `sub` so you can complete provisioning.
+
+---
+
+## Step 6 — Start and test
+
+```bash
+docker compose up --build -d
+# Watch the startup logs for "OIDC authentication mode enabled"
+docker compose logs openrag --tail 50 | grep -i OIDC
+```
+
+Open your browser at `https://rag.mycorp.com/` → it redirects to your SSO → you log in → you come back authenticated.
+
+If something goes wrong, see the full **[troubleshooting section in `docs/oidc.md`](./oidc.md#troubleshooting)**. Most issues fall into one of three categories:
+
+1. **Issuer mismatch** (Step 2 — trailing slash).
+2. **Invalid redirect URI** (Step 1 — must match byte-for-byte).
+3. **User not registered** (Step 5 — `external_user_id` ≠ `sub`).
+
+---
+
+## Appendix — Programmatic access in SSO mode
+
+Once `AUTH_MODE=oidc`, human users go through SSO. **CI pipelines, scripts, and external agents** keep working by using the per-user bearer token (`users.token`) — the same one returned at `POST /users/` creation. Example:
+
+```bash
+# The token printed when you created alice in Step 5:
+curl -H "Authorization: Bearer or-xxxxxxxxxxxxxxxx" https://rag.mycorp.com/v1/models
+```
+
+This gives you the best of both worlds: human-friendly SSO for the UI, token-based auth for automation.

--- a/docs/sso-quickstart.md
+++ b/docs/sso-quickstart.md
@@ -15,10 +15,9 @@ Give them the following information (replace `<openrag-host>` with the public UR
 | **Client type**               | `confidential` (server-to-server token exchange)           |
 | **Grant type**                | `authorization_code`                                       |
 | **Response type**             | `code`                                                     |
-| **PKCE**                      | `S256` required                                            |
 | **Valid redirect URIs**       | `<openrag-host>/auth/callback`                             |
 | **Back-channel logout URI**   | `<openrag-host>/auth/backchannel-logout`                   |
-| **Post-logout redirect URIs** | `<openrag-host>/`                                          |
+| **Post-logout redirect URIs** | an optional URL **outside** OpenRag (see §Step 4 below)    |
 | **Allowed scopes**            | `openid`, `email`, `profile`, `offline_access`             |
 | **Include `sid` in tokens**   | ✅ enabled (required for back-channel logout)              |
 | **Send refresh token**        | ✅ enabled (so the session doesn't drop every few minutes) |
@@ -87,7 +86,17 @@ OIDC_TOKEN_ENCRYPTION_KEY=XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
 # OIDC_SCOPES="openid email profile offline_access"   # default
 # OIDC_CLAIM_SOURCE=id_token                          # default ; alternative: userinfo
 # OIDC_CLAIM_MAPPING=                                 # default: empty (no sync of display_name/email from IdP)
-# OIDC_POST_LOGOUT_REDIRECT_URI=/                     # default
+
+# ⚠ Where the IdP sends the user AFTER logging out.
+#   A ("/") lands on the OpenRag root, which immediately re-triggers
+#   OIDC login — if the IdP session is still alive you appear to be
+#   re-logged-in instantly (no apparent "logout" effect); if it was killed
+#   you land back on the IdP form in a loop. Prefer a URL OUTSIDE OpenRag
+#   or nothing to let SSO doing its job:
+#     - your corporate intranet / landing page
+#     - a static "you are logged out" page you control
+#     - the IdP's own post-logout URL (e.g. https://sso.mycorp.com/)
+# OIDC_POST_LOGOUT_REDIRECT_URI=https://intranet.mycorp.com/
 ```
 
 > **Tip — values with spaces (like `OIDC_SCOPES`)**: quote them to stay safe across dotenv parsers:

--- a/docs/sso-quickstart.md
+++ b/docs/sso-quickstart.md
@@ -68,6 +68,7 @@ Store this in your secrets manager — **losing it invalidates every stored sess
 Copy this block at the end of your `.env` and fill in your values:
 
 ```env
+# Switch OpenRag from the legacy Bearer-token login to OIDC. REQUIRED.
 AUTH_MODE=oidc
 
 # Issuer URL — EXACT match with the curl|jq output from Step 2.

--- a/openrag/api.py
+++ b/openrag/api.py
@@ -13,7 +13,7 @@ from dotenv import dotenv_values
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 ray.init(dashboard_host="0.0.0.0")
@@ -253,6 +253,23 @@ app.add_middleware(
 
 app.state.app_state = AppState(config)
 app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")
+
+
+@app.get("/", include_in_schema=False)
+def root_redirect():
+    """Root handler — sends authenticated users to the indexer-ui (if
+    configured on a separate host) or the chainlit chat mounted on this
+    app. Prevents a bare ``http://localhost:APP_PORT/`` from returning 404
+    after an OIDC login that used ``next=/``.
+    """
+    # INDEXERUI_URL always has a default (localhost:INDEXERUI_PORT); only
+    # redirect there when it points to a different host/port than us —
+    # otherwise we'd loop.
+    if INDEXERUI_URL and f":{os.getenv('APP_PORT', '8080')}" not in INDEXERUI_URL:
+        return RedirectResponse(url=INDEXERUI_URL, status_code=302)
+    if WITH_CHAINLIT_UI:
+        return RedirectResponse(url="/chainlit/", status_code=302)
+    return JSONResponse({"status": "ok", "app": "openrag", "version": app.version})
 
 
 @app.get("/health_check", summary="Health check endpoint for API", dependencies=[])

--- a/openrag/api.py
+++ b/openrag/api.py
@@ -89,20 +89,55 @@ WITH_OPENAI_API: bool = os.getenv("WITH_OPENAI_API", "true").lower() == "true"
 
 AUTH_MODE: str = os.getenv("AUTH_MODE", "token").strip().lower()
 if AUTH_MODE not in ("token", "oidc"):
-    raise RuntimeError(
-        f"Invalid AUTH_MODE={AUTH_MODE!r}. Expected 'token' or 'oidc'."
-    )
+    raise RuntimeError(f"Invalid AUTH_MODE={AUTH_MODE!r}. Expected 'token' or 'oidc'.")
 
 # OIDC configuration (only required when AUTH_MODE=oidc)
 OIDC_ENDPOINT: str | None = os.getenv("OIDC_ENDPOINT")
 OIDC_CLIENT_ID: str | None = os.getenv("OIDC_CLIENT_ID")
 OIDC_CLIENT_SECRET: str | None = os.getenv("OIDC_CLIENT_SECRET")
 OIDC_REDIRECT_URI: str | None = os.getenv("OIDC_REDIRECT_URI")
-OIDC_EMAIL_SOURCE: str = os.getenv("OIDC_EMAIL_SOURCE", "id_token").strip().lower()
+OIDC_CLAIM_SOURCE: str = os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower()
+OIDC_CLAIM_MAPPING: str = os.getenv("OIDC_CLAIM_MAPPING", "").strip()
 OIDC_SCOPES: str = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
 OIDC_TOKEN_ENCRYPTION_KEY: str | None = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY")
 OIDC_POST_LOGOUT_REDIRECT_URI: str = os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
-OIDC_ALLOWED_EMAIL_DOMAINS: str = os.getenv("OIDC_ALLOWED_EMAIL_DOMAINS", "")
+
+# Whitelist of writable DB fields populated by OIDC claim mapping.
+# Never allow is_admin / external_user_id / file_quota / token here —
+# those are either identity-defining or privilege-escalation vectors.
+_OIDC_CLAIM_MAPPING_ALLOWED_FIELDS = {"display_name", "email"}
+
+
+def _parse_oidc_claim_mapping(raw: str) -> dict[str, str]:
+    """Parse the ``OIDC_CLAIM_MAPPING`` env var (CSV of ``db_field:claim`` pairs).
+
+    Validates each pair against the whitelist and enforces non-empty values so
+    misconfiguration fails fast at startup rather than silently at login time.
+    """
+    if not raw:
+        return {}
+    mapping: dict[str, str] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if ":" not in pair:
+            raise RuntimeError(f"Invalid OIDC_CLAIM_MAPPING entry {pair!r}: expected 'db_field:claim'")
+        db_field, claim = pair.split(":", 1)
+        db_field = db_field.strip()
+        claim = claim.strip()
+        if db_field not in _OIDC_CLAIM_MAPPING_ALLOWED_FIELDS:
+            raise RuntimeError(
+                f"OIDC_CLAIM_MAPPING db_field {db_field!r} is not writable "
+                f"(allowed: {sorted(_OIDC_CLAIM_MAPPING_ALLOWED_FIELDS)})"
+            )
+        if not claim:
+            raise RuntimeError(f"OIDC_CLAIM_MAPPING entry for {db_field!r} has empty claim name")
+        mapping[db_field] = claim
+    return mapping
+
+
+OIDC_CLAIM_MAPPING_PARSED: dict[str, str] = _parse_oidc_claim_mapping(OIDC_CLAIM_MAPPING)
 
 if AUTH_MODE == "oidc":
     _missing = [
@@ -117,18 +152,14 @@ if AUTH_MODE == "oidc":
         if not val
     ]
     if _missing:
-        raise RuntimeError(
-            "AUTH_MODE=oidc but the following env vars are missing or empty: "
-            + ", ".join(_missing)
-        )
-    if OIDC_EMAIL_SOURCE not in ("id_token", "userinfo"):
-        raise RuntimeError(
-            f"Invalid OIDC_EMAIL_SOURCE={OIDC_EMAIL_SOURCE!r}. Expected 'id_token' or 'userinfo'."
-        )
+        raise RuntimeError("AUTH_MODE=oidc but the following env vars are missing or empty: " + ", ".join(_missing))
+    if OIDC_CLAIM_SOURCE not in ("id_token", "userinfo"):
+        raise RuntimeError(f"Invalid OIDC_CLAIM_SOURCE={OIDC_CLAIM_SOURCE!r}. Expected 'id_token' or 'userinfo'.")
     logger.info(
         "OIDC authentication mode enabled",
         issuer=OIDC_ENDPOINT,
-        email_source=OIDC_EMAIL_SOURCE,
+        claim_source=OIDC_CLAIM_SOURCE,
+        claim_mapping_fields=sorted(OIDC_CLAIM_MAPPING_PARSED.keys()),
     )
 
 

--- a/openrag/api.py
+++ b/openrag/api.py
@@ -100,7 +100,7 @@ OIDC_CLAIM_SOURCE: str = os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lowe
 OIDC_CLAIM_MAPPING: str = os.getenv("OIDC_CLAIM_MAPPING", "").strip()
 OIDC_SCOPES: str = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
 OIDC_TOKEN_ENCRYPTION_KEY: str | None = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY")
-OIDC_POST_LOGOUT_REDIRECT_URI: str = os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+OIDC_POST_LOGOUT_REDIRECT_URI: str | None = os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI")
 
 # Whitelist of writable DB fields populated by OIDC claim mapping.
 # Never allow is_admin / external_user_id / file_quota / token here —

--- a/openrag/api.py
+++ b/openrag/api.py
@@ -23,7 +23,9 @@ ray.init(dashboard_host="0.0.0.0")
 # flake8: noqa: E402
 
 
+from components.auth.middleware import AuthMiddleware
 from routers.actors import router as actors_router
+from routers.auth import router as auth_router
 from routers.extract import router as extract_router
 from routers.indexer import router as indexer_router
 from routers.monitoring import MonitoringMiddleware
@@ -85,6 +87,50 @@ INDEXERUI_URL: str | None = os.getenv("INDEXERUI_URL", f"http://localhost:{INDEX
 WITH_CHAINLIT_UI: bool = os.getenv("WITH_CHAINLIT_UI", "true").lower() == "true"
 WITH_OPENAI_API: bool = os.getenv("WITH_OPENAI_API", "true").lower() == "true"
 
+AUTH_MODE: str = os.getenv("AUTH_MODE", "token").strip().lower()
+if AUTH_MODE not in ("token", "oidc"):
+    raise RuntimeError(
+        f"Invalid AUTH_MODE={AUTH_MODE!r}. Expected 'token' or 'oidc'."
+    )
+
+# OIDC configuration (only required when AUTH_MODE=oidc)
+OIDC_ENDPOINT: str | None = os.getenv("OIDC_ENDPOINT")
+OIDC_CLIENT_ID: str | None = os.getenv("OIDC_CLIENT_ID")
+OIDC_CLIENT_SECRET: str | None = os.getenv("OIDC_CLIENT_SECRET")
+OIDC_REDIRECT_URI: str | None = os.getenv("OIDC_REDIRECT_URI")
+OIDC_EMAIL_SOURCE: str = os.getenv("OIDC_EMAIL_SOURCE", "id_token").strip().lower()
+OIDC_SCOPES: str = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
+OIDC_TOKEN_ENCRYPTION_KEY: str | None = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY")
+OIDC_POST_LOGOUT_REDIRECT_URI: str = os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+OIDC_ALLOWED_EMAIL_DOMAINS: str = os.getenv("OIDC_ALLOWED_EMAIL_DOMAINS", "")
+
+if AUTH_MODE == "oidc":
+    _missing = [
+        name
+        for name, val in [
+            ("OIDC_ENDPOINT", OIDC_ENDPOINT),
+            ("OIDC_CLIENT_ID", OIDC_CLIENT_ID),
+            ("OIDC_CLIENT_SECRET", OIDC_CLIENT_SECRET),
+            ("OIDC_REDIRECT_URI", OIDC_REDIRECT_URI),
+            ("OIDC_TOKEN_ENCRYPTION_KEY", OIDC_TOKEN_ENCRYPTION_KEY),
+        ]
+        if not val
+    ]
+    if _missing:
+        raise RuntimeError(
+            "AUTH_MODE=oidc but the following env vars are missing or empty: "
+            + ", ".join(_missing)
+        )
+    if OIDC_EMAIL_SOURCE not in ("id_token", "userinfo"):
+        raise RuntimeError(
+            f"Invalid OIDC_EMAIL_SOURCE={OIDC_EMAIL_SOURCE!r}. Expected 'id_token' or 'userinfo'."
+        )
+    logger.info(
+        "OIDC authentication mode enabled",
+        issuer=OIDC_ENDPOINT,
+        email_source=OIDC_EMAIL_SOURCE,
+    )
+
 
 try:
     app_version = get_package_version("openrag")
@@ -135,61 +181,8 @@ class TokenRedactingMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class AuthMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        vectordb = get_vectordb()
-        # Skip if no AUTH_TOKEN configured
-        if AUTH_TOKEN is None:
-            user = await vectordb.get_user.remote(1)
-            user_partitions = await vectordb.list_user_partitions.remote(1)
-            request.state.user = user
-            request.state.user_partitions = user_partitions
-            return await call_next(request)
-
-        # routes to allow access to without token bearer
-        if request.url.path in [
-            "/docs",
-            "/openapi.json",
-            "/redoc",
-            "/health_check",
-            "/version",
-        ] or request.url.path.startswith("/chainlit"):  # Allow chainlit without auth
-            return await call_next(request)
-
-        # Extract token
-        token = None
-
-        # For /static routes, allow token via query parameter (this easy file viewing with a link without a bearer)
-        # usage http://localhost:8080/static?token=api_key
-        if request.url.path.startswith("/static"):
-            # Use preserved original token (before redaction) if available
-            token = getattr(request.state, "original_token", None)
-        else:
-            # For all other routes, require Bearer header
-            # # Extract Bearer token
-            auth = request.headers.get("authorization", "")
-            if auth and auth.lower().startswith("bearer "):
-                token = auth.split(" ", 1)[1]
-
-        if not token:
-            return JSONResponse(status_code=403, content={"detail": "Missing token"})
-
-        # Lookup user in DB
-        user = await vectordb.get_user_by_token.remote(token)
-        if not user:
-            return JSONResponse(status_code=403, content={"detail": "Invalid token"})
-
-        # Load user partitions
-        user_partitions = await vectordb.list_user_partitions.remote(user["id"])
-
-        # Attach to request
-        request.state.user = user
-        request.state.user_partitions = user_partitions
-        return await call_next(request)
-
-
 # Register middlewares (order matters - last added runs first)
-app.add_middleware(AuthMiddleware)
+app.add_middleware(AuthMiddleware, get_vectordb=get_vectordb)
 app.add_middleware(TokenRedactingMiddleware)
 app.add_middleware(MonitoringMiddleware)
 
@@ -267,6 +260,10 @@ app.include_router(workspaces_router, tags=[Tags.WORKSPACES])
 app.include_router(monitoring_router, tags=[Tags.MONITORING])
 
 app.include_router(tools_router, prefix="/v1", tags=[Tags.TOOLS])
+
+# Mount the auth router (OIDC flows). Routes are mostly bypassed by AuthMiddleware
+# except `/auth/me` which remains protected.
+app.include_router(auth_router, tags=["Authentication"])
 
 # Mount openai router if either OpenAI API or Chainlit UI is enabled (chainlit uses openai api endpoints)
 if WITH_OPENAI_API or WITH_CHAINLIT_UI:

--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -16,6 +16,7 @@ logger = get_logger()
 
 PERSISTENCY = os.environ.get("CHAINLIT_DATALAYER_COMPOSE", "") != ""
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN", "")
+AUTH_MODE = os.environ.get("AUTH_MODE", "token").strip().lower()
 
 # Chainlit authentication
 CHAINLIT_AUTH_SECRET = os.environ.get("CHAINLIT_AUTH_SECRET")
@@ -54,6 +55,19 @@ def get_headers(api_key):
     return headers
 
 
+def _extract_cookie(cookie_header: str, name: str) -> str | None:
+    """Parse a single cookie value from a Cookie header. No dependency on http.cookies for simplicity."""
+    if not cookie_header:
+        return None
+    for part in cookie_header.split(";"):
+        part = part.strip()
+        if "=" in part:
+            k, _, v = part.partition("=")
+            if k.strip() == name:
+                return v.strip()
+    return None
+
+
 if PERSISTENCY:
 
     @cl.on_chat_resume
@@ -61,7 +75,7 @@ if PERSISTENCY:
         pass
 
 
-if AUTH_TOKEN:
+if AUTH_TOKEN and AUTH_MODE != "oidc":
     if not CHAINLIT_AUTH_SECRET:
         # logger.warning(
         #     "`CHAINLIT_AUTH_SECRET` is not set a default value will be used. Not recommended for production."
@@ -95,6 +109,44 @@ if AUTH_TOKEN:
         except Exception as e:
             logger.exception("Unexpected error during authentication", error=str(e))
             return None
+
+elif AUTH_MODE == "oidc":
+    if not CHAINLIT_AUTH_SECRET:
+        os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"
+
+    @cl.header_auth_callback
+    async def header_auth_callback(headers: dict) -> cl.User | None:
+        """Authenticate Chainlit users via the openrag_session cookie posted by /auth/callback."""
+        cookie_header = headers.get("cookie") or headers.get("Cookie") or ""
+        session_token = _extract_cookie(cookie_header, "openrag_session")
+        if not session_token:
+            logger.info("No openrag_session cookie in Chainlit request")
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+                response = await client.get(
+                    url=f"{INTERNAL_BASE_URL}/users/info",
+                    headers=get_headers(session_token),
+                )
+                response.raise_for_status()
+                data = response.json()
+        except httpx.HTTPStatusError as e:
+            logger.info("Session cookie rejected by /users/info", status=e.response.status_code)
+            return None
+        except Exception as e:
+            logger.exception("Chainlit header_auth_callback failure", error=str(e))
+            return None
+
+        return cl.User(
+            identifier=data.get("display_name", "user"),
+            metadata={
+                "role": "admin" if data.pop("is_admin", False) else "user",
+                "provider": "oidc",
+                "api_key": session_token,  # opaque cookie value — used as Bearer for internal calls
+                "extra": data,
+            },
+        )
 
 
 def get_external_url():

--- a/openrag/components/auth/__init__.py
+++ b/openrag/components/auth/__init__.py
@@ -1,0 +1,11 @@
+from components.auth.deps import get_oidc_client, reset_oidc_client
+from components.auth.oidc_client import OIDCClient, TokenBundle, LogoutTokenClaims
+from components.auth.session_tokens import issue_session_token, encrypt_token, decrypt_token, hash_session_token
+from components.auth.state_cookie import StateCookieSerializer, StateCookiePayload
+
+__all__ = [
+    "OIDCClient", "TokenBundle", "LogoutTokenClaims",
+    "issue_session_token", "encrypt_token", "decrypt_token", "hash_session_token",
+    "StateCookieSerializer", "StateCookiePayload",
+    "get_oidc_client", "reset_oidc_client",
+]

--- a/openrag/components/auth/__init__.py
+++ b/openrag/components/auth/__init__.py
@@ -1,11 +1,18 @@
 from components.auth.deps import get_oidc_client, reset_oidc_client
-from components.auth.oidc_client import OIDCClient, TokenBundle, LogoutTokenClaims
-from components.auth.session_tokens import issue_session_token, encrypt_token, decrypt_token, hash_session_token
-from components.auth.state_cookie import StateCookieSerializer, StateCookiePayload
+from components.auth.oidc_client import LogoutTokenClaims, OIDCClient, TokenBundle
+from components.auth.session_tokens import decrypt_token, encrypt_token, hash_session_token, issue_session_token
+from components.auth.state_cookie import StateCookiePayload, StateCookieSerializer
 
 __all__ = [
-    "OIDCClient", "TokenBundle", "LogoutTokenClaims",
-    "issue_session_token", "encrypt_token", "decrypt_token", "hash_session_token",
-    "StateCookieSerializer", "StateCookiePayload",
-    "get_oidc_client", "reset_oidc_client",
+    "OIDCClient",
+    "TokenBundle",
+    "LogoutTokenClaims",
+    "issue_session_token",
+    "encrypt_token",
+    "decrypt_token",
+    "hash_session_token",
+    "StateCookieSerializer",
+    "StateCookiePayload",
+    "get_oidc_client",
+    "reset_oidc_client",
 ]

--- a/openrag/components/auth/deps.py
+++ b/openrag/components/auth/deps.py
@@ -55,7 +55,29 @@ def get_oidc_client() -> OIDCClient:
 
 
 def reset_oidc_client() -> None:
-    """Test hook — drops the cached client so the next call rebuilds from env."""
+    """Test hook — drops the cached client so the next call rebuilds from env.
+
+    Best-effort closes the underlying httpx.AsyncClient to avoid "Unclosed
+    client session" warnings and leaking connections when tests repeatedly
+    reset the singleton. If no event loop is running we skip the close call
+    — the GC will eventually reclaim the socket.
+    """
     global _client
     with _lock:
+        old = _client
         _client = None
+    if old is None:
+        return
+    try:
+        import asyncio
+
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+        if loop.is_running():
+            # Schedule close on the running loop without awaiting — caller
+            # doesn't need to be async.
+            loop.create_task(old.aclose())
+        else:
+            loop.run_until_complete(old.aclose())
+    except Exception:
+        # Closing is best-effort; never let a reset blow up the caller.
+        pass

--- a/openrag/components/auth/deps.py
+++ b/openrag/components/auth/deps.py
@@ -1,0 +1,61 @@
+"""Lazy, process-local singleton for the OIDCClient.
+
+Kept in a dedicated module to avoid circular imports between the router
+(``openrag/routers/auth.py``) and the application entry point (``openrag/api.py``).
+
+The OIDC config env vars are resolved here via ``os.getenv`` — the same values
+that ``openrag/api.py`` validates at startup. In ``AUTH_MODE=oidc`` mode, these
+are guaranteed to be non-empty (api.py refuses to start otherwise), so this
+module simply trusts them.
+"""
+
+from __future__ import annotations
+
+import os
+from threading import Lock
+
+from components.auth.oidc_client import OIDCClient
+
+_client: OIDCClient | None = None
+_lock = Lock()
+
+
+def get_oidc_client() -> OIDCClient:
+    """Return the shared OIDCClient instance, creating it on first call.
+
+    The instance caches the discovery doc and JWKS, so a single shared client
+    per worker process is both correct and more efficient than one-per-request.
+
+    Env vars read (all required in AUTH_MODE=oidc):
+      - OIDC_ENDPOINT
+      - OIDC_CLIENT_ID
+      - OIDC_CLIENT_SECRET
+      - OIDC_REDIRECT_URI
+      - OIDC_SCOPES (default ``openid email profile offline_access``)
+    """
+    global _client
+    if _client is not None:
+        return _client
+    with _lock:
+        if _client is not None:
+            return _client
+        issuer = os.environ["OIDC_ENDPOINT"]
+        client_id = os.environ["OIDC_CLIENT_ID"]
+        client_secret = os.environ["OIDC_CLIENT_SECRET"]
+        redirect_uri = os.environ["OIDC_REDIRECT_URI"]
+        scopes = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
+        _client = OIDCClient(
+            issuer=issuer,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+            scopes=scopes,
+        )
+    return _client
+
+
+def reset_oidc_client() -> None:
+    """Test hook — drops the cached client so the next call rebuilds from env."""
+    global _client
+    with _lock:
+        _client = None

--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -1,0 +1,234 @@
+"""Auth middleware — Phase 5 of the OIDC integration.
+
+Extracted from ``openrag/api.py`` so the dispatch logic can be unit tested
+without importing the full application (which bootstraps Ray actors at
+import time).
+
+The middleware supports both authentication modes:
+
+  * ``AUTH_MODE=token`` (legacy) — single Bearer token from
+    ``Authorization: Bearer ...`` or ``?token=`` for ``/static``. On missing
+    or invalid token returns **403** with the legacy JSON body (the existing
+    Robot Framework suite asserts this shape).
+
+  * ``AUTH_MODE=oidc`` — cookie-based session (set by the OIDC callback),
+    with lazy access-token refresh. A Bearer token is still accepted as a
+    fallback for programmatic clients. On missing/invalid credentials:
+
+      - UI paths → **302** to ``/auth/login?next=<encoded>``
+      - API paths → **401** JSON ``{"detail": "Unauthenticated"}``
+
+Environment configuration (``AUTH_MODE``, ``AUTH_TOKEN``,
+``OIDC_TOKEN_ENCRYPTION_KEY``) is read via ``os.getenv`` at **dispatch** time,
+not at import time, so tests can monkeypatch ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+from urllib.parse import quote
+
+from fastapi import Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from components.auth.refresh import refresh_session_if_needed
+from utils.logger import get_logger
+
+logger = get_logger()
+
+
+SESSION_COOKIE_NAME = "openrag_session"
+
+
+_BYPASS_PATHS = frozenset(
+    {
+        "/docs",
+        "/openapi.json",
+        "/redoc",
+        "/health_check",
+        "/version",
+        "/auth/login",
+        "/auth/callback",
+        "/auth/backchannel-logout",
+        "/auth/logout",
+    }
+)
+
+# Paths that are part of the REST API — unauthenticated requests here must
+# get JSON 401/403, never an HTML redirect to /auth/login (which would break
+# programmatic clients that follow redirects).
+_API_PREFIXES = (
+    "/v1/",
+    "/indexer/",
+    "/search/",
+    "/users/",
+    "/partition/",
+    "/workspaces/",
+    "/queue/",
+    "/extract/",
+    "/actors/",
+    "/monitoring/",
+    "/tools/",
+)
+
+# Browser-facing paths — unauthenticated access in oidc mode → 302 /auth/login.
+_UI_PATH_PREFIXES = ("/static",)
+
+
+def is_ui_path(path: str) -> bool:
+    """True if this path is a browser-facing page (UI), not an API route.
+
+    Used only in ``AUTH_MODE=oidc`` to decide between a 302 redirect to
+    ``/auth/login`` (UI) and a 401 JSON response (API). When in doubt we
+    return ``False`` to avoid redirect loops on non-browser clients.
+    """
+    if path == "/":
+        return True
+    if any(path.startswith(p) for p in _API_PREFIXES):
+        return False
+    if any(path.startswith(p) for p in _UI_PATH_PREFIXES):
+        return True
+    return False
+
+
+def is_bypass_path(path: str) -> bool:
+    return path in _BYPASS_PATHS or path.startswith("/chainlit")
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """FastAPI middleware enforcing authentication for both token and oidc modes.
+
+    Constructor takes a ``get_vectordb`` callable returning the Ray actor
+    handle — this indirection keeps the middleware decoupled from
+    ``utils.dependencies`` so tests can inject a ``MagicMock``.
+    """
+
+    def __init__(self, app, *, get_vectordb: Callable[[], object]):
+        super().__init__(app)
+        self._get_vectordb = get_vectordb
+
+    async def dispatch(self, request: Request, call_next):
+        # Read env lazily so tests can flip AUTH_MODE per-test.
+        auth_mode = os.getenv("AUTH_MODE", "token").strip().lower()
+        auth_token = os.getenv("AUTH_TOKEN")
+        enc_key = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY") or ""
+
+        vectordb = self._get_vectordb()
+
+        # --- Dev mode: AUTH_MODE=token + AUTH_TOKEN unset → user 1 bypass.
+        if auth_mode == "token" and auth_token is None:
+            user = await vectordb.get_user.remote(1)
+            user_partitions = await vectordb.list_user_partitions.remote(1)
+            request.state.user = user
+            request.state.user_partitions = user_partitions
+            request.state.oidc_session = None
+            return await call_next(request)
+
+        # --- Bypass list (docs, health, /auth/* callbacks, chainlit).
+        path = request.url.path
+        if is_bypass_path(path):
+            return await call_next(request)
+
+        user = None
+        session = None
+
+        # --- 1) Cookie session (OIDC UI flow).
+        cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
+        if cookie_token:
+            session = await vectordb.get_oidc_session_by_token.remote(cookie_token)
+            if session is not None:
+                refreshed = await refresh_session_if_needed(
+                    session=session,
+                    enc_key=enc_key,
+                    vectordb=vectordb,
+                )
+                if refreshed is None:
+                    # Refresh failed or session unusable → revoke and fall through.
+                    try:
+                        await vectordb.revoke_oidc_session_by_id.remote(session["id"])
+                    except Exception as e:
+                        logger.bind(error=str(e)).warning(
+                            "Failed to revoke invalid OIDC session"
+                        )
+                    session = None
+                else:
+                    session = refreshed
+                    user = await vectordb.get_user.remote(session["user_id"])
+
+        # --- 2) Fallback: Bearer / ?token= (programmatic clients + internal
+        #        callers like Chainlit's header_auth_callback which forwards
+        #        the browser cookie value in the Authorization header).
+        if user is None:
+            token = None
+            if path.startswith("/static"):
+                token = getattr(request.state, "original_token", None)
+            else:
+                auth = request.headers.get("authorization", "")
+                if auth and auth.lower().startswith("bearer "):
+                    token = auth.split(" ", 1)[1]
+
+            if token is not None:
+                # In oidc mode, a Bearer may carry an OIDC session token (not
+                # a ``users.token`` hash). Try the session lookup first with
+                # the same lazy-refresh semantics as the cookie branch above.
+                if auth_mode == "oidc":
+                    session = await vectordb.get_oidc_session_by_token.remote(token)
+                    if session is not None:
+                        refreshed = await refresh_session_if_needed(
+                            session=session,
+                            enc_key=enc_key,
+                            vectordb=vectordb,
+                        )
+                        if refreshed is None:
+                            try:
+                                await vectordb.revoke_oidc_session_by_id.remote(
+                                    session["id"]
+                                )
+                            except Exception as e:
+                                logger.bind(error=str(e)).warning(
+                                    "Failed to revoke invalid OIDC session (bearer path)"
+                                )
+                            session = None
+                        else:
+                            session = refreshed
+                            user = await vectordb.get_user.remote(session["user_id"])
+
+                if user is None:
+                    # Either token mode, or oidc mode with no matching session
+                    # — fall back to the long-lived ``users.token`` used by
+                    # programmatic clients (CI, scripts, service agents).
+                    user = await vectordb.get_user_by_token.remote(token)
+                    if not user and auth_mode == "token":
+                        # Legacy test contract: robot suite asserts 403 + "Invalid token".
+                        return JSONResponse(
+                            status_code=403, content={"detail": "Invalid token"}
+                        )
+            elif auth_mode == "token":
+                # Token mode: no cookie + no bearer → legacy 403 "Missing token".
+                return JSONResponse(
+                    status_code=403, content={"detail": "Missing token"}
+                )
+
+        # --- 3) Unauthenticated: redirect UI in oidc mode, else 401 JSON.
+        if user is None:
+            if auth_mode == "oidc" and is_ui_path(path):
+                next_path = path
+                if request.url.query:
+                    next_path = f"{path}?{request.url.query}"
+                return RedirectResponse(
+                    url=f"/auth/login?next={quote(next_path, safe='')}",
+                    status_code=302,
+                )
+            return JSONResponse(
+                status_code=401, content={"detail": "Unauthenticated"}
+            )
+
+        # --- Happy path: user resolved.
+        request.state.user = user
+        request.state.user_partitions = await vectordb.list_user_partitions.remote(
+            user["id"]
+        )
+        request.state.oidc_session = session  # None when authenticated via Bearer
+        return await call_next(request)

--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -26,14 +26,13 @@ not at import time, so tests can monkeypatch ``os.environ``.
 from __future__ import annotations
 
 import os
-from typing import Callable
+from collections.abc import Callable
 from urllib.parse import quote
 
+from components.auth.refresh import refresh_session_if_needed
 from fastapi import Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.middleware.base import BaseHTTPMiddleware
-
-from components.auth.refresh import refresh_session_if_needed
 from utils.logger import get_logger
 
 logger = get_logger()
@@ -149,9 +148,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     try:
                         await vectordb.revoke_oidc_session_by_id.remote(session["id"])
                     except Exception as e:
-                        logger.bind(error=str(e)).warning(
-                            "Failed to revoke invalid OIDC session"
-                        )
+                        logger.bind(error=str(e)).warning("Failed to revoke invalid OIDC session")
                     session = None
                 else:
                     session = refreshed
@@ -183,13 +180,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         )
                         if refreshed is None:
                             try:
-                                await vectordb.revoke_oidc_session_by_id.remote(
-                                    session["id"]
-                                )
+                                await vectordb.revoke_oidc_session_by_id.remote(session["id"])
                             except Exception as e:
-                                logger.bind(error=str(e)).warning(
-                                    "Failed to revoke invalid OIDC session (bearer path)"
-                                )
+                                logger.bind(error=str(e)).warning("Failed to revoke invalid OIDC session (bearer path)")
                             session = None
                         else:
                             session = refreshed
@@ -202,14 +195,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     user = await vectordb.get_user_by_token.remote(token)
                     if not user and auth_mode == "token":
                         # Legacy test contract: robot suite asserts 403 + "Invalid token".
-                        return JSONResponse(
-                            status_code=403, content={"detail": "Invalid token"}
-                        )
+                        return JSONResponse(status_code=403, content={"detail": "Invalid token"})
             elif auth_mode == "token":
                 # Token mode: no cookie + no bearer → legacy 403 "Missing token".
-                return JSONResponse(
-                    status_code=403, content={"detail": "Missing token"}
-                )
+                return JSONResponse(status_code=403, content={"detail": "Missing token"})
 
         # --- 3) Unauthenticated: redirect UI in oidc mode, else 401 JSON.
         if user is None:
@@ -221,14 +210,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     url=f"/auth/login?next={quote(next_path, safe='')}",
                     status_code=302,
                 )
-            return JSONResponse(
-                status_code=401, content={"detail": "Unauthenticated"}
-            )
+            return JSONResponse(status_code=401, content={"detail": "Unauthenticated"})
 
         # --- Happy path: user resolved.
         request.state.user = user
-        request.state.user_partitions = await vectordb.list_user_partitions.remote(
-            user["id"]
-        )
+        request.state.user_partitions = await vectordb.list_user_partitions.remote(user["id"])
         request.state.oidc_session = session  # None when authenticated via Bearer
         return await call_next(request)

--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -133,8 +133,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
         user = None
         session = None
 
-        # --- 1) Cookie session (OIDC UI flow).
-        cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
+        # --- 1) Cookie session (OIDC UI flow). Gated on oidc mode so the
+        #        legacy token-mode contract remains strictly Bearer-only —
+        #        a stray openrag_session cookie must not authenticate a
+        #        request when AUTH_MODE=token.
+        cookie_token = request.cookies.get(SESSION_COOKIE_NAME) if auth_mode == "oidc" else None
         if cookie_token:
             session = await vectordb.get_oidc_session_by_token.remote(cookie_token)
             if session is not None:

--- a/openrag/components/auth/oidc_client.py
+++ b/openrag/components/auth/oidc_client.py
@@ -35,8 +35,8 @@ class TokenBundle:
     id_token: str
     access_token: str
     refresh_token: str | None
-    expires_in: int         # seconds
-    token_type: str         # usually "Bearer"
+    expires_in: int  # seconds
+    token_type: str  # usually "Bearer"
     claims: dict[str, Any]  # verified claims from id_token
 
 
@@ -59,7 +59,7 @@ class OIDCClient:
     """
 
     _DISCOVERY_TTL = 3600  # 1 hour
-    _JWKS_TTL = 3600       # 1 hour
+    _JWKS_TTL = 3600  # 1 hour
 
     def __init__(
         self,
@@ -105,9 +105,7 @@ class OIDCClient:
         self._metadata = resp.json()
         self._metadata_fetched_at = time.time()
         if self._metadata.get("issuer") != self.issuer:
-            raise ValueError(
-                f"Issuer mismatch: configured {self.issuer!r}, got {self._metadata.get('issuer')!r}"
-            )
+            raise ValueError(f"Issuer mismatch: configured {self.issuer!r}, got {self._metadata.get('issuer')!r}")
         return self._metadata
 
     # ------------------------------------------------------------------
@@ -150,9 +148,7 @@ class OIDCClient:
     # Authorization URL
     # ------------------------------------------------------------------
 
-    async def build_authorization_url(
-        self, *, state: str, nonce: str, code_challenge: str
-    ) -> str:
+    async def build_authorization_url(self, *, state: str, nonce: str, code_challenge: str) -> str:
         """Build the full authorization URL to redirect the browser to."""
         meta = await self.discover()
         params = {
@@ -171,9 +167,7 @@ class OIDCClient:
     # Code exchange
     # ------------------------------------------------------------------
 
-    async def exchange_code(
-        self, *, code: str, code_verifier: str, expected_nonce: str
-    ) -> TokenBundle:
+    async def exchange_code(self, *, code: str, code_verifier: str, expected_nonce: str) -> TokenBundle:
         """Exchange an authorization code for tokens.
 
         Verifies the returned id_token (signature, iss, aud, exp, nonce).
@@ -195,9 +189,7 @@ class OIDCClient:
             "client_secret": self.client_secret,
             "code_verifier": code_verifier,
         }
-        resp = await self._http.post(
-            meta["token_endpoint"], data=data, headers={"Accept": "application/json"}
-        )
+        resp = await self._http.post(meta["token_endpoint"], data=data, headers={"Accept": "application/json"})
         resp.raise_for_status()
         payload = resp.json()
         id_token = payload["id_token"]
@@ -233,9 +225,7 @@ class OIDCClient:
             "client_id": self.client_id,
             "client_secret": self.client_secret,
         }
-        resp = await self._http.post(
-            meta["token_endpoint"], data=data, headers={"Accept": "application/json"}
-        )
+        resp = await self._http.post(meta["token_endpoint"], data=data, headers={"Accept": "application/json"})
         resp.raise_for_status()
         payload = resp.json()
         new_id_token = payload.get("id_token")
@@ -270,9 +260,7 @@ class OIDCClient:
     # ID token verification
     # ------------------------------------------------------------------
 
-    async def _verify_id_token(
-        self, token: str, *, expected_nonce: str | None
-    ) -> dict[str, Any]:
+    async def _verify_id_token(self, token: str, *, expected_nonce: str | None) -> dict[str, Any]:
         """Verify an ID token's signature and standard claims.
 
         Retries with a fresh JWKS fetch on kid-miss (covers IdP key rotation).

--- a/openrag/components/auth/oidc_client.py
+++ b/openrag/components/auth/oidc_client.py
@@ -1,0 +1,388 @@
+"""Lightweight OIDC Relying Party client for OpenRAG.
+
+Wraps Authlib's JWT/JWK primitives with:
+- Discovery endpoint caching (1 h TTL)
+- JWKS caching with automatic refresh on kid-miss
+- PKCE pair generation (S256)
+- Authorization URL builder
+- Code exchange with ID token verification
+- Token refresh (lazy, called by middleware when access_token near expiry)
+- Userinfo fetch
+- Back-channel logout token verification
+
+One instance per (issuer, client_id, client_secret) tuple.
+The instance is not thread-safe for writes but safe for concurrent reads once
+the metadata and JWKS caches are populated.
+"""
+
+import base64
+import hashlib
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from authlib.jose import JsonWebKey, JsonWebToken
+from authlib.jose.errors import JoseError
+
+
+@dataclass
+class TokenBundle:
+    """Holds the token set returned by the IdP together with verified ID token claims."""
+
+    id_token: str
+    access_token: str
+    refresh_token: str | None
+    expires_in: int         # seconds
+    token_type: str         # usually "Bearer"
+    claims: dict[str, Any]  # verified claims from id_token
+
+
+@dataclass
+class LogoutTokenClaims:
+    """Verified claims from a back-channel logout token."""
+
+    iss: str
+    aud: str | list[str]
+    sub: str | None
+    sid: str | None
+    iat: int
+    jti: str | None
+
+
+class OIDCClient:
+    """Lightweight OIDC Relying Party client.
+
+    One instance per (issuer, client_id, client_secret) tuple.
+    """
+
+    _DISCOVERY_TTL = 3600  # 1 hour
+    _JWKS_TTL = 3600       # 1 hour
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        scopes: str,
+        http_client: httpx.AsyncClient | None = None,
+    ):
+        # Keep the issuer string verbatim (including any trailing "/") — the OIDC
+        # spec mandates strict byte-for-byte equality between ``self.issuer``, the
+        # issuer advertised by the discovery document, and the ``iss`` claim in
+        # tokens. Operators must configure ``OIDC_ENDPOINT`` to match EXACTLY
+        # what the IdP returns.
+        self.issuer = issuer
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.scopes = scopes
+        self._http = http_client or httpx.AsyncClient(timeout=10.0)
+        self._metadata: dict | None = None
+        self._metadata_fetched_at: float = 0.0
+        self._jwks: JsonWebKey | None = None
+        self._jwks_fetched_at: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    async def discover(self) -> dict:
+        """Fetch and cache the OIDC discovery document.
+
+        Returns the cached document if it is less than _DISCOVERY_TTL seconds old.
+        Raises ValueError if the returned issuer does not match the configured one.
+        """
+        if self._metadata and (time.time() - self._metadata_fetched_at) < self._DISCOVERY_TTL:
+            return self._metadata
+        url = f"{self.issuer.rstrip('/')}/.well-known/openid-configuration"
+        resp = await self._http.get(url)
+        resp.raise_for_status()
+        self._metadata = resp.json()
+        self._metadata_fetched_at = time.time()
+        if self._metadata.get("issuer") != self.issuer:
+            raise ValueError(
+                f"Issuer mismatch: configured {self.issuer!r}, got {self._metadata.get('issuer')!r}"
+            )
+        return self._metadata
+
+    # ------------------------------------------------------------------
+    # JWKS
+    # ------------------------------------------------------------------
+
+    async def _load_jwks(self, force: bool = False) -> JsonWebKey:
+        meta = await self.discover()
+        if not force and self._jwks and (time.time() - self._jwks_fetched_at) < self._JWKS_TTL:
+            return self._jwks
+        resp = await self._http.get(meta["jwks_uri"])
+        resp.raise_for_status()
+        self._jwks = JsonWebKey.import_key_set(resp.json())
+        self._jwks_fetched_at = time.time()
+        return self._jwks
+
+    # ------------------------------------------------------------------
+    # PKCE helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def generate_pkce_pair() -> tuple[str, str]:
+        """Generate a PKCE (code_verifier, code_challenge) pair using S256.
+
+        Returns:
+            (verifier, challenge) — verifier is 128 url-safe chars,
+            challenge is the base64url-encoded SHA-256 of the verifier.
+        """
+        verifier = secrets.token_urlsafe(96)[:128]
+        digest = hashlib.sha256(verifier.encode()).digest()
+        challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        return verifier, challenge
+
+    @staticmethod
+    def generate_state_and_nonce() -> tuple[str, str]:
+        """Generate cryptographically random state and nonce values."""
+        return secrets.token_urlsafe(32), secrets.token_urlsafe(32)
+
+    # ------------------------------------------------------------------
+    # Authorization URL
+    # ------------------------------------------------------------------
+
+    async def build_authorization_url(
+        self, *, state: str, nonce: str, code_challenge: str
+    ) -> str:
+        """Build the full authorization URL to redirect the browser to."""
+        meta = await self.discover()
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scopes,
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        return f"{meta['authorization_endpoint']}?{urlencode(params)}"
+
+    # ------------------------------------------------------------------
+    # Code exchange
+    # ------------------------------------------------------------------
+
+    async def exchange_code(
+        self, *, code: str, code_verifier: str, expected_nonce: str
+    ) -> TokenBundle:
+        """Exchange an authorization code for tokens.
+
+        Verifies the returned id_token (signature, iss, aud, exp, nonce).
+
+        Args:
+            code: The authorization code from the IdP callback.
+            code_verifier: The PKCE verifier corresponding to the challenge sent earlier.
+            expected_nonce: The nonce value that was sent in the authorization request.
+
+        Returns:
+            A TokenBundle with verified claims.
+        """
+        meta = await self.discover()
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "code_verifier": code_verifier,
+        }
+        resp = await self._http.post(
+            meta["token_endpoint"], data=data, headers={"Accept": "application/json"}
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        id_token = payload["id_token"]
+        claims = await self._verify_id_token(id_token, expected_nonce=expected_nonce)
+        return TokenBundle(
+            id_token=id_token,
+            access_token=payload["access_token"],
+            refresh_token=payload.get("refresh_token"),
+            expires_in=int(payload.get("expires_in", 0)),
+            token_type=payload.get("token_type", "Bearer"),
+            claims=claims,
+        )
+
+    # ------------------------------------------------------------------
+    # Token refresh
+    # ------------------------------------------------------------------
+
+    async def refresh_access_token(self, refresh_token: str) -> TokenBundle:
+        """Use the refresh_token to obtain a new access_token.
+
+        If the IdP returns a new id_token, it is re-verified (nonce check skipped
+        per RFC 8252 §8.2 — nonce is only required during the initial code exchange).
+        If the IdP omits the refresh_token in the response, the caller's existing
+        refresh_token is preserved.
+
+        Returns:
+            A new TokenBundle.
+        """
+        meta = await self.discover()
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        resp = await self._http.post(
+            meta["token_endpoint"], data=data, headers={"Accept": "application/json"}
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        new_id_token = payload.get("id_token")
+        claims: dict[str, Any] = {}
+        if new_id_token:
+            claims = await self._verify_id_token(new_id_token, expected_nonce=None)
+        return TokenBundle(
+            id_token=new_id_token or "",
+            access_token=payload["access_token"],
+            # Some IdPs omit the refresh_token on rotation — keep the old one.
+            refresh_token=payload.get("refresh_token", refresh_token),
+            expires_in=int(payload.get("expires_in", 0)),
+            token_type=payload.get("token_type", "Bearer"),
+            claims=claims,
+        )
+
+    # ------------------------------------------------------------------
+    # Userinfo
+    # ------------------------------------------------------------------
+
+    async def fetch_userinfo(self, access_token: str) -> dict:
+        """Fetch the userinfo endpoint with the given access token."""
+        meta = await self.discover()
+        resp = await self._http.get(
+            meta["userinfo_endpoint"],
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # ID token verification
+    # ------------------------------------------------------------------
+
+    async def _verify_id_token(
+        self, token: str, *, expected_nonce: str | None
+    ) -> dict[str, Any]:
+        """Verify an ID token's signature and standard claims.
+
+        Retries with a fresh JWKS fetch on kid-miss (covers IdP key rotation).
+        Raises JoseError / ValueError on any validation failure.
+        """
+        jwks = await self._load_jwks()
+        jwt = JsonWebToken(["RS256", "ES256", "EdDSA", "RS384", "RS512"])
+        try:
+            claims = jwt.decode(token, jwks)
+        except JoseError:
+            # Force JWKS refresh in case of kid rotation; retry once.
+            jwks = await self._load_jwks(force=True)
+            claims = jwt.decode(token, jwks)
+
+        # Manual validation — avoids authlib version differences around claims.params
+        decoded: dict[str, Any] = dict(claims)
+        now = int(time.time())
+
+        if decoded.get("iss") != self.issuer:
+            raise ValueError(f"ID token iss mismatch: expected {self.issuer!r}, got {decoded.get('iss')!r}")
+
+        aud = decoded.get("aud")
+        if isinstance(aud, list):
+            if self.client_id not in aud:
+                raise ValueError(f"ID token aud {aud!r} does not contain client_id {self.client_id!r}")
+        elif aud != self.client_id:
+            raise ValueError(f"ID token aud {aud!r} != client_id {self.client_id!r}")
+
+        if "exp" not in decoded:
+            raise ValueError("ID token missing exp claim")
+        if int(decoded["exp"]) < now:
+            raise ValueError("ID token has expired")
+
+        if "iat" not in decoded:
+            raise ValueError("ID token missing iat claim")
+
+        if expected_nonce is not None:
+            if decoded.get("nonce") != expected_nonce:
+                raise ValueError("OIDC nonce mismatch")
+
+        return decoded
+
+    # ------------------------------------------------------------------
+    # Back-channel logout token verification
+    # ------------------------------------------------------------------
+
+    async def verify_logout_token(self, token: str) -> LogoutTokenClaims:
+        """Verify an OIDC back-channel logout token.
+
+        Validates:
+        - Signature (with JWKS kid-miss retry)
+        - Standard claims (iss, aud, iat)
+        - events claim contains the back-channel-logout URI key
+        - nonce must NOT be present (spec requirement)
+        - At least one of sub or sid must be present
+
+        Returns:
+            LogoutTokenClaims with the verified values.
+        Raises:
+            ValueError: on any spec violation.
+        """
+        jwks = await self._load_jwks()
+        jwt = JsonWebToken(["RS256", "ES256", "EdDSA", "RS384", "RS512"])
+        try:
+            claims = jwt.decode(token, jwks)
+        except JoseError:
+            jwks = await self._load_jwks(force=True)
+            claims = jwt.decode(token, jwks)
+
+        decoded: dict[str, Any] = dict(claims)
+        now = int(time.time())
+
+        if decoded.get("iss") != self.issuer:
+            raise ValueError(f"logout_token iss mismatch: expected {self.issuer!r}, got {decoded.get('iss')!r}")
+
+        aud = decoded.get("aud")
+        if isinstance(aud, list):
+            if self.client_id not in aud:
+                raise ValueError(f"logout_token aud {aud!r} does not contain client_id {self.client_id!r}")
+        elif aud != self.client_id:
+            raise ValueError(f"logout_token aud {aud!r} != client_id {self.client_id!r}")
+
+        if "iat" not in decoded:
+            raise ValueError("logout_token missing iat claim")
+        if int(decoded.get("exp", now + 1)) < now:
+            raise ValueError("logout_token has expired")
+
+        events = decoded.get("events") or {}
+        if "http://schemas.openid.net/event/backchannel-logout" not in events:
+            raise ValueError("logout_token missing required back-channel-logout event claim")
+
+        if decoded.get("nonce"):
+            raise ValueError("logout_token must not contain nonce")
+
+        if not decoded.get("sub") and not decoded.get("sid"):
+            raise ValueError("logout_token must contain sub or sid")
+
+        return LogoutTokenClaims(
+            iss=decoded["iss"],
+            aud=decoded["aud"],
+            sub=decoded.get("sub"),
+            sid=decoded.get("sid"),
+            iat=int(decoded["iat"]),
+            jti=decoded.get("jti"),
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._http.aclose()

--- a/openrag/components/auth/refresh.py
+++ b/openrag/components/auth/refresh.py
@@ -1,0 +1,183 @@
+"""Lazy refresh helper for OIDC access tokens.
+
+Extracted from ``AuthMiddleware`` (Phase 5) to keep ``api.py`` small and
+independently testable. Called per-request when a valid cookie session is
+found; a no-op when the access token is still fresh.
+
+Timezone policy
+---------------
+Phase 2 stores all OIDC session timestamps as **naive local time** via
+``datetime.now()`` (see ``test_oidc_sessions.py`` and
+``PartitionFileManager.get_oidc_session_by_token``). We match that style
+everywhere in this module to avoid tz-mismatch bugs when comparing
+``access_token_expires_at`` against "now".
+
+Refresh-token stampede guard (M1)
+---------------------------------
+IdPs with refresh_token rotation enabled invalidate the old refresh_token the
+first time it is redeemed. Under concurrency, multiple requests can each notice
+"my access_token is about to expire" at the same time and race each other to
+the token endpoint. The second attempt fails with ``invalid_grant`` and
+(without a guard) its session would be revoked mid-flight.
+
+We mitigate that with two cooperating mechanisms:
+
+1. A **short-circuit** here: if ``last_refresh_at`` was bumped less than 5
+   seconds ago, we assume a sibling request already rotated the tokens,
+   re-read the row, and reuse those freshly rotated tokens instead of calling
+   the IdP.
+2. A **row-level write lock** in :meth:`PartitionFileManager.update_oidc_session_tokens`
+   (``SELECT ... FOR UPDATE``) so that only one writer commits at a time on
+   Postgres.
+3. An **error-recovery branch** here: if the IdP does reject our refresh_token
+   (typically because a sibling raced us and won), we re-read the row once
+   more and, if the tokens were advanced meanwhile, return the fresh session
+   rather than giving up.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from components.auth.deps import get_oidc_client
+from components.auth.session_tokens import decrypt_token, encrypt_token
+from utils.logger import get_logger
+
+_REFRESH_BUFFER = timedelta(seconds=60)
+_STAMPEDE_WINDOW = timedelta(seconds=5)
+
+logger = get_logger()
+
+
+def _to_dt(val: Any) -> datetime:
+    """Coerce a datetime-or-ISO-string into a ``datetime``.
+
+    Ray occasionally ships values across actors in serialised form; accept
+    either shape so callers never have to care about the transport.
+    """
+    if isinstance(val, datetime):
+        return val
+    if isinstance(val, str):
+        return datetime.fromisoformat(val)
+    raise TypeError(f"Expected datetime or ISO string, got {type(val).__name__}")
+
+
+async def refresh_session_if_needed(
+    *,
+    session: dict[str, Any],
+    enc_key: str,
+    vectordb: Any,
+) -> dict[str, Any] | None:
+    """Refresh the IdP access_token if it is within ``_REFRESH_BUFFER`` of expiry.
+
+    Behaviour:
+      - If the access_token is still valid with the 60s buffer → return ``session`` unchanged.
+      - Stampede guard: if another request has just refreshed this session
+        (``last_refresh_at`` within 5s), re-read the row and reuse the fresh
+        tokens without calling the IdP.
+      - If near/past expiry AND a ``refresh_token_encrypted`` blob is stored →
+        call the IdP, persist rotated tokens, return an updated session dict.
+      - If near/past expiry AND no refresh_token is stored → return ``session`` as-is
+        when still formally valid, or ``None`` when already expired (caller should
+        treat as a revoked session).
+      - If the refresh call raises (typically because a sibling already rotated
+        the tokens and the IdP now rejects ours) → re-read the row; if a sibling
+        succeeded, return their fresh session; otherwise ``None``.
+
+    The session dict returned mirrors the DB row shape produced by
+    ``PartitionFileManager._oidc_session_to_dict``.
+    """
+    now = datetime.now()
+    access_exp = _to_dt(session["access_token_expires_at"])
+
+    if access_exp > now + _REFRESH_BUFFER:
+        return session
+
+    # --- Stampede short-circuit -------------------------------------------
+    # If a sibling request just refreshed this same session, re-read the row
+    # and reuse the freshly rotated tokens. This avoids racing the IdP with a
+    # refresh_token that the sibling's success has already invalidated.
+    last_refresh_at = session.get("last_refresh_at")
+    if last_refresh_at is not None:
+        try:
+            last_refresh_at_dt = _to_dt(last_refresh_at)
+        except TypeError:
+            last_refresh_at_dt = None
+        if (
+            last_refresh_at_dt is not None
+            and (now - last_refresh_at_dt) < _STAMPEDE_WINDOW
+        ):
+            try:
+                fresh = await vectordb.get_oidc_session_by_id.remote(session["id"])
+            except Exception as e:
+                logger.bind(session_id=session.get("id"), error=str(e)).warning(
+                    "Stampede-guard re-read failed; falling through to refresh"
+                )
+                fresh = None
+            if fresh is not None:
+                fresh_exp = _to_dt(fresh["access_token_expires_at"])
+                if fresh_exp > now + _REFRESH_BUFFER:
+                    return fresh
+
+    refresh_enc = session.get("refresh_token_encrypted")
+    if not refresh_enc:
+        # No refresh_token available.
+        # - If still formally valid (within the 60s buffer window but not yet past exp),
+        #   keep using it.
+        # - If already expired, caller should treat the session as dead.
+        return session if access_exp > now else None
+
+    try:
+        refresh_token = decrypt_token(refresh_enc, enc_key)
+        client = get_oidc_client()
+        bundle = await client.refresh_access_token(refresh_token)
+    except Exception as e:
+        # Maybe a sibling refreshed between our staleness check and the IdP call
+        # and the IdP has already invalidated our refresh_token. Re-read the
+        # row once before giving up: if the tokens were rotated meanwhile,
+        # treat this as a successful refresh (the sibling's).
+        logger.bind(session_id=session.get("id"), error=str(e)).warning(
+            "OIDC refresh_token exchange failed — re-reading session for stampede recovery"
+        )
+        try:
+            fresh = await vectordb.get_oidc_session_by_id.remote(session["id"])
+        except Exception as re:
+            logger.bind(session_id=session.get("id"), error=str(re)).error(
+                "Post-failure re-read of OIDC session failed — invalidating"
+            )
+            return None
+        if fresh is not None:
+            fresh_exp = _to_dt(fresh["access_token_expires_at"])
+            if fresh_exp > now + _REFRESH_BUFFER:
+                return fresh
+        return None
+
+    new_access_exp = now + timedelta(seconds=max(int(bundle.expires_in or 0), 60))
+    new_access_enc = encrypt_token(bundle.access_token, enc_key)
+    new_refresh_enc = (
+        encrypt_token(bundle.refresh_token, enc_key)
+        if bundle.refresh_token
+        else refresh_enc
+    )
+
+    try:
+        await vectordb.update_oidc_session_tokens.remote(
+            session_id=session["id"],
+            access_token_encrypted=new_access_enc,
+            refresh_token_encrypted=new_refresh_enc,
+            access_token_expires_at=new_access_exp,
+        )
+    except Exception as e:
+        logger.bind(session_id=session.get("id"), error=str(e)).error(
+            "Failed to persist refreshed OIDC tokens — invalidating session"
+        )
+        return None
+
+    return {
+        **session,
+        "access_token_encrypted": new_access_enc,
+        "access_token_expires_at": new_access_exp,
+        "refresh_token_encrypted": new_refresh_enc,
+        "last_refresh_at": now,
+    }

--- a/openrag/components/auth/refresh.py
+++ b/openrag/components/auth/refresh.py
@@ -104,10 +104,7 @@ async def refresh_session_if_needed(
             last_refresh_at_dt = _to_dt(last_refresh_at)
         except TypeError:
             last_refresh_at_dt = None
-        if (
-            last_refresh_at_dt is not None
-            and (now - last_refresh_at_dt) < _STAMPEDE_WINDOW
-        ):
+        if last_refresh_at_dt is not None and (now - last_refresh_at_dt) < _STAMPEDE_WINDOW:
             try:
                 fresh = await vectordb.get_oidc_session_by_id.remote(session["id"])
             except Exception as e:
@@ -155,11 +152,7 @@ async def refresh_session_if_needed(
 
     new_access_exp = now + timedelta(seconds=max(int(bundle.expires_in or 0), 60))
     new_access_enc = encrypt_token(bundle.access_token, enc_key)
-    new_refresh_enc = (
-        encrypt_token(bundle.refresh_token, enc_key)
-        if bundle.refresh_token
-        else refresh_enc
-    )
+    new_refresh_enc = encrypt_token(bundle.refresh_token, enc_key) if bundle.refresh_token else refresh_enc
 
     try:
         await vectordb.update_oidc_session_tokens.remote(

--- a/openrag/components/auth/session_tokens.py
+++ b/openrag/components/auth/session_tokens.py
@@ -1,0 +1,64 @@
+"""Session token utilities for OpenRAG OIDC sessions.
+
+Opaque session tokens are issued at callback and stored hashed (SHA-256) in the DB.
+IdP tokens (access_token, refresh_token) are encrypted with Fernet before storage.
+
+The Fernet key is provided via the OIDC_TOKEN_ENCRYPTION_KEY environment variable.
+Generate one with:
+    python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+"""
+
+import hashlib
+import secrets
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+def issue_session_token() -> tuple[str, str]:
+    """Generate a new session token.
+
+    Returns:
+        (plaintext, sha256_hex) — the plaintext is set in the cookie,
+        the hash is stored in the database.
+    """
+    plain = secrets.token_urlsafe(32)  # 43 chars, >= 256 bits entropy
+    return plain, hash_session_token(plain)
+
+
+def hash_session_token(token: str) -> str:
+    """Return the SHA-256 hex digest of the session token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _fernet(key: str | bytes) -> Fernet:
+    try:
+        return Fernet(key.encode("utf-8") if isinstance(key, str) else key)
+    except Exception as e:
+        raise ValueError(
+            "OIDC_TOKEN_ENCRYPTION_KEY is not a valid Fernet key. "
+            "Generate one with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
+        ) from e
+
+
+def encrypt_token(plaintext: str | None, key: str) -> bytes | None:
+    """Encrypt a plaintext token string.
+
+    Returns None if plaintext is None (refresh_token may be absent).
+    """
+    if plaintext is None:
+        return None
+    return _fernet(key).encrypt(plaintext.encode("utf-8"))
+
+
+def decrypt_token(ciphertext: bytes | None, key: str) -> str | None:
+    """Decrypt a Fernet-encrypted token.
+
+    Returns None if ciphertext is None.
+    Raises ValueError on key mismatch or data corruption.
+    """
+    if ciphertext is None:
+        return None
+    try:
+        return _fernet(key).decrypt(ciphertext).decode("utf-8")
+    except InvalidToken as e:
+        raise ValueError("Failed to decrypt stored OIDC token — key mismatch or corruption") from e

--- a/openrag/components/auth/state_cookie.py
+++ b/openrag/components/auth/state_cookie.py
@@ -1,0 +1,55 @@
+"""Signed state cookie for OIDC Authorization Code + PKCE flow.
+
+The cookie transports state/nonce/code_verifier between /auth/login and /auth/callback.
+It is signed (not encrypted) using itsdangerous.URLSafeTimedSerializer with HMAC-SHA1.
+
+The signing key is the OIDC_TOKEN_ENCRYPTION_KEY (a Fernet base64url key, which is
+valid arbitrary bytes for HMAC). The consuming code (phase 4 router) will pass the
+key to StateCookieSerializer(key). Using the same key for both Fernet encryption and
+HMAC signing is safe since itsdangerous derives separate subkeys via HMAC.
+
+TTL defaults to 600 s (10 minutes) — long enough for a slow user at the IdP login page.
+"""
+
+from dataclasses import asdict, dataclass
+
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+
+@dataclass
+class StateCookiePayload:
+    state: str
+    nonce: str
+    code_verifier: str
+    next_url: str = "/"
+
+
+class StateCookieSerializer:
+    """Signs/verifies the short-lived cookie holding OIDC state/nonce/code_verifier.
+
+    TTL defaults to 600 s (10 minutes) — long enough for a slow user at the IdP.
+    """
+
+    COOKIE_NAME = "openrag_oidc_state"
+    DEFAULT_TTL_SECONDS = 600
+
+    def __init__(self, secret_key: str, salt: str = "openrag-oidc-state-v1"):
+        self._serializer = URLSafeTimedSerializer(secret_key, salt=salt)
+
+    def dumps(self, payload: StateCookiePayload) -> str:
+        """Serialize and sign the payload, returning an opaque cookie value."""
+        return self._serializer.dumps(asdict(payload))
+
+    def loads(self, token: str, max_age: int = DEFAULT_TTL_SECONDS) -> StateCookiePayload:
+        """Verify and deserialize the cookie value.
+
+        Raises:
+            ValueError: if the cookie is expired or the signature is invalid.
+        """
+        try:
+            data = self._serializer.loads(token, max_age=max_age)
+        except SignatureExpired as e:
+            raise ValueError("OIDC state cookie expired") from e
+        except BadSignature as e:
+            raise ValueError("OIDC state cookie signature invalid") from e
+        return StateCookiePayload(**data)

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -4,8 +4,9 @@ These tests mount the middleware on a minimal FastAPI app with a ``MagicMock``
 ``vectordb`` — no Ray, no Postgres, no Milvus. They exercise the decision tree
 documented in ``.omc/plans/oidc-auth/plan.md`` §6.1.
 
-Timezone policy: Phase 2 stores session timestamps as naive UTC (``datetime.now()``),
-so the refresh helper compares naive datetimes. These tests follow suit.
+Timezone policy: Phase 2 stores session timestamps as naive local time
+(``datetime.now()``), so the refresh helper compares naive datetimes. These
+tests follow suit.
 """
 
 from __future__ import annotations

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -14,11 +14,9 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from components.auth.middleware import AuthMiddleware, is_ui_path
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-
-from components.auth.middleware import AuthMiddleware, is_ui_path
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -423,9 +421,7 @@ class TestRefreshHelper:
             side_effect=AssertionError("IdP must not be called during stampede short-circuit")
         )
         with patch.object(refresh_mod, "get_oidc_client", return_value=fake_client):
-            out = await refresh_session_if_needed(
-                session=stale_session, enc_key="k", vectordb=vdb
-            )
+            out = await refresh_session_if_needed(session=stale_session, enc_key="k", vectordb=vdb)
 
         assert out is fresh_row
         fake_client.refresh_access_token.assert_not_awaited()
@@ -459,16 +455,12 @@ class TestRefreshHelper:
         vdb.get_oidc_session_by_id.remote = AsyncMock(return_value=fresh_row)
 
         fake_client = MagicMock()
-        fake_client.refresh_access_token = AsyncMock(
-            side_effect=RuntimeError("invalid_grant")
-        )
+        fake_client.refresh_access_token = AsyncMock(side_effect=RuntimeError("invalid_grant"))
         with (
             patch.object(refresh_mod, "get_oidc_client", return_value=fake_client),
             patch.object(refresh_mod, "decrypt_token", return_value="old-refresh-plain"),
         ):
-            out = await refresh_session_if_needed(
-                session=stale_session, enc_key="k", vectordb=vdb
-            )
+            out = await refresh_session_if_needed(session=stale_session, enc_key="k", vectordb=vdb)
 
         assert out is fresh_row
         fake_client.refresh_access_token.assert_awaited_once()
@@ -495,15 +487,11 @@ class TestRefreshHelper:
         vdb.get_oidc_session_by_id.remote = AsyncMock(return_value=stale_row_from_db)
 
         fake_client = MagicMock()
-        fake_client.refresh_access_token = AsyncMock(
-            side_effect=RuntimeError("invalid_grant")
-        )
+        fake_client.refresh_access_token = AsyncMock(side_effect=RuntimeError("invalid_grant"))
         with (
             patch.object(refresh_mod, "get_oidc_client", return_value=fake_client),
             patch.object(refresh_mod, "decrypt_token", return_value="old-refresh-plain"),
         ):
-            out = await refresh_session_if_needed(
-                session=stale_session, enc_key="k", vectordb=vdb
-            )
+            out = await refresh_session_if_needed(session=stale_session, enc_key="k", vectordb=vdb)
 
         assert out is None

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -1,0 +1,509 @@
+"""Unit tests for the Phase-5 ``AuthMiddleware``.
+
+These tests mount the middleware on a minimal FastAPI app with a ``MagicMock``
+``vectordb`` — no Ray, no Postgres, no Milvus. They exercise the decision tree
+documented in ``.omc/plans/oidc-auth/plan.md`` §6.1.
+
+Timezone policy: Phase 2 stores session timestamps as naive UTC (``datetime.now()``),
+so the refresh helper compares naive datetimes. These tests follow suit.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from components.auth.middleware import AuthMiddleware, is_ui_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vectordb_mock(
+    *,
+    user=None,
+    user_by_token=None,
+    session=None,
+    partitions=None,
+):
+    """Return a MagicMock exposing the Ray-actor surface used by the middleware.
+
+    Every ``.remote(...)`` call returns a *coroutine* since the middleware
+    awaits it.
+    """
+    mock = MagicMock()
+
+    mock.get_user = MagicMock()
+    mock.get_user.remote = AsyncMock(return_value=user or {"id": 1, "display_name": "Admin"})
+
+    mock.get_user_by_token = MagicMock()
+    mock.get_user_by_token.remote = AsyncMock(return_value=user_by_token)
+
+    mock.get_oidc_session_by_token = MagicMock()
+    mock.get_oidc_session_by_token.remote = AsyncMock(return_value=session)
+
+    mock.list_user_partitions = MagicMock()
+    mock.list_user_partitions.remote = AsyncMock(return_value=partitions or [])
+
+    mock.revoke_oidc_session_by_id = MagicMock()
+    mock.revoke_oidc_session_by_id.remote = AsyncMock(return_value=None)
+
+    mock.update_oidc_session_tokens = MagicMock()
+    mock.update_oidc_session_tokens.remote = AsyncMock(return_value=None)
+
+    return mock
+
+
+def _build_app(vectordb_mock) -> FastAPI:
+    """Construct a FastAPI app with the middleware under test."""
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware, get_vectordb=lambda: vectordb_mock)
+
+    @app.get("/")
+    async def root(request: Request):
+        return {"user": request.state.user["id"]}
+
+    @app.get("/v1/chat/completions")
+    async def chat(request: Request):
+        return {"user": request.state.user["id"]}
+
+    @app.get("/indexer/foo")
+    async def indexer_foo(request: Request):
+        return {"user": request.state.user["id"]}
+
+    @app.get("/users/info")
+    async def users_info(request: Request):
+        return {"user": request.state.user["id"]}
+
+    @app.get("/static/foo.pdf")
+    async def static_file(request: Request):
+        return {"user": request.state.user["id"]}
+
+    @app.get("/health_check")
+    async def hc():
+        return "ok"
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# is_ui_path — pure function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/", True),
+        ("/static/x.pdf", True),
+        ("/static", True),
+        ("/v1/chat/completions", False),
+        ("/v1/models", False),
+        ("/indexer/add_file", False),
+        ("/search/foo", False),
+        ("/users/info", False),
+        ("/partition/foo", False),
+        ("/workspaces/list", False),
+        ("/queue/info", False),
+        ("/extract/something", False),
+        ("/actors/", False),
+        ("/monitoring/status", False),
+        ("/tools/execute", False),
+        ("/unknown/thing", False),  # default: not UI (avoid redirect loops)
+    ],
+)
+def test_is_ui_path(path, expected):
+    assert is_ui_path(path) is expected
+
+
+# ---------------------------------------------------------------------------
+# Token mode (legacy) — must preserve 403 + legacy error bodies
+# ---------------------------------------------------------------------------
+
+
+class TestTokenModeLegacy:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("AUTH_MODE", "token")
+        monkeypatch.setenv("AUTH_TOKEN", "configured-admin-token")
+
+    def test_bearer_valid_returns_200(self):
+        vdb = _make_vectordb_mock(user_by_token={"id": 7, "display_name": "U"})
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get(
+                "/v1/chat/completions",
+                headers={"Authorization": "Bearer good-token"},
+            )
+        assert r.status_code == 200
+        assert r.json() == {"user": 7}
+
+    def test_bearer_invalid_returns_403(self):
+        vdb = _make_vectordb_mock(user_by_token=None)
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get(
+                "/v1/chat/completions",
+                headers={"Authorization": "Bearer bogus"},
+            )
+        assert r.status_code == 403
+        assert r.json() == {"detail": "Invalid token"}
+
+    def test_missing_token_returns_403(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/v1/chat/completions")
+        assert r.status_code == 403
+        assert r.json() == {"detail": "Missing token"}
+
+    def test_bypass_path_open(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/health_check")
+        assert r.status_code == 200
+
+
+class TestTokenModeDevBypass:
+    """AUTH_MODE=token, AUTH_TOKEN unset → all requests resolve to user id=1."""
+
+    def test_no_token_resolves_user_1(self, monkeypatch):
+        monkeypatch.setenv("AUTH_MODE", "token")
+        monkeypatch.delenv("AUTH_TOKEN", raising=False)
+        vdb = _make_vectordb_mock(user={"id": 1, "display_name": "Admin"})
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/v1/chat/completions")
+        assert r.status_code == 200
+        assert r.json() == {"user": 1}
+        vdb.get_user.remote.assert_awaited_with(1)
+
+
+# ---------------------------------------------------------------------------
+# OIDC mode
+# ---------------------------------------------------------------------------
+
+
+class TestOIDCMode:
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch):
+        monkeypatch.setenv("AUTH_MODE", "oidc")
+        # refresh helper reads OIDC_TOKEN_ENCRYPTION_KEY but we patch the helper
+        # in refresh-related tests, so a dummy value is fine.
+        monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", "dummy")
+
+    def _fresh_session(self, user_id=42):
+        """A session whose access_token is still well within lifetime."""
+        return {
+            "id": 1,
+            "user_id": user_id,
+            "sub": "sub-abc",
+            "sid": "sid-xyz",
+            "id_token_encrypted": None,
+            "access_token_encrypted": b"enc-access",
+            "refresh_token_encrypted": b"enc-refresh",
+            "access_token_expires_at": datetime.now() + timedelta(minutes=30),
+            "session_expires_at": datetime.now() + timedelta(hours=8),
+            "revoked_at": None,
+            "last_refresh_at": None,
+        }
+
+    # -- cookie session happy path ------------------------------------------
+
+    def test_cookie_valid_and_access_token_fresh_no_refresh(self):
+        session = self._fresh_session(user_id=42)
+        user = {"id": 42, "display_name": "Alice"}
+        vdb = _make_vectordb_mock(user=user, session=session)
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            client.cookies.set("openrag_session", "plain-cookie")
+            r = client.get("/v1/chat/completions")
+        assert r.status_code == 200
+        assert r.json() == {"user": 42}
+        vdb.update_oidc_session_tokens.remote.assert_not_awaited()
+        vdb.revoke_oidc_session_by_id.remote.assert_not_awaited()
+
+    def test_cookie_near_expiry_triggers_refresh(self, monkeypatch):
+        """access_token within 60s of expiry AND refresh_token present → refresh."""
+        session = self._fresh_session(user_id=42)
+        # Force the refresh helper to "see" the token as near-expiry.
+        session["access_token_expires_at"] = datetime.now() + timedelta(seconds=5)
+        user = {"id": 42}
+        vdb = _make_vectordb_mock(user=user, session=session)
+
+        # Patch the helper at its import site inside the middleware module
+        # to avoid any dependency on a real OIDC client.
+        async def fake_refresh(*, session, enc_key, vectordb):
+            new_exp = datetime.now() + timedelta(minutes=30)
+            await vectordb.update_oidc_session_tokens.remote(
+                session_id=session["id"],
+                access_token_encrypted=b"new-enc-access",
+                refresh_token_encrypted=b"new-enc-refresh",
+                access_token_expires_at=new_exp,
+            )
+            return {
+                **session,
+                "access_token_encrypted": b"new-enc-access",
+                "access_token_expires_at": new_exp,
+                "refresh_token_encrypted": b"new-enc-refresh",
+            }
+
+        with patch(
+            "components.auth.middleware.refresh_session_if_needed",
+            side_effect=fake_refresh,
+        ):
+            app = _build_app(vdb)
+            with TestClient(app) as client:
+                client.cookies.set("openrag_session", "plain-cookie")
+                r = client.get("/v1/chat/completions")
+
+        assert r.status_code == 200
+        vdb.update_oidc_session_tokens.remote.assert_awaited()
+
+    def test_cookie_refresh_fails_session_revoked_and_302(self):
+        """access_token expired + refresh fails → session revoked, UI request → 302."""
+        session = self._fresh_session(user_id=42)
+        session["access_token_expires_at"] = datetime.now() - timedelta(minutes=1)
+        vdb = _make_vectordb_mock(user=None, session=session)
+
+        async def fake_refresh(*, session, enc_key, vectordb):
+            return None  # refresh failed → invalid session
+
+        with patch(
+            "components.auth.middleware.refresh_session_if_needed",
+            side_effect=fake_refresh,
+        ):
+            app = _build_app(vdb)
+            with TestClient(app) as client:
+                client.cookies.set("openrag_session", "plain-cookie")
+                r = client.get("/", follow_redirects=False)
+
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/auth/login?next=")
+        vdb.revoke_oidc_session_by_id.remote.assert_awaited_with(1)
+
+    # -- bearer fallback ----------------------------------------------------
+
+    def test_bearer_fallback_accepted_in_oidc_mode(self):
+        """Programmatic clients keep using ``users.token`` in oidc mode."""
+        vdb = _make_vectordb_mock(user_by_token={"id": 9, "display_name": "bot"})
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get(
+                "/v1/chat/completions",
+                headers={"Authorization": "Bearer ci-token"},
+            )
+        assert r.status_code == 200
+        assert r.json() == {"user": 9}
+
+    # -- unauthenticated branching ------------------------------------------
+
+    def test_no_creds_api_path_returns_401(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/indexer/foo")
+        assert r.status_code == 401
+        assert r.json() == {"detail": "Unauthenticated"}
+
+    def test_no_creds_root_path_returns_302(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/", follow_redirects=False)
+        assert r.status_code == 302
+        # ``next`` must preserve the original path+query
+        assert r.headers["location"] == "/auth/login?next=%2F"
+
+    def test_no_creds_root_with_query_preserves_next(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/?foo=bar", follow_redirects=False)
+        assert r.status_code == 302
+        # %2F / %3F / %3D — full url-encoding
+        assert "next=" in r.headers["location"]
+        assert "%2F" in r.headers["location"]
+
+    def test_no_creds_static_path_returns_302(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/static/foo.pdf", follow_redirects=False)
+        assert r.status_code == 302
+
+    def test_no_creds_v1_chat_returns_401(self):
+        vdb = _make_vectordb_mock()
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/v1/chat/completions")
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# refresh_session_if_needed — behavioural unit test
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshHelper:
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_token_fresh(self):
+        from components.auth.refresh import refresh_session_if_needed
+
+        session = {
+            "id": 1,
+            "access_token_expires_at": datetime.now() + timedelta(minutes=30),
+            "refresh_token_encrypted": b"foo",
+        }
+        vdb = MagicMock()
+        vdb.update_oidc_session_tokens = MagicMock()
+        vdb.update_oidc_session_tokens.remote = AsyncMock()
+
+        out = await refresh_session_if_needed(session=session, enc_key="k", vectordb=vdb)
+        assert out is session
+        vdb.update_oidc_session_tokens.remote.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_expired_no_refresh_token_returns_none(self):
+        from components.auth.refresh import refresh_session_if_needed
+
+        session = {
+            "id": 1,
+            "access_token_expires_at": datetime.now() - timedelta(minutes=1),
+            "refresh_token_encrypted": None,
+        }
+        vdb = MagicMock()
+        out = await refresh_session_if_needed(session=session, enc_key="k", vectordb=vdb)
+        assert out is None
+
+    # ------------------------------------------------------------------
+    # M1: refresh-token stampede guard
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_refresh_short_circuit_when_last_refresh_recent(self):
+        """If another request refreshed <5s ago, reuse the fresh row; do NOT
+        hit the IdP again with a refresh_token that has already been rotated."""
+        from components.auth import refresh as refresh_mod
+        from components.auth.refresh import refresh_session_if_needed
+
+        now = datetime.now()
+        fresh_exp = now + timedelta(minutes=30)
+        fresh_row = {
+            "id": 1,
+            "access_token_expires_at": fresh_exp,
+            "refresh_token_encrypted": b"new-refresh",
+            "access_token_encrypted": b"new-access",
+            "last_refresh_at": now,
+        }
+        stale_session = {
+            "id": 1,
+            # About to expire → normally we would call the IdP.
+            "access_token_expires_at": now + timedelta(seconds=5),
+            "refresh_token_encrypted": b"old-refresh",
+            "last_refresh_at": now - timedelta(seconds=2),  # sibling just refreshed
+        }
+
+        vdb = MagicMock()
+        vdb.get_oidc_session_by_id = MagicMock()
+        vdb.get_oidc_session_by_id.remote = AsyncMock(return_value=fresh_row)
+        vdb.update_oidc_session_tokens = MagicMock()
+        vdb.update_oidc_session_tokens.remote = AsyncMock()
+
+        # Sentinel: the IdP client must NOT be contacted.
+        fake_client = MagicMock()
+        fake_client.refresh_access_token = AsyncMock(
+            side_effect=AssertionError("IdP must not be called during stampede short-circuit")
+        )
+        with patch.object(refresh_mod, "get_oidc_client", return_value=fake_client):
+            out = await refresh_session_if_needed(
+                session=stale_session, enc_key="k", vectordb=vdb
+            )
+
+        assert out is fresh_row
+        fake_client.refresh_access_token.assert_not_awaited()
+        vdb.update_oidc_session_tokens.remote.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_refresh_recovers_when_idp_rejects_stale_refresh_token(self):
+        """IdP rejects our refresh_token (sibling already rotated it); the helper
+        re-reads the session and returns the sibling's fresh tokens."""
+        from components.auth import refresh as refresh_mod
+        from components.auth.refresh import refresh_session_if_needed
+
+        now = datetime.now()
+        stale_session = {
+            "id": 1,
+            "access_token_expires_at": now + timedelta(seconds=5),
+            "refresh_token_encrypted": b"old-refresh",
+            # No recent last_refresh_at → stampede short-circuit does NOT fire.
+            "last_refresh_at": None,
+        }
+        fresh_row = {
+            "id": 1,
+            "access_token_expires_at": now + timedelta(minutes=30),
+            "refresh_token_encrypted": b"new-refresh",
+            "access_token_encrypted": b"new-access",
+            "last_refresh_at": now,
+        }
+
+        vdb = MagicMock()
+        vdb.get_oidc_session_by_id = MagicMock()
+        vdb.get_oidc_session_by_id.remote = AsyncMock(return_value=fresh_row)
+
+        fake_client = MagicMock()
+        fake_client.refresh_access_token = AsyncMock(
+            side_effect=RuntimeError("invalid_grant")
+        )
+        with (
+            patch.object(refresh_mod, "get_oidc_client", return_value=fake_client),
+            patch.object(refresh_mod, "decrypt_token", return_value="old-refresh-plain"),
+        ):
+            out = await refresh_session_if_needed(
+                session=stale_session, enc_key="k", vectordb=vdb
+            )
+
+        assert out is fresh_row
+        fake_client.refresh_access_token.assert_awaited_once()
+        vdb.get_oidc_session_by_id.remote.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_none_when_idp_rejects_and_no_concurrent_refresh(self):
+        """IdP rejects us and no sibling rotated the tokens → invalidate session."""
+        from components.auth import refresh as refresh_mod
+        from components.auth.refresh import refresh_session_if_needed
+
+        now = datetime.now()
+        stale_session = {
+            "id": 1,
+            "access_token_expires_at": now + timedelta(seconds=5),
+            "refresh_token_encrypted": b"old-refresh",
+            "last_refresh_at": None,
+        }
+        # Re-read returns the same stale row (no sibling rotation).
+        stale_row_from_db = dict(stale_session)
+
+        vdb = MagicMock()
+        vdb.get_oidc_session_by_id = MagicMock()
+        vdb.get_oidc_session_by_id.remote = AsyncMock(return_value=stale_row_from_db)
+
+        fake_client = MagicMock()
+        fake_client.refresh_access_token = AsyncMock(
+            side_effect=RuntimeError("invalid_grant")
+        )
+        with (
+            patch.object(refresh_mod, "get_oidc_client", return_value=fake_client),
+            patch.object(refresh_mod, "decrypt_token", return_value="old-refresh-plain"),
+        ):
+            out = await refresh_session_if_needed(
+                session=stale_session, enc_key="k", vectordb=vdb
+            )
+
+        assert out is None

--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -1,14 +1,12 @@
 """Unit tests for oidc_client.py — uses respx to mock httpx calls."""
 
-import json
 import time
 
 import httpx
 import pytest
 import pytest_asyncio
 import respx
-from authlib.jose import JsonWebKey, OctKey
-
+from authlib.jose import JsonWebKey
 from components.auth.oidc_client import LogoutTokenClaims, OIDCClient, TokenBundle
 
 # ---------------------------------------------------------------------------
@@ -78,16 +76,16 @@ def _id_token_payload(nonce: str, *, extra: dict | None = None) -> dict:
     return payload
 
 
-def _logout_token_payload(*, sub: str | None = "user-sub-001", sid: str | None = None, extra: dict | None = None) -> dict:
+def _logout_token_payload(
+    *, sub: str | None = "user-sub-001", sid: str | None = None, extra: dict | None = None
+) -> dict:
     now = int(time.time())
     payload = {
         "iss": ISSUER,
         "aud": CLIENT_ID,
         "iat": now,
         "jti": "logout-jti-001",
-        "events": {
-            "http://schemas.openid.net/event/backchannel-logout": {}
-        },
+        "events": {"http://schemas.openid.net/event/backchannel-logout": {}},
     }
     if sub is not None:
         payload["sub"] = sub
@@ -102,17 +100,16 @@ def _logout_token_payload(*, sub: str | None = "user-sub-001", sid: str | None =
 # Fixture — OIDCClient with mocked httpx transport
 # ---------------------------------------------------------------------------
 
-@pytest.fixture
-def mock_transport():
-    """Return a respx mock transport; caller activates with `with respx.mock(transport=...)`."""
-    return respx.MockTransport()
-
 
 @pytest_asyncio.fixture
 async def client():
-    """OIDCClient backed by a real httpx.AsyncClient using respx mock transport."""
-    transport = respx.MockTransport(assert_all_called=False)
-    http = httpx.AsyncClient(transport=transport)
+    """OIDCClient backed by a real httpx.AsyncClient wired to a respx MockRouter.
+
+    respx >= 0.22 removed the top-level ``MockTransport``; use ``MockRouter``
+    plus ``httpx.MockTransport(router.handler)`` instead.
+    """
+    router = respx.MockRouter(assert_all_called=False)
+    http = httpx.AsyncClient(transport=httpx.MockTransport(router.handler))
     oc = OIDCClient(
         issuer=ISSUER,
         client_id=CLIENT_ID,
@@ -121,27 +118,24 @@ async def client():
         scopes=SCOPES,
         http_client=http,
     )
-    # Pre-register common mock routes on the transport's router
-    oc._mock_transport = transport
+    # Expose the router so individual tests can register additional routes.
+    oc._mock_router = router
     yield oc
     await oc.aclose()
 
 
-def _setup_discovery(transport: respx.MockTransport):
-    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
-        return_value=httpx.Response(200, json=DISCOVERY_DOC)
-    )
+def _setup_discovery(router: respx.MockRouter):
+    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(return_value=httpx.Response(200, json=DISCOVERY_DOC))
 
 
-def _setup_jwks(transport: respx.MockTransport):
-    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
-        return_value=httpx.Response(200, json=JWKS_RESPONSE)
-    )
+def _setup_jwks(router: respx.MockRouter):
+    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(return_value=httpx.Response(200, json=JWKS_RESPONSE))
 
 
 # ---------------------------------------------------------------------------
 # PKCE generation tests (pure, no HTTP)
 # ---------------------------------------------------------------------------
+
 
 class TestPKCE:
     def test_verifier_length(self):
@@ -153,11 +147,7 @@ class TestPKCE:
         import hashlib
 
         verifier, challenge = OIDCClient.generate_pkce_pair()
-        expected = (
-            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
-            .rstrip(b"=")
-            .decode()
-        )
+        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
         assert challenge == expected
 
     def test_unique_pairs(self):
@@ -173,13 +163,12 @@ class TestPKCE:
 # Authorization URL
 # ---------------------------------------------------------------------------
 
+
 class TestBuildAuthorizationUrl:
     @pytest.mark.asyncio
     async def test_required_params(self, client):
-        _setup_discovery(client._mock_transport)
-        url = await client.build_authorization_url(
-            state="mystate", nonce="mynonce", code_challenge="mychallenge"
-        )
+        _setup_discovery(client._mock_router)
+        url = await client.build_authorization_url(state="mystate", nonce="mynonce", code_challenge="mychallenge")
         assert "response_type=code" in url
         assert "client_id=openrag-client" in url
         assert "state=mystate" in url
@@ -193,19 +182,20 @@ class TestBuildAuthorizationUrl:
 # Discovery
 # ---------------------------------------------------------------------------
 
+
 class TestDiscover:
     @pytest.mark.asyncio
     async def test_issuer_mismatch_raises(self, client):
         bad_doc = dict(DISCOVERY_DOC, issuer="https://evil.example.com")
-        client._mock_transport.router.get(
-            f"{ISSUER}/.well-known/openid-configuration"
-        ).mock(return_value=httpx.Response(200, json=bad_doc))
+        client._mock_router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+            return_value=httpx.Response(200, json=bad_doc)
+        )
         with pytest.raises(ValueError, match="Issuer mismatch"):
             await client.discover()
 
     @pytest.mark.asyncio
     async def test_caching(self, client):
-        _setup_discovery(client._mock_transport)
+        _setup_discovery(client._mock_router)
         doc1 = await client.discover()
         doc2 = await client.discover()
         # Same object from cache
@@ -216,11 +206,12 @@ class TestDiscover:
 # Code exchange
 # ---------------------------------------------------------------------------
 
+
 class TestExchangeCode:
     @pytest.mark.asyncio
     async def test_success(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         nonce = "test-nonce-abc"
         id_token = _sign_jwt(_id_token_payload(nonce))
@@ -231,13 +222,11 @@ class TestExchangeCode:
             "expires_in": 300,
             "token_type": "Bearer",
         }
-        client._mock_transport.router.post(
-            f"{ISSUER}/protocol/openid-connect/token"
-        ).mock(return_value=httpx.Response(200, json=token_response))
-
-        bundle = await client.exchange_code(
-            code="auth-code", code_verifier="verifier", expected_nonce=nonce
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
         )
+
+        bundle = await client.exchange_code(code="auth-code", code_verifier="verifier", expected_nonce=nonce)
         assert isinstance(bundle, TokenBundle)
         assert bundle.access_token == "at-123"
         assert bundle.refresh_token == "rt-456"
@@ -246,8 +235,8 @@ class TestExchangeCode:
 
     @pytest.mark.asyncio
     async def test_nonce_mismatch_raises(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         id_token = _sign_jwt(_id_token_payload("correct-nonce"))
         token_response = {
@@ -256,25 +245,24 @@ class TestExchangeCode:
             "expires_in": 300,
             "token_type": "Bearer",
         }
-        client._mock_transport.router.post(
-            f"{ISSUER}/protocol/openid-connect/token"
-        ).mock(return_value=httpx.Response(200, json=token_response))
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
 
         with pytest.raises(ValueError, match="nonce"):
-            await client.exchange_code(
-                code="code", code_verifier="v", expected_nonce="wrong-nonce"
-            )
+            await client.exchange_code(code="code", code_verifier="v", expected_nonce="wrong-nonce")
 
 
 # ---------------------------------------------------------------------------
 # Token refresh
 # ---------------------------------------------------------------------------
 
+
 class TestRefreshAccessToken:
     @pytest.mark.asyncio
     async def test_keeps_old_refresh_token_when_omitted(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         # IdP returns no refresh_token in the response
         token_response = {
@@ -283,9 +271,9 @@ class TestRefreshAccessToken:
             "token_type": "Bearer",
             # no refresh_token
         }
-        client._mock_transport.router.post(
-            f"{ISSUER}/protocol/openid-connect/token"
-        ).mock(return_value=httpx.Response(200, json=token_response))
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
 
         bundle = await client.refresh_access_token("old-rt")
         assert bundle.refresh_token == "old-rt"
@@ -293,8 +281,8 @@ class TestRefreshAccessToken:
 
     @pytest.mark.asyncio
     async def test_uses_new_refresh_token_when_provided(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         token_response = {
             "access_token": "new-at",
@@ -302,9 +290,9 @@ class TestRefreshAccessToken:
             "expires_in": 300,
             "token_type": "Bearer",
         }
-        client._mock_transport.router.post(
-            f"{ISSUER}/protocol/openid-connect/token"
-        ).mock(return_value=httpx.Response(200, json=token_response))
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
 
         bundle = await client.refresh_access_token("old-rt")
         assert bundle.refresh_token == "new-rt"
@@ -314,15 +302,16 @@ class TestRefreshAccessToken:
 # Userinfo
 # ---------------------------------------------------------------------------
 
+
 class TestFetchUserinfo:
     @pytest.mark.asyncio
     async def test_returns_userinfo(self, client):
-        _setup_discovery(client._mock_transport)
+        _setup_discovery(client._mock_router)
 
         userinfo = {"sub": "user-sub-001", "email": "user@example.com"}
-        client._mock_transport.router.get(
-            f"{ISSUER}/protocol/openid-connect/userinfo"
-        ).mock(return_value=httpx.Response(200, json=userinfo))
+        client._mock_router.get(f"{ISSUER}/protocol/openid-connect/userinfo").mock(
+            return_value=httpx.Response(200, json=userinfo)
+        )
 
         result = await client.fetch_userinfo("at-123")
         assert result["email"] == "user@example.com"
@@ -332,11 +321,12 @@ class TestFetchUserinfo:
 # Logout token verification
 # ---------------------------------------------------------------------------
 
+
 class TestVerifyLogoutToken:
     @pytest.mark.asyncio
     async def test_valid_logout_token_with_sub(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         token = _sign_jwt(_logout_token_payload(sub="user-sub-001"))
         claims = await client.verify_logout_token(token)
@@ -345,8 +335,8 @@ class TestVerifyLogoutToken:
 
     @pytest.mark.asyncio
     async def test_valid_logout_token_with_sid(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         token = _sign_jwt(_logout_token_payload(sub=None, sid="session-abc"))
         claims = await client.verify_logout_token(token)
@@ -355,8 +345,8 @@ class TestVerifyLogoutToken:
 
     @pytest.mark.asyncio
     async def test_missing_events_claim_raises(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         payload = _logout_token_payload()
         del payload["events"]
@@ -366,8 +356,8 @@ class TestVerifyLogoutToken:
 
     @pytest.mark.asyncio
     async def test_wrong_events_key_raises(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         payload = _logout_token_payload()
         payload["events"] = {"http://schemas.openid.net/event/OTHER": {}}
@@ -377,8 +367,8 @@ class TestVerifyLogoutToken:
 
     @pytest.mark.asyncio
     async def test_nonce_present_raises(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         payload = _logout_token_payload()
         payload["nonce"] = "forbidden"
@@ -388,8 +378,8 @@ class TestVerifyLogoutToken:
 
     @pytest.mark.asyncio
     async def test_missing_sub_and_sid_raises(self, client):
-        _setup_discovery(client._mock_transport)
-        _setup_jwks(client._mock_transport)
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
 
         token = _sign_jwt(_logout_token_payload(sub=None, sid=None))
         with pytest.raises(ValueError, match="sub or sid"):

--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -32,8 +32,8 @@ def _make_rsa_key_pair():
 _RSA_PRIVATE, _RSA_PRIVATE_JWK, _RSA_PUBLIC_JWK = _make_rsa_key_pair()
 _RSA_PUBLIC_JWK["use"] = "sig"
 _RSA_PUBLIC_JWK["alg"] = "RS256"
-_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
-_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+_RSA_PUBLIC_JWK["kid"] = "test-key-1"
+_RSA_PRIVATE_JWK["kid"] = "test-key-1"
 
 JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
 

--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -1,0 +1,396 @@
+"""Unit tests for oidc_client.py — uses respx to mock httpx calls."""
+
+import json
+import time
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from authlib.jose import JsonWebKey, OctKey
+
+from components.auth.oidc_client import LogoutTokenClaims, OIDCClient, TokenBundle
+
+# ---------------------------------------------------------------------------
+# Helpers — RSA test key + JWT factory
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://idp.example.com/realms/openrag"
+CLIENT_ID = "openrag-client"
+CLIENT_SECRET = "test-secret"
+REDIRECT_URI = "https://openrag.example.com/auth/callback"
+SCOPES = "openid email profile offline_access"
+
+
+def _make_rsa_key_pair():
+    """Generate an RSA-2048 key pair using authlib's JsonWebKey."""
+    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private_jwk = private.as_dict(is_private=True)
+    public_jwk = private.as_dict()
+    return private, private_jwk, public_jwk
+
+
+# Generate once per module
+_RSA_PRIVATE, _RSA_PRIVATE_JWK, _RSA_PUBLIC_JWK = _make_rsa_key_pair()
+_RSA_PUBLIC_JWK["use"] = "sig"
+_RSA_PUBLIC_JWK["alg"] = "RS256"
+_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
+_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+
+JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
+
+DISCOVERY_DOC = {
+    "issuer": ISSUER,
+    "authorization_endpoint": f"{ISSUER}/protocol/openid-connect/auth",
+    "token_endpoint": f"{ISSUER}/protocol/openid-connect/token",
+    "userinfo_endpoint": f"{ISSUER}/protocol/openid-connect/userinfo",
+    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
+    "end_session_endpoint": f"{ISSUER}/protocol/openid-connect/logout",
+}
+
+
+def _sign_jwt(payload: dict) -> str:
+    """Sign payload with the test RSA private key, returning a compact JWT string."""
+    from authlib.jose import JsonWebToken
+
+    header = {"alg": "RS256", "kid": "test-key-1"}
+    jwt = JsonWebToken()
+    token = jwt.encode(header, payload, _RSA_PRIVATE)
+    # authlib returns bytes
+    if isinstance(token, bytes):
+        return token.decode()
+    return token
+
+
+def _id_token_payload(nonce: str, *, extra: dict | None = None) -> dict:
+    now = int(time.time())
+    payload = {
+        "iss": ISSUER,
+        "sub": "user-sub-001",
+        "aud": CLIENT_ID,
+        "exp": now + 300,
+        "iat": now,
+        "nonce": nonce,
+        "email": "user@example.com",
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _logout_token_payload(*, sub: str | None = "user-sub-001", sid: str | None = None, extra: dict | None = None) -> dict:
+    now = int(time.time())
+    payload = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "iat": now,
+        "jti": "logout-jti-001",
+        "events": {
+            "http://schemas.openid.net/event/backchannel-logout": {}
+        },
+    }
+    if sub is not None:
+        payload["sub"] = sub
+    if sid is not None:
+        payload["sid"] = sid
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Fixture — OIDCClient with mocked httpx transport
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_transport():
+    """Return a respx mock transport; caller activates with `with respx.mock(transport=...)`."""
+    return respx.MockTransport()
+
+
+@pytest_asyncio.fixture
+async def client():
+    """OIDCClient backed by a real httpx.AsyncClient using respx mock transport."""
+    transport = respx.MockTransport(assert_all_called=False)
+    http = httpx.AsyncClient(transport=transport)
+    oc = OIDCClient(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        scopes=SCOPES,
+        http_client=http,
+    )
+    # Pre-register common mock routes on the transport's router
+    oc._mock_transport = transport
+    yield oc
+    await oc.aclose()
+
+
+def _setup_discovery(transport: respx.MockTransport):
+    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json=DISCOVERY_DOC)
+    )
+
+
+def _setup_jwks(transport: respx.MockTransport):
+    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
+        return_value=httpx.Response(200, json=JWKS_RESPONSE)
+    )
+
+
+# ---------------------------------------------------------------------------
+# PKCE generation tests (pure, no HTTP)
+# ---------------------------------------------------------------------------
+
+class TestPKCE:
+    def test_verifier_length(self):
+        verifier, _ = OIDCClient.generate_pkce_pair()
+        assert 43 <= len(verifier) <= 128
+
+    def test_challenge_is_urlsafe_base64(self):
+        import base64
+        import hashlib
+
+        verifier, challenge = OIDCClient.generate_pkce_pair()
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        assert challenge == expected
+
+    def test_unique_pairs(self):
+        pairs = {OIDCClient.generate_pkce_pair()[0] for _ in range(20)}
+        assert len(pairs) == 20
+
+    def test_state_and_nonce_unique(self):
+        states = {OIDCClient.generate_state_and_nonce()[0] for _ in range(20)}
+        assert len(states) == 20
+
+
+# ---------------------------------------------------------------------------
+# Authorization URL
+# ---------------------------------------------------------------------------
+
+class TestBuildAuthorizationUrl:
+    @pytest.mark.asyncio
+    async def test_required_params(self, client):
+        _setup_discovery(client._mock_transport)
+        url = await client.build_authorization_url(
+            state="mystate", nonce="mynonce", code_challenge="mychallenge"
+        )
+        assert "response_type=code" in url
+        assert "client_id=openrag-client" in url
+        assert "state=mystate" in url
+        assert "nonce=mynonce" in url
+        assert "code_challenge=mychallenge" in url
+        assert "code_challenge_method=S256" in url
+        assert url.startswith(DISCOVERY_DOC["authorization_endpoint"])
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+class TestDiscover:
+    @pytest.mark.asyncio
+    async def test_issuer_mismatch_raises(self, client):
+        bad_doc = dict(DISCOVERY_DOC, issuer="https://evil.example.com")
+        client._mock_transport.router.get(
+            f"{ISSUER}/.well-known/openid-configuration"
+        ).mock(return_value=httpx.Response(200, json=bad_doc))
+        with pytest.raises(ValueError, match="Issuer mismatch"):
+            await client.discover()
+
+    @pytest.mark.asyncio
+    async def test_caching(self, client):
+        _setup_discovery(client._mock_transport)
+        doc1 = await client.discover()
+        doc2 = await client.discover()
+        # Same object from cache
+        assert doc1 is doc2
+
+
+# ---------------------------------------------------------------------------
+# Code exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeCode:
+    @pytest.mark.asyncio
+    async def test_success(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        nonce = "test-nonce-abc"
+        id_token = _sign_jwt(_id_token_payload(nonce))
+        token_response = {
+            "id_token": id_token,
+            "access_token": "at-123",
+            "refresh_token": "rt-456",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+        client._mock_transport.router.post(
+            f"{ISSUER}/protocol/openid-connect/token"
+        ).mock(return_value=httpx.Response(200, json=token_response))
+
+        bundle = await client.exchange_code(
+            code="auth-code", code_verifier="verifier", expected_nonce=nonce
+        )
+        assert isinstance(bundle, TokenBundle)
+        assert bundle.access_token == "at-123"
+        assert bundle.refresh_token == "rt-456"
+        assert bundle.claims["sub"] == "user-sub-001"
+        assert bundle.claims["nonce"] == nonce
+
+    @pytest.mark.asyncio
+    async def test_nonce_mismatch_raises(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        id_token = _sign_jwt(_id_token_payload("correct-nonce"))
+        token_response = {
+            "id_token": id_token,
+            "access_token": "at",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+        client._mock_transport.router.post(
+            f"{ISSUER}/protocol/openid-connect/token"
+        ).mock(return_value=httpx.Response(200, json=token_response))
+
+        with pytest.raises(ValueError, match="nonce"):
+            await client.exchange_code(
+                code="code", code_verifier="v", expected_nonce="wrong-nonce"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Token refresh
+# ---------------------------------------------------------------------------
+
+class TestRefreshAccessToken:
+    @pytest.mark.asyncio
+    async def test_keeps_old_refresh_token_when_omitted(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        # IdP returns no refresh_token in the response
+        token_response = {
+            "access_token": "new-at",
+            "expires_in": 300,
+            "token_type": "Bearer",
+            # no refresh_token
+        }
+        client._mock_transport.router.post(
+            f"{ISSUER}/protocol/openid-connect/token"
+        ).mock(return_value=httpx.Response(200, json=token_response))
+
+        bundle = await client.refresh_access_token("old-rt")
+        assert bundle.refresh_token == "old-rt"
+        assert bundle.access_token == "new-at"
+
+    @pytest.mark.asyncio
+    async def test_uses_new_refresh_token_when_provided(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        token_response = {
+            "access_token": "new-at",
+            "refresh_token": "new-rt",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+        client._mock_transport.router.post(
+            f"{ISSUER}/protocol/openid-connect/token"
+        ).mock(return_value=httpx.Response(200, json=token_response))
+
+        bundle = await client.refresh_access_token("old-rt")
+        assert bundle.refresh_token == "new-rt"
+
+
+# ---------------------------------------------------------------------------
+# Userinfo
+# ---------------------------------------------------------------------------
+
+class TestFetchUserinfo:
+    @pytest.mark.asyncio
+    async def test_returns_userinfo(self, client):
+        _setup_discovery(client._mock_transport)
+
+        userinfo = {"sub": "user-sub-001", "email": "user@example.com"}
+        client._mock_transport.router.get(
+            f"{ISSUER}/protocol/openid-connect/userinfo"
+        ).mock(return_value=httpx.Response(200, json=userinfo))
+
+        result = await client.fetch_userinfo("at-123")
+        assert result["email"] == "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Logout token verification
+# ---------------------------------------------------------------------------
+
+class TestVerifyLogoutToken:
+    @pytest.mark.asyncio
+    async def test_valid_logout_token_with_sub(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        token = _sign_jwt(_logout_token_payload(sub="user-sub-001"))
+        claims = await client.verify_logout_token(token)
+        assert isinstance(claims, LogoutTokenClaims)
+        assert claims.sub == "user-sub-001"
+
+    @pytest.mark.asyncio
+    async def test_valid_logout_token_with_sid(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        token = _sign_jwt(_logout_token_payload(sub=None, sid="session-abc"))
+        claims = await client.verify_logout_token(token)
+        assert claims.sid == "session-abc"
+        assert claims.sub is None
+
+    @pytest.mark.asyncio
+    async def test_missing_events_claim_raises(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        payload = _logout_token_payload()
+        del payload["events"]
+        token = _sign_jwt(payload)
+        with pytest.raises(ValueError, match="back-channel-logout"):
+            await client.verify_logout_token(token)
+
+    @pytest.mark.asyncio
+    async def test_wrong_events_key_raises(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        payload = _logout_token_payload()
+        payload["events"] = {"http://schemas.openid.net/event/OTHER": {}}
+        token = _sign_jwt(payload)
+        with pytest.raises(ValueError, match="back-channel-logout"):
+            await client.verify_logout_token(token)
+
+    @pytest.mark.asyncio
+    async def test_nonce_present_raises(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        payload = _logout_token_payload()
+        payload["nonce"] = "forbidden"
+        token = _sign_jwt(payload)
+        with pytest.raises(ValueError, match="nonce"):
+            await client.verify_logout_token(token)
+
+    @pytest.mark.asyncio
+    async def test_missing_sub_and_sid_raises(self, client):
+        _setup_discovery(client._mock_transport)
+        _setup_jwks(client._mock_transport)
+
+        token = _sign_jwt(_logout_token_payload(sub=None, sid=None))
+        with pytest.raises(ValueError, match="sub or sid"):
+            await client.verify_logout_token(token)

--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -52,7 +52,8 @@ def _sign_jwt(payload: dict) -> str:
     from authlib.jose import JsonWebToken
 
     header = {"alg": "RS256", "kid": "test-key-1"}
-    jwt = JsonWebToken()
+    # Authlib >=1.0 requires the allowed-algorithms list on JsonWebToken.
+    jwt = JsonWebToken(["RS256"])
     token = jwt.encode(header, payload, _RSA_PRIVATE)
     # authlib returns bytes
     if isinstance(token, bytes):

--- a/openrag/components/auth/test_session_tokens.py
+++ b/openrag/components/auth/test_session_tokens.py
@@ -1,0 +1,69 @@
+"""Unit tests for session_tokens.py."""
+
+import pytest
+from cryptography.fernet import Fernet
+
+from components.auth.session_tokens import (
+    decrypt_token,
+    encrypt_token,
+    hash_session_token,
+    issue_session_token,
+)
+
+
+def _valid_key() -> str:
+    return Fernet.generate_key().decode()
+
+
+class TestIssueSessionToken:
+    def test_returns_tuple_of_two_strings(self):
+        plain, hashed = issue_session_token()
+        assert isinstance(plain, str)
+        assert isinstance(hashed, str)
+
+    def test_hash_is_64_hex_chars(self):
+        _, hashed = issue_session_token()
+        assert len(hashed) == 64
+        assert all(c in "0123456789abcdef" for c in hashed)
+
+    def test_tokens_are_unique(self):
+        tokens = {issue_session_token()[0] for _ in range(20)}
+        assert len(tokens) == 20
+
+    def test_hash_matches_plain(self):
+        plain, hashed = issue_session_token()
+        assert hash_session_token(plain) == hashed
+
+
+class TestHashSessionToken:
+    def test_deterministic(self):
+        assert hash_session_token("abc") == hash_session_token("abc")
+
+    def test_different_inputs_differ(self):
+        assert hash_session_token("abc") != hash_session_token("def")
+
+
+class TestEncryptDecryptRoundTrip:
+    def test_round_trip(self):
+        key = _valid_key()
+        plaintext = "super-secret-access-token"
+        ciphertext = encrypt_token(plaintext, key)
+        assert ciphertext is not None
+        assert decrypt_token(ciphertext, key) == plaintext
+
+    def test_none_plaintext_returns_none(self):
+        assert encrypt_token(None, _valid_key()) is None
+
+    def test_none_ciphertext_returns_none(self):
+        assert decrypt_token(None, _valid_key()) is None
+
+    def test_wrong_key_raises_value_error(self):
+        key1 = _valid_key()
+        key2 = _valid_key()
+        ciphertext = encrypt_token("secret", key1)
+        with pytest.raises(ValueError, match="decrypt"):
+            decrypt_token(ciphertext, key2)
+
+    def test_invalid_key_raises_value_error(self):
+        with pytest.raises(ValueError, match="valid Fernet"):
+            encrypt_token("data", "not-a-fernet-key")

--- a/openrag/components/auth/test_session_tokens.py
+++ b/openrag/components/auth/test_session_tokens.py
@@ -1,14 +1,13 @@
 """Unit tests for session_tokens.py."""
 
 import pytest
-from cryptography.fernet import Fernet
-
 from components.auth.session_tokens import (
     decrypt_token,
     encrypt_token,
     hash_session_token,
     issue_session_token,
 )
+from cryptography.fernet import Fernet
 
 
 def _valid_key() -> str:

--- a/openrag/components/auth/test_state_cookie.py
+++ b/openrag/components/auth/test_state_cookie.py
@@ -3,9 +3,7 @@
 import time
 
 import pytest
-
 from components.auth.state_cookie import StateCookiePayload, StateCookieSerializer
-
 
 SECRET = "test-secret-key-for-state-cookie"
 

--- a/openrag/components/auth/test_state_cookie.py
+++ b/openrag/components/auth/test_state_cookie.py
@@ -1,0 +1,69 @@
+"""Unit tests for state_cookie.py."""
+
+import time
+
+import pytest
+
+from components.auth.state_cookie import StateCookiePayload, StateCookieSerializer
+
+
+SECRET = "test-secret-key-for-state-cookie"
+
+
+def _serializer() -> StateCookieSerializer:
+    return StateCookieSerializer(SECRET)
+
+
+def _payload() -> StateCookiePayload:
+    return StateCookiePayload(
+        state="abc123",
+        nonce="xyz789",
+        code_verifier="verifier_value",
+        next_url="/dashboard",
+    )
+
+
+class TestRoundTrip:
+    def test_dumps_loads_roundtrip(self):
+        ser = _serializer()
+        p = _payload()
+        token = ser.dumps(p)
+        result = ser.loads(token)
+        assert result.state == p.state
+        assert result.nonce == p.nonce
+        assert result.code_verifier == p.code_verifier
+        assert result.next_url == p.next_url
+
+    def test_default_next_url(self):
+        ser = _serializer()
+        p = StateCookiePayload(state="s", nonce="n", code_verifier="v")
+        token = ser.dumps(p)
+        result = ser.loads(token)
+        assert result.next_url == "/"
+
+
+class TestTampering:
+    def test_tampered_cookie_raises_value_error(self):
+        ser = _serializer()
+        token = ser.dumps(_payload())
+        # Flip a character near the end of the token
+        tampered = token[:-4] + "XXXX"
+        with pytest.raises(ValueError, match="signature invalid"):
+            ser.loads(tampered)
+
+    def test_different_secret_raises_value_error(self):
+        ser1 = _serializer()
+        ser2 = StateCookieSerializer("different-secret")
+        token = ser1.dumps(_payload())
+        with pytest.raises(ValueError, match="signature invalid"):
+            ser2.loads(token)
+
+
+class TestExpiry:
+    def test_expired_cookie_raises_value_error(self):
+        ser = _serializer()
+        token = ser.dumps(_payload())
+        # Use max_age=0: any token older than 0 seconds is expired
+        time.sleep(1)
+        with pytest.raises(ValueError, match="expired"):
+            ser.loads(token, max_age=0)

--- a/openrag/components/indexer/vectordb/models.py
+++ b/openrag/components/indexer/vectordb/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     String,
     UniqueConstraint,
 )
@@ -102,12 +103,41 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     external_user_id = Column(String, unique=True, nullable=True, index=True)
     display_name = Column(String, nullable=True)
+    email = Column(String, unique=True, nullable=True, index=True)
     token = Column(String, unique=True, nullable=True, index=True)
     is_admin = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=datetime.now, nullable=False)
     file_quota = Column(Integer, nullable=True, default=None)
     file_count = Column(Integer, nullable=False, default=0)
     memberships = relationship("PartitionMembership", back_populates="user", cascade="all, delete-orphan")
+    oidc_sessions = relationship("OIDCSession", back_populates="user", cascade="all, delete-orphan")
+
+
+class OIDCSession(Base):
+    __tablename__ = "oidc_sessions"
+
+    id = Column(Integer, primary_key=True)
+    session_token_hash = Column(String(64), unique=True, nullable=False, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    sid = Column(String, nullable=True, index=True)  # OIDC session id claim (for back-channel logout)
+    sub = Column(String, nullable=False)  # OIDC subject claim
+    id_token_encrypted = Column(LargeBinary, nullable=True)
+    access_token_encrypted = Column(LargeBinary, nullable=True)
+    refresh_token_encrypted = Column(LargeBinary, nullable=True)
+    access_token_expires_at = Column(DateTime, nullable=False)
+    session_expires_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+    last_refresh_at = Column(DateTime, nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+
+    user = relationship("User", back_populates="oidc_sessions")
+
+    __table_args__ = (Index("ix_oidc_sessions_user_sub", "user_id", "sub"),)
 
 
 class PartitionMembership(Base):

--- a/openrag/components/indexer/vectordb/test_oidc_sessions.py
+++ b/openrag/components/indexer/vectordb/test_oidc_sessions.py
@@ -1,0 +1,367 @@
+"""Unit tests for OIDC user/session methods on ``PartitionFileManager``.
+
+These tests exercise the real ORM methods added in Phase 2 of the OIDC
+integration (see ``.omc/plans/oidc-auth/plan.md`` §4, §6.3). They run
+against an in-memory SQLite database — no Ray, no Postgres, no Milvus
+required.
+
+A ``PartitionFileManager`` instance is created without invoking
+``__init__`` (which assumes Postgres + ``sqlalchemy_utils.database_exists``
+semantics); we instead wire up a SQLite engine via ``Base.metadata.create_all``
+and attach it to the object. This mirrors how ``PartitionFileManager``
+itself initialises the schema in production (see ``utils.py``:``__init__``
+which does the same ``Base.metadata.create_all`` call against Postgres).
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from components.indexer.vectordb.models import Base, User
+from components.indexer.vectordb.utils import PartitionFileManager
+from utils.logger import get_logger
+
+
+@pytest.fixture()
+def pfm():
+    """In-memory ``PartitionFileManager`` with a clean schema per test."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    # Bypass __init__ — it targets Postgres and uses sqlalchemy_utils'
+    # create_database() which misbehaves with in-memory SQLite. Instead,
+    # construct a bare PartitionFileManager and attach the schema-ready
+    # engine ourselves. This keeps the method bodies under test untouched.
+    mgr = PartitionFileManager.__new__(PartitionFileManager)
+    mgr.engine = engine
+    mgr.Session = Session
+    mgr.logger = get_logger()
+    mgr.file_quota_per_user = -1  # unlimited for tests
+
+    yield mgr
+    engine.dispose()
+
+
+def _make_user(
+    pfm,
+    *,
+    display_name: str = "Test User",
+    email: str | None = None,
+    external_user_id: str | None = None,
+) -> int:
+    """Helper — insert a user row directly (bypasses create_user's token
+    hashing since we don't need the API token path here) and return the id."""
+    with pfm.Session() as s:
+        u = User(
+            display_name=display_name,
+            email=email,
+            external_user_id=external_user_id,
+            is_admin=False,
+        )
+        s.add(u)
+        s.commit()
+        s.refresh(u)
+        return u.id
+
+
+# ---------------------------------------------------------------------------
+# user lookup by email / external_user_id
+# ---------------------------------------------------------------------------
+
+
+def test_get_user_by_email_returns_user(pfm):
+    user_id = _make_user(pfm, email="alice@example.com")
+    found = pfm.get_user_by_email("alice@example.com")
+    assert found is not None
+    assert found["id"] == user_id
+    assert found["email"] == "alice@example.com"
+
+
+def test_get_user_by_email_returns_none_for_unknown(pfm):
+    _make_user(pfm, email="alice@example.com")
+    assert pfm.get_user_by_email("bob@example.com") is None
+
+
+def test_get_user_by_email_is_case_sensitive(pfm):
+    """Documented behaviour — matching is exact. Callers must normalise."""
+    _make_user(pfm, email="alice@example.com")
+    assert pfm.get_user_by_email("ALICE@example.com") is None
+
+
+def test_get_user_by_external_id_returns_user(pfm):
+    user_id = _make_user(pfm, external_user_id="sub-abc-123")
+    found = pfm.get_user_by_external_id("sub-abc-123")
+    assert found is not None
+    assert found["id"] == user_id
+    assert found["external_user_id"] == "sub-abc-123"
+
+
+def test_get_user_by_external_id_returns_none_for_unknown(pfm):
+    _make_user(pfm, external_user_id="sub-abc-123")
+    assert pfm.get_user_by_external_id("sub-other") is None
+
+
+# ---------------------------------------------------------------------------
+# set_user_external_id — backfill semantics
+# ---------------------------------------------------------------------------
+
+
+def test_set_user_external_id_backfills_when_null(pfm):
+    user_id = _make_user(pfm, email="alice@example.com", external_user_id=None)
+    pfm.set_user_external_id(user_id, "sub-abc-123")
+    # confirm it was persisted
+    refreshed = pfm.get_user_by_external_id("sub-abc-123")
+    assert refreshed is not None
+    assert refreshed["id"] == user_id
+
+
+def test_set_user_external_id_noop_when_equal(pfm):
+    """Calling twice with the same value must not raise (idempotent)."""
+    user_id = _make_user(pfm, external_user_id="sub-abc-123")
+    pfm.set_user_external_id(user_id, "sub-abc-123")  # must not raise
+
+
+def test_set_user_external_id_raises_on_conflict(pfm):
+    """If the user already has a *different* external_user_id, callers need
+    to be alerted (AC6d — identity conflict must produce a 403)."""
+    user_id = _make_user(pfm, external_user_id="sub-original")
+    with pytest.raises(ValueError, match="mismatch"):
+        pfm.set_user_external_id(user_id, "sub-different")
+
+
+def test_set_user_external_id_raises_for_unknown_user(pfm):
+    with pytest.raises(ValueError, match="does not exist"):
+        pfm.set_user_external_id(999999, "sub-whatever")
+
+
+# ---------------------------------------------------------------------------
+# create_oidc_session / get_oidc_session_by_token — round-trip
+# ---------------------------------------------------------------------------
+
+
+def _session_kwargs(user_id, *, sid="sid-xyz", session_token_plain="plain-token-aaaa"):
+    now = datetime.now()
+    return dict(
+        user_id=user_id,
+        sub="sub-abc-123",
+        sid=sid,
+        session_token_plain=session_token_plain,
+        id_token_encrypted=b"\x01\x02\x03",
+        access_token_encrypted=b"\xaa\xbb\xcc",
+        refresh_token_encrypted=b"\xdd\xee\xff",
+        access_token_expires_at=now + timedelta(minutes=5),
+        session_expires_at=now + timedelta(hours=8),
+    )
+
+
+def test_create_and_get_oidc_session_round_trip(pfm):
+    user_id = _make_user(pfm)
+    kwargs = _session_kwargs(user_id, session_token_plain="tok-roundtrip-01")
+    created = pfm.create_oidc_session(**kwargs)
+    assert created["id"] is not None
+    assert created["user_id"] == user_id
+    assert created["sub"] == kwargs["sub"]
+    assert created["sid"] == kwargs["sid"]
+    # encrypted blobs passed through untouched
+    assert created["access_token_encrypted"] == kwargs["access_token_encrypted"]
+    assert created["revoked_at"] is None
+
+    fetched = pfm.get_oidc_session_by_token("tok-roundtrip-01")
+    assert fetched is not None
+    assert fetched["id"] == created["id"]
+    assert fetched["user_id"] == user_id
+
+
+def test_get_oidc_session_by_token_returns_none_for_unknown(pfm):
+    user_id = _make_user(pfm)
+    pfm.create_oidc_session(**_session_kwargs(user_id, session_token_plain="tok-A"))
+    assert pfm.get_oidc_session_by_token("tok-does-not-exist") is None
+
+
+# ---------------------------------------------------------------------------
+# revocation + expiry visibility
+# ---------------------------------------------------------------------------
+
+
+def test_get_oidc_session_returns_none_when_revoked(pfm):
+    user_id = _make_user(pfm)
+    created = pfm.create_oidc_session(
+        **_session_kwargs(user_id, session_token_plain="tok-revoke")
+    )
+    pfm.revoke_oidc_session_by_id(created["id"])
+    assert pfm.get_oidc_session_by_token("tok-revoke") is None
+
+
+def test_get_oidc_session_returns_none_when_session_expired(pfm):
+    user_id = _make_user(pfm)
+    past = datetime.now() - timedelta(hours=1)
+    pfm.create_oidc_session(
+        user_id=user_id,
+        sub="sub-abc-123",
+        sid="sid-expired",
+        session_token_plain="tok-expired",
+        id_token_encrypted=None,
+        access_token_encrypted=None,
+        refresh_token_encrypted=None,
+        access_token_expires_at=past,
+        session_expires_at=past,  # already expired at insert time
+    )
+    assert pfm.get_oidc_session_by_token("tok-expired") is None
+
+
+def test_revoke_oidc_sessions_by_sid_revokes_all_matching(pfm):
+    user_id = _make_user(pfm)
+    # Two sessions sharing one sid, one with a different sid.
+    pfm.create_oidc_session(
+        **_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-1")
+    )
+    pfm.create_oidc_session(
+        **_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-2")
+    )
+    pfm.create_oidc_session(
+        **_session_kwargs(user_id, sid="sid-other", session_token_plain="tok-3")
+    )
+
+    count = pfm.revoke_oidc_sessions_by_sid("sid-shared")
+    assert count == 2
+
+    # The revoked sessions must no longer be retrievable by token.
+    assert pfm.get_oidc_session_by_token("tok-1") is None
+    assert pfm.get_oidc_session_by_token("tok-2") is None
+    # The other-sid session must still be live.
+    assert pfm.get_oidc_session_by_token("tok-3") is not None
+
+
+def test_revoke_oidc_sessions_by_sid_idempotent(pfm):
+    """Calling twice with the same sid must only revoke non-revoked rows."""
+    user_id = _make_user(pfm)
+    pfm.create_oidc_session(
+        **_session_kwargs(user_id, sid="sid-X", session_token_plain="tok-X")
+    )
+    first = pfm.revoke_oidc_sessions_by_sid("sid-X")
+    second = pfm.revoke_oidc_sessions_by_sid("sid-X")
+    assert first == 1
+    assert second == 0  # already revoked
+
+
+# ---------------------------------------------------------------------------
+# update_oidc_session_tokens — post-refresh update
+# ---------------------------------------------------------------------------
+
+
+def test_update_oidc_session_tokens_updates_fields_and_last_refresh(pfm):
+    user_id = _make_user(pfm)
+    created = pfm.create_oidc_session(
+        **_session_kwargs(user_id, session_token_plain="tok-refresh")
+    )
+    original_session_expiry = created["session_expires_at"]
+    new_expiry = datetime.now() + timedelta(minutes=10)
+
+    pfm.update_oidc_session_tokens(
+        session_id=created["id"],
+        access_token_encrypted=b"\x11\x22\x33",
+        refresh_token_encrypted=b"\x44\x55\x66",
+        access_token_expires_at=new_expiry,
+    )
+
+    fetched = pfm.get_oidc_session_by_token("tok-refresh")
+    assert fetched is not None
+    assert fetched["access_token_encrypted"] == b"\x11\x22\x33"
+    assert fetched["refresh_token_encrypted"] == b"\x44\x55\x66"
+    # datetime comparison — tolerate microsecond differences from DB round-trip
+    assert abs((fetched["access_token_expires_at"] - new_expiry).total_seconds()) < 1
+    assert fetched["last_refresh_at"] is not None
+    # session_expires_at (the hard cap) is untouched
+    assert fetched["session_expires_at"] == original_session_expiry
+
+
+def test_update_oidc_session_tokens_accepts_none_refresh(pfm):
+    """Some IdPs don't rotate refresh_token on refresh (omit refresh_token
+    in the response). We must keep the old encrypted value."""
+    user_id = _make_user(pfm)
+    created = pfm.create_oidc_session(
+        **_session_kwargs(user_id, session_token_plain="tok-nrr")
+    )
+    new_expiry = datetime.now() + timedelta(minutes=10)
+    pfm.update_oidc_session_tokens(
+        session_id=created["id"],
+        access_token_encrypted=b"\x99\x88\x77",
+        refresh_token_encrypted=None,
+        access_token_expires_at=new_expiry,
+    )
+    fetched = pfm.get_oidc_session_by_token("tok-nrr")
+    assert fetched["refresh_token_encrypted"] == b"\xdd\xee\xff"  # original
+
+
+def test_update_oidc_session_tokens_raises_for_unknown_id(pfm):
+    with pytest.raises(ValueError, match="does not exist"):
+        pfm.update_oidc_session_tokens(
+            session_id=424242,
+            access_token_encrypted=b"x",
+            refresh_token_encrypted=None,
+            access_token_expires_at=datetime.now(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# cleanup_expired_oidc_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_deletes_only_rows_older_than_retention(pfm):
+    """Rows are purged only once ``session_expires_at`` is older than
+    the 7-day retention window. Still-live and recently-expired rows stay."""
+    user_id = _make_user(pfm)
+    now = datetime.now()
+
+    # (1) Live — must stay
+    pfm.create_oidc_session(
+        user_id=user_id,
+        sub="sub",
+        sid="sid-live",
+        session_token_plain="tok-live",
+        id_token_encrypted=None,
+        access_token_encrypted=None,
+        refresh_token_encrypted=None,
+        access_token_expires_at=now + timedelta(minutes=5),
+        session_expires_at=now + timedelta(hours=1),
+    )
+
+    # (2) Recently expired (within 7-day retention) — must stay
+    pfm.create_oidc_session(
+        user_id=user_id,
+        sub="sub",
+        sid="sid-recent",
+        session_token_plain="tok-recent",
+        id_token_encrypted=None,
+        access_token_encrypted=None,
+        refresh_token_encrypted=None,
+        access_token_expires_at=now - timedelta(hours=2),
+        session_expires_at=now - timedelta(days=1),
+    )
+
+    # (3) Past retention — must be deleted
+    pfm.create_oidc_session(
+        user_id=user_id,
+        sub="sub",
+        sid="sid-stale",
+        session_token_plain="tok-stale",
+        id_token_encrypted=None,
+        access_token_encrypted=None,
+        refresh_token_encrypted=None,
+        access_token_expires_at=now - timedelta(days=30),
+        session_expires_at=now - timedelta(days=10),
+    )
+
+    deleted = pfm.cleanup_expired_oidc_sessions()
+    assert deleted == 1
+
+    # Live session still retrievable.
+    assert pfm.get_oidc_session_by_token("tok-live") is not None
+    # Recently expired: row kept, but still_masked as expired by get_by_token.
+    assert pfm.get_oidc_session_by_token("tok-recent") is None
+    # Stale: row gone entirely.
+    assert pfm.get_oidc_session_by_token("tok-stale") is None

--- a/openrag/components/indexer/vectordb/test_oidc_sessions.py
+++ b/openrag/components/indexer/vectordb/test_oidc_sessions.py
@@ -16,11 +16,10 @@ which does the same ``Base.metadata.create_all`` call against Postgres).
 from datetime import datetime, timedelta
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
 from components.indexer.vectordb.models import Base, User
 from components.indexer.vectordb.utils import PartitionFileManager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 from utils.logger import get_logger
 
 
@@ -68,27 +67,8 @@ def _make_user(
 
 
 # ---------------------------------------------------------------------------
-# user lookup by email / external_user_id
+# user lookup by external_user_id
 # ---------------------------------------------------------------------------
-
-
-def test_get_user_by_email_returns_user(pfm):
-    user_id = _make_user(pfm, email="alice@example.com")
-    found = pfm.get_user_by_email("alice@example.com")
-    assert found is not None
-    assert found["id"] == user_id
-    assert found["email"] == "alice@example.com"
-
-
-def test_get_user_by_email_returns_none_for_unknown(pfm):
-    _make_user(pfm, email="alice@example.com")
-    assert pfm.get_user_by_email("bob@example.com") is None
-
-
-def test_get_user_by_email_is_case_sensitive(pfm):
-    """Documented behaviour — matching is exact. Callers must normalise."""
-    _make_user(pfm, email="alice@example.com")
-    assert pfm.get_user_by_email("ALICE@example.com") is None
 
 
 def test_get_user_by_external_id_returns_user(pfm):
@@ -105,36 +85,63 @@ def test_get_user_by_external_id_returns_none_for_unknown(pfm):
 
 
 # ---------------------------------------------------------------------------
-# set_user_external_id — backfill semantics
+# update_user_fields — OIDC claim-mapping write path
 # ---------------------------------------------------------------------------
 
 
-def test_set_user_external_id_backfills_when_null(pfm):
-    user_id = _make_user(pfm, email="alice@example.com", external_user_id=None)
-    pfm.set_user_external_id(user_id, "sub-abc-123")
-    # confirm it was persisted
-    refreshed = pfm.get_user_by_external_id("sub-abc-123")
-    assert refreshed is not None
-    assert refreshed["id"] == user_id
+def test_update_user_fields_updates_display_name_and_lowercases_email(pfm):
+    user_id = _make_user(pfm, display_name="Old", email="old@example.com")
+    pfm.update_user_fields(user_id, {"display_name": "New Name", "email": "NEW@Example.COM"})
+    refreshed = pfm.get_user_by_external_id("sub-missing")  # None lookup, use session
+    # Re-read via direct ORM since the user has no external_user_id set.
+    with pfm.Session() as s:
+        row = s.query(User).filter_by(id=user_id).first()
+        assert row.display_name == "New Name"
+        assert row.email == "new@example.com"  # normalised
+    # `refreshed` is unrelated to the assertions — silences unused warning.
+    assert refreshed is None
 
 
-def test_set_user_external_id_noop_when_equal(pfm):
-    """Calling twice with the same value must not raise (idempotent)."""
-    user_id = _make_user(pfm, external_user_id="sub-abc-123")
-    pfm.set_user_external_id(user_id, "sub-abc-123")  # must not raise
+def test_update_user_fields_raises_on_non_whitelisted_field(pfm):
+    user_id = _make_user(pfm)
+    with pytest.raises(ValueError, match="non-whitelisted"):
+        pfm.update_user_fields(user_id, {"is_admin": True})
 
 
-def test_set_user_external_id_raises_on_conflict(pfm):
-    """If the user already has a *different* external_user_id, callers need
-    to be alerted (AC6d — identity conflict must produce a 403)."""
-    user_id = _make_user(pfm, external_user_id="sub-original")
-    with pytest.raises(ValueError, match="mismatch"):
-        pfm.set_user_external_id(user_id, "sub-different")
+def test_update_user_fields_raises_for_unknown_user(pfm):
+    with pytest.raises(ValueError, match="not found"):
+        pfm.update_user_fields(999999, {"display_name": "Ghost"})
 
 
-def test_set_user_external_id_raises_for_unknown_user(pfm):
-    with pytest.raises(ValueError, match="does not exist"):
-        pfm.set_user_external_id(999999, "sub-whatever")
+def test_update_user_fields_drops_none_values(pfm):
+    user_id = _make_user(pfm, display_name="Keep", email="keep@example.com")
+    # None values are silently dropped — here every value is None so nothing
+    # should be written and the row must remain intact.
+    pfm.update_user_fields(user_id, {"display_name": None, "email": None})
+    with pfm.Session() as s:
+        row = s.query(User).filter_by(id=user_id).first()
+        assert row.display_name == "Keep"
+        assert row.email == "keep@example.com"
+
+
+def test_update_user_fields_empty_dict_is_noop(pfm):
+    """Empty dict must short-circuit before opening a DB session."""
+    user_id = _make_user(pfm, display_name="Stable")
+    # Monkey-patch Session to detect unexpected opens.
+    original_session = pfm.Session
+    opened = {"count": 0}
+
+    class _SpySession:
+        def __call__(self, *a, **kw):
+            opened["count"] += 1
+            return original_session(*a, **kw)
+
+    pfm.Session = _SpySession()
+    try:
+        pfm.update_user_fields(user_id, {})
+        assert opened["count"] == 0, "update_user_fields({}) must short-circuit before touching the DB"
+    finally:
+        pfm.Session = original_session
 
 
 # ---------------------------------------------------------------------------
@@ -144,17 +151,17 @@ def test_set_user_external_id_raises_for_unknown_user(pfm):
 
 def _session_kwargs(user_id, *, sid="sid-xyz", session_token_plain="plain-token-aaaa"):
     now = datetime.now()
-    return dict(
-        user_id=user_id,
-        sub="sub-abc-123",
-        sid=sid,
-        session_token_plain=session_token_plain,
-        id_token_encrypted=b"\x01\x02\x03",
-        access_token_encrypted=b"\xaa\xbb\xcc",
-        refresh_token_encrypted=b"\xdd\xee\xff",
-        access_token_expires_at=now + timedelta(minutes=5),
-        session_expires_at=now + timedelta(hours=8),
-    )
+    return {
+        "user_id": user_id,
+        "sub": "sub-abc-123",
+        "sid": sid,
+        "session_token_plain": session_token_plain,
+        "id_token_encrypted": b"\x01\x02\x03",
+        "access_token_encrypted": b"\xaa\xbb\xcc",
+        "refresh_token_encrypted": b"\xdd\xee\xff",
+        "access_token_expires_at": now + timedelta(minutes=5),
+        "session_expires_at": now + timedelta(hours=8),
+    }
 
 
 def test_create_and_get_oidc_session_round_trip(pfm):
@@ -188,9 +195,7 @@ def test_get_oidc_session_by_token_returns_none_for_unknown(pfm):
 
 def test_get_oidc_session_returns_none_when_revoked(pfm):
     user_id = _make_user(pfm)
-    created = pfm.create_oidc_session(
-        **_session_kwargs(user_id, session_token_plain="tok-revoke")
-    )
+    created = pfm.create_oidc_session(**_session_kwargs(user_id, session_token_plain="tok-revoke"))
     pfm.revoke_oidc_session_by_id(created["id"])
     assert pfm.get_oidc_session_by_token("tok-revoke") is None
 
@@ -215,15 +220,9 @@ def test_get_oidc_session_returns_none_when_session_expired(pfm):
 def test_revoke_oidc_sessions_by_sid_revokes_all_matching(pfm):
     user_id = _make_user(pfm)
     # Two sessions sharing one sid, one with a different sid.
-    pfm.create_oidc_session(
-        **_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-1")
-    )
-    pfm.create_oidc_session(
-        **_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-2")
-    )
-    pfm.create_oidc_session(
-        **_session_kwargs(user_id, sid="sid-other", session_token_plain="tok-3")
-    )
+    pfm.create_oidc_session(**_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-1"))
+    pfm.create_oidc_session(**_session_kwargs(user_id, sid="sid-shared", session_token_plain="tok-2"))
+    pfm.create_oidc_session(**_session_kwargs(user_id, sid="sid-other", session_token_plain="tok-3"))
 
     count = pfm.revoke_oidc_sessions_by_sid("sid-shared")
     assert count == 2
@@ -238,9 +237,7 @@ def test_revoke_oidc_sessions_by_sid_revokes_all_matching(pfm):
 def test_revoke_oidc_sessions_by_sid_idempotent(pfm):
     """Calling twice with the same sid must only revoke non-revoked rows."""
     user_id = _make_user(pfm)
-    pfm.create_oidc_session(
-        **_session_kwargs(user_id, sid="sid-X", session_token_plain="tok-X")
-    )
+    pfm.create_oidc_session(**_session_kwargs(user_id, sid="sid-X", session_token_plain="tok-X"))
     first = pfm.revoke_oidc_sessions_by_sid("sid-X")
     second = pfm.revoke_oidc_sessions_by_sid("sid-X")
     assert first == 1
@@ -254,9 +251,7 @@ def test_revoke_oidc_sessions_by_sid_idempotent(pfm):
 
 def test_update_oidc_session_tokens_updates_fields_and_last_refresh(pfm):
     user_id = _make_user(pfm)
-    created = pfm.create_oidc_session(
-        **_session_kwargs(user_id, session_token_plain="tok-refresh")
-    )
+    created = pfm.create_oidc_session(**_session_kwargs(user_id, session_token_plain="tok-refresh"))
     original_session_expiry = created["session_expires_at"]
     new_expiry = datetime.now() + timedelta(minutes=10)
 
@@ -282,9 +277,7 @@ def test_update_oidc_session_tokens_accepts_none_refresh(pfm):
     """Some IdPs don't rotate refresh_token on refresh (omit refresh_token
     in the response). We must keep the old encrypted value."""
     user_id = _make_user(pfm)
-    created = pfm.create_oidc_session(
-        **_session_kwargs(user_id, session_token_plain="tok-nrr")
-    )
+    created = pfm.create_oidc_session(**_session_kwargs(user_id, session_token_plain="tok-nrr"))
     new_expiry = datetime.now() + timedelta(minutes=10)
     pfm.update_oidc_session_tokens(
         session_id=created["id"],

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -1,10 +1,11 @@
 import hashlib
 import os
 import secrets
+from datetime import datetime, timedelta
 
 from config import load_config
 from models.user import UserCreate, UserUpdate
-from sqlalchemy import create_engine, delete, func, select, text
+from sqlalchemy import create_engine, delete, func, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import (
@@ -14,7 +15,16 @@ from sqlalchemy_utils import (
 from utils.exceptions.vectordb import *
 from utils.logger import get_logger
 
-from .models import Base, File, Partition, PartitionMembership, User, Workspace, WorkspaceFile
+from .models import (
+    Base,
+    File,
+    OIDCSession,
+    Partition,
+    PartitionMembership,
+    User,
+    Workspace,
+    WorkspaceFile,
+)
 
 logger = get_logger()
 config = load_config()
@@ -319,6 +329,7 @@ class PartitionFileManager:
             user = User(
                 display_name=body.display_name,
                 external_user_id=body.external_user_id,
+                email=(body.email.strip().lower() if body.email else None),
                 token=hashed_token,
                 is_admin=body.is_admin,
                 file_quota=file_quota,
@@ -331,6 +342,7 @@ class PartitionFileManager:
                 "id": user.id,
                 "display_name": user.display_name,
                 "external_user_id": user.external_user_id,
+                "email": user.email,
                 "token": token,
                 "is_admin": user.is_admin,
                 "file_quota": user.file_quota,
@@ -824,3 +836,276 @@ class PartitionFileManager:
                 )
             )
             session.commit()
+
+    # ------------------------------------------------------------------
+    # OIDC — users lookup / external_user_id backfill
+    # ------------------------------------------------------------------
+
+    def _user_to_dict(self, user: User) -> dict:
+        """Serialize a User ORM object to the dict shape used elsewhere."""
+        memberships = [
+            {
+                "partition": m.partition_name,
+                "role": m.role,
+                "added_at": m.added_at.isoformat(),
+            }
+            for m in user.memberships
+        ]
+        return {
+            "id": user.id,
+            "display_name": user.display_name,
+            "email": user.email,
+            "external_user_id": user.external_user_id,
+            "is_admin": user.is_admin,
+            "file_quota": user.file_quota,
+            "file_count": user.file_count,
+            "memberships": memberships,
+        }
+
+    def get_user_by_external_id(self, external_user_id: str) -> dict | None:
+        """Return the user (as dict) whose ``external_user_id`` matches, or None.
+
+        ``external_user_id`` stores the stable OIDC ``sub`` claim in OIDC mode.
+        """
+        with self.Session() as s:
+            user = s.query(User).filter(User.external_user_id == external_user_id).first()
+            if not user:
+                return None
+            return self._user_to_dict(user)
+
+    def get_user_by_email(self, email: str) -> dict | None:
+        """Return the user (as dict) whose ``email`` matches exactly, or None.
+
+        NOTE: comparison is **case-sensitive**. OIDC email claims are typically
+        lowercased by the IdP, but this is not guaranteed by the spec
+        (RFC 7519 §4.1 treats it as arbitrary string). Callers doing lookups
+        against user-provided input should normalize upstream if needed.
+        """
+        with self.Session() as s:
+            user = s.query(User).filter(User.email == email).first()
+            if not user:
+                return None
+            return self._user_to_dict(user)
+
+    def set_user_external_id(self, user_id: int, external_user_id: str) -> None:
+        """Backfill ``users.external_user_id`` on first successful OIDC login.
+
+        Behaviour:
+        - if currently NULL → set to ``external_user_id`` (backfill).
+        - if already equal to ``external_user_id`` → no-op.
+        - if set to a *different* value → raise ValueError (identity conflict;
+          caller must handle by logging and returning 403 — see AC6d).
+        """
+        with self.Session() as s:
+            user = s.query(User).filter(User.id == user_id).first()
+            if user is None:
+                raise ValueError(f"user_id={user_id} does not exist")
+            if user.external_user_id is None:
+                user.external_user_id = external_user_id
+                s.commit()
+                self.logger.info(
+                    f"Backfilled external_user_id for user_id={user_id}"
+                )
+                return
+            if user.external_user_id == external_user_id:
+                return  # idempotent no-op
+            raise ValueError(
+                "external_user_id mismatch for user_id="
+                f"{user_id}: stored={user.external_user_id!r}, "
+                f"incoming={external_user_id!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # OIDC — sessions
+    # ------------------------------------------------------------------
+
+    def _oidc_session_to_dict(self, session_row: OIDCSession) -> dict:
+        """Serialize an OIDCSession ORM row to a dict. Encrypted blobs are
+        passed through untouched — the caller (middleware) decrypts them."""
+        return {
+            "id": session_row.id,
+            "user_id": session_row.user_id,
+            "sub": session_row.sub,
+            "sid": session_row.sid,
+            "id_token_encrypted": session_row.id_token_encrypted,
+            "access_token_encrypted": session_row.access_token_encrypted,
+            "refresh_token_encrypted": session_row.refresh_token_encrypted,
+            "access_token_expires_at": session_row.access_token_expires_at,
+            "session_expires_at": session_row.session_expires_at,
+            "created_at": session_row.created_at,
+            "last_refresh_at": session_row.last_refresh_at,
+            "revoked_at": session_row.revoked_at,
+        }
+
+    def create_oidc_session(
+        self,
+        *,
+        user_id: int,
+        sub: str,
+        sid: str | None,
+        session_token_plain: str,
+        id_token_encrypted: bytes | None,
+        access_token_encrypted: bytes | None,
+        refresh_token_encrypted: bytes | None,
+        access_token_expires_at: datetime,
+        session_expires_at: datetime,
+    ) -> dict:
+        """Insert a new OIDC session row. ``session_token_plain`` is hashed
+        (SHA-256) before storage — the plaintext is never persisted.
+
+        Returns the row as a dict. Caller is responsible for setting the
+        ``openrag_session`` cookie with ``session_token_plain``.
+        """
+        session_token_hash = self.hash_token(session_token_plain)
+        with self.Session() as s:
+            row = OIDCSession(
+                session_token_hash=session_token_hash,
+                user_id=user_id,
+                sub=sub,
+                sid=sid,
+                id_token_encrypted=id_token_encrypted,
+                access_token_encrypted=access_token_encrypted,
+                refresh_token_encrypted=refresh_token_encrypted,
+                access_token_expires_at=access_token_expires_at,
+                session_expires_at=session_expires_at,
+            )
+            s.add(row)
+            s.commit()
+            s.refresh(row)
+            self.logger.bind(user_id=user_id, sid=sid).info("Created OIDC session")
+            return self._oidc_session_to_dict(row)
+
+    def get_oidc_session_by_token(self, session_token_plain: str) -> dict | None:
+        """Look up an OIDC session by its plaintext cookie token.
+
+        Returns None if:
+        - no row with matching ``session_token_hash``
+        - the row is revoked (``revoked_at IS NOT NULL``)
+        - the session has expired (``session_expires_at < now()``)
+        """
+        session_token_hash = self.hash_token(session_token_plain)
+        now = datetime.now()
+        with self.Session() as s:
+            row = (
+                s.query(OIDCSession)
+                .filter(OIDCSession.session_token_hash == session_token_hash)
+                .first()
+            )
+            if row is None:
+                return None
+            if row.revoked_at is not None:
+                return None
+            if row.session_expires_at < now:
+                return None
+            return self._oidc_session_to_dict(row)
+
+    def get_oidc_session_by_id(self, session_id: int) -> dict | None:
+        """Look up an OIDC session by primary key.
+
+        Used by the refresh-token stampede guard in
+        ``components.auth.refresh.refresh_session_if_needed``: when a concurrent
+        request may have already rotated the tokens, the helper re-reads the row
+        to see whether it can reuse the fresh tokens instead of calling the IdP
+        with the (now-invalidated) old refresh_token.
+
+        Returns the row as a dict, or ``None`` if the row does not exist, is
+        revoked, or the hard session cap has elapsed.
+        """
+        now = datetime.now()
+        with self.Session() as s:
+            row = s.query(OIDCSession).filter(OIDCSession.id == session_id).first()
+            if row is None:
+                return None
+            if row.revoked_at is not None:
+                return None
+            if row.session_expires_at < now:
+                return None
+            return self._oidc_session_to_dict(row)
+
+    def update_oidc_session_tokens(
+        self,
+        *,
+        session_id: int,
+        access_token_encrypted: bytes,
+        refresh_token_encrypted: bytes | None,
+        access_token_expires_at: datetime,
+    ) -> None:
+        """Persist refreshed tokens after a successful refresh_token exchange.
+
+        Also bumps ``last_refresh_at`` to ``now()``. Does NOT extend
+        ``session_expires_at`` — the hard session cap is set at creation time
+        and is unaffected by access-token rotation.
+
+        The row is locked with ``SELECT ... FOR UPDATE`` so that concurrent
+        refresh calls on the same session serialize at the DB level (Postgres).
+        SQLite silently ignores the lock hint, which is fine for tests — the
+        ``last_refresh_at`` short-circuit in :mod:`components.auth.refresh`
+        already handles the common stampede case without needing a real lock.
+        """
+        with self.Session() as s:
+            row = (
+                s.query(OIDCSession)
+                .filter(OIDCSession.id == session_id)
+                .with_for_update()
+                .first()
+            )
+            if row is None:
+                raise ValueError(f"oidc_session id={session_id} does not exist")
+            row.access_token_encrypted = access_token_encrypted
+            if refresh_token_encrypted is not None:
+                row.refresh_token_encrypted = refresh_token_encrypted
+            row.access_token_expires_at = access_token_expires_at
+            row.last_refresh_at = datetime.now()
+            s.commit()
+
+    def revoke_oidc_sessions_by_sid(self, sid: str) -> int:
+        """Revoke all non-revoked sessions matching the given OIDC ``sid``.
+
+        Used by the OIDC Back-Channel Logout flow — the IdP POSTs a signed
+        logout_token with a ``sid`` claim; we mark every session with that
+        sid as revoked. Returns the count affected.
+        """
+        now = datetime.now()
+        with self.Session() as s:
+            stmt = (
+                update(OIDCSession)
+                .where(OIDCSession.sid == sid)
+                .where(OIDCSession.revoked_at.is_(None))
+                .values(revoked_at=now)
+            )
+            result = s.execute(stmt)
+            s.commit()
+            count = result.rowcount or 0
+            self.logger.bind(sid=sid, count=count).info(
+                "Revoked OIDC sessions by sid"
+            )
+            return count
+
+    def revoke_oidc_session_by_id(self, session_id: int) -> None:
+        """Revoke a single session by primary key. Used by RP-initiated logout."""
+        now = datetime.now()
+        with self.Session() as s:
+            row = s.query(OIDCSession).filter(OIDCSession.id == session_id).first()
+            if row is None:
+                return
+            if row.revoked_at is None:
+                row.revoked_at = now
+                s.commit()
+                self.logger.bind(session_id=session_id).info("Revoked OIDC session")
+
+    def cleanup_expired_oidc_sessions(self) -> int:
+        """Delete rows whose ``session_expires_at`` is older than 7 days.
+
+        A retention window after expiry helps post-mortem debugging while
+        keeping the table bounded. Intended to be called by a future cron.
+        Returns the number of rows deleted.
+        """
+        cutoff = datetime.now() - timedelta(days=7)
+        with self.Session() as s:
+            stmt = delete(OIDCSession).where(OIDCSession.session_expires_at < cutoff)
+            result = s.execute(stmt)
+            s.commit()
+            count = result.rowcount or 0
+            if count:
+                self.logger.info(f"Cleaned up {count} expired OIDC sessions")
+            return count

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -838,8 +838,15 @@ class PartitionFileManager:
             session.commit()
 
     # ------------------------------------------------------------------
-    # OIDC — users lookup / external_user_id backfill
+    # OIDC — user lookup by sub + optional claim-mapping update
     # ------------------------------------------------------------------
+
+    # Whitelist mirrored in ``api._OIDC_CLAIM_MAPPING_ALLOWED_FIELDS`` and in
+    # ``routers/auth.py`` — three locations on purpose: the startup validator
+    # and request-time parser both filter their own inputs, and the DB method
+    # refuses writes outside this set as a last line of defence against a
+    # caller bypassing the upstream checks.
+    _OIDC_WRITABLE_USER_FIELDS = {"display_name", "email"}
 
     def _user_to_dict(self, user: User) -> dict:
         """Serialize a User ORM object to the dict shape used elsewhere."""
@@ -873,47 +880,33 @@ class PartitionFileManager:
                 return None
             return self._user_to_dict(user)
 
-    def get_user_by_email(self, email: str) -> dict | None:
-        """Return the user (as dict) whose ``email`` matches exactly, or None.
+    def update_user_fields(self, user_id: int, fields: dict[str, object]) -> None:
+        """Update whitelisted scalar fields on the users table.
 
-        NOTE: comparison is **case-sensitive**. OIDC email claims are typically
-        lowercased by the IdP, but this is not guaranteed by the spec
-        (RFC 7519 §4.1 treats it as arbitrary string). Callers doing lookups
-        against user-provided input should normalize upstream if needed.
+        Enforces the same whitelist as the OIDC claim-mapping parser
+        (``display_name``, ``email``) — writing to any other field raises
+        ``ValueError``. ``None`` values are silently dropped (defensive: the
+        claim was missing upstream). Empty mapping is a no-op and does not
+        open a DB session.
         """
+        if not fields:
+            return
+        bad = set(fields) - self._OIDC_WRITABLE_USER_FIELDS
+        if bad:
+            raise ValueError(f"Cannot update non-whitelisted user fields: {sorted(bad)}")
+        cleaned = {k: v for k, v in fields.items() if v is not None}
+        if not cleaned:
+            return
+        # Normalize email to lowercase if present (consistent with create_user).
+        if "email" in cleaned and isinstance(cleaned["email"], str):
+            cleaned["email"] = cleaned["email"].strip().lower()
         with self.Session() as s:
-            user = s.query(User).filter(User.email == email).first()
-            if not user:
-                return None
-            return self._user_to_dict(user)
-
-    def set_user_external_id(self, user_id: int, external_user_id: str) -> None:
-        """Backfill ``users.external_user_id`` on first successful OIDC login.
-
-        Behaviour:
-        - if currently NULL → set to ``external_user_id`` (backfill).
-        - if already equal to ``external_user_id`` → no-op.
-        - if set to a *different* value → raise ValueError (identity conflict;
-          caller must handle by logging and returning 403 — see AC6d).
-        """
-        with self.Session() as s:
-            user = s.query(User).filter(User.id == user_id).first()
+            user = s.query(User).filter_by(id=user_id).first()
             if user is None:
-                raise ValueError(f"user_id={user_id} does not exist")
-            if user.external_user_id is None:
-                user.external_user_id = external_user_id
-                s.commit()
-                self.logger.info(
-                    f"Backfilled external_user_id for user_id={user_id}"
-                )
-                return
-            if user.external_user_id == external_user_id:
-                return  # idempotent no-op
-            raise ValueError(
-                "external_user_id mismatch for user_id="
-                f"{user_id}: stored={user.external_user_id!r}, "
-                f"incoming={external_user_id!r}"
-            )
+                raise ValueError(f"User {user_id} not found")
+            for k, v in cleaned.items():
+                setattr(user, k, v)
+            s.commit()
 
     # ------------------------------------------------------------------
     # OIDC — sessions
@@ -986,11 +979,7 @@ class PartitionFileManager:
         session_token_hash = self.hash_token(session_token_plain)
         now = datetime.now()
         with self.Session() as s:
-            row = (
-                s.query(OIDCSession)
-                .filter(OIDCSession.session_token_hash == session_token_hash)
-                .first()
-            )
+            row = s.query(OIDCSession).filter(OIDCSession.session_token_hash == session_token_hash).first()
             if row is None:
                 return None
             if row.revoked_at is not None:
@@ -1043,12 +1032,7 @@ class PartitionFileManager:
         already handles the common stampede case without needing a real lock.
         """
         with self.Session() as s:
-            row = (
-                s.query(OIDCSession)
-                .filter(OIDCSession.id == session_id)
-                .with_for_update()
-                .first()
-            )
+            row = s.query(OIDCSession).filter(OIDCSession.id == session_id).with_for_update().first()
             if row is None:
                 raise ValueError(f"oidc_session id={session_id} does not exist")
             row.access_token_encrypted = access_token_encrypted
@@ -1076,9 +1060,7 @@ class PartitionFileManager:
             result = s.execute(stmt)
             s.commit()
             count = result.rowcount or 0
-            self.logger.bind(sid=sid, count=count).info(
-                "Revoked OIDC sessions by sid"
-            )
+            self.logger.bind(sid=sid, count=count).info("Revoked OIDC sessions by sid")
             return count
 
     def revoke_oidc_session_by_id(self, session_id: int) -> None:

--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -1236,12 +1236,9 @@ class MilvusDB(BaseVectorDB):
     async def get_user_by_external_id(self, external_user_id: str):
         return self.partition_file_manager.get_user_by_external_id(external_user_id)
 
-    async def get_user_by_email(self, email: str):
-        return self.partition_file_manager.get_user_by_email(email)
-
-    async def set_user_external_id(self, user_id: int, external_user_id: str):
+    async def update_user_fields(self, user_id: int, fields: dict):
         self._check_user_exists(user_id)
-        return self.partition_file_manager.set_user_external_id(user_id, external_user_id)
+        return self.partition_file_manager.update_user_fields(user_id, fields)
 
     async def create_oidc_session(
         self,

--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -1229,6 +1229,76 @@ class MilvusDB(BaseVectorDB):
         self._check_user_exists(user_id)
         return self.partition_file_manager.list_user_partitions(user_id)
 
+    # ------------------------------------------------------------------
+    # OIDC — exposed on the Ray actor (thin delegations)
+    # ------------------------------------------------------------------
+
+    async def get_user_by_external_id(self, external_user_id: str):
+        return self.partition_file_manager.get_user_by_external_id(external_user_id)
+
+    async def get_user_by_email(self, email: str):
+        return self.partition_file_manager.get_user_by_email(email)
+
+    async def set_user_external_id(self, user_id: int, external_user_id: str):
+        self._check_user_exists(user_id)
+        return self.partition_file_manager.set_user_external_id(user_id, external_user_id)
+
+    async def create_oidc_session(
+        self,
+        *,
+        user_id: int,
+        sub: str,
+        sid: str | None,
+        session_token_plain: str,
+        id_token_encrypted: bytes | None,
+        access_token_encrypted: bytes | None,
+        refresh_token_encrypted: bytes | None,
+        access_token_expires_at,
+        session_expires_at,
+    ):
+        self._check_user_exists(user_id)
+        return self.partition_file_manager.create_oidc_session(
+            user_id=user_id,
+            sub=sub,
+            sid=sid,
+            session_token_plain=session_token_plain,
+            id_token_encrypted=id_token_encrypted,
+            access_token_encrypted=access_token_encrypted,
+            refresh_token_encrypted=refresh_token_encrypted,
+            access_token_expires_at=access_token_expires_at,
+            session_expires_at=session_expires_at,
+        )
+
+    async def get_oidc_session_by_token(self, session_token_plain: str):
+        return self.partition_file_manager.get_oidc_session_by_token(session_token_plain)
+
+    async def get_oidc_session_by_id(self, session_id: int):
+        return self.partition_file_manager.get_oidc_session_by_id(session_id)
+
+    async def update_oidc_session_tokens(
+        self,
+        *,
+        session_id: int,
+        access_token_encrypted: bytes,
+        refresh_token_encrypted: bytes | None,
+        access_token_expires_at,
+    ):
+        return self.partition_file_manager.update_oidc_session_tokens(
+            session_id=session_id,
+            access_token_encrypted=access_token_encrypted,
+            refresh_token_encrypted=refresh_token_encrypted,
+            access_token_expires_at=access_token_expires_at,
+        )
+
+    async def revoke_oidc_sessions_by_sid(self, sid: str) -> int:
+        return self.partition_file_manager.revoke_oidc_sessions_by_sid(sid)
+
+    async def revoke_oidc_session_by_id(self, session_id: int) -> None:
+        return self.partition_file_manager.revoke_oidc_session_by_id(session_id)
+
+    async def cleanup_expired_oidc_sessions(self) -> int:
+        return self.partition_file_manager.cleanup_expired_oidc_sessions()
+
     async def list_partition_members(self, partition: str) -> list[dict]:
         self._check_partition_exists(partition)
         return self.partition_file_manager.list_partition_members(partition)

--- a/openrag/models/user.py
+++ b/openrag/models/user.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class UserBase(BaseModel):
     display_name: str | None = None
     external_user_id: str | None = None
+    email: str | None = None
     is_admin: bool = False
     file_quota: int | None = Field(default=10)
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -269,11 +269,13 @@ async def callback(request: Request, code: str | None = None, state: str | None 
             code_verifier=payload.code_verifier,
             expected_nonce=payload.nonce,
         )
-    except Exception as e:
-        logger.warning(f"OIDC code exchange failed: {e}")
+    except Exception:
+        # Log full exception for operators; return a generic message so IdP
+        # URLs / stack-adjacent internals don't leak via the HTTP response.
+        logger.exception("OIDC code exchange failed")
         return _json_error(
             status.HTTP_400_BAD_REQUEST,
-            f"OIDC code exchange failed: {e}",
+            "OIDC code exchange failed",
             delete_state_cookie=True,
         )
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -91,8 +91,16 @@ def _claim_mapping() -> dict[str, str]:
     return mapping
 
 
-def _post_logout_redirect_uri() -> str:
-    return os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+def _post_logout_redirect_uri() -> str | None:
+    """Return the configured post-logout redirect URI, or None if unset.
+
+    No default is provided: a default of "/" would land the user back on
+    OpenRag's root which immediately re-triggers OIDC login (silent re-auth
+    if the IdP session is still alive, or a loop on the IdP form if not).
+    Operators deliberately choose a URL outside OpenRag (corporate intranet,
+    a static 'you are logged out' page, the IdP's own post-logout page).
+    """
+    return os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI")
 
 
 def _oidc_client_id() -> str:
@@ -463,24 +471,31 @@ async def logout(request: Request):
             except Exception as e:
                 logger.warning(f"Failed to revoke oidc_session during logout: {e}")
 
-    # Build redirect target: IdP end_session if discovery provides one, else local.
+    # Build redirect target: IdP end_session if discovery provides one,
+    # otherwise the configured post-logout URL. If neither is available
+    # we return a plain 200 with the cookie deleted — better than a 302
+    # loop through the root.
     local_target = _post_logout_redirect_uri()
-    redirect_target = local_target
+    redirect_target: str | None = local_target
     try:
         meta = await client.discover()
         end_session = meta.get("end_session_endpoint")
         if end_session:
-            params = {
-                "client_id": _oidc_client_id(),
-                "post_logout_redirect_uri": local_target,
-            }
+            params: dict[str, str] = {"client_id": _oidc_client_id()}
+            if local_target:
+                params["post_logout_redirect_uri"] = local_target
             if id_token_hint:
                 params["id_token_hint"] = id_token_hint
             redirect_target = f"{end_session}?{urlencode(params)}"
     except Exception as e:
-        logger.warning(f"OIDC discovery failed during logout, redirecting locally: {e}")
+        logger.warning(f"OIDC discovery failed during logout, skipping IdP redirect: {e}")
 
-    response = RedirectResponse(url=redirect_target, status_code=302)
+    if redirect_target:
+        response = RedirectResponse(url=redirect_target, status_code=302)
+    else:
+        # No IdP end_session and no local post-logout URL → just confirm the
+        # logout in-place. The cookie deletion below still takes effect.
+        response = JSONResponse(status_code=200, content={"detail": "Logged out"})
     response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
     return response
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -20,9 +20,6 @@ from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urlencode, urlparse
 
-from fastapi import APIRouter, Form, HTTPException, Request, Response, status
-from fastapi.responses import JSONResponse, RedirectResponse
-
 from components.auth import (
     OIDCClient,
     StateCookiePayload,
@@ -32,8 +29,14 @@ from components.auth import (
     get_oidc_client,
     issue_session_token,
 )
+from fastapi import APIRouter, Form, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
 from utils.dependencies import get_vectordb
 from utils.logger import get_logger
+
+# Whitelist mirrors ``api._OIDC_CLAIM_MAPPING_ALLOWED_FIELDS`` — kept in sync
+# at the DB layer too (``PartitionFileManager.update_user_fields``).
+_OIDC_CLAIM_MAPPING_ALLOWED_FIELDS = {"display_name", "email"}
 
 logger = get_logger()
 router = APIRouter()
@@ -46,6 +49,7 @@ SESSION_COOKIE_NAME = "openrag_session"
 # Env helpers — read lazily so tests can monkeypatch os.environ
 # ---------------------------------------------------------------------------
 
+
 def _auth_mode() -> str:
     return os.getenv("AUTH_MODE", "token").strip().lower()
 
@@ -57,15 +61,34 @@ def _token_encryption_key() -> str:
     return key
 
 
-def _email_source() -> str:
-    return os.getenv("OIDC_EMAIL_SOURCE", "id_token").strip().lower()
+def _claim_source() -> str:
+    return os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower()
 
 
-def _allowed_email_domains() -> list[str]:
-    raw = os.getenv("OIDC_ALLOWED_EMAIL_DOMAINS", "").strip()
+def _claim_mapping() -> dict[str, str]:
+    """Parse ``OIDC_CLAIM_MAPPING`` at request time so tests can monkeypatch it.
+
+    Shares the validation rules with ``api._parse_oidc_claim_mapping``: entries
+    whose ``db_field`` is not whitelisted are silently dropped here because the
+    hard-failure path belongs to the startup validator in ``api.py`` — at login
+    time we prefer to log and continue rather than break the flow on a
+    misconfiguration the operator has already been warned about.
+    """
+    raw = os.getenv("OIDC_CLAIM_MAPPING", "").strip()
     if not raw:
-        return []
-    return [d.strip().lower() for d in raw.split(",") if d.strip()]
+        return {}
+    mapping: dict[str, str] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair or ":" not in pair:
+            continue
+        db_field, claim = pair.split(":", 1)
+        db_field = db_field.strip()
+        claim = claim.strip()
+        if db_field not in _OIDC_CLAIM_MAPPING_ALLOWED_FIELDS or not claim:
+            continue
+        mapping[db_field] = claim
+    return mapping
 
 
 def _post_logout_redirect_uri() -> str:
@@ -144,9 +167,7 @@ def _delete_state_cookie(response: Response) -> None:
     )
 
 
-def _json_error(
-    status_code: int, detail: str, *, delete_state_cookie: bool = False
-) -> JSONResponse:
+def _json_error(status_code: int, detail: str, *, delete_state_cookie: bool = False) -> JSONResponse:
     r = JSONResponse(status_code=status_code, content={"detail": detail})
     if delete_state_cookie:
         _delete_state_cookie(r)
@@ -157,6 +178,7 @@ def _json_error(
 # GET /auth/login
 # ---------------------------------------------------------------------------
 
+
 @router.get("/auth/login", include_in_schema=False)
 async def login(request: Request, next: str | None = None):
     _require_oidc_mode()
@@ -166,9 +188,7 @@ async def login(request: Request, next: str | None = None):
     code_verifier, code_challenge = OIDCClient.generate_pkce_pair()
 
     try:
-        auth_url = await client.build_authorization_url(
-            state=state, nonce=nonce, code_challenge=code_challenge
-        )
+        auth_url = await client.build_authorization_url(state=state, nonce=nonce, code_challenge=code_challenge)
     except Exception as e:
         logger.error(f"Failed to build OIDC authorization URL: {e}")
         raise HTTPException(
@@ -200,6 +220,7 @@ async def login(request: Request, next: str | None = None):
 # ---------------------------------------------------------------------------
 # GET /auth/callback
 # ---------------------------------------------------------------------------
+
 
 @router.get("/auth/callback", include_in_schema=False)
 async def callback(request: Request, code: str | None = None, state: str | None = None):
@@ -256,7 +277,7 @@ async def callback(request: Request, code: str | None = None, state: str | None 
             delete_state_cookie=True,
         )
 
-    # --- 4. Extract claims -----------------------------------------------------
+    # --- 4. Extract sub and match user ----------------------------------------
     sub = bundle.claims.get("sub")
     if not sub:
         return _json_error(
@@ -265,106 +286,54 @@ async def callback(request: Request, code: str | None = None, state: str | None 
             delete_state_cookie=True,
         )
 
-    email: str | None
-    if _email_source() == "id_token":
-        email = bundle.claims.get("email")
-    else:
-        # userinfo
-        try:
-            userinfo = await client.fetch_userinfo(bundle.access_token)
-        except Exception as e:
-            logger.warning(f"OIDC userinfo fetch failed: {e}")
-            return _json_error(
-                status.HTTP_400_BAD_REQUEST,
-                "Failed to fetch userinfo from IdP.",
-                delete_state_cookie=True,
-            )
-        email = userinfo.get("email")
-
-    if not email:
+    vdb = get_vectordb()
+    user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
+    if user is None:
+        logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
         return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "IdP did not return an email address.",
+            status.HTTP_403_FORBIDDEN,
+            "User not registered",
             delete_state_cookie=True,
         )
 
-    email = email.strip().lower()
-
-    # --- 5. Optional email-domain whitelist ------------------------------------
-    allowed = _allowed_email_domains()
-    if allowed:
-        try:
-            domain = email.split("@", 1)[1].lower()
-        except IndexError:
-            return _json_error(
-                status.HTTP_400_BAD_REQUEST,
-                "Invalid email address format.",
-                delete_state_cookie=True,
-            )
-        if domain not in allowed:
-            logger.warning(
-                f"OIDC login rejected — email domain {domain!r} not in whitelist"
-            )
-            return _json_error(
-                status.HTTP_403_FORBIDDEN,
-                f"Email domain {domain!r} is not allowed.",
-                delete_state_cookie=True,
-            )
-
-    # --- 6. User matching ------------------------------------------------------
-    vdb = get_vectordb()
-
-    user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
-    if user is None:
-        user = await vdb.get_user_by_email.remote(email)
-        if user is None:
-            logger.warning(
-                f"OIDC login rejected — user not registered (email={email!r}, sub={sub!r})"
-            )
-            return _json_error(
-                status.HTTP_403_FORBIDDEN,
-                "User not registered",
-                delete_state_cookie=True,
-            )
-
-        stored_ext = user.get("external_user_id")
-        if stored_ext is None:
-            # Backfill external_user_id = sub.
+    # --- 5. Optional claim-mapping update --------------------------------------
+    mapping = _claim_mapping()
+    if mapping:
+        if _claim_source() == "userinfo":
             try:
-                await vdb.set_user_external_id.remote(user["id"], sub)
-                logger.info(
-                    f"Backfilled external_user_id for user_id={user['id']} (sub={sub!r})"
-                )
+                claims_for_mapping: dict[str, Any] = await client.fetch_userinfo(bundle.access_token)
             except Exception as e:
-                logger.warning(
-                    f"set_user_external_id failed for user_id={user['id']}: {e}"
-                )
-            # Re-fetch via sub — this proves the backfill actually won the race.
-            user = await vdb.get_user_by_external_id.remote(sub)
-            if user is None:
+                logger.warning(f"OIDC userinfo fetch failed: {e}")
                 return _json_error(
-                    status.HTTP_403_FORBIDDEN,
-                    "External user ID mismatch",
+                    status.HTTP_400_BAD_REQUEST,
+                    "Failed to fetch userinfo from IdP.",
                     delete_state_cookie=True,
                 )
-        elif stored_ext != sub:
-            logger.warning(
-                "OIDC login rejected — external_user_id mismatch: "
-                f"user_id={user['id']}, stored={stored_ext!r}, claim_sub={sub!r}"
-            )
-            return _json_error(
-                status.HTTP_403_FORBIDDEN,
-                "External user ID mismatch",
-                delete_state_cookie=True,
-            )
+        else:
+            claims_for_mapping = bundle.claims
 
-    # Defensive sanity check (should be impossible after the lookup-by-sub path).
-    assert user.get("external_user_id") in (None, sub), (
-        f"OIDC invariant violated: external_user_id={user.get('external_user_id')!r} "
-        f"but matching sub={sub!r}"
-    )
+        updates: dict[str, Any] = {}
+        for db_field, claim in mapping.items():
+            value = claims_for_mapping.get(claim)
+            if value is None:
+                continue
+            # No-op filter: skip fields already matching, so we don't churn the DB.
+            if user.get(db_field) == value:
+                continue
+            updates[db_field] = value
 
-    # --- 7. Timestamps ---------------------------------------------------------
+        if updates:
+            try:
+                await vdb.update_user_fields.remote(user["id"], updates)
+            except Exception as e:
+                logger.warning(f"update_user_fields failed for user_id={user['id']}: {e}")
+            else:
+                # Refresh the user dict so anything downstream sees the new values.
+                refreshed = await vdb.get_user_by_external_id.remote(sub)
+                if refreshed is not None:
+                    user = refreshed
+
+    # --- 6. Timestamps ---------------------------------------------------------
     now = _utcnow()
     expires_in = max(int(bundle.expires_in or 0), 60)
     access_token_expires_at = now + timedelta(seconds=expires_in)
@@ -373,7 +342,7 @@ async def callback(request: Request, code: str | None = None, state: str | None 
     else:
         session_expires_at = access_token_expires_at
 
-    # --- 8. Issue session & encrypt ------------------------------------------
+    # --- 7. Issue session & encrypt ------------------------------------------
     plain, _hashed = issue_session_token()
     key = _token_encryption_key()
     id_token_encrypted = encrypt_token(bundle.id_token, key=key)
@@ -393,7 +362,7 @@ async def callback(request: Request, code: str | None = None, state: str | None 
         session_expires_at=session_expires_at,
     )
 
-    # --- 9. Build redirect: clear state cookie, set session cookie -----------
+    # --- 8. Build redirect: clear state cookie, set session cookie -----------
     next_url = _sanitize_next_url(payload.next_url)
     redirect = RedirectResponse(url=next_url, status_code=302)
     _delete_state_cookie(redirect)
@@ -409,15 +378,14 @@ async def callback(request: Request, code: str | None = None, state: str | None 
         path="/",
     )
 
-    logger.info(
-        f"OIDC login success — user_id={user['id']}, sid={sid!r}, next={next_url!r}"
-    )
+    logger.info(f"OIDC login success — user_id={user['id']}, sid={sid!r}, next={next_url!r}")
     return redirect
 
 
 # ---------------------------------------------------------------------------
 # POST /auth/backchannel-logout
 # ---------------------------------------------------------------------------
+
 
 @router.post("/auth/backchannel-logout", include_in_schema=False)
 async def backchannel_logout(logout_token: str = Form(...)):
@@ -449,9 +417,7 @@ async def backchannel_logout(logout_token: str = Form(...)):
     if claims.sid:
         vdb = get_vectordb()
         count = await vdb.revoke_oidc_sessions_by_sid.remote(claims.sid)
-        logger.info(
-            f"Back-channel logout revoked sessions — sid={claims.sid!r}, count={count}"
-        )
+        logger.info(f"Back-channel logout revoked sessions — sid={claims.sid!r}, count={count}")
     else:
         # Plan §2 #10 limits back-channel logout scope to sid only.
         # Still return 200 to keep the IdP happy.
@@ -469,6 +435,7 @@ async def backchannel_logout(logout_token: str = Form(...)):
 # ---------------------------------------------------------------------------
 # GET /auth/logout
 # ---------------------------------------------------------------------------
+
 
 @router.get("/auth/logout", include_in_schema=False)
 async def logout(request: Request):
@@ -519,6 +486,7 @@ async def logout(request: Request):
 # ---------------------------------------------------------------------------
 # GET /auth/me  — standard AuthMiddleware applies (route NOT in bypass list)
 # ---------------------------------------------------------------------------
+
 
 @router.get("/auth/me")
 async def me(request: Request):

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -1,0 +1,547 @@
+"""OIDC authentication routes — phase 4 of the OIDC integration.
+
+Routes exposed (all bypassed by ``AuthMiddleware``):
+  - ``GET  /auth/login``              — start Authorization Code + PKCE flow
+  - ``GET  /auth/callback``           — handle IdP redirect, create session
+  - ``POST /auth/backchannel-logout`` — IdP-driven session revocation (OIDC spec)
+  - ``GET  /auth/logout``             — RP-initiated logout (local + IdP)
+
+One more route sits *behind* the middleware:
+  - ``GET  /auth/me``                 — debug endpoint returning the current user.
+
+All routes return ``400`` when ``AUTH_MODE != "oidc"`` — the feature is dormant
+in ``token`` mode.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+from fastapi import APIRouter, Form, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from components.auth import (
+    OIDCClient,
+    StateCookiePayload,
+    StateCookieSerializer,
+    decrypt_token,
+    encrypt_token,
+    get_oidc_client,
+    issue_session_token,
+)
+from utils.dependencies import get_vectordb
+from utils.logger import get_logger
+
+logger = get_logger()
+router = APIRouter()
+
+
+SESSION_COOKIE_NAME = "openrag_session"
+
+
+# ---------------------------------------------------------------------------
+# Env helpers — read lazily so tests can monkeypatch os.environ
+# ---------------------------------------------------------------------------
+
+def _auth_mode() -> str:
+    return os.getenv("AUTH_MODE", "token").strip().lower()
+
+
+def _token_encryption_key() -> str:
+    key = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY")
+    if not key:
+        raise RuntimeError("OIDC_TOKEN_ENCRYPTION_KEY is not set")
+    return key
+
+
+def _email_source() -> str:
+    return os.getenv("OIDC_EMAIL_SOURCE", "id_token").strip().lower()
+
+
+def _allowed_email_domains() -> list[str]:
+    raw = os.getenv("OIDC_ALLOWED_EMAIL_DOMAINS", "").strip()
+    if not raw:
+        return []
+    return [d.strip().lower() for d in raw.split(",") if d.strip()]
+
+
+def _post_logout_redirect_uri() -> str:
+    return os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+
+
+def _oidc_client_id() -> str:
+    return os.environ["OIDC_CLIENT_ID"]
+
+
+def _require_oidc_mode():
+    if _auth_mode() != "oidc":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="AUTH_MODE is not 'oidc' — authentication routes are disabled.",
+        )
+
+
+def _is_request_secure(request: Request) -> bool:
+    """True if the client-observed scheme is HTTPS.
+
+    ``request.url.scheme`` already accounts for reverse-proxy headers when the
+    app is started with ``proxy_headers=True`` (see ``api.py``).
+    """
+    return request.url.scheme == "https"
+
+
+def _state_serializer() -> StateCookieSerializer:
+    return StateCookieSerializer(secret_key=_token_encryption_key())
+
+
+def _allowed_next_origins() -> set[str]:
+    """Origins (scheme://host[:port]) accepted as redirect targets after login.
+
+    Mirrors the CORS allow_origins from ``api.py``: localhost dev ports plus
+    ``INDEXERUI_URL`` so that the indexer-ui (served on a different port) can
+    receive the user back after the OIDC flow completes.
+    """
+    origins = {"http://localhost:3042", "http://localhost:5173"}
+    indexer_ui = os.getenv("INDEXERUI_URL")
+    if indexer_ui:
+        origins.add(indexer_ui.rstrip("/"))
+    return origins
+
+
+def _sanitize_next_url(next_url: str | None) -> str:
+    """Accept either a same-origin relative path (``/...`` but not ``//...``)
+    or an absolute URL whose origin is explicitly whitelisted (indexer-ui,
+    dev-only localhost). Fall back to ``/`` on any mismatch — protects against
+    open-redirect attacks.
+    """
+    if not next_url:
+        return "/"
+    if next_url.startswith("/") and not next_url.startswith("//"):
+        return next_url
+    # Absolute URL: only allow whitelisted origins.
+    parsed = urlparse(next_url)
+    if parsed.scheme in ("http", "https") and parsed.netloc:
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if origin in _allowed_next_origins():
+            return next_url
+    return "/"
+
+
+def _utcnow() -> datetime:
+    # DB-side timestamps are naive local time (models' default is ``datetime.now``),
+    # and every read site compares against ``datetime.now()``. Using ``datetime.now()``
+    # here keeps newly-issued sessions from appearing pre-expired on non-UTC hosts.
+    return datetime.now()
+
+
+def _delete_state_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=StateCookieSerializer.COOKIE_NAME,
+        path="/",
+    )
+
+
+def _json_error(
+    status_code: int, detail: str, *, delete_state_cookie: bool = False
+) -> JSONResponse:
+    r = JSONResponse(status_code=status_code, content={"detail": detail})
+    if delete_state_cookie:
+        _delete_state_cookie(r)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/login
+# ---------------------------------------------------------------------------
+
+@router.get("/auth/login", include_in_schema=False)
+async def login(request: Request, next: str | None = None):
+    _require_oidc_mode()
+    client: OIDCClient = get_oidc_client()
+
+    state, nonce = OIDCClient.generate_state_and_nonce()
+    code_verifier, code_challenge = OIDCClient.generate_pkce_pair()
+
+    try:
+        auth_url = await client.build_authorization_url(
+            state=state, nonce=nonce, code_challenge=code_challenge
+        )
+    except Exception as e:
+        logger.error(f"Failed to build OIDC authorization URL: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="OIDC discovery failed — see server logs.",
+        ) from e
+
+    payload = StateCookiePayload(
+        state=state,
+        nonce=nonce,
+        code_verifier=code_verifier,
+        next_url=_sanitize_next_url(next),
+    )
+    cookie_value = _state_serializer().dumps(payload)
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key=StateCookieSerializer.COOKIE_NAME,
+        value=cookie_value,
+        max_age=StateCookieSerializer.DEFAULT_TTL_SECONDS,
+        httponly=True,
+        secure=_is_request_secure(request),
+        samesite="lax",
+        path="/",
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/callback
+# ---------------------------------------------------------------------------
+
+@router.get("/auth/callback", include_in_schema=False)
+async def callback(request: Request, code: str | None = None, state: str | None = None):
+    _require_oidc_mode()
+
+    if not code or not state:
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "Missing 'code' or 'state' query parameter.",
+            delete_state_cookie=True,
+        )
+
+    # --- 1. Parse state cookie -------------------------------------------------
+    cookie_raw = request.cookies.get(StateCookieSerializer.COOKIE_NAME)
+    if not cookie_raw:
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "OIDC state cookie missing.",
+            delete_state_cookie=True,
+        )
+
+    try:
+        payload = _state_serializer().loads(cookie_raw)
+    except ValueError as e:
+        logger.warning(f"Invalid OIDC state cookie: {e}")
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "Invalid or expired OIDC state cookie.",
+            delete_state_cookie=True,
+        )
+
+    # --- 2. CSRF check --------------------------------------------------------
+    if state != payload.state:
+        logger.warning("OIDC state mismatch between query and cookie")
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "OIDC state mismatch.",
+            delete_state_cookie=True,
+        )
+
+    # --- 3. Exchange code ------------------------------------------------------
+    client: OIDCClient = get_oidc_client()
+    try:
+        bundle = await client.exchange_code(
+            code=code,
+            code_verifier=payload.code_verifier,
+            expected_nonce=payload.nonce,
+        )
+    except Exception as e:
+        logger.warning(f"OIDC code exchange failed: {e}")
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            f"OIDC code exchange failed: {e}",
+            delete_state_cookie=True,
+        )
+
+    # --- 4. Extract claims -----------------------------------------------------
+    sub = bundle.claims.get("sub")
+    if not sub:
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "ID token missing 'sub' claim.",
+            delete_state_cookie=True,
+        )
+
+    email: str | None
+    if _email_source() == "id_token":
+        email = bundle.claims.get("email")
+    else:
+        # userinfo
+        try:
+            userinfo = await client.fetch_userinfo(bundle.access_token)
+        except Exception as e:
+            logger.warning(f"OIDC userinfo fetch failed: {e}")
+            return _json_error(
+                status.HTTP_400_BAD_REQUEST,
+                "Failed to fetch userinfo from IdP.",
+                delete_state_cookie=True,
+            )
+        email = userinfo.get("email")
+
+    if not email:
+        return _json_error(
+            status.HTTP_400_BAD_REQUEST,
+            "IdP did not return an email address.",
+            delete_state_cookie=True,
+        )
+
+    email = email.strip().lower()
+
+    # --- 5. Optional email-domain whitelist ------------------------------------
+    allowed = _allowed_email_domains()
+    if allowed:
+        try:
+            domain = email.split("@", 1)[1].lower()
+        except IndexError:
+            return _json_error(
+                status.HTTP_400_BAD_REQUEST,
+                "Invalid email address format.",
+                delete_state_cookie=True,
+            )
+        if domain not in allowed:
+            logger.warning(
+                f"OIDC login rejected — email domain {domain!r} not in whitelist"
+            )
+            return _json_error(
+                status.HTTP_403_FORBIDDEN,
+                f"Email domain {domain!r} is not allowed.",
+                delete_state_cookie=True,
+            )
+
+    # --- 6. User matching ------------------------------------------------------
+    vdb = get_vectordb()
+
+    user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
+    if user is None:
+        user = await vdb.get_user_by_email.remote(email)
+        if user is None:
+            logger.warning(
+                f"OIDC login rejected — user not registered (email={email!r}, sub={sub!r})"
+            )
+            return _json_error(
+                status.HTTP_403_FORBIDDEN,
+                "User not registered",
+                delete_state_cookie=True,
+            )
+
+        stored_ext = user.get("external_user_id")
+        if stored_ext is None:
+            # Backfill external_user_id = sub.
+            try:
+                await vdb.set_user_external_id.remote(user["id"], sub)
+                logger.info(
+                    f"Backfilled external_user_id for user_id={user['id']} (sub={sub!r})"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"set_user_external_id failed for user_id={user['id']}: {e}"
+                )
+            # Re-fetch via sub — this proves the backfill actually won the race.
+            user = await vdb.get_user_by_external_id.remote(sub)
+            if user is None:
+                return _json_error(
+                    status.HTTP_403_FORBIDDEN,
+                    "External user ID mismatch",
+                    delete_state_cookie=True,
+                )
+        elif stored_ext != sub:
+            logger.warning(
+                "OIDC login rejected — external_user_id mismatch: "
+                f"user_id={user['id']}, stored={stored_ext!r}, claim_sub={sub!r}"
+            )
+            return _json_error(
+                status.HTTP_403_FORBIDDEN,
+                "External user ID mismatch",
+                delete_state_cookie=True,
+            )
+
+    # Defensive sanity check (should be impossible after the lookup-by-sub path).
+    assert user.get("external_user_id") in (None, sub), (
+        f"OIDC invariant violated: external_user_id={user.get('external_user_id')!r} "
+        f"but matching sub={sub!r}"
+    )
+
+    # --- 7. Timestamps ---------------------------------------------------------
+    now = _utcnow()
+    expires_in = max(int(bundle.expires_in or 0), 60)
+    access_token_expires_at = now + timedelta(seconds=expires_in)
+    if bundle.refresh_token:
+        session_expires_at = now + timedelta(days=7)
+    else:
+        session_expires_at = access_token_expires_at
+
+    # --- 8. Issue session & encrypt ------------------------------------------
+    plain, _hashed = issue_session_token()
+    key = _token_encryption_key()
+    id_token_encrypted = encrypt_token(bundle.id_token, key=key)
+    access_token_encrypted = encrypt_token(bundle.access_token, key=key)
+    refresh_token_encrypted = encrypt_token(bundle.refresh_token, key=key)
+    sid = bundle.claims.get("sid")
+
+    await vdb.create_oidc_session.remote(
+        user_id=user["id"],
+        sub=sub,
+        sid=sid,
+        session_token_plain=plain,
+        id_token_encrypted=id_token_encrypted,
+        access_token_encrypted=access_token_encrypted,
+        refresh_token_encrypted=refresh_token_encrypted,
+        access_token_expires_at=access_token_expires_at,
+        session_expires_at=session_expires_at,
+    )
+
+    # --- 9. Build redirect: clear state cookie, set session cookie -----------
+    next_url = _sanitize_next_url(payload.next_url)
+    redirect = RedirectResponse(url=next_url, status_code=302)
+    _delete_state_cookie(redirect)
+
+    max_age = max(int((session_expires_at - now).total_seconds()), 1)
+    redirect.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=plain,
+        max_age=max_age,
+        httponly=True,
+        secure=_is_request_secure(request),
+        samesite="lax",
+        path="/",
+    )
+
+    logger.info(
+        f"OIDC login success — user_id={user['id']}, sid={sid!r}, next={next_url!r}"
+    )
+    return redirect
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/backchannel-logout
+# ---------------------------------------------------------------------------
+
+@router.post("/auth/backchannel-logout", include_in_schema=False)
+async def backchannel_logout(logout_token: str = Form(...)):
+    """IdP-initiated logout per OIDC Back-Channel Logout spec.
+
+    Content-Type: ``application/x-www-form-urlencoded`` with field ``logout_token``.
+    """
+    _require_oidc_mode()
+
+    client: OIDCClient = get_oidc_client()
+
+    try:
+        claims = await client.verify_logout_token(logout_token)
+    except ValueError as e:
+        logger.warning(f"Invalid back-channel logout token: {e}")
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"error": "invalid_request", "error_description": str(e)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except Exception as e:
+        logger.warning(f"Back-channel logout token verification failed: {e}")
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"error": "invalid_request"},
+            headers={"Cache-Control": "no-store"},
+        )
+
+    if claims.sid:
+        vdb = get_vectordb()
+        count = await vdb.revoke_oidc_sessions_by_sid.remote(claims.sid)
+        logger.info(
+            f"Back-channel logout revoked sessions — sid={claims.sid!r}, count={count}"
+        )
+    else:
+        # Plan §2 #10 limits back-channel logout scope to sid only.
+        # Still return 200 to keep the IdP happy.
+        logger.warning(
+            f"Received sid-less back-channel logout token — not supported; "
+            f"ignoring per implementation policy (sub={claims.sub!r})"
+        )
+
+    return Response(
+        status_code=status.HTTP_200_OK,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/logout
+# ---------------------------------------------------------------------------
+
+@router.get("/auth/logout", include_in_schema=False)
+async def logout(request: Request):
+    _require_oidc_mode()
+
+    vdb = get_vectordb()
+    client: OIDCClient = get_oidc_client()
+
+    # Look up & revoke the session; keep the id_token to forward as id_token_hint.
+    id_token_hint: str | None = None
+    cookie_value = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie_value:
+        session = await vdb.get_oidc_session_by_token.remote(cookie_value)
+        if session:
+            enc = session.get("id_token_encrypted")
+            if enc:
+                try:
+                    id_token_hint = decrypt_token(enc, key=_token_encryption_key())
+                except ValueError as e:
+                    logger.warning(f"Failed to decrypt id_token for logout: {e}")
+            try:
+                await vdb.revoke_oidc_session_by_id.remote(session["id"])
+            except Exception as e:
+                logger.warning(f"Failed to revoke oidc_session during logout: {e}")
+
+    # Build redirect target: IdP end_session if discovery provides one, else local.
+    local_target = _post_logout_redirect_uri()
+    redirect_target = local_target
+    try:
+        meta = await client.discover()
+        end_session = meta.get("end_session_endpoint")
+        if end_session:
+            params = {
+                "client_id": _oidc_client_id(),
+                "post_logout_redirect_uri": local_target,
+            }
+            if id_token_hint:
+                params["id_token_hint"] = id_token_hint
+            redirect_target = f"{end_session}?{urlencode(params)}"
+    except Exception as e:
+        logger.warning(f"OIDC discovery failed during logout, redirecting locally: {e}")
+
+    response = RedirectResponse(url=redirect_target, status_code=302)
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/me  — standard AuthMiddleware applies (route NOT in bypass list)
+# ---------------------------------------------------------------------------
+
+@router.get("/auth/me")
+async def me(request: Request):
+    """Debug/health endpoint — returns the user bound by AuthMiddleware."""
+    user = getattr(request.state, "user", None)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No authenticated user on request.state",
+        )
+    oidc_session = getattr(request.state, "oidc_session", None)
+    session_expires_at = None
+    if oidc_session and oidc_session.get("session_expires_at"):
+        exp = oidc_session["session_expires_at"]
+        try:
+            # naive datetime → iso str
+            session_expires_at = exp.isoformat()
+        except AttributeError:
+            session_expires_at = str(exp)
+
+    return {
+        "user_id": user.get("id"),
+        "email": user.get("email"),
+        "auth_method": "oidc" if oidc_session else "token",
+        "session_expires_at": session_expires_at,
+    }

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -36,7 +36,6 @@ from cryptography.fernet import Fernet  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Constants — align with the existing auth unit tests
 # ---------------------------------------------------------------------------
@@ -139,7 +138,6 @@ class _StubVectorDB:
     def __init__(self):
         self.calls: list[tuple[str, tuple, dict]] = []
         self._users_by_sub: dict[str, dict] = {}
-        self._users_by_email: dict[str, dict] = {}
         self._users_by_id: dict[int, dict] = {}
         self._sessions: dict[int, dict] = {}
         self._sessions_by_token: dict[str, int] = {}
@@ -148,15 +146,8 @@ class _StubVectorDB:
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
-        self.get_user_by_email = _RayMethodStub(
-            "get_user_by_email", self._impl_get_user_by_email, self.calls
-        )
-        self.set_user_external_id = _RayMethodStub(
-            "set_user_external_id", self._impl_set_user_external_id, self.calls
-        )
-        self.create_oidc_session = _RayMethodStub(
-            "create_oidc_session", self._impl_create_oidc_session, self.calls
-        )
+        self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
+        self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
         self.get_oidc_session_by_token = _RayMethodStub(
             "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
         )
@@ -170,17 +161,21 @@ class _StubVectorDB:
     # Test-only helpers -----------------------------------------------------
 
     def add_user(
-        self, *, user_id: int, email: str, external_user_id: str | None = None
+        self,
+        *,
+        user_id: int,
+        email: str | None = None,
+        external_user_id: str | None = None,
+        display_name: str | None = None,
     ) -> dict:
         user = {
             "id": user_id,
             "email": email,
             "external_user_id": external_user_id,
             "is_admin": False,
-            "display_name": f"user-{user_id}",
+            "display_name": display_name or f"user-{user_id}",
         }
         self._users_by_id[user_id] = user
-        self._users_by_email[email] = user
         if external_user_id:
             self._users_by_sub[external_user_id] = user
         return user
@@ -190,20 +185,20 @@ class _StubVectorDB:
     def _impl_get_user_by_external_id(self, external_user_id: str):
         return self._users_by_sub.get(external_user_id)
 
-    def _impl_get_user_by_email(self, email: str):
-        return self._users_by_email.get(email)
-
-    def _impl_set_user_external_id(self, user_id: int, external_user_id: str):
+    def _impl_update_user_fields(self, user_id: int, fields: dict):
         user = self._users_by_id.get(user_id)
         if user is None:
-            raise ValueError(f"user_id={user_id} does not exist")
-        if user["external_user_id"] is None:
-            user["external_user_id"] = external_user_id
-            self._users_by_sub[external_user_id] = user
-            return
-        if user["external_user_id"] == external_user_id:
-            return
-        raise ValueError("external_user_id mismatch")
+            raise ValueError(f"User {user_id} not found")
+        _ALLOWED = {"display_name", "email"}
+        bad = set(fields) - _ALLOWED
+        if bad:
+            raise ValueError(f"Cannot update non-whitelisted user fields: {sorted(bad)}")
+        for k, v in fields.items():
+            if v is None:
+                continue
+            if k == "email" and isinstance(v, str):
+                v = v.strip().lower()
+            user[k] = v
 
     def _impl_create_oidc_session(self, **kwargs):
         sid = self._next_session_id
@@ -212,11 +207,7 @@ class _StubVectorDB:
             "id": sid,
             "session_expires_at": kwargs["session_expires_at"],
             "id_token_encrypted": kwargs["id_token_encrypted"],
-            **{
-                k: v
-                for k, v in kwargs.items()
-                if k != "session_token_plain"
-            },
+            **{k: v for k, v in kwargs.items() if k != "session_token_plain"},
         }
         self._sessions[sid] = row
         self._sessions_by_token[kwargs["session_token_plain"]] = sid
@@ -297,9 +288,9 @@ def env_oidc(monkeypatch):
     monkeypatch.setenv("OIDC_REDIRECT_URI", REDIRECT_URI)
     monkeypatch.setenv("OIDC_SCOPES", SCOPES)
     monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", _FERNET_KEY)
-    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "id_token")
+    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "id_token")
     monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
-    monkeypatch.delenv("OIDC_ALLOWED_EMAIL_DOMAINS", raising=False)
+    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
     _auth_deps.reset_oidc_client()
 
 
@@ -452,9 +443,7 @@ def _mock_token_endpoint(transport, id_token: str, *, refresh_token: str | None 
 
 
 def test_callback_success_by_external_id(client, fresh_stub_vectordb):
-    fresh_stub_vectordb.add_user(
-        user_id=42, email="user@example.com", external_user_id="sub-abc"
-    )
+    fresh_stub_vectordb.add_user(user_id=42, email="user@example.com", external_user_id="sub-abc")
     _setup_jwks(client.oidc_transport)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-abc"))
@@ -471,33 +460,11 @@ def test_callback_success_by_external_id(client, fresh_stub_vectordb):
     assert any(c[0] == "create_oidc_session" for c in fresh_stub_vectordb.calls)
 
 
-def test_callback_backfills_external_user_id(client, fresh_stub_vectordb):
-    fresh_stub_vectordb.add_user(
-        user_id=7, email="alice@example.com", external_user_id=None
-    )
-    _setup_jwks(client.oidc_transport)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="sub-new", email="alice@example.com")
-    )
-    _mock_token_endpoint(client.oidc_transport, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    # The user row should now have external_user_id filled.
-    user = fresh_stub_vectordb._users_by_id[7]
-    assert user["external_user_id"] == "sub-new"
-
-
 def test_callback_user_not_registered(client, fresh_stub_vectordb):
+    """Unknown sub → 403 (no email fallback, no auto-provisioning)."""
     _setup_jwks(client.oidc_transport)
     state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com")
-    )
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com"))
     _mock_token_endpoint(client.oidc_transport, id_token)
 
     r = client.get(
@@ -508,14 +475,25 @@ def test_callback_user_not_registered(client, fresh_stub_vectordb):
     assert "not registered" in r.json()["detail"].lower()
 
 
-def test_callback_external_id_mismatch(client, fresh_stub_vectordb):
+def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectordb, monkeypatch):
+    """With OIDC_CLAIM_MAPPING set, claims from the ID token update the user row."""
+    monkeypatch.setenv("OIDC_CLAIM_MAPPING", "display_name:name,email:email")
+    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "id_token")
     fresh_stub_vectordb.add_user(
-        user_id=11, email="bob@example.com", external_user_id="sub-stored"
+        user_id=42,
+        email="old@example.com",
+        external_user_id="sub-abc",
+        display_name="Old Name",
     )
     _setup_jwks(client.oidc_transport)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="sub-different", email="bob@example.com")
+        _id_token_payload(
+            nonce,
+            sub="sub-abc",
+            email="dwho@badwolf.org",
+            extra={"name": "Doctor Who"},
+        )
     )
     _mock_token_endpoint(client.oidc_transport, id_token)
 
@@ -523,47 +501,36 @@ def test_callback_external_id_mismatch(client, fresh_stub_vectordb):
         f"/auth/callback?code=c&state={state}",
         follow_redirects=False,
     )
-    # Lookup by sub=sub-different returns None → fallback to email → user has
-    # external_user_id=sub-stored != sub-different → 403.
-    assert r.status_code == 403
-    assert "mismatch" in r.json()["detail"].lower()
+    assert r.status_code == 302, r.text
+    user = fresh_stub_vectordb._users_by_id[42]
+    assert user["display_name"] == "Doctor Who"
+    # email lowercased by update_user_fields stub
+    assert user["email"] == "dwho@badwolf.org"
+    # update_user_fields was called exactly once
+    assert sum(1 for c in fresh_stub_vectordb.calls if c[0] == "update_user_fields") == 1
 
 
-def test_callback_email_domain_not_whitelisted(
-    client, fresh_stub_vectordb, monkeypatch
-):
-    monkeypatch.setenv("OIDC_ALLOWED_EMAIL_DOMAINS", "corp.example.com, ok.example.com")
+def test_callback_applies_claim_mapping_from_userinfo(client, fresh_stub_vectordb, monkeypatch):
+    """With OIDC_CLAIM_SOURCE=userinfo the claim fetch goes to /userinfo."""
+    monkeypatch.setenv("OIDC_CLAIM_MAPPING", "display_name:name,email:email")
+    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "userinfo")
     fresh_stub_vectordb.add_user(
-        user_id=1, email="x@other.example.com", external_user_id="sub-x"
+        user_id=55,
+        email=None,
+        external_user_id="sub-ui",
+        display_name="legacy",
     )
     _setup_jwks(client.oidc_transport)
     state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="sub-x", email="x@other.example.com")
-    )
-    _mock_token_endpoint(client.oidc_transport, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 403
-    assert "domain" in r.json()["detail"].lower()
-
-
-def test_callback_userinfo_source(client, fresh_stub_vectordb, monkeypatch):
-    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "userinfo")
-    fresh_stub_vectordb.add_user(
-        user_id=55, email="ui@example.com", external_user_id="sub-ui"
-    )
-    _setup_jwks(client.oidc_transport)
-    state, nonce = _begin_login_and_extract_state(client)
-    # ID token has NO email claim — must come from userinfo.
+    # ID token carries no name/email — the router must pull them from /userinfo.
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-ui", email=None))
     _mock_token_endpoint(client.oidc_transport, id_token)
-    userinfo_route = client.oidc_transport.router.get(
-        f"{ISSUER}/protocol/openid-connect/userinfo"
-    ).mock(return_value=httpx.Response(200, json={"sub": "sub-ui", "email": "ui@example.com"}))
+    userinfo_route = client.oidc_transport.router.get(f"{ISSUER}/protocol/openid-connect/userinfo").mock(
+        return_value=httpx.Response(
+            200,
+            json={"sub": "sub-ui", "name": "UI User", "email": "ui@example.com"},
+        )
+    )
 
     r = client.get(
         f"/auth/callback?code=c&state={state}",
@@ -571,6 +538,43 @@ def test_callback_userinfo_source(client, fresh_stub_vectordb, monkeypatch):
     )
     assert r.status_code == 302, r.text
     assert userinfo_route.called
+    user = fresh_stub_vectordb._users_by_id[55]
+    assert user["display_name"] == "UI User"
+    assert user["email"] == "ui@example.com"
+
+
+def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypatch):
+    """Without OIDC_CLAIM_MAPPING the user row is not touched."""
+    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
+    fresh_stub_vectordb.add_user(
+        user_id=77,
+        email="tester@example.com",
+        external_user_id="sub-plain",
+        display_name="Initial",
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(
+            nonce,
+            sub="sub-plain",
+            email="different@example.com",
+            extra={"name": "Should Be Ignored"},
+        )
+    )
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    user = fresh_stub_vectordb._users_by_id[77]
+    # Untouched by the callback when OIDC_CLAIM_MAPPING is empty
+    assert user["display_name"] == "Initial"
+    assert user["email"] == "tester@example.com"
+    # update_user_fields was never called
+    assert not any(c[0] == "update_user_fields" for c in fresh_stub_vectordb.calls)
 
 
 # ---------------------------------------------------------------------------
@@ -636,10 +640,7 @@ def test_logout_revokes_session_and_deletes_cookie(client, fresh_stub_vectordb):
     assert fresh_stub_vectordb._sessions[1]["revoked_at"] is not None
     # Cookie cleared in response (max-age=0 or Expires=past)
     set_cookie_headers = r.headers.get_list("set-cookie")
-    assert any(
-        "openrag_session=" in h and ("Max-Age=0" in h or "expires=" in h.lower())
-        for h in set_cookie_headers
-    )
+    assert any("openrag_session=" in h and ("Max-Age=0" in h or "expires=" in h.lower()) for h in set_cookie_headers)
 
 
 def test_logout_rejected_in_token_mode(env_token, fresh_stub_vectordb):
@@ -672,9 +673,7 @@ def test_me_returns_user_info_with_valid_cookie():
 # ---------------------------------------------------------------------------
 
 
-def test_callback_session_not_prematurely_expired_under_nonutc_tz(
-    client, fresh_stub_vectordb, monkeypatch
-):
+def test_callback_session_not_prematurely_expired_under_nonutc_tz(client, fresh_stub_vectordb, monkeypatch):
     """Callback in a non-UTC timezone must produce an immediately usable session."""
     import os as _os
 
@@ -690,14 +689,10 @@ def test_callback_session_not_prematurely_expired_under_nonutc_tz(
     try:
         # Teach the stub to back get_oidc_session_by_token with the same dict we
         # created in create_oidc_session (the default stub already does).
-        fresh_stub_vectordb.add_user(
-            user_id=77, email="tz@example.com", external_user_id="sub-tz"
-        )
+        fresh_stub_vectordb.add_user(user_id=77, email="tz@example.com", external_user_id="sub-tz")
         _setup_jwks(client.oidc_transport)
         state, nonce = _begin_login_and_extract_state(client)
-        id_token = _sign_jwt(
-            _id_token_payload(nonce, sub="sub-tz", email="tz@example.com")
-        )
+        id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-tz", email="tz@example.com"))
         _mock_token_endpoint(client.oidc_transport, id_token)
 
         r = client.get(
@@ -713,18 +708,14 @@ def test_callback_session_not_prematurely_expired_under_nonutc_tz(
         assert session_cookie, "callback did not set openrag_session cookie"
 
         fetched = fresh_stub_vectordb._impl_get_oidc_session_by_token(session_cookie)
-        assert fetched is not None, (
-            "Session appeared expired IMMEDIATELY after creation — tz bug (M2)"
-        )
+        assert fetched is not None, "Session appeared expired IMMEDIATELY after creation — tz bug (M2)"
 
         # Additional sanity: session_expires_at must be strictly in the future
         # from the perspective of datetime.now() (the read-site clock).
         from datetime import datetime as _dt
 
         session_exp = fetched["session_expires_at"]
-        assert session_exp > _dt.now(), (
-            f"session_expires_at={session_exp} is not in the future vs datetime.now()"
-        )
+        assert session_exp > _dt.now(), f"session_expires_at={session_exp} is not in the future vs datetime.now()"
     finally:
         if original_tz is None:
             _os.environ.pop("TZ", None)

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -72,7 +72,8 @@ JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
 
 def _sign_jwt(payload: dict) -> str:
     header = {"alg": "RS256", "kid": "test-key-1"}
-    jwt = JsonWebToken()
+    # Authlib >=1.0 requires the allowed-algorithms list on JsonWebToken.
+    jwt = JsonWebToken(["RS256"])
     token = jwt.encode(header, payload, _RSA_PRIVATE)
     return token.decode() if isinstance(token, bytes) else token
 
@@ -319,8 +320,10 @@ def client(env_oidc, fresh_stub_vectordb):
     app.include_router(auth_router)
 
     # Replace the OIDCClient's internal httpx client with one backed by respx.
-    transport = respx.MockTransport(assert_all_called=False)
-    http = httpx.AsyncClient(transport=transport)
+    # respx >= 0.22 removed the top-level MockTransport; use MockRouter +
+    # httpx.MockTransport(router.handler) instead.
+    router = respx.MockRouter(assert_all_called=False)
+    http = httpx.AsyncClient(transport=httpx.MockTransport(router.handler))
 
     # Force singleton creation using our mocked http client.
     _auth_deps.reset_oidc_client()
@@ -334,18 +337,18 @@ def client(env_oidc, fresh_stub_vectordb):
     )
 
     c = TestClient(app)
-    c.oidc_transport = transport  # type: ignore[attr-defined]
+    c.oidc_router = router  # type: ignore[attr-defined]
     yield c
 
 
-def _setup_discovery(transport):
-    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+def _setup_discovery(router):
+    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
         return_value=httpx.Response(200, json=DISCOVERY_DOC)
     )
 
 
-def _setup_jwks(transport):
-    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
+def _setup_jwks(router):
+    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
         return_value=httpx.Response(200, json=JWKS_RESPONSE)
     )
 

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -1,0 +1,733 @@
+"""Integration tests for the OIDC auth router.
+
+The router transitively imports ``utils.dependencies``, which spins up Ray
+actors at import time (indexer, marker pool, semaphores, …). To avoid that
+in a unit-test context, we stub ``utils.dependencies`` in ``sys.modules``
+*before* importing the router, then drive it via FastAPI's ``TestClient``.
+
+IdP interactions are mocked end-to-end with ``respx`` using a real RSA key
+pair so the router exercises actual JWT verification.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# pytest sometimes initialises warning filters before we run — tolerate it.
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("respx")
+pytest.importorskip("httpx")
+pytest.importorskip("authlib")
+pytest.importorskip("fastapi")
+pytest.importorskip("itsdangerous")
+pytest.importorskip("cryptography")
+
+import httpx  # noqa: E402
+import respx  # noqa: E402
+from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
+from cryptography.fernet import Fernet  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Constants — align with the existing auth unit tests
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://idp.example.com/realms/openrag"
+CLIENT_ID = "openrag-client"
+CLIENT_SECRET = "test-secret"
+REDIRECT_URI = "https://openrag.example.com/auth/callback"
+SCOPES = "openid email profile offline_access"
+
+DISCOVERY_DOC = {
+    "issuer": ISSUER,
+    "authorization_endpoint": f"{ISSUER}/protocol/openid-connect/auth",
+    "token_endpoint": f"{ISSUER}/protocol/openid-connect/token",
+    "userinfo_endpoint": f"{ISSUER}/protocol/openid-connect/userinfo",
+    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
+    "end_session_endpoint": f"{ISSUER}/protocol/openid-connect/logout",
+}
+
+
+def _make_rsa_key_pair():
+    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    return private, private.as_dict(is_private=True), private.as_dict()
+
+
+_RSA_PRIVATE, _RSA_PRIVATE_JWK, _RSA_PUBLIC_JWK = _make_rsa_key_pair()
+_RSA_PUBLIC_JWK["use"] = "sig"
+_RSA_PUBLIC_JWK["alg"] = "RS256"
+_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
+_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+
+JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
+
+
+def _sign_jwt(payload: dict) -> str:
+    header = {"alg": "RS256", "kid": "test-key-1"}
+    jwt = JsonWebToken()
+    token = jwt.encode(header, payload, _RSA_PRIVATE)
+    return token.decode() if isinstance(token, bytes) else token
+
+
+def _id_token_payload(
+    nonce: str, *, sub: str = "sub-abc", email: str | None = "user@example.com", extra: dict | None = None
+) -> dict:
+    now = int(time.time())
+    payload = {
+        "iss": ISSUER,
+        "sub": sub,
+        "aud": CLIENT_ID,
+        "exp": now + 300,
+        "iat": now,
+        "nonce": nonce,
+    }
+    if email is not None:
+        payload["email"] = email
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _logout_token_payload(*, sid: str | None = None, sub: str | None = None) -> dict:
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "iat": now,
+        "jti": "lt-001",
+        "events": {"http://schemas.openid.net/event/backchannel-logout": {}},
+    }
+    if sid is not None:
+        payload["sid"] = sid
+    if sub is not None:
+        payload["sub"] = sub
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies BEFORE importing the router
+# ---------------------------------------------------------------------------
+
+_FERNET_KEY = Fernet.generate_key().decode()
+
+
+class _RayMethodStub:
+    """Mimics a Ray actor method: ``method.remote(...)`` returns an awaitable."""
+
+    def __init__(self, name: str, fn, call_log: list):
+        self._name = name
+        self._fn = fn
+        self._call_log = call_log
+
+    async def remote(self, *args, **kwargs):
+        self._call_log.append((self._name, args, kwargs))
+        return self._fn(*args, **kwargs)
+
+
+class _StubVectorDB:
+    """Minimal Ray-actor stand-in — exposes ``.method.remote(...)`` awaitables."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self._users_by_sub: dict[str, dict] = {}
+        self._users_by_email: dict[str, dict] = {}
+        self._users_by_id: dict[int, dict] = {}
+        self._sessions: dict[int, dict] = {}
+        self._sessions_by_token: dict[str, int] = {}
+        self._next_session_id = 1
+        # Bind each underlying impl as an actor-style accessor.
+        self.get_user_by_external_id = _RayMethodStub(
+            "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
+        )
+        self.get_user_by_email = _RayMethodStub(
+            "get_user_by_email", self._impl_get_user_by_email, self.calls
+        )
+        self.set_user_external_id = _RayMethodStub(
+            "set_user_external_id", self._impl_set_user_external_id, self.calls
+        )
+        self.create_oidc_session = _RayMethodStub(
+            "create_oidc_session", self._impl_create_oidc_session, self.calls
+        )
+        self.get_oidc_session_by_token = _RayMethodStub(
+            "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
+        )
+        self.revoke_oidc_session_by_id = _RayMethodStub(
+            "revoke_oidc_session_by_id", self._impl_revoke_oidc_session_by_id, self.calls
+        )
+        self.revoke_oidc_sessions_by_sid = _RayMethodStub(
+            "revoke_oidc_sessions_by_sid", self._impl_revoke_oidc_sessions_by_sid, self.calls
+        )
+
+    # Test-only helpers -----------------------------------------------------
+
+    def add_user(
+        self, *, user_id: int, email: str, external_user_id: str | None = None
+    ) -> dict:
+        user = {
+            "id": user_id,
+            "email": email,
+            "external_user_id": external_user_id,
+            "is_admin": False,
+            "display_name": f"user-{user_id}",
+        }
+        self._users_by_id[user_id] = user
+        self._users_by_email[email] = user
+        if external_user_id:
+            self._users_by_sub[external_user_id] = user
+        return user
+
+    # Impls ------------------------------------------------------------------
+
+    def _impl_get_user_by_external_id(self, external_user_id: str):
+        return self._users_by_sub.get(external_user_id)
+
+    def _impl_get_user_by_email(self, email: str):
+        return self._users_by_email.get(email)
+
+    def _impl_set_user_external_id(self, user_id: int, external_user_id: str):
+        user = self._users_by_id.get(user_id)
+        if user is None:
+            raise ValueError(f"user_id={user_id} does not exist")
+        if user["external_user_id"] is None:
+            user["external_user_id"] = external_user_id
+            self._users_by_sub[external_user_id] = user
+            return
+        if user["external_user_id"] == external_user_id:
+            return
+        raise ValueError("external_user_id mismatch")
+
+    def _impl_create_oidc_session(self, **kwargs):
+        sid = self._next_session_id
+        self._next_session_id += 1
+        row = {
+            "id": sid,
+            "session_expires_at": kwargs["session_expires_at"],
+            "id_token_encrypted": kwargs["id_token_encrypted"],
+            **{
+                k: v
+                for k, v in kwargs.items()
+                if k != "session_token_plain"
+            },
+        }
+        self._sessions[sid] = row
+        self._sessions_by_token[kwargs["session_token_plain"]] = sid
+        return row
+
+    def _impl_get_oidc_session_by_token(self, session_token_plain: str):
+        # Mirror PartitionFileManager.get_oidc_session_by_token semantics:
+        # reject revoked rows AND rows whose session_expires_at is in the past
+        # relative to datetime.now(). The expiry check is what makes this stub
+        # a faithful regression target for the M2 timezone fix.
+        from datetime import datetime as _dt
+
+        sid = self._sessions_by_token.get(session_token_plain)
+        if sid is None:
+            return None
+        row = self._sessions[sid]
+        if row.get("revoked_at"):
+            return None
+        exp = row.get("session_expires_at")
+        if isinstance(exp, _dt) and exp < _dt.now():
+            return None
+        return row
+
+    def _impl_revoke_oidc_session_by_id(self, session_id: int):
+        row = self._sessions.get(session_id)
+        if row:
+            row["revoked_at"] = time.time()
+
+    def _impl_revoke_oidc_sessions_by_sid(self, sid: str) -> int:
+        count = 0
+        for row in self._sessions.values():
+            if row.get("sid") == sid and not row.get("revoked_at"):
+                row["revoked_at"] = time.time()
+                count += 1
+        return count
+
+
+_stub_vectordb_singleton = _StubVectorDB()
+
+
+def _install_dependencies_stub():
+    """Replace ``utils.dependencies`` with a stub providing only ``get_vectordb``."""
+    stub = types.ModuleType("utils.dependencies")
+    stub.get_vectordb = lambda: _stub_vectordb_singleton
+    stub.get_task_state_manager = lambda: None
+    stub.get_serializer = lambda: None
+    stub.get_indexer = lambda: None
+    stub.get_marker_pool = lambda: None
+    sys.modules["utils.dependencies"] = stub
+
+
+_install_dependencies_stub()
+
+
+# Now we can import the router.
+import importlib  # noqa: E402
+
+# Reset the OIDC client singleton between tests — important when env changes.
+from components.auth import deps as _auth_deps  # noqa: E402
+
+# Import the router module, forcing a fresh import.
+sys.modules.pop("routers.auth", None)
+_auth_router_module = importlib.import_module("routers.auth")
+auth_router = _auth_router_module.router
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_oidc(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    monkeypatch.setenv("OIDC_ENDPOINT", ISSUER)
+    monkeypatch.setenv("OIDC_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("OIDC_CLIENT_SECRET", CLIENT_SECRET)
+    monkeypatch.setenv("OIDC_REDIRECT_URI", REDIRECT_URI)
+    monkeypatch.setenv("OIDC_SCOPES", SCOPES)
+    monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", _FERNET_KEY)
+    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "id_token")
+    monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+    monkeypatch.delenv("OIDC_ALLOWED_EMAIL_DOMAINS", raising=False)
+    _auth_deps.reset_oidc_client()
+
+
+@pytest.fixture
+def env_token(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "token")
+    _auth_deps.reset_oidc_client()
+
+
+@pytest.fixture
+def fresh_stub_vectordb():
+    global _stub_vectordb_singleton
+    # Re-create so tests see a clean state.
+    _stub_vectordb_singleton.__init__()
+    return _stub_vectordb_singleton
+
+
+@pytest.fixture
+def client(env_oidc, fresh_stub_vectordb):
+    """TestClient for the minimal FastAPI app.
+
+    The OIDCClient singleton uses a shared respx-mocked transport so every
+    IdP route can be stubbed per-test via ``mock.router.get(...)``.
+    """
+    app = FastAPI()
+    app.include_router(auth_router)
+
+    # Replace the OIDCClient's internal httpx client with one backed by respx.
+    transport = respx.MockTransport(assert_all_called=False)
+    http = httpx.AsyncClient(transport=transport)
+
+    # Force singleton creation using our mocked http client.
+    _auth_deps.reset_oidc_client()
+    _auth_deps._client = _auth_router_module.OIDCClient(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        scopes=SCOPES,
+        http_client=http,
+    )
+
+    c = TestClient(app)
+    c.oidc_transport = transport  # type: ignore[attr-defined]
+    yield c
+
+
+def _setup_discovery(transport):
+    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json=DISCOVERY_DOC)
+    )
+
+
+def _setup_jwks(transport):
+    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
+        return_value=httpx.Response(200, json=JWKS_RESPONSE)
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/login
+# ---------------------------------------------------------------------------
+
+
+def test_login_rejected_in_token_mode(env_token, fresh_stub_vectordb):
+    app = FastAPI()
+    app.include_router(auth_router)
+    c = TestClient(app)
+    r = c.get("/auth/login", follow_redirects=False)
+    assert r.status_code == 400
+
+
+def test_login_redirects_to_idp_with_pkce(client):
+    _setup_discovery(client.oidc_transport)
+    r = client.get("/auth/login", follow_redirects=False)
+    assert r.status_code == 302
+    loc = r.headers["location"]
+    assert loc.startswith(f"{ISSUER}/protocol/openid-connect/auth")
+    assert "code_challenge_method=S256" in loc
+    assert "state=" in loc
+    assert "nonce=" in loc
+    assert "code_challenge=" in loc
+    # State cookie set
+    assert "openrag_oidc_state" in r.cookies
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/callback — failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_callback_rejected_in_token_mode(env_token, fresh_stub_vectordb):
+    app = FastAPI()
+    app.include_router(auth_router)
+    c = TestClient(app)
+    r = c.get("/auth/callback?code=x&state=y", follow_redirects=False)
+    assert r.status_code == 400
+
+
+def test_callback_missing_state_cookie(client):
+    r = client.get("/auth/callback?code=x&state=y", follow_redirects=False)
+    assert r.status_code == 400
+    assert "state cookie" in r.json()["detail"].lower()
+
+
+def test_callback_state_mismatch(client):
+    _setup_discovery(client.oidc_transport)
+    # First, obtain a legitimate state cookie via /auth/login.
+    login_resp = client.get("/auth/login", follow_redirects=False)
+    assert login_resp.status_code == 302
+
+    # Now call /auth/callback with a *different* state in the query.
+    r = client.get(
+        "/auth/callback?code=x&state=WRONG",
+        follow_redirects=False,
+    )
+    assert r.status_code == 400
+    assert "state" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/callback — success paths
+# ---------------------------------------------------------------------------
+
+
+def _begin_login_and_extract_state(client) -> tuple[str, str]:
+    """Call /auth/login and return (state, nonce) values from the redirect query."""
+    _setup_discovery(client.oidc_transport)
+    r = client.get("/auth/login", follow_redirects=False)
+    assert r.status_code == 302
+    loc = r.headers["location"]
+    from urllib.parse import parse_qs, urlparse
+
+    qs = parse_qs(urlparse(loc).query)
+    return qs["state"][0], qs["nonce"][0]
+
+
+def _mock_token_endpoint(transport, id_token: str, *, refresh_token: str | None = "rt-1"):
+    payload = {
+        "id_token": id_token,
+        "access_token": "at-1",
+        "expires_in": 300,
+        "token_type": "Bearer",
+    }
+    if refresh_token is not None:
+        payload["refresh_token"] = refresh_token
+    transport.router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+
+def test_callback_success_by_external_id(client, fresh_stub_vectordb):
+    fresh_stub_vectordb.add_user(
+        user_id=42, email="user@example.com", external_user_id="sub-abc"
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-abc"))
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=authcode&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    assert r.headers["location"] == "/"
+    assert "openrag_session" in r.cookies
+    # At least one create_oidc_session call recorded.
+    assert any(c[0] == "create_oidc_session" for c in fresh_stub_vectordb.calls)
+
+
+def test_callback_backfills_external_user_id(client, fresh_stub_vectordb):
+    fresh_stub_vectordb.add_user(
+        user_id=7, email="alice@example.com", external_user_id=None
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-new", email="alice@example.com")
+    )
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    # The user row should now have external_user_id filled.
+    user = fresh_stub_vectordb._users_by_id[7]
+    assert user["external_user_id"] == "sub-new"
+
+
+def test_callback_user_not_registered(client, fresh_stub_vectordb):
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com")
+    )
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 403
+    assert "not registered" in r.json()["detail"].lower()
+
+
+def test_callback_external_id_mismatch(client, fresh_stub_vectordb):
+    fresh_stub_vectordb.add_user(
+        user_id=11, email="bob@example.com", external_user_id="sub-stored"
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-different", email="bob@example.com")
+    )
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    # Lookup by sub=sub-different returns None → fallback to email → user has
+    # external_user_id=sub-stored != sub-different → 403.
+    assert r.status_code == 403
+    assert "mismatch" in r.json()["detail"].lower()
+
+
+def test_callback_email_domain_not_whitelisted(
+    client, fresh_stub_vectordb, monkeypatch
+):
+    monkeypatch.setenv("OIDC_ALLOWED_EMAIL_DOMAINS", "corp.example.com, ok.example.com")
+    fresh_stub_vectordb.add_user(
+        user_id=1, email="x@other.example.com", external_user_id="sub-x"
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-x", email="x@other.example.com")
+    )
+    _mock_token_endpoint(client.oidc_transport, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 403
+    assert "domain" in r.json()["detail"].lower()
+
+
+def test_callback_userinfo_source(client, fresh_stub_vectordb, monkeypatch):
+    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "userinfo")
+    fresh_stub_vectordb.add_user(
+        user_id=55, email="ui@example.com", external_user_id="sub-ui"
+    )
+    _setup_jwks(client.oidc_transport)
+    state, nonce = _begin_login_and_extract_state(client)
+    # ID token has NO email claim — must come from userinfo.
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-ui", email=None))
+    _mock_token_endpoint(client.oidc_transport, id_token)
+    userinfo_route = client.oidc_transport.router.get(
+        f"{ISSUER}/protocol/openid-connect/userinfo"
+    ).mock(return_value=httpx.Response(200, json={"sub": "sub-ui", "email": "ui@example.com"}))
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    assert userinfo_route.called
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/backchannel-logout
+# ---------------------------------------------------------------------------
+
+
+def test_backchannel_logout_rejects_invalid_token(client):
+    _setup_discovery(client.oidc_transport)
+    _setup_jwks(client.oidc_transport)
+    r = client.post(
+        "/auth/backchannel-logout",
+        data={"logout_token": "not-a-jwt"},
+    )
+    assert r.status_code == 400
+
+
+def test_backchannel_logout_revokes_by_sid(client, fresh_stub_vectordb):
+    _setup_jwks(client.oidc_transport)
+    _setup_discovery(client.oidc_transport)
+
+    # Seed a session to be revoked
+    fresh_stub_vectordb._sessions[1] = {
+        "id": 1,
+        "sid": "sid-target",
+        "revoked_at": None,
+    }
+    token = _sign_jwt(_logout_token_payload(sid="sid-target"))
+    r = client.post(
+        "/auth/backchannel-logout",
+        data={"logout_token": token},
+    )
+    assert r.status_code == 200
+    # The stub increments revoked_at on matching sid
+    assert fresh_stub_vectordb._sessions[1]["revoked_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/logout
+# ---------------------------------------------------------------------------
+
+
+def test_logout_revokes_session_and_deletes_cookie(client, fresh_stub_vectordb):
+    _setup_discovery(client.oidc_transport)
+    # Seed a session & cookie
+    session_token = "sess-logout-tok"
+    fresh_stub_vectordb._sessions[1] = {
+        "id": 1,
+        "sid": "sid-1",
+        "id_token_encrypted": None,  # skip decrypt path
+        "session_expires_at": time.time() + 3600,
+        "revoked_at": None,
+    }
+    fresh_stub_vectordb._sessions_by_token[session_token] = 1
+
+    r = client.get(
+        "/auth/logout",
+        cookies={"openrag_session": session_token},
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    # Session marked revoked
+    assert fresh_stub_vectordb._sessions[1]["revoked_at"] is not None
+    # Cookie cleared in response (max-age=0 or Expires=past)
+    set_cookie_headers = r.headers.get_list("set-cookie")
+    assert any(
+        "openrag_session=" in h and ("Max-Age=0" in h or "expires=" in h.lower())
+        for h in set_cookie_headers
+    )
+
+
+def test_logout_rejected_in_token_mode(env_token, fresh_stub_vectordb):
+    app = FastAPI()
+    app.include_router(auth_router)
+    c = TestClient(app)
+    r = c.get("/auth/logout", follow_redirects=False)
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Skips — scenarios we can add once the full middleware stack is wired (phase 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(reason="requires phase-5 middleware for cookie-based auth on /auth/me")
+def test_me_returns_user_info_with_valid_cookie():
+    pass
+
+
+# ---------------------------------------------------------------------------
+# M2: timezone-consistency regression test
+#
+# Before the fix, routers/auth.py wrote ``access_token_expires_at`` /
+# ``session_expires_at`` via ``datetime.utcnow()`` while every read site
+# compared against ``datetime.now()``. On a host whose TZ is east of UTC
+# (e.g. Europe/Paris), a newly-issued session thus appeared "already
+# expired" by tz_offset hours and ``get_oidc_session_by_token`` returned
+# None immediately after the callback.
+# ---------------------------------------------------------------------------
+
+
+def test_callback_session_not_prematurely_expired_under_nonutc_tz(
+    client, fresh_stub_vectordb, monkeypatch
+):
+    """Callback in a non-UTC timezone must produce an immediately usable session."""
+    import os as _os
+
+    # Force a non-UTC timezone for the duration of this test. If the platform
+    # doesn't support ``time.tzset`` (e.g. Windows CI runners), skip gracefully.
+    tzset = getattr(time, "tzset", None)
+    if tzset is None:
+        pytest.skip("time.tzset not available on this platform; cannot force TZ")
+
+    original_tz = _os.environ.get("TZ")
+    monkeypatch.setenv("TZ", "Europe/Paris")
+    tzset()
+    try:
+        # Teach the stub to back get_oidc_session_by_token with the same dict we
+        # created in create_oidc_session (the default stub already does).
+        fresh_stub_vectordb.add_user(
+            user_id=77, email="tz@example.com", external_user_id="sub-tz"
+        )
+        _setup_jwks(client.oidc_transport)
+        state, nonce = _begin_login_and_extract_state(client)
+        id_token = _sign_jwt(
+            _id_token_payload(nonce, sub="sub-tz", email="tz@example.com")
+        )
+        _mock_token_endpoint(client.oidc_transport, id_token)
+
+        r = client.get(
+            f"/auth/callback?code=c&state={state}",
+            follow_redirects=False,
+        )
+        assert r.status_code == 302, r.text
+
+        # Pull the session cookie value from the response and look it up via
+        # the stub — this exercises the same staleness comparison the real
+        # middleware uses at request time.
+        session_cookie = r.cookies.get("openrag_session")
+        assert session_cookie, "callback did not set openrag_session cookie"
+
+        fetched = fresh_stub_vectordb._impl_get_oidc_session_by_token(session_cookie)
+        assert fetched is not None, (
+            "Session appeared expired IMMEDIATELY after creation — tz bug (M2)"
+        )
+
+        # Additional sanity: session_expires_at must be strictly in the future
+        # from the perspective of datetime.now() (the read-site clock).
+        from datetime import datetime as _dt
+
+        session_exp = fetched["session_expires_at"]
+        assert session_exp > _dt.now(), (
+            f"session_expires_at={session_exp} is not in the future vs datetime.now()"
+        )
+    finally:
+        if original_tz is None:
+            _os.environ.pop("TZ", None)
+        else:
+            _os.environ["TZ"] = original_tz
+        tzset()

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -342,15 +342,11 @@ def client(env_oidc, fresh_stub_vectordb):
 
 
 def _setup_discovery(router):
-    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
-        return_value=httpx.Response(200, json=DISCOVERY_DOC)
-    )
+    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(return_value=httpx.Response(200, json=DISCOVERY_DOC))
 
 
 def _setup_jwks(router):
-    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
-        return_value=httpx.Response(200, json=JWKS_RESPONSE)
-    )
+    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(return_value=httpx.Response(200, json=JWKS_RESPONSE))
 
 
 # ---------------------------------------------------------------------------
@@ -367,7 +363,7 @@ def test_login_rejected_in_token_mode(env_token, fresh_stub_vectordb):
 
 
 def test_login_redirects_to_idp_with_pkce(client):
-    _setup_discovery(client.oidc_transport)
+    _setup_discovery(client.oidc_router)
     r = client.get("/auth/login", follow_redirects=False)
     assert r.status_code == 302
     loc = r.headers["location"]
@@ -400,7 +396,7 @@ def test_callback_missing_state_cookie(client):
 
 
 def test_callback_state_mismatch(client):
-    _setup_discovery(client.oidc_transport)
+    _setup_discovery(client.oidc_router)
     # First, obtain a legitimate state cookie via /auth/login.
     login_resp = client.get("/auth/login", follow_redirects=False)
     assert login_resp.status_code == 302
@@ -421,7 +417,7 @@ def test_callback_state_mismatch(client):
 
 def _begin_login_and_extract_state(client) -> tuple[str, str]:
     """Call /auth/login and return (state, nonce) values from the redirect query."""
-    _setup_discovery(client.oidc_transport)
+    _setup_discovery(client.oidc_router)
     r = client.get("/auth/login", follow_redirects=False)
     assert r.status_code == 302
     loc = r.headers["location"]
@@ -431,7 +427,7 @@ def _begin_login_and_extract_state(client) -> tuple[str, str]:
     return qs["state"][0], qs["nonce"][0]
 
 
-def _mock_token_endpoint(transport, id_token: str, *, refresh_token: str | None = "rt-1"):
+def _mock_token_endpoint(router, id_token: str, *, refresh_token: str | None = "rt-1"):
     payload = {
         "id_token": id_token,
         "access_token": "at-1",
@@ -440,17 +436,15 @@ def _mock_token_endpoint(transport, id_token: str, *, refresh_token: str | None 
     }
     if refresh_token is not None:
         payload["refresh_token"] = refresh_token
-    transport.router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
-        return_value=httpx.Response(200, json=payload)
-    )
+    router.post(f"{ISSUER}/protocol/openid-connect/token").mock(return_value=httpx.Response(200, json=payload))
 
 
 def test_callback_success_by_external_id(client, fresh_stub_vectordb):
     fresh_stub_vectordb.add_user(user_id=42, email="user@example.com", external_user_id="sub-abc")
-    _setup_jwks(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-abc"))
-    _mock_token_endpoint(client.oidc_transport, id_token)
+    _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(
         f"/auth/callback?code=authcode&state={state}",
@@ -465,10 +459,10 @@ def test_callback_success_by_external_id(client, fresh_stub_vectordb):
 
 def test_callback_user_not_registered(client, fresh_stub_vectordb):
     """Unknown sub → 403 (no email fallback, no auto-provisioning)."""
-    _setup_jwks(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com"))
-    _mock_token_endpoint(client.oidc_transport, id_token)
+    _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(
         f"/auth/callback?code=c&state={state}",
@@ -488,7 +482,7 @@ def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectord
         external_user_id="sub-abc",
         display_name="Old Name",
     )
-    _setup_jwks(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(
         _id_token_payload(
@@ -498,7 +492,7 @@ def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectord
             extra={"name": "Doctor Who"},
         )
     )
-    _mock_token_endpoint(client.oidc_transport, id_token)
+    _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(
         f"/auth/callback?code=c&state={state}",
@@ -523,12 +517,12 @@ def test_callback_applies_claim_mapping_from_userinfo(client, fresh_stub_vectord
         external_user_id="sub-ui",
         display_name="legacy",
     )
-    _setup_jwks(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     # ID token carries no name/email — the router must pull them from /userinfo.
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-ui", email=None))
-    _mock_token_endpoint(client.oidc_transport, id_token)
-    userinfo_route = client.oidc_transport.router.get(f"{ISSUER}/protocol/openid-connect/userinfo").mock(
+    _mock_token_endpoint(client.oidc_router, id_token)
+    userinfo_route = client.oidc_router.get(f"{ISSUER}/protocol/openid-connect/userinfo").mock(
         return_value=httpx.Response(
             200,
             json={"sub": "sub-ui", "name": "UI User", "email": "ui@example.com"},
@@ -555,7 +549,7 @@ def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypa
         external_user_id="sub-plain",
         display_name="Initial",
     )
-    _setup_jwks(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(
         _id_token_payload(
@@ -565,7 +559,7 @@ def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypa
             extra={"name": "Should Be Ignored"},
         )
     )
-    _mock_token_endpoint(client.oidc_transport, id_token)
+    _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(
         f"/auth/callback?code=c&state={state}",
@@ -586,8 +580,8 @@ def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypa
 
 
 def test_backchannel_logout_rejects_invalid_token(client):
-    _setup_discovery(client.oidc_transport)
-    _setup_jwks(client.oidc_transport)
+    _setup_discovery(client.oidc_router)
+    _setup_jwks(client.oidc_router)
     r = client.post(
         "/auth/backchannel-logout",
         data={"logout_token": "not-a-jwt"},
@@ -596,8 +590,8 @@ def test_backchannel_logout_rejects_invalid_token(client):
 
 
 def test_backchannel_logout_revokes_by_sid(client, fresh_stub_vectordb):
-    _setup_jwks(client.oidc_transport)
-    _setup_discovery(client.oidc_transport)
+    _setup_jwks(client.oidc_router)
+    _setup_discovery(client.oidc_router)
 
     # Seed a session to be revoked
     fresh_stub_vectordb._sessions[1] = {
@@ -621,7 +615,7 @@ def test_backchannel_logout_revokes_by_sid(client, fresh_stub_vectordb):
 
 
 def test_logout_revokes_session_and_deletes_cookie(client, fresh_stub_vectordb):
-    _setup_discovery(client.oidc_transport)
+    _setup_discovery(client.oidc_router)
     # Seed a session & cookie
     session_token = "sess-logout-tok"
     fresh_stub_vectordb._sessions[1] = {
@@ -693,10 +687,10 @@ def test_callback_session_not_prematurely_expired_under_nonutc_tz(client, fresh_
         # Teach the stub to back get_oidc_session_by_token with the same dict we
         # created in create_oidc_session (the default stub already does).
         fresh_stub_vectordb.add_user(user_id=77, email="tz@example.com", external_user_id="sub-tz")
-        _setup_jwks(client.oidc_transport)
+        _setup_jwks(client.oidc_router)
         state, nonce = _begin_login_and_extract_state(client)
         id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-tz", email="tz@example.com"))
-        _mock_token_endpoint(client.oidc_transport, id_token)
+        _mock_token_endpoint(client.oidc_router, id_token)
 
         r = client.get(
             f"/auth/callback?code=c&state={state}",

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -64,8 +64,8 @@ def _make_rsa_key_pair():
 _RSA_PRIVATE, _RSA_PRIVATE_JWK, _RSA_PUBLIC_JWK = _make_rsa_key_pair()
 _RSA_PUBLIC_JWK["use"] = "sig"
 _RSA_PUBLIC_JWK["alg"] = "RS256"
-_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
-_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+_RSA_PUBLIC_JWK["kid"] = "test-key-1"
+_RSA_PRIVATE_JWK["kid"] = "test-key-1"
 
 JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
 

--- a/openrag/scripts/migrations/alembic/versions/f5b6c918f741_add_oidc_auth.py
+++ b/openrag/scripts/migrations/alembic/versions/f5b6c918f741_add_oidc_auth.py
@@ -1,0 +1,77 @@
+"""add users.email and oidc_sessions table for OIDC auth
+
+Revision ID: f5b6c918f741
+Revises: f1a2b3c4d5e6
+Create Date: 2026-04-17 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f5b6c918f741"
+down_revision: str | Sequence[str] | None = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: add users.email column and create oidc_sessions table."""
+    # users.email (nullable, unique, indexed)
+    op.add_column("users", sa.Column("email", sa.String(), nullable=True))
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    # oidc_sessions table
+    op.create_table(
+        "oidc_sessions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "session_token_hash",
+            sa.String(length=64),
+            nullable=False,
+            unique=True,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("sid", sa.String(), nullable=True, index=True),
+        sa.Column("sub", sa.String(), nullable=False),
+        sa.Column("id_token_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column("access_token_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column("refresh_token_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column("access_token_expires_at", sa.DateTime(), nullable=False),
+        sa.Column("session_expires_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("last_refresh_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+    )
+    # Composite index (user_id, sub) for fast lookup by (user, OIDC subject).
+    # The individual session_token_hash, user_id, and sid indexes are already
+    # created implicitly via the Column(..., index=True/unique=True) directives above.
+    op.create_index(
+        "ix_oidc_sessions_user_sub",
+        "oidc_sessions",
+        ["user_id", "sub"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema: drop oidc_sessions table and users.email column."""
+    op.drop_index("ix_oidc_sessions_user_sub", table_name="oidc_sessions")
+    # Drop table — this cascades the implicit per-column indexes.
+    op.drop_table("oidc_sessions")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_column("users", "email")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,16 @@ dependencies = [
     "pymilvus>=2.6.9",
     "protobuf>=5.27,<6.0",
     "faster-whisper>=1.1.0",
+    "authlib>=1.3",
+    "itsdangerous>=2.2",
+    "cryptography>=42",
 ]
 
 [dependency-groups]
 dev = [
     "pytest>=8.4.1",
     "pytest-asyncio>=1.3.0",
+    "respx>=0.22",
 ]
 lint = [
     "ruff>=0.14.1",

--- a/tests/api_tests/OIDC_TEST_COVERAGE.md
+++ b/tests/api_tests/OIDC_TEST_COVERAGE.md
@@ -10,10 +10,7 @@ test(s) that cover it.
 | AC3 | `AUTH_MODE=oidc` — API path without cookie/Bearer → 401 JSON | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_no_creds_api_path_returns_401`, `::test_no_creds_v1_chat_returns_401` |
 | AC4 | `GET /auth/login` → 302 with `state`, `nonce`, `code_challenge` (PKCE S256), `scope openid email` | `openrag/routers/test_auth_router.py::test_login_redirects_to_idp_with_pkce`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 1) |
 | AC5 | `GET /auth/callback` with valid code+state → sets `openrag_session` cookie + 302 to `next_url` | `openrag/routers/test_auth_router.py::test_callback_success_by_external_id`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 3) |
-| AC6 | Callback with unknown email AND unknown sub → 403, no session created | `openrag/routers/test_auth_router.py::test_callback_user_not_registered` |
-| AC6b | Callback: match by sub directly (user already linked), no email fallback | `openrag/routers/test_auth_router.py::test_callback_success_by_external_id` |
-| AC6c | Callback: match by email, backfill `external_user_id=sub`, session created | `openrag/routers/test_auth_router.py::test_callback_backfills_external_user_id`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (steps 3–4) |
-| AC6d | Callback: `external_user_id` already set to different sub → 403 conflict | `openrag/routers/test_auth_router.py::test_callback_external_id_mismatch` |
+| AC6 | Callback with unknown `sub` → 403, no session created (no email fallback) | `openrag/routers/test_auth_router.py::test_callback_user_not_registered` |
 | AC7 | Callback with invalid/mismatched `state` → 400 | `openrag/routers/test_auth_router.py::test_callback_state_mismatch`, `::test_callback_missing_state_cookie` |
 | AC8 | Callback with nonce mismatch in ID token → 400 | `openrag/components/auth/test_oidc_client.py` (exchange_code nonce validation tests) |
 | AC9 | Request with valid session cookie → `request.state.user` populated, normal flow | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_cookie_valid_and_access_token_fresh_no_refresh`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 5) |
@@ -26,3 +23,6 @@ test(s) that cover it.
 | AC16 | `access_token` and `refresh_token` stored encrypted (Fernet), unreadable without key | `openrag/components/auth/test_session_tokens.py::TestEncryptDecrypt::test_round_trip`, `::test_wrong_key_raises_value_error` |
 | AC17 | Alembic migration upgrade/downgrade idempotent | Manual: `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` |
 | AC18 | `OIDC_TOKEN_ENCRYPTION_KEY` missing in oidc mode → clear startup error | `openrag/components/auth/test_oidc_client.py` (startup/config validation tests) |
+| AC19 | `OIDC_CLAIM_MAPPING` unset → callback does NOT update user row | `openrag/routers/test_auth_router.py::test_callback_skips_mapping_when_unset` |
+| AC20 | `OIDC_CLAIM_MAPPING` set + `OIDC_CLAIM_SOURCE=id_token` → user row updated from ID token claims | `openrag/routers/test_auth_router.py::test_callback_applies_claim_mapping_from_id_token` |
+| AC21 | `OIDC_CLAIM_MAPPING` set + `OIDC_CLAIM_SOURCE=userinfo` → `/userinfo` fetched, user row updated | `openrag/routers/test_auth_router.py::test_callback_applies_claim_mapping_from_userinfo` |

--- a/tests/api_tests/OIDC_TEST_COVERAGE.md
+++ b/tests/api_tests/OIDC_TEST_COVERAGE.md
@@ -1,0 +1,28 @@
+# OIDC Test Coverage Matrix
+
+Maps every acceptance criterion from `.omc/plans/oidc-auth/plan.md` §7 to the
+test(s) that cover it.
+
+| AC | Description | Test file : function |
+|----|-------------|----------------------|
+| AC1 | `AUTH_MODE=token` behaviour strictly unchanged | `openrag/components/auth/test_middleware.py::TestTokenModeLegacy::test_bearer_valid_returns_200`, `::test_bearer_invalid_returns_403`, `::test_missing_token_returns_403` |
+| AC2 | `AUTH_MODE=oidc` — UI path without cookie → 302 to `/auth/login` | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_no_creds_root_path_returns_302`, `::test_no_creds_static_path_returns_302` |
+| AC3 | `AUTH_MODE=oidc` — API path without cookie/Bearer → 401 JSON | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_no_creds_api_path_returns_401`, `::test_no_creds_v1_chat_returns_401` |
+| AC4 | `GET /auth/login` → 302 with `state`, `nonce`, `code_challenge` (PKCE S256), `scope openid email` | `openrag/routers/test_auth_router.py::test_login_redirects_to_idp_with_pkce`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 1) |
+| AC5 | `GET /auth/callback` with valid code+state → sets `openrag_session` cookie + 302 to `next_url` | `openrag/routers/test_auth_router.py::test_callback_success_by_external_id`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 3) |
+| AC6 | Callback with unknown email AND unknown sub → 403, no session created | `openrag/routers/test_auth_router.py::test_callback_user_not_registered` |
+| AC6b | Callback: match by sub directly (user already linked), no email fallback | `openrag/routers/test_auth_router.py::test_callback_success_by_external_id` |
+| AC6c | Callback: match by email, backfill `external_user_id=sub`, session created | `openrag/routers/test_auth_router.py::test_callback_backfills_external_user_id`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (steps 3–4) |
+| AC6d | Callback: `external_user_id` already set to different sub → 403 conflict | `openrag/routers/test_auth_router.py::test_callback_external_id_mismatch` |
+| AC7 | Callback with invalid/mismatched `state` → 400 | `openrag/routers/test_auth_router.py::test_callback_state_mismatch`, `::test_callback_missing_state_cookie` |
+| AC8 | Callback with nonce mismatch in ID token → 400 | `openrag/components/auth/test_oidc_client.py` (exchange_code nonce validation tests) |
+| AC9 | Request with valid session cookie → `request.state.user` populated, normal flow | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_cookie_valid_and_access_token_fresh_no_refresh`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 5) |
+| AC10 | Cookie with near-expiry access_token + refresh_token → transparent refresh, new tokens in DB | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_cookie_near_expiry_triggers_refresh`, `::TestRefreshHelper::test_no_refresh_when_token_fresh` |
+| AC11 | Cookie with expired access_token, no refresh_token → session revoked, 302 to `/auth/login` | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_cookie_refresh_fails_session_revoked_and_302`, `::TestRefreshHelper::test_expired_no_refresh_token_returns_none` |
+| AC12 | `POST /auth/backchannel-logout` with valid signed `logout_token` (sid match) → 200, sessions revoked | `openrag/routers/test_auth_router.py::test_backchannel_logout_revokes_by_sid`, `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 6) |
+| AC13 | `POST /auth/backchannel-logout` with invalid signature → 400, no revocation | `openrag/routers/test_auth_router.py::test_backchannel_logout_rejects_invalid_token` |
+| AC14 | After backchannel-logout, old cookie rejected (401/302) | `tests/api_tests/test_oidc_lifecycle.py::test_full_oidc_lifecycle` (step 7) |
+| AC15 | Bearer `users.token` accepted in `AUTH_MODE=oidc` for programmatic access | `openrag/components/auth/test_middleware.py::TestOIDCMode::test_bearer_fallback_accepted_in_oidc_mode` |
+| AC16 | `access_token` and `refresh_token` stored encrypted (Fernet), unreadable without key | `openrag/components/auth/test_session_tokens.py::TestEncryptDecrypt::test_round_trip`, `::test_wrong_key_raises_value_error` |
+| AC17 | Alembic migration upgrade/downgrade idempotent | Manual: `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` |
+| AC18 | `OIDC_TOKEN_ENCRYPTION_KEY` missing in oidc mode → clear startup error | `openrag/components/auth/test_oidc_client.py` (startup/config validation tests) |

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -72,7 +72,8 @@ JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
 
 def _sign_jwt(payload: dict) -> str:
     header = {"alg": "RS256", "kid": "test-key-1"}
-    jwt = JsonWebToken()
+    # Authlib >=1.0 requires the allowed-algorithms list.
+    jwt = JsonWebToken(["RS256"])
     token = jwt.encode(header, payload, _RSA_PRIVATE)
     return token.decode() if isinstance(token, bytes) else token
 
@@ -270,9 +271,10 @@ _users_router_mod = importlib.import_module("routers.users")
 # ---------------------------------------------------------------------------
 
 
-def _make_app(transport) -> tuple[FastAPI, TestClient]:
+def _make_app(router) -> tuple[FastAPI, TestClient]:
     """Build a minimal FastAPI app combining auth + users routers, with a
-    mocked IdP transport injected into the OIDCClient singleton."""
+    respx MockRouter injected into the OIDCClient singleton. respx >= 0.22
+    exposes MockRouter + httpx.MockTransport(router.handler)."""
     app = FastAPI()
 
     # Install the AuthMiddleware (from components.auth.middleware)
@@ -283,7 +285,7 @@ def _make_app(transport) -> tuple[FastAPI, TestClient]:
     app.include_router(_auth_router_mod.router)
     app.include_router(_users_router_mod.router, prefix="/users")
 
-    # Override OIDCClient singleton with our mocked transport
+    # Override OIDCClient singleton with our mocked http transport.
     _auth_deps.reset_oidc_client()
     _auth_deps._client = _auth_router_mod.OIDCClient(
         issuer=ISSUER,
@@ -291,7 +293,7 @@ def _make_app(transport) -> tuple[FastAPI, TestClient]:
         client_secret=CLIENT_SECRET,
         redirect_uri=REDIRECT_URI,
         scopes=SCOPES,
-        http_client=httpx.AsyncClient(transport=transport),
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(router.handler)),
     )
 
     client = TestClient(app, raise_server_exceptions=True)
@@ -333,15 +335,15 @@ def test_full_oidc_lifecycle(monkeypatch):
     )
 
     # ── Build app with mocked transport ──────────────────────────────────────
-    transport = respx.MockTransport(assert_all_called=False)
-    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+    router = respx.MockRouter(assert_all_called=False)
+    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
         return_value=httpx.Response(200, json=DISCOVERY_DOC)
     )
-    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
+    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
         return_value=httpx.Response(200, json=JWKS_RESPONSE)
     )
 
-    _, client = _make_app(transport)
+    _, client = _make_app(router)
 
     # ── Step 1: GET /auth/login → 302 to IdP ─────────────────────────────────
     r1 = client.get("/auth/login", follow_redirects=False)
@@ -364,7 +366,7 @@ def test_full_oidc_lifecycle(monkeypatch):
     ALICE_SID = "sess-123"
     id_tok = _id_token(nonce, sub=ALICE_SUB, email="alice@example.com", sid=ALICE_SID)
 
-    transport.router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+    router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -431,8 +433,6 @@ def test_full_oidc_lifecycle(monkeypatch):
         cookies={"openrag_session": session_cookie},
         follow_redirects=False,
     )
-    # /users/info is an API path → 401, not 302 (per plan §6.1 decision)
-    assert r5.status_code in (401, 302), (
-        f"Revoked session must be rejected, got {r5.status_code}: {r5.text}"
-    )
-    assert r5.status_code != 200, "Revoked session must NOT return 200"
+    # /users/info is an API path → strict 401 JSON (per plan §6.1 decision:
+    # API paths never 302-redirect to /auth/login — that's for UI paths only).
+    assert r5.status_code == 401, f"Revoked API session must return 401, got {r5.status_code}: {r5.text}"

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -136,12 +136,8 @@ class _StubVectorDB:
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
-        self.update_user_fields = _RayMethodStub(
-            "update_user_fields", self._impl_update_user_fields, self.calls
-        )
-        self.create_oidc_session = _RayMethodStub(
-            "create_oidc_session", self._impl_create_oidc_session, self.calls
-        )
+        self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
+        self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
         self.get_oidc_session_by_token = _RayMethodStub(
             "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
         )
@@ -153,12 +149,8 @@ class _StubVectorDB:
         )
         # The middleware also calls these two
         self.get_user = _RayMethodStub("get_user", self._impl_get_user, self.calls)
-        self.list_user_partitions = _RayMethodStub(
-            "list_user_partitions", lambda *a, **kw: [], self.calls
-        )
-        self.get_user_by_token = _RayMethodStub(
-            "get_user_by_token", lambda *a, **kw: None, self.calls
-        )
+        self.list_user_partitions = _RayMethodStub("list_user_partitions", lambda *a, **kw: [], self.calls)
+        self.get_user_by_token = _RayMethodStub("get_user_by_token", lambda *a, **kw: None, self.calls)
         self.update_oidc_session_tokens = _RayMethodStub(
             "update_oidc_session_tokens", lambda *a, **kw: None, self.calls
         )
@@ -330,18 +322,12 @@ def test_full_oidc_lifecycle(monkeypatch):
     # ── Pre-seed alice with the exact sub that the IdP mock will return ────────
     ALICE_SUB = "alice-sub"
     _stub_vdb.__init__()  # reset state
-    _stub_vdb.add_user(
-        user_id=99, email="alice@example.com", external_user_id=ALICE_SUB
-    )
+    _stub_vdb.add_user(user_id=99, email="alice@example.com", external_user_id=ALICE_SUB)
 
     # ── Build app with mocked transport ──────────────────────────────────────
     router = respx.MockRouter(assert_all_called=False)
-    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
-        return_value=httpx.Response(200, json=DISCOVERY_DOC)
-    )
-    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
-        return_value=httpx.Response(200, json=JWKS_RESPONSE)
-    )
+    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(return_value=httpx.Response(200, json=DISCOVERY_DOC))
+    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(return_value=httpx.Response(200, json=JWKS_RESPONSE))
 
     _, client = _make_app(router)
 
@@ -400,9 +386,7 @@ def test_full_oidc_lifecycle(monkeypatch):
     # oidc_sessions row created with correct sid
     assert len(_stub_vdb._sessions) == 1, "Expected exactly one oidc_sessions row"
     session_row = next(iter(_stub_vdb._sessions.values()))
-    assert session_row.get("sid") == ALICE_SID, (
-        f"Expected sid='{ALICE_SID}', got '{session_row.get('sid')}'"
-    )
+    assert session_row.get("sid") == ALICE_SID, f"Expected sid='{ALICE_SID}', got '{session_row.get('sid')}'"
     assert session_row.get("revoked_at") is None, "Session must not be revoked yet"
 
     # ── Step 5: GET /users/info with session cookie → 200 alice profile ───────
@@ -410,9 +394,7 @@ def test_full_oidc_lifecycle(monkeypatch):
     # The users router depends on task_state_manager for file counts; since we
     # stub it as None the endpoint may 500 on full wiring — we accept 200 or
     # verify the middleware resolved alice (status != 401/302).
-    assert r3.status_code not in (401, 302), (
-        f"Middleware should resolve alice, got {r3.status_code}: {r3.text}"
-    )
+    assert r3.status_code not in (401, 302), f"Middleware should resolve alice, got {r3.status_code}: {r3.text}"
 
     # ── Step 6: POST /auth/backchannel-logout → 200, session revoked ──────────
     logout_tok = _logout_token(sid=ALICE_SID, sub=ALICE_SUB)
@@ -423,9 +405,7 @@ def test_full_oidc_lifecycle(monkeypatch):
     assert r4.status_code == 200, f"Expected 200, got {r4.status_code}: {r4.text}"
 
     # oidc_sessions row now has revoked_at set
-    assert session_row.get("revoked_at") is not None, (
-        "Session row must have revoked_at after backchannel-logout"
-    )
+    assert session_row.get("revoked_at") is not None, "Session row must have revoked_at after backchannel-logout"
 
     # ── Step 7: GET /users/info with same cookie → 302 /auth/login ───────────
     r5 = client.get(

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -62,11 +62,11 @@ _FERNET_KEY = Fernet.generate_key().decode()
 
 _RSA_PRIVATE = JsonWebKey.generate_key("RSA", 2048, is_private=True)
 _RSA_PRIVATE_JWK = _RSA_PRIVATE.as_dict(is_private=True)
-_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+_RSA_PRIVATE_JWK["kid"] = "test-key-1"
 _RSA_PUBLIC_JWK = _RSA_PRIVATE.as_dict()
 _RSA_PUBLIC_JWK["use"] = "sig"
 _RSA_PUBLIC_JWK["alg"] = "RS256"
-_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
+_RSA_PUBLIC_JWK["kid"] = "test-key-1"
 JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
 
 

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -1,0 +1,431 @@
+"""End-to-end OIDC lifecycle test.
+
+Exercises the *full* login → session → backchannel-logout → revoked-cookie
+sequence in a single test function so that integration bugs between phases
+are caught immediately.
+
+No Ray / Milvus / Docker required: the vectordb is replaced by the same
+_StubVectorDB used in ``openrag/routers/test_auth_router.py``, mounted via
+``utils.dependencies`` stubbing. The IdP is faked with ``respx``.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytest.importorskip("respx")
+pytest.importorskip("httpx")
+pytest.importorskip("authlib")
+pytest.importorskip("fastapi")
+pytest.importorskip("itsdangerous")
+pytest.importorskip("cryptography")
+
+import httpx  # noqa: E402
+import importlib  # noqa: E402
+import respx  # noqa: E402
+from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
+from cryptography.fernet import Fernet  # noqa: E402
+from fastapi import FastAPI, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# IdP constants
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://idp.example.com/realms/openrag"
+CLIENT_ID = "openrag-client"
+CLIENT_SECRET = "test-secret"
+REDIRECT_URI = "https://openrag.example.com/auth/callback"
+SCOPES = "openid email profile offline_access"
+
+DISCOVERY_DOC = {
+    "issuer": ISSUER,
+    "authorization_endpoint": f"{ISSUER}/protocol/openid-connect/auth",
+    "token_endpoint": f"{ISSUER}/protocol/openid-connect/token",
+    "userinfo_endpoint": f"{ISSUER}/protocol/openid-connect/userinfo",
+    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
+    "end_session_endpoint": f"{ISSUER}/protocol/openid-connect/logout",
+}
+
+_FERNET_KEY = Fernet.generate_key().decode()
+
+# ---------------------------------------------------------------------------
+# RSA key pair (shared for entire module)
+# ---------------------------------------------------------------------------
+
+_RSA_PRIVATE = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+_RSA_PRIVATE_JWK = _RSA_PRIVATE.as_dict(is_private=True)
+_RSA_PRIVATE_JWK.setdefault("kid", "test-key-1")
+_RSA_PUBLIC_JWK = _RSA_PRIVATE.as_dict()
+_RSA_PUBLIC_JWK["use"] = "sig"
+_RSA_PUBLIC_JWK["alg"] = "RS256"
+_RSA_PUBLIC_JWK.setdefault("kid", "test-key-1")
+JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
+
+
+def _sign_jwt(payload: dict) -> str:
+    header = {"alg": "RS256", "kid": "test-key-1"}
+    jwt = JsonWebToken()
+    token = jwt.encode(header, payload, _RSA_PRIVATE)
+    return token.decode() if isinstance(token, bytes) else token
+
+
+def _id_token(nonce: str, *, sub: str, email: str, sid: str | None = None) -> str:
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "iss": ISSUER,
+        "sub": sub,
+        "aud": CLIENT_ID,
+        "exp": now + 300,
+        "iat": now,
+        "nonce": nonce,
+        "email": email,
+    }
+    if sid:
+        payload["sid"] = sid
+    return _sign_jwt(payload)
+
+
+def _logout_token(*, sid: str, sub: str) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "iat": now,
+        "jti": "lt-lifecycle-001",
+        "events": {"http://schemas.openid.net/event/backchannel-logout": {}},
+        "sid": sid,
+        "sub": sub,
+    }
+    return _sign_jwt(payload)
+
+
+# ---------------------------------------------------------------------------
+# Stub VectorDB — mirrors the one in test_auth_router.py exactly
+# ---------------------------------------------------------------------------
+
+
+class _RayMethodStub:
+    def __init__(self, name: str, fn, call_log: list):
+        self._name = name
+        self._fn = fn
+        self._call_log = call_log
+
+    async def remote(self, *args, **kwargs):
+        self._call_log.append((self._name, args, kwargs))
+        return self._fn(*args, **kwargs)
+
+
+class _StubVectorDB:
+    def __init__(self):
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self._users_by_sub: dict[str, dict] = {}
+        self._users_by_email: dict[str, dict] = {}
+        self._users_by_id: dict[int, dict] = {}
+        self._sessions: dict[int, dict] = {}
+        self._sessions_by_token: dict[str, int] = {}
+        self._next_session_id = 1
+
+        self.get_user_by_external_id = _RayMethodStub(
+            "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
+        )
+        self.get_user_by_email = _RayMethodStub(
+            "get_user_by_email", self._impl_get_user_by_email, self.calls
+        )
+        self.set_user_external_id = _RayMethodStub(
+            "set_user_external_id", self._impl_set_user_external_id, self.calls
+        )
+        self.create_oidc_session = _RayMethodStub(
+            "create_oidc_session", self._impl_create_oidc_session, self.calls
+        )
+        self.get_oidc_session_by_token = _RayMethodStub(
+            "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
+        )
+        self.revoke_oidc_session_by_id = _RayMethodStub(
+            "revoke_oidc_session_by_id", self._impl_revoke_oidc_session_by_id, self.calls
+        )
+        self.revoke_oidc_sessions_by_sid = _RayMethodStub(
+            "revoke_oidc_sessions_by_sid", self._impl_revoke_oidc_sessions_by_sid, self.calls
+        )
+        # The middleware also calls these two
+        self.get_user = _RayMethodStub("get_user", self._impl_get_user, self.calls)
+        self.list_user_partitions = _RayMethodStub(
+            "list_user_partitions", lambda *a, **kw: [], self.calls
+        )
+        self.get_user_by_token = _RayMethodStub(
+            "get_user_by_token", lambda *a, **kw: None, self.calls
+        )
+        self.update_oidc_session_tokens = _RayMethodStub(
+            "update_oidc_session_tokens", lambda *a, **kw: None, self.calls
+        )
+
+    def add_user(self, *, user_id: int, email: str, external_user_id: str | None = None) -> dict:
+        user = {
+            "id": user_id,
+            "email": email,
+            "external_user_id": external_user_id,
+            "is_admin": False,
+            "display_name": f"user-{user_id}",
+        }
+        self._users_by_id[user_id] = user
+        self._users_by_email[email] = user
+        if external_user_id:
+            self._users_by_sub[external_user_id] = user
+        return user
+
+    def _impl_get_user_by_external_id(self, external_user_id: str):
+        return self._users_by_sub.get(external_user_id)
+
+    def _impl_get_user_by_email(self, email: str):
+        return self._users_by_email.get(email)
+
+    def _impl_set_user_external_id(self, user_id: int, external_user_id: str):
+        user = self._users_by_id.get(user_id)
+        if user is None:
+            raise ValueError(f"user_id={user_id} does not exist")
+        if user["external_user_id"] is None:
+            user["external_user_id"] = external_user_id
+            self._users_by_sub[external_user_id] = user
+            return
+        if user["external_user_id"] == external_user_id:
+            return
+        raise ValueError("external_user_id mismatch")
+
+    def _impl_create_oidc_session(self, **kwargs):
+        sid_key = self._next_session_id
+        self._next_session_id += 1
+        row = {
+            "id": sid_key,
+            "session_expires_at": kwargs["session_expires_at"],
+            "id_token_encrypted": kwargs.get("id_token_encrypted"),
+            **{k: v for k, v in kwargs.items() if k != "session_token_plain"},
+        }
+        self._sessions[sid_key] = row
+        self._sessions_by_token[kwargs["session_token_plain"]] = sid_key
+        return row
+
+    def _impl_get_oidc_session_by_token(self, session_token_plain: str):
+        sid_key = self._sessions_by_token.get(session_token_plain)
+        if sid_key is None:
+            return None
+        row = self._sessions[sid_key]
+        if row.get("revoked_at"):
+            return None
+        return row
+
+    def _impl_get_user(self, user_id: int):
+        return self._users_by_id.get(user_id)
+
+    def _impl_revoke_oidc_session_by_id(self, session_id: int):
+        row = self._sessions.get(session_id)
+        if row:
+            row["revoked_at"] = time.time()
+
+    def _impl_revoke_oidc_sessions_by_sid(self, sid: str) -> int:
+        count = 0
+        for row in self._sessions.values():
+            if row.get("sid") == sid and not row.get("revoked_at"):
+                row["revoked_at"] = time.time()
+                count += 1
+        return count
+
+
+# ---------------------------------------------------------------------------
+# Module-level stub installation — must happen BEFORE any router imports
+# ---------------------------------------------------------------------------
+
+_stub_vdb = _StubVectorDB()
+
+
+def _install_stubs():
+    stub = types.ModuleType("utils.dependencies")
+    stub.get_vectordb = lambda: _stub_vdb
+    stub.get_task_state_manager = lambda: None
+    stub.get_serializer = lambda: None
+    stub.get_indexer = lambda: None
+    stub.get_marker_pool = lambda: None
+    sys.modules["utils.dependencies"] = stub
+
+
+_install_stubs()
+
+# Reload auth deps + routers after stub installation
+from components.auth import deps as _auth_deps  # noqa: E402
+
+sys.modules.pop("routers.auth", None)
+sys.modules.pop("routers.users", None)
+_auth_router_mod = importlib.import_module("routers.auth")
+_users_router_mod = importlib.import_module("routers.users")
+
+# ---------------------------------------------------------------------------
+# Build the composite app (auth + users)
+# ---------------------------------------------------------------------------
+
+
+def _make_app(transport) -> tuple[FastAPI, TestClient]:
+    """Build a minimal FastAPI app combining auth + users routers, with a
+    mocked IdP transport injected into the OIDCClient singleton."""
+    app = FastAPI()
+
+    # Install the AuthMiddleware (from components.auth.middleware)
+    from components.auth.middleware import AuthMiddleware  # noqa: E402
+
+    app.add_middleware(AuthMiddleware, get_vectordb=lambda: _stub_vdb)
+
+    app.include_router(_auth_router_mod.router)
+    app.include_router(_users_router_mod.router, prefix="/users")
+
+    # Override OIDCClient singleton with our mocked transport
+    _auth_deps.reset_oidc_client()
+    _auth_deps._client = _auth_router_mod.OIDCClient(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        scopes=SCOPES,
+        http_client=httpx.AsyncClient(transport=transport),
+    )
+
+    client = TestClient(app, raise_server_exceptions=True)
+    return app, client
+
+
+# ---------------------------------------------------------------------------
+# THE lifecycle test
+# ---------------------------------------------------------------------------
+
+
+def test_full_oidc_lifecycle(monkeypatch):
+    """Single end-to-end flow: login → callback → /users/info → backchannel
+    logout → revoked cookie check.
+
+    Covers AC4, AC5, AC6c, AC9, AC12, AC14 with live component wiring.
+    """
+    # ── Env ──────────────────────────────────────────────────────────────────
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    monkeypatch.setenv("OIDC_ENDPOINT", ISSUER)
+    monkeypatch.setenv("OIDC_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("OIDC_CLIENT_SECRET", CLIENT_SECRET)
+    monkeypatch.setenv("OIDC_REDIRECT_URI", REDIRECT_URI)
+    monkeypatch.setenv("OIDC_SCOPES", SCOPES)
+    monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", _FERNET_KEY)
+    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "id_token")
+    monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
+    monkeypatch.delenv("OIDC_ALLOWED_EMAIL_DOMAINS", raising=False)
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    _auth_deps.reset_oidc_client()
+
+    # ── Pre-seed alice ────────────────────────────────────────────────────────
+    _stub_vdb.__init__()  # reset state
+    _stub_vdb.add_user(user_id=99, email="alice@example.com", external_user_id=None)
+
+    # ── Build app with mocked transport ──────────────────────────────────────
+    transport = respx.MockTransport(assert_all_called=False)
+    transport.router.get(f"{ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json=DISCOVERY_DOC)
+    )
+    transport.router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(
+        return_value=httpx.Response(200, json=JWKS_RESPONSE)
+    )
+
+    _, client = _make_app(transport)
+
+    # ── Step 1: GET /auth/login → 302 to IdP ─────────────────────────────────
+    r1 = client.get("/auth/login", follow_redirects=False)
+    assert r1.status_code == 302, f"Expected 302, got {r1.status_code}: {r1.text}"
+    loc = r1.headers["location"]
+    assert loc.startswith(f"{ISSUER}/protocol/openid-connect/auth"), loc
+    assert "code_challenge_method=S256" in loc
+    assert "state=" in loc
+    assert "nonce=" in loc
+
+    # Capture state + nonce from redirect URL
+    qs = parse_qs(urlparse(loc).query)
+    state = qs["state"][0]
+    nonce = qs["nonce"][0]
+
+    # State cookie must be set
+    assert "openrag_oidc_state" in r1.cookies
+
+    # ── Step 2: Simulate IdP token response ──────────────────────────────────
+    ALICE_SUB = "alice-sub"
+    ALICE_SID = "sess-123"
+    id_tok = _id_token(nonce, sub=ALICE_SUB, email="alice@example.com", sid=ALICE_SID)
+
+    transport.router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id_token": id_tok,
+                "access_token": "at-lifecycle",
+                "refresh_token": "rt-lifecycle",
+                "expires_in": 300,
+                "token_type": "Bearer",
+            },
+        )
+    )
+
+    # ── Step 3: GET /auth/callback → 302 to /, openrag_session cookie set ────
+    r2 = client.get(
+        f"/auth/callback?code=auth-code-xyz&state={state}",
+        follow_redirects=False,
+    )
+    assert r2.status_code == 302, f"Expected 302, got {r2.status_code}: {r2.text}"
+    assert r2.headers["location"] == "/"
+    assert "openrag_session" in r2.cookies
+    session_cookie = r2.cookies["openrag_session"]
+
+    # ── Step 4: Assert DB state ───────────────────────────────────────────────
+    # external_user_id backfilled
+    alice = _stub_vdb._users_by_id[99]
+    assert alice["external_user_id"] == ALICE_SUB, (
+        f"Expected external_user_id='{ALICE_SUB}', got '{alice['external_user_id']}'"
+    )
+
+    # oidc_sessions row created with correct sid
+    assert len(_stub_vdb._sessions) == 1, "Expected exactly one oidc_sessions row"
+    session_row = next(iter(_stub_vdb._sessions.values()))
+    assert session_row.get("sid") == ALICE_SID, (
+        f"Expected sid='{ALICE_SID}', got '{session_row.get('sid')}'"
+    )
+    assert session_row.get("revoked_at") is None, "Session must not be revoked yet"
+
+    # ── Step 5: GET /users/info with session cookie → 200 alice profile ───────
+    r3 = client.get("/users/info", cookies={"openrag_session": session_cookie})
+    # The users router depends on task_state_manager for file counts; since we
+    # stub it as None the endpoint may 500 on full wiring — we accept 200 or
+    # verify the middleware resolved alice (status != 401/302).
+    assert r3.status_code not in (401, 302), (
+        f"Middleware should resolve alice, got {r3.status_code}: {r3.text}"
+    )
+
+    # ── Step 6: POST /auth/backchannel-logout → 200, session revoked ──────────
+    logout_tok = _logout_token(sid=ALICE_SID, sub=ALICE_SUB)
+    r4 = client.post(
+        "/auth/backchannel-logout",
+        data={"logout_token": logout_tok},
+    )
+    assert r4.status_code == 200, f"Expected 200, got {r4.status_code}: {r4.text}"
+
+    # oidc_sessions row now has revoked_at set
+    assert session_row.get("revoked_at") is not None, (
+        "Session row must have revoked_at after backchannel-logout"
+    )
+
+    # ── Step 7: GET /users/info with same cookie → 302 /auth/login ───────────
+    r5 = client.get(
+        "/users/info",
+        cookies={"openrag_session": session_cookie},
+        follow_redirects=False,
+    )
+    # /users/info is an API path → 401, not 302 (per plan §6.1 decision)
+    assert r5.status_code in (401, 302), (
+        f"Revoked session must be rejected, got {r5.status_code}: {r5.text}"
+    )
+    assert r5.status_code != 200, "Revoked session must NOT return 200"

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -26,12 +26,13 @@ pytest.importorskip("fastapi")
 pytest.importorskip("itsdangerous")
 pytest.importorskip("cryptography")
 
-import httpx  # noqa: E402
 import importlib  # noqa: E402
+
+import httpx  # noqa: E402
 import respx  # noqa: E402
 from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
 from cryptography.fernet import Fernet  # noqa: E402
-from fastapi import FastAPI, Request  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 # ---------------------------------------------------------------------------

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -126,7 +126,6 @@ class _StubVectorDB:
     def __init__(self):
         self.calls: list[tuple[str, tuple, dict]] = []
         self._users_by_sub: dict[str, dict] = {}
-        self._users_by_email: dict[str, dict] = {}
         self._users_by_id: dict[int, dict] = {}
         self._sessions: dict[int, dict] = {}
         self._sessions_by_token: dict[str, int] = {}
@@ -135,11 +134,8 @@ class _StubVectorDB:
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
-        self.get_user_by_email = _RayMethodStub(
-            "get_user_by_email", self._impl_get_user_by_email, self.calls
-        )
-        self.set_user_external_id = _RayMethodStub(
-            "set_user_external_id", self._impl_set_user_external_id, self.calls
+        self.update_user_fields = _RayMethodStub(
+            "update_user_fields", self._impl_update_user_fields, self.calls
         )
         self.create_oidc_session = _RayMethodStub(
             "create_oidc_session", self._impl_create_oidc_session, self.calls
@@ -165,7 +161,13 @@ class _StubVectorDB:
             "update_oidc_session_tokens", lambda *a, **kw: None, self.calls
         )
 
-    def add_user(self, *, user_id: int, email: str, external_user_id: str | None = None) -> dict:
+    def add_user(
+        self,
+        *,
+        user_id: int,
+        email: str | None = None,
+        external_user_id: str | None = None,
+    ) -> dict:
         user = {
             "id": user_id,
             "email": email,
@@ -174,7 +176,6 @@ class _StubVectorDB:
             "display_name": f"user-{user_id}",
         }
         self._users_by_id[user_id] = user
-        self._users_by_email[email] = user
         if external_user_id:
             self._users_by_sub[external_user_id] = user
         return user
@@ -182,20 +183,20 @@ class _StubVectorDB:
     def _impl_get_user_by_external_id(self, external_user_id: str):
         return self._users_by_sub.get(external_user_id)
 
-    def _impl_get_user_by_email(self, email: str):
-        return self._users_by_email.get(email)
-
-    def _impl_set_user_external_id(self, user_id: int, external_user_id: str):
+    def _impl_update_user_fields(self, user_id: int, fields: dict):
         user = self._users_by_id.get(user_id)
         if user is None:
-            raise ValueError(f"user_id={user_id} does not exist")
-        if user["external_user_id"] is None:
-            user["external_user_id"] = external_user_id
-            self._users_by_sub[external_user_id] = user
-            return
-        if user["external_user_id"] == external_user_id:
-            return
-        raise ValueError("external_user_id mismatch")
+            raise ValueError(f"User {user_id} not found")
+        _ALLOWED = {"display_name", "email"}
+        bad = set(fields) - _ALLOWED
+        if bad:
+            raise ValueError(f"Cannot update non-whitelisted user fields: {sorted(bad)}")
+        for k, v in fields.items():
+            if v is None:
+                continue
+            if k == "email" and isinstance(v, str):
+                v = v.strip().lower()
+            user[k] = v
 
     def _impl_create_oidc_session(self, **kwargs):
         sid_key = self._next_session_id
@@ -305,7 +306,9 @@ def test_full_oidc_lifecycle(monkeypatch):
     """Single end-to-end flow: login → callback → /users/info → backchannel
     logout → revoked cookie check.
 
-    Covers AC4, AC5, AC6c, AC9, AC12, AC14 with live component wiring.
+    Covers AC4, AC5, AC9, AC12, AC14 with live component wiring.
+    Pre-provisions alice with ``external_user_id`` matching the mocked IdP's
+    ``sub`` — email is pure metadata in the simplified flow.
     """
     # ── Env ──────────────────────────────────────────────────────────────────
     monkeypatch.setenv("AUTH_MODE", "oidc")
@@ -315,15 +318,18 @@ def test_full_oidc_lifecycle(monkeypatch):
     monkeypatch.setenv("OIDC_REDIRECT_URI", REDIRECT_URI)
     monkeypatch.setenv("OIDC_SCOPES", SCOPES)
     monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", _FERNET_KEY)
-    monkeypatch.setenv("OIDC_EMAIL_SOURCE", "id_token")
+    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "id_token")
     monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
-    monkeypatch.delenv("OIDC_ALLOWED_EMAIL_DOMAINS", raising=False)
+    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
     monkeypatch.delenv("AUTH_TOKEN", raising=False)
     _auth_deps.reset_oidc_client()
 
-    # ── Pre-seed alice ────────────────────────────────────────────────────────
+    # ── Pre-seed alice with the exact sub that the IdP mock will return ────────
+    ALICE_SUB = "alice-sub"
     _stub_vdb.__init__()  # reset state
-    _stub_vdb.add_user(user_id=99, email="alice@example.com", external_user_id=None)
+    _stub_vdb.add_user(
+        user_id=99, email="alice@example.com", external_user_id=ALICE_SUB
+    )
 
     # ── Build app with mocked transport ──────────────────────────────────────
     transport = respx.MockTransport(assert_all_called=False)
@@ -354,7 +360,6 @@ def test_full_oidc_lifecycle(monkeypatch):
     assert "openrag_oidc_state" in r1.cookies
 
     # ── Step 2: Simulate IdP token response ──────────────────────────────────
-    ALICE_SUB = "alice-sub"
     ALICE_SID = "sess-123"
     id_tok = _id_token(nonce, sub=ALICE_SUB, email="alice@example.com", sid=ALICE_SID)
 
@@ -382,7 +387,8 @@ def test_full_oidc_lifecycle(monkeypatch):
     session_cookie = r2.cookies["openrag_session"]
 
     # ── Step 4: Assert DB state ───────────────────────────────────────────────
-    # external_user_id backfilled
+    # User pre-provisioning is the admin's responsibility — the flow must not
+    # mutate external_user_id at all (no backfill anymore).
     alice = _stub_vdb._users_by_id[99]
     assert alice["external_user_id"] == ALICE_SUB, (
         f"Expected external_user_id='{ALICE_SUB}', got '{alice['external_user_id']}'"


### PR DESCRIPTION
## Summary

Adds a second authentication mode, `AUTH_MODE=oidc`, that replaces the Chainlit token form with a full OpenID Connect Authorization Code + PKCE flow and supports spec-compliant Back-Channel Logout. Bearer `users.token` keeps working for programmatic access (CI, agents, tests).

Pairs with linagora/openrag-admin-ui#18 (indexer-ui side).

## Design decisions (validated up-front)

- **Ephemeral opaque session token** issued on `/auth/callback` — stored SHA-256-hashed in a new `oidc_sessions` table. We never try to read back the user's `users.token` (which is also hashed) — the two credentials are cleanly separated.
- **User matching order**: `external_user_id=sub` (fast, stable) → `email` (with backfill of `external_user_id=sub` on success) → **403, no auto-provisioning**.
- **Bearer `users.token` still accepted** in oidc mode for programmatic clients. Humans go through OIDC only.
- **Back-channel logout by `sid`** (OIDC spec); the same IdP-revocation cascades across indexer-ui, Chainlit, and the API surface because they all share `oidc_sessions`.
- **Lazy access-token refresh** (no background worker) with `last_refresh_at < 5s` short-circuit and `SELECT … FOR UPDATE` — protects against the refresh-token-rotation stampede.
- **IdP tokens encrypted at rest** (Fernet, key in `OIDC_TOKEN_ENCRYPTION_KEY`).

## What's in the box

### Backend
- `openrag/components/auth/` package (Authlib-based client, session tokens, state cookie, middleware, refresh helper)
- `openrag/routers/auth.py`: `GET /auth/login`, `GET /auth/callback`, `POST /auth/backchannel-logout`, `GET /auth/logout`, `GET /auth/me`
- `AuthMiddleware` refactor:
  - cookie `openrag_session` → `oidc_sessions` lookup
  - Bearer fallback → `oidc_sessions` then `users.token` (fixes Chainlit's `header_auth_callback` which forwards the cookie as Bearer to `/users/info`)
  - UI paths → 302 `/auth/login?next=…`
  - API paths → 401 JSON
  - Token-mode branch byte-for-byte identical (legacy 403 messages preserved)

### DB
- Alembic migration `f5b6c918f741`: `users.email` (unique nullable) + `oidc_sessions` (encrypted tokens, `sid`/`user_sub` indexes)
- `UserCreate` model extended with `email`; `create_user` persists it
- 9 new methods on `PartitionFileManager` exposed as Ray actor methods

### Chainlit
- `header_auth_callback` in oidc mode (reads `openrag_session` cookie)
- `password_auth_callback` gated behind `AUTH_MODE != "oidc"`

### Cross-origin (indexer-ui)
- `_sanitize_next_url` now accepts absolute URLs whose origin ∈ `{INDEXERUI_URL, localhost:3042, localhost:5173}` (anti open-redirect preserved)
- `docker-compose.yaml`: `AUTH_MODE` propagated to indexer-ui; `extra_hosts` for host-gateway (IdP on the host)

### Docs
- `docs/oidc.md` (~700 lines): flow diagram, config table, Keycloak + LemonLDAP::NG setup, programmatic access, back-channel logout, troubleshooting (incl. trailing-slash issuer-mismatch gotcha with per-IdP table), security considerations
- `CLAUDE.md` Authentication section extended
- `README.md` + `.env.example`

### Tests
- 11 DB tests (`test_oidc_sessions.py`)
- OIDC client tests with mocked IdP (`respx` + RSA JWT signing)
- Session-tokens / state-cookie / middleware / refresh helper tests (covers M1 refresh stampede + M2 tz bug)
- Auth router integration tests (all AC from the plan except `/auth/me` which requires a live middleware)
- End-to-end lifecycle test (`tests/api_tests/test_oidc_lifecycle.py`): login → callback → DB assertions → `/users/info` via cookie → back-channel-logout → cookie rejected
- Coverage matrix: `tests/api_tests/OIDC_TEST_COVERAGE.md`

## Configuration

New env vars (see `docs/oidc.md` for details):

| Var | Required (oidc) | Purpose |
|-----|---|---|
| `AUTH_MODE` | — | `token` (default) \| `oidc` |
| `OIDC_ENDPOINT` | yes | Issuer URL (must match `.well-known/openid-configuration.issuer` byte-for-byte) |
| `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | yes | Registered confidential client |
| `OIDC_REDIRECT_URI` | yes | Must match IdP registration |
| `OIDC_TOKEN_ENCRYPTION_KEY` | yes | Fernet key for IdP tokens at rest |
| `OIDC_EMAIL_SOURCE` | no | `id_token` (default) \| `userinfo` |
| `OIDC_SCOPES` | no | default `openid email profile offline_access` |
| `OIDC_POST_LOGOUT_REDIRECT_URI` | no | default `/` |
| `OIDC_ALLOWED_EMAIL_DOMAINS` | no | CSV whitelist |

Startup refuses to boot if any required var is missing, with a clear error listing which ones.

## Backward compatibility

`AUTH_MODE=token` (the default) is strictly unchanged. The existing password-auth Chainlit flow, `AUTH_TOKEN` dev bypass, CORS config, and 403 error bodies are all preserved. Token-mode tests pass without modification.

## Architect review

Done (APPROVED WITH CAVEATS). The two MAJOR items (M1 refresh stampede, M2 timezone) are fixed in this PR. Remaining minors (cookie redaction in logs, startup Fernet-key validity check, `/auth/me` test un-skip, open-redirect hardening on `post_logout_redirect_uri`) are tracked for a follow-up.

## Test plan

- [ ] `docker compose up --build -d` + `docker compose exec openrag-cpu uv run pytest openrag/` — unit tests green
- [ ] `docker compose exec openrag-cpu uv run pytest tests/api_tests/` — integration green (incl. `test_oidc_lifecycle.py`)
- [ ] Robot suite unchanged: `tests/api/users.robot` still returns 403 on bad Bearer
- [ ] Manual: `AUTH_MODE=token` → existing Chainlit login form, unchanged flow
- [ ] Manual: `AUTH_MODE=oidc` + Keycloak local → login → cookie posed → Chainlit loads
- [ ] Manual: indexer-ui on different port → redirect preserves origin after OIDC
- [ ] Manual: back-channel logout from IdP admin → next request 302s to login
- [ ] Manual: `curl -H "Authorization: Bearer <AUTH_TOKEN>" /v1/models` in oidc mode → 200 (agent path works)

## Draft

Live testing ongoing. Will be flipped to ready once the full end-to-end flow is verified against a real IdP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added OpenID Connect (OIDC) authentication mode for integration with corporate identity providers, selectable via `AUTH_MODE` configuration
  * Bearer token authentication continues to work for programmatic access in OIDC mode

* **Documentation**
  * Added comprehensive OIDC setup guides and SSO quick-start instructions for administrators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->