### PR TITLE
fix(auth): detect HTTPS behind TLS-terminating reverse proxy

### DIFF
--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -124,6 +124,7 @@ def _is_request_secure(request: Request) -> bool:
     3. ``request.url.scheme`` (accounts for proxy_headers=True in uvicorn)
     """
     import os
+
     if os.environ.get("PREFERRED_URL_SCHEME", "").lower() == "https":
         return True
     if request.headers.get("x-forwarded-proto", "").lower() == "https":

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -118,9 +118,16 @@ def _require_oidc_mode():
 def _is_request_secure(request: Request) -> bool:
     """True if the client-observed scheme is HTTPS.
 
-    ``request.url.scheme`` already accounts for reverse-proxy headers when the
-    app is started with ``proxy_headers=True`` (see ``api.py``).
+    Checks multiple indicators:
+    1. ``PREFERRED_URL_SCHEME`` env var (set when behind a TLS-terminating proxy)
+    2. ``X-Forwarded-Proto`` header (set by reverse proxies like Traefik/Nginx)
+    3. ``request.url.scheme`` (accounts for proxy_headers=True in uvicorn)
     """
+    import os
+    if os.environ.get("PREFERRED_URL_SCHEME", "").lower() == "https":
+        return True
+    if request.headers.get("x-forwarded-proto", "").lower() == "https":
+        return True
     return request.url.scheme == "https"
 
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -123,11 +123,12 @@ def _is_request_secure(request: Request) -> bool:
     2. ``X-Forwarded-Proto`` header (set by reverse proxies like Traefik/Nginx)
     3. ``request.url.scheme`` (accounts for proxy_headers=True in uvicorn)
     """
-    import os
-
     if os.environ.get("PREFERRED_URL_SCHEME", "").lower() == "https":
         return True
-    if request.headers.get("x-forwarded-proto", "").lower() == "https":
+    # X-Forwarded-Proto can be comma-separated when chained through multiple
+    # proxies (e.g. "https, http"); the client-most hop is the first entry.
+    xfp = request.headers.get("x-forwarded-proto", "")
+    if xfp.split(",", 1)[0].strip().lower() == "https":
         return True
     return request.url.scheme == "https"
 


### PR DESCRIPTION
## Summary

Narrow-scope revival of #313: extracts **only** the OIDC cookie fix (9 lines) from that PR, leaving the unrelated feature bundle behind.

When OpenRag runs behind a TLS-terminating reverse proxy (Traefik/Nginx), `request.url.scheme` is `http` because TLS is terminated by the proxy. As a result, the OIDC state cookie is set without the `Secure` flag, the browser drops it on the HTTPS callback, and the Authorization Code + PKCE exchange fails with `OIDC code exchange failed`.

## Fix

`_is_request_secure()` now checks three indicators:
1. `PREFERRED_URL_SCHEME=https` env var (explicit config; already used elsewhere in OpenRag)
2. `X-Forwarded-Proto: https` header (standard reverse-proxy header)
3. `request.url.scheme` (existing fallback)

## Relation to #313

Credit to @etiquet — commit is cherry-picked from #313 with authorship preserved. The other ~3,300 lines in #313 (parallel JWT OIDC module, Drive connector, notifications subsystem, 990-line admin router, two non-idempotent migrations, Linagora-internal deployment notes) are out of scope for this fix and should be discussed separately.

## Test plan

- [ ] Deploy behind a TLS-terminating proxy; verify OIDC login completes
- [ ] Verify `openrag_session` cookie has `Secure` flag when `X-Forwarded-Proto: https` is set
- [ ] Verify direct HTTP access still works (Secure=false)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of secure connections to better support deployment scenarios with proxies and load balancers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->