### PR TITLE
feat(deploy): INDEXERUI_BASE_PATH build-arg + bump indexer-ui submodule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,13 @@ RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 # critical with the newest version of UV
 
 INCLUDE_CREDENTIALS=false                       # set true if fastapi authentification is enabled, i.e AUTH_TOKEN is set
 INDEXERUI_PORT=8060                             # Port to expose the Indexer UI (default is 3042)
-INDEXERUI_URL='http://X.X.X.X:INDEXERUI_PORT'                 
-API_BASE_URL='http://X.X.X.X:APP_PORT'          # Base URL of your FastAPI backend. 
+INDEXERUI_URL='http://X.X.X.X:INDEXERUI_PORT'
+API_BASE_URL='http://X.X.X.X:APP_PORT'          # Base URL of your FastAPI backend.
+# Mount the indexer-ui under a subpath (e.g. `/indexerui`) on a shared vhost
+# that also hosts the backend. Leave EMPTY for root-level deployment (default).
+# Consumed as a Docker build ARG — run `docker compose build indexer-ui`
+# after changing this value; it is NOT read at runtime.
+# INDEXERUI_BASE_PATH=/indexerui
 
 # Web Search
 # WEBSEARCH_API_TOKEN=      # Web search provider API token. If unset, web search is silently disabled.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,6 +75,12 @@ services:
     build:
       context: ./extern/indexer-ui
       dockerfile: Dockerfile
+      args:
+        # Mount indexer-ui under a subpath (e.g. /indexerui/) on a shared
+        # vhost with the backend. Empty = root-level (default). See
+        # docs/oidc.md §"Single vhost deployment" for the matching nginx
+        # rules.
+        BASE_PATH: ${INDEXERUI_BASE_PATH:-}
     environment:
       - API_BASE_URL=${API_BASE_URL:-http://localhost:${APP_PORT:-8080}}
       - INCLUDE_CREDENTIALS=${INCLUDE_CREDENTIALS:-false}

--- a/docs/content/docs/documentation/setup_indexerui.md
+++ b/docs/content/docs/documentation/setup_indexerui.md
@@ -44,3 +44,54 @@ INDEXERUI_PORT=8060 # Port for the Indexer UI (default: 3042)
 INDEXERUI_URL='http://X.X.X.X:INDEXERUI_PORT'
 API_BASE_URL='http://X.X.X.X:APP_PORT'
 ```
+
+### 3. Mount the Indexer UI under a Subpath (optional)
+
+By default the Indexer UI is served at the root of its own origin (`http://host:INDEXERUI_PORT/`). If you want to expose it **on the same vhost as the backend** (behind a reverse proxy), you can mount it under a subpath via `INDEXERUI_BASE_PATH`. The typical reason is to keep the frontend and the backend same-origin.
+With this setup, the backend's session cookie is first-party to the UI (this matters when `AUTH_MODE=oidc`, where a cross-origin `openrag_session` cookie is dropped by the browser).
+
+```bash
+# Empty (default) → root-level deployment.
+# Set to mount under a subpath — leading slash required, no trailing slash.
+INDEXERUI_BASE_PATH=/indexerui
+```
+
+:::caution[Rebuild required]
+`INDEXERUI_BASE_PATH` is consumed as a **Docker build ARG** (passed to the `indexer-ui` Dockerfile via `docker-compose.yaml`), not a runtime variable. The SvelteKit app bakes the value into every asset URL and every API call at build time. After changing it you must rebuild the image:
+
+```bash
+docker compose build indexer-ui
+docker compose up -d indexer-ui
+```
+:::
+
+#### Example nginx rules (single vhost)
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name rag.example.com;
+
+    # ... TLS config ...
+
+    # Indexer UI mounted under /indexerui/
+    location /indexerui/ {
+        proxy_pass         http://indexer-ui:3000/;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # Everything else → backend (API, /auth/*, /chainlit, /static, ...)
+    location / {
+        proxy_pass         http://openrag:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+The trailing slash on `proxy_pass http://indexer-ui:3000/;` is load-bearing — it strips the `/indexerui` prefix before forwarding, leaving the SvelteKit app to re-add its `base` via `INDEXERUI_BASE_PATH`.


### PR DESCRIPTION
## Summary

Enables deploying indexer-ui under a subpath (e.g. `/indexerui/`) on the same vhost as the OpenRag backend. Needed by environments behind a single TLS-terminating reverse proxy where we want a single origin to avoid cross-origin cookie handling (and the SameSite pain that goes with it).

## Changes

- **`docker-compose.yaml`** (service `indexer-ui`): forward `INDEXERUI_BASE_PATH` env to the container build as the `BASE_PATH` Docker build-arg.
- **`.env.example`**: document `INDEXERUI_BASE_PATH` (commented out, empty = root-level as today, rebuild required after change).
- **`extern/indexer-ui`**: bump submodule pointer to `c967017` (the merged OIDC support on `openrag-admin-ui@main`).

## Dependency

Pairs with **linagora/openrag-admin-ui#19** (`feat(base-path): subpath mounting via BASE_PATH env`). Without that PR merged, setting `INDEXERUI_BASE_PATH` in `.env` has no effect — the build-arg is passed through compose but the Dockerfile it reaches doesn't read it yet. Merge #19, then bump the submodule pointer again in a follow-up to actually enable the feature.

## Usage once both PRs land

```bash
# .env
INDEXERUI_BASE_PATH=/indexerui

# then:
docker compose build indexer-ui
docker compose up -d
```

Reverse proxy (nginx):
```nginx
location /indexerui/ {
    proxy_pass http://indexer-ui:3000;   # NO trailing slash = path kept intact
}
location / {
    proxy_pass http://openrag-backend:8080;
}
```

## Test plan

- [x] `docker compose config indexer-ui` — build.args.BASE_PATH visible
- [ ] Empty `INDEXERUI_BASE_PATH` (default) → image builds with empty base, app still at root
- [ ] `INDEXERUI_BASE_PATH=/indexerui` → image builds with `base=/indexerui`, app reachable at `<host>/indexerui/` through the proxy rule above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving indexer-ui under a custom subpath configuration.

* **Documentation**
  * Updated configuration examples and guidance for subpath setup; clarified that Docker rebuild is required after configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->