### PR TITLE
refactor(users): align regenerate_token with documented behavior

### DIFF
--- a/openrag/routers/users.py
+++ b/openrag/routers/users.py
@@ -223,10 +223,19 @@ Returns user details including the new token:
 **Note:** Store the new token securely - the old token is now invalid.
 """,
 )
-async def regenerate_user_token(user_id: int, vectordb=Depends(get_vectordb)):
+async def regenerate_user_token(
+    user_id: int,
+    current=Depends(current_user),
+    vectordb=Depends(get_vectordb),
+):
     """
-    Regenerate a user's token.
+    Regenerate a user's token. Caller must be admin or the target user themselves.
     """
+    if not current.get("is_admin") and current.get("id") != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only regenerate your own token",
+        )
     user = await vectordb.regenerate_user_token.remote(user_id)
     logger.info("Regenerated user token", user_id=user_id)
     return JSONResponse(status_code=status.HTTP_200_OK, content=user)

--- a/tests/api/users.robot
+++ b/tests/api/users.robot
@@ -31,6 +31,22 @@ Get Created User
     Should Be Equal As Strings    ${json}[id]    ${USER_ID}
     Dictionary Should Not Contain Key    ${json}    token
 
+Non-Admin Can Regenerate Own Token
+    Skip If Auth Disabled
+    &{user_headers}=    Create Dictionary    Authorization=Bearer ${USER_TOKEN}
+    ${response}=    POST    ${USERS_ENDPOINT}/${USER_ID}/regenerate_token    headers=${user_headers}    expected_status=200
+    ${json}=    Set Variable    ${response.json()}
+    Dictionary Should Contain Key    ${json}    token
+    Should Not Be Equal As Strings    ${json}[token]    ${USER_TOKEN}
+    Set Suite Variable    ${USER_TOKEN}    ${json}[token]
+
+Non-Admin Cannot Regenerate Other User Token
+    Skip If Auth Disabled
+    &{user_headers}=    Create Dictionary    Authorization=Bearer ${USER_TOKEN}
+    ${response}=    POST    ${USERS_ENDPOINT}/1/regenerate_token    headers=${user_headers}    expected_status=403
+    ${json}=    Set Variable    ${response.json()}
+    Should Contain    ${json}[detail]    You can only regenerate your own token
+
 Regenerate Token
     ${response}=    POST    ${USERS_ENDPOINT}/${USER_ID}/regenerate_token    headers=${HEADERS}    expected_status=200
     ${json}=    Set Variable    ${response.json()}


### PR DESCRIPTION
 We align `regenerate_token` with its documented behavior.
                                                                                                                                                            
 We add the admin-or-self check described in the endpoint documentation, following the same `is_admin` pattern already used in the other  functions of this file.                                                                                                                                   
                                                                                                                                                            
 Two Robot cases added in `tests/api/users.robot` to cover the two expected behaviors (self → 200, cross-user → 403).     
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token regeneration API: non-admin users can now regenerate their own tokens.

* **Improvements**
  * Added configurable timeout and automatic retry mechanisms with exponential backoff for audio transcription, PDF document processing, and document marking operations to improve reliability and error recovery.

* **Tests**
  * Added authorization test cases for token regeneration endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->