### PR TITLE
add notion sync action for refacto docs

### DIFF
--- a/.github/workflows/sync_notion_docs.yml
+++ b/.github/workflows/sync_notion_docs.yml
@@ -1,0 +1,62 @@
+name: Sync refacto docs from Notion
+
+# Manual-only. Pulls the three refacto spec pages from Notion, writes them to
+# .claude/skills/openrag-refacto/, and commits the result back to
+# refactor/hexagonal if anything changed.
+#
+# Required repo secret:
+#   NOTION_API_KEY         (mapped to NOTION_TOKEN below, which is what notion2md reads)
+#
+# Required repo variables (Settings > Secrets and variables > Actions > Variables):
+#   NOTION_PAGE_STRATEGY   — page ID for REFACTORING_STRATEGY_v1.md
+#   NOTION_PAGE_WORKFLOW   — page ID for REFACTORING_DEV_WORKFLOW.md
+#   NOTION_PAGE_GUIDE      — page ID for "Refactoring OpenRAG for Enterprise.md"
+#
+# The Notion integration must be shared on each page (Share > Invite > select
+# the integration) or it returns 404.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-notion-docs
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refactor/hexagonal
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install sync deps
+        run: pip install 'notion2md==2.9.0'
+
+      - name: Sync pages
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_API_KEY }}
+          NOTION_PAGE_STRATEGY: ${{ vars.NOTION_PAGE_STRATEGY }}
+          NOTION_PAGE_WORKFLOW: ${{ vars.NOTION_PAGE_WORKFLOW }}
+          NOTION_PAGE_GUIDE: ${{ vars.NOTION_PAGE_GUIDE }}
+        run: python scripts/sync_notion_docs.py
+
+      - name: Commit and push if changed
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "no changes to commit"
+            exit 0
+          fi
+          git config user.name "openrag-notion-sync"
+          git config user.email "openrag-notion-sync@users.noreply.github.com"
+          git add .claude/skills/openrag-refacto/
+          git commit -m "sync refacto docs from notion"
+          git push origin HEAD:refactor/hexagonal

--- a/scripts/sync_notion_docs.py
+++ b/scripts/sync_notion_docs.py
@@ -1,0 +1,91 @@
+"""Sync the three refacto docs from Notion into `.claude/skills/openrag-refacto/`.
+
+Reads config from environment variables (set by the GitHub workflow):
+
+  NOTION_TOKEN               — integration token (required; read by notion2md)
+  NOTION_PAGE_STRATEGY       — page ID for REFACTORING_STRATEGY_v1.md
+  NOTION_PAGE_WORKFLOW       — page ID for REFACTORING_DEV_WORKFLOW.md
+  NOTION_PAGE_GUIDE          — page ID for "Refactoring OpenRAG for Enterprise.md"
+
+For each configured page, fetches the block tree, converts to markdown via
+notion2md, and writes to the target file only if the content changed.
+Per-page errors (e.g. 404 when the integration isn't shared on a page) are
+caught so one bad page doesn't abort the rest.
+
+Exit codes:
+  0 — all configured pages synced (or skipped because their ID env var was unset)
+  1 — at least one configured page failed to fetch
+  2 — required config (NOTION_TOKEN) is missing
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from notion2md.exporter.block import StringExporter
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = REPO_ROOT / ".claude" / "skills" / "openrag-refacto"
+
+# (env var holding the Notion page ID, output filename)
+PAGES = [
+    ("NOTION_PAGE_STRATEGY", "REFACTORING_STRATEGY_v1.md"),
+    ("NOTION_PAGE_WORKFLOW", "REFACTORING_DEV_WORKFLOW.md"),
+    ("NOTION_PAGE_GUIDE", "Refactoring OpenRAG for Enterprise.md"),
+]
+
+
+def fetch_markdown(page_id: str) -> str:
+    return StringExporter(block_id=page_id).export()
+
+
+def sync_page(page_id: str, output_path: Path) -> bool:
+    """Write `output_path` if the fetched markdown differs. Return True on change."""
+    new_content = fetch_markdown(page_id)
+    if output_path.exists() and output_path.read_text(encoding="utf-8") == new_content:
+        return False
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    if not os.environ.get("NOTION_TOKEN"):
+        print("error: NOTION_TOKEN not set", file=sys.stderr)
+        return 2
+
+    changed: list[str] = []
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    for env_var, filename in PAGES:
+        page_id = os.environ.get(env_var, "").strip()
+        if not page_id:
+            print(f"skip: {env_var} not set")
+            skipped.append(filename)
+            continue
+        target = OUTPUT_DIR / filename
+        print(f"sync: {env_var} -> {target.relative_to(REPO_ROOT)}")
+        try:
+            if sync_page(page_id, target):
+                changed.append(filename)
+        except Exception as exc:
+            print(f"fail: {filename}: {exc!r}", file=sys.stderr)
+            failed.append(filename)
+
+    if skipped:
+        print(f"\nskipped ({len(skipped)}): {', '.join(skipped)}")
+    if failed:
+        print(f"failed ({len(failed)}): {', '.join(failed)}")
+    if changed:
+        print(f"changed ({len(changed)}): {', '.join(changed)}")
+    else:
+        print("no changes")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Manual GitHub Action that pulls the three refacto spec pages from Notion and commits them back to `refactor/hexagonal` if anything changed.

Scope kept tight on purpose: the three pages behind `.claude/skills/openrag-refacto/{REFACTORING_STRATEGY_v1.md, REFACTORING_DEV_WORKFLOW.md, Refactoring OpenRAG for Enterprise.md}`. `SKILL.md` stays hand-authored.

## Setup the admin needs to do once

Repo secret (Settings > Secrets and variables > Actions > Secrets):
- `NOTION_API_KEY` — Notion integration token

Repo variables (same page, Variables tab):
- `NOTION_PAGE_STRATEGY`
- `NOTION_PAGE_WORKFLOW`
- `NOTION_PAGE_GUIDE`

Each page in Notion needs the integration shared onto it (Share > Invite > select the integration), otherwise the API returns 404.

## How it runs

Trigger it from the Actions tab (`workflow_dispatch` only, no schedule). Per run:
1. Check out `refactor/hexagonal`.
2. For each of the three pages, fetch blocks via `notion-client` and render markdown via `notion2md`.
3. Write the file only if the content differs from what's on disk.
4. If `git status` shows no changes, exit silently.
5. Otherwise, commit as `openrag-notion-sync <openrag-notion-sync@users.noreply.github.com>` with message `sync refacto docs from notion` and push to `refactor/hexagonal`.

## Notes

- Uses `GITHUB_TOKEN` for the push (has workflow + contents write by default when `permissions: contents: write` is set on the job).
- Commits land directly on `refactor/hexagonal`; no PR dance. Matches the scope choice for this action.
- If any of the three page ID variables is unset, that page is skipped with a printed note — the action still succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to synchronize documentation pages from Notion into the repository as markdown files, with manual trigger capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->