### PR TITLE
Phase 3: config schemas split into core/config/

### DIFF
--- a/openrag/config/__init__.py
+++ b/openrag/config/__init__.py
@@ -1,3 +1,5 @@
+# Re-export from canonical location for backward compatibility.
+# New code should import from openrag.core.config directly.
 """OpenRAG configuration package.
 
 Public API:
@@ -8,13 +10,13 @@ Public API:
 
 from functools import lru_cache
 
-from .models import Settings
+from openrag.core.config.root import Settings  # noqa: F401
 
 
 @lru_cache
 def get_settings() -> Settings:
     """Cached singleton — one Settings instance per process."""
-    from .loader import load_config as _load
+    from openrag.core.config.loader import load_config as _load
 
     return _load()
 
@@ -28,7 +30,7 @@ def load_config(config_path=None, overrides=None) -> Settings:
     The ``overrides`` parameter bypasses the cache (useful for tests).
     """
     if overrides or config_path:
-        from .loader import load_config as _load
+        from openrag.core.config.loader import load_config as _load
 
         return _load(conf_dir=config_path, overrides=overrides)
     return get_settings()

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -1,0 +1,24 @@
+"""Authentication configuration — token mode + OIDC settings."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class OIDCConfig(BaseModel):
+    """OIDC configuration for Keycloak / external IdP integration.
+
+    All fields are optional — if OIDC is not enabled, this section is ignored.
+    Populated from environment variables (OIDC_ENDPOINT, OIDC_CLIENT_ID, etc.).
+    """
+
+    enabled: bool = False
+    issuer_url: str = ""
+    client_id: str = ""
+    client_secret: str = ""
+    redirect_uri: str = ""
+    scopes: str = "openid email profile offline_access"
+    token_encryption_key: str = ""
+    claim_source: str = "id_token"
+    claim_mapping: str = ""
+    post_logout_redirect_uri: str = ""

--- a/openrag/core/config/base.py
+++ b/openrag/core/config/base.py
@@ -1,0 +1,44 @@
+"""Base config mixin — frozen Pydantic models with dict-like backward compatibility."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ConfigMixin(BaseModel):
+    """Frozen Pydantic model with dict-like access for backward compatibility.
+
+    Existing code using ``config.section.get("key")``, ``config.section["key"]``,
+    ``dict(config.section)``, and ``**config.section`` keeps working.
+    """
+
+    model_config = {"frozen": True}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            return default
+
+    def __getitem__(self, key: str) -> Any:
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def keys(self):
+        return list(type(self).model_fields.keys())
+
+    def values(self):
+        return [getattr(self, k) for k in type(self).model_fields]
+
+    def items(self):
+        return [(k, getattr(self, k)) for k in type(self).model_fields]
+
+    def __iter__(self):
+        return iter(type(self).model_fields)
+
+    def __contains__(self, key: str) -> bool:
+        return key in type(self).model_fields

--- a/openrag/core/config/chunking.py
+++ b/openrag/core/config/chunking.py
@@ -1,0 +1,16 @@
+"""Chunking configuration."""
+
+from __future__ import annotations
+
+from openrag.core.config.base import ConfigMixin
+
+
+class ChunkerConfig(ConfigMixin):
+    """Chunking strategy settings."""
+
+    name: str = "recursive_splitter"
+    contextual_retrieval: bool = True
+    contextualization_timeout: int = 120
+    max_concurrent_contextualization: int = 10
+    chunk_size: int = 512
+    chunk_overlap_rate: float = 0.2

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -1,0 +1,56 @@
+"""Model endpoint configuration — LLM, VLM, embedder, semaphore settings."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from openrag.core.config.base import ConfigMixin
+
+
+class LLMParamsConfig(ConfigMixin):
+    """Shared parameters for LLM/VLM endpoints."""
+
+    temperature: float = 0.1
+    timeout: int = 60
+    max_retries: int = 2
+    logprobs: bool = True
+
+
+class LLMConfig(LLMParamsConfig):
+    """LLM endpoint configuration."""
+
+    base_url: str = ""
+    model: str = ""
+    api_key: str = Field(default="", repr=False)
+
+
+class VLMConfig(LLMParamsConfig):
+    """Vision-Language Model endpoint configuration."""
+
+    base_url: str = ""
+    model: str = ""
+    api_key: str = Field(default="", repr=False)
+
+
+class EmbedderConfig(ConfigMixin):
+    """Embedding model endpoint configuration."""
+
+    provider: str = "openai"
+    model_name: str = "jinaai/jina-embeddings-v3"
+    base_url: str = "http://vllm:8000/v1"
+    api_key: str = Field(default="EMPTY", repr=False)
+    max_model_len: int = 8192
+
+
+class SemaphoreConfig(ConfigMixin):
+    """Concurrency limits for LLM and VLM calls."""
+
+    llm_semaphore: int = 10
+    vlm_semaphore: int = 10
+
+
+class LLMContextConfig(ConfigMixin):
+    """Token budget settings for LLM context."""
+
+    max_llm_context_size: int = 8192
+    max_output_tokens: int = 1024

--- a/openrag/core/config/indexation.py
+++ b/openrag/core/config/indexation.py
@@ -1,0 +1,157 @@
+"""Indexation pipeline configuration — loaders, parsers, transcribers."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from openrag.core.config.base import ConfigMixin
+
+# ---------------------------------------------------------------------------
+# Transcriber (nested under loader)
+# ---------------------------------------------------------------------------
+
+
+class TranscriberConfig(ConfigMixin):
+    base_url: str = "http://transcriber:8000/v1"
+    api_key: str = Field(default="EMPTY", repr=False)
+    model_name: str = "openai/whisper-large-v3-turbo"
+    timeout: int = 3600
+    max_concurrent_chunks: int = 20
+    use_whisper_lang_detector: bool = True
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Loader (nested under loader)
+# ---------------------------------------------------------------------------
+
+
+class OpenAILoaderConfig(ConfigMixin):
+    base_url: str = "http://openai:8000/v1"
+    api_key: str = Field(default="EMPTY", repr=False)
+    model: str = "dotsocr-model"
+    temperature: float = 0.2
+    timeout: int = 180
+    max_retries: int = 2
+    top_p: float = 0.9
+    concurrency_limit: int = 20
+
+
+# ---------------------------------------------------------------------------
+# Local Whisper (nested under loader)
+# ---------------------------------------------------------------------------
+
+
+class LocalWhisperConfig(ConfigMixin):
+    model: str = "base"
+    whisper_n_workers: int = 3
+    whisper_num_gpus: float = 0.01
+    whisper_concurrency_per_worker: int = 2
+    whisper_timeout: int = 1800
+    whisper_max_task_retry: int = 1
+    whisper_retry_base_delay: float = 2.0
+
+
+# ---------------------------------------------------------------------------
+# File loaders mapping (nested under loader)
+# ---------------------------------------------------------------------------
+
+
+class FileLoadersConfig(ConfigMixin):
+    txt: str = "TextLoader"
+    pdf: str = "MarkerLoader"
+    eml: str = "EmlLoader"
+    docx: str = "DocxLoader"
+    pptx: str = "PPTXLoader"
+    doc: str = "DocLoader"
+    png: str = "ImageLoader"
+    jpeg: str = "ImageLoader"
+    jpg: str = "ImageLoader"
+    svg: str = "ImageLoader"
+    wav: str = "LocalWhisperLoader"
+    mp3: str = "LocalWhisperLoader"
+    flac: str = "LocalWhisperLoader"
+    ogg: str = "LocalWhisperLoader"
+    aac: str = "LocalWhisperLoader"
+    flv: str = "LocalWhisperLoader"
+    wma: str = "LocalWhisperLoader"
+    mp4: str = "LocalWhisperLoader"
+    md: str = "MarkdownLoader"
+
+
+# ---------------------------------------------------------------------------
+# Mimetypes mapping (nested under loader)
+# ---------------------------------------------------------------------------
+
+
+class MimetypesConfig(ConfigMixin):
+    """Maps MIME type strings to file extensions.
+
+    Access via .to_dict() for {mime_type: extension} mapping.
+    """
+
+    text_plain: str = Field(default=".txt", alias="text/plain")
+    text_markdown: str = Field(default=".md", alias="text/markdown")
+    application_pdf: str = Field(default=".pdf", alias="application/pdf")
+    message_rfc822: str = Field(default=".eml", alias="message/rfc822")
+    application_docx: str = Field(
+        default=".docx",
+        alias="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    application_pptx: str = Field(
+        default=".pptx",
+        alias="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    )
+    application_msword: str = Field(default=".doc", alias="application/msword")
+    image_png: str = Field(default=".png", alias="image/png")
+    image_jpeg: str = Field(default=".jpeg", alias="image/jpeg")
+    audio_wav: str = Field(default=".wav", alias="audio/wav")
+    audio_mpeg: str = Field(default=".mp3", alias="audio/mpeg")
+    audio_flac: str = Field(default=".flac", alias="audio/flac")
+    audio_ogg: str = Field(default=".ogg", alias="audio/ogg")
+    audio_aac: str = Field(default=".aac", alias="audio/aac")
+    video_x_flv: str = Field(default=".flv", alias="video/x-flv")
+    audio_x_ms_wma: str = Field(default=".wma", alias="audio/x-ms-wma")
+    video_mp4: str = Field(default=".mp4", alias="video/mp4")
+
+    model_config = {"frozen": True, "extra": "allow", "populate_by_name": True}
+
+    def to_dict(self) -> dict[str, str]:
+        """Return {mime_type: extension} mapping using aliases as keys."""
+        result = {}
+        for field_name, field_info in type(self).model_fields.items():
+            alias = field_info.alias or field_name
+            result[alias] = getattr(self, field_name)
+        if self.__pydantic_extra__:
+            result.update(self.__pydantic_extra__)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Loader (top-level indexation config)
+# ---------------------------------------------------------------------------
+
+
+class LoaderConfig(ConfigMixin):
+    image_captioning: bool = True
+    image_captioning_url: bool = True
+    save_markdown: bool = False
+    mimetypes: MimetypesConfig = Field(default_factory=MimetypesConfig)
+    local_whisper: LocalWhisperConfig = Field(default_factory=LocalWhisperConfig)
+    file_loaders: FileLoadersConfig = Field(default_factory=FileLoadersConfig)
+    marker_max_tasks_per_child: int = 20
+    marker_pool_size: int = 1
+    marker_max_processes: int = 2
+    marker_num_gpus: float = 0.01
+    marker_timeout: int = 3600
+    marker_pdftext_workers: int = 2
+    marker_chunk_size: int = 10
+    marker_max_task_retry: int = 3
+    marker_retry_base_delay: float = 2.0
+    docling_num_gpus: float = Field(default=0.01, ge=0)
+    docling_pool_size: int = Field(default=1, ge=1)
+    docling_max_tasks_per_worker: int = Field(default=2, ge=1)
+    docling_timeout: int = 3600
+    docling_max_task_retry: int = 3
+    docling_retry_base_delay: float = 2.0
+    transcriber: TranscriberConfig = Field(default_factory=TranscriberConfig)
+    openai: OpenAILoaderConfig = Field(default_factory=OpenAILoaderConfig)

--- a/openrag/core/config/infrastructure.py
+++ b/openrag/core/config/infrastructure.py
@@ -1,0 +1,128 @@
+"""Infrastructure configuration — VectorDB, Postgres, Ray, paths, server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field
+
+from openrag.core.config.base import ConfigMixin
+
+# ---------------------------------------------------------------------------
+# VectorDB (Milvus)
+# ---------------------------------------------------------------------------
+
+
+class VectorDBConfig(ConfigMixin):
+    host: str = "milvus"
+    port: int = 19530
+    connector_name: str = "milvus"
+    collection_name: str = "vdb_test"
+    hybrid_search: bool = True
+    enable: bool = True
+    schema_version: int = 1
+
+
+# ---------------------------------------------------------------------------
+# RDB (Postgres)
+# ---------------------------------------------------------------------------
+
+
+class RDBConfig(ConfigMixin):
+    host: str = "rdb"
+    port: int = 5432
+    user: str = "root"
+    password: str = Field(default="", repr=False)
+    default_file_quota: int = -1
+
+
+# ---------------------------------------------------------------------------
+# Ray — concurrency groups, serve config
+# ---------------------------------------------------------------------------
+
+
+class IndexerConcurrencyGroupsConfig(ConfigMixin):
+    default: int = 1000
+    update: int = 100
+    search: int = 100
+    delete: int = 100
+    serialize: int = 50
+    chunk: int = 1000
+    insert: int = 100
+
+
+class RayIndexerConfig(ConfigMixin):
+    max_task_retries: int = 2
+    serialize_timeout: int = 3600
+    vectordb_timeout: int = 30
+    concurrency_groups: IndexerConcurrencyGroupsConfig = Field(
+        default_factory=IndexerConcurrencyGroupsConfig,
+    )
+
+
+class RaySemaphoreConfig(ConfigMixin):
+    concurrency: int = 100000
+
+
+class RayServeConfig(ConfigMixin):
+    enable: bool = False
+    num_replicas: int = 1
+    host: str = "0.0.0.0"
+    port: int = 8080
+    chainlit_port: int = 8090
+
+
+class RayConfig(ConfigMixin):
+    num_gpus: float = 0.01
+    pool_size: int = 1
+    max_tasks_per_worker: int = 8
+    indexer: RayIndexerConfig = Field(default_factory=RayIndexerConfig)
+    semaphore: RaySemaphoreConfig = Field(default_factory=RaySemaphoreConfig)
+    serve: RayServeConfig = Field(default_factory=RayServeConfig)
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+class PathsConfig(ConfigMixin):
+    prompts_dir: Path = Path("../prompts/example1")
+    data_dir: Path = Path("../data")
+    db_dir: Path = Path("/app/db")
+    log_dir: Path = Path("/app/logs")
+
+    model_config = {**ConfigMixin.model_config, "arbitrary_types_allowed": True}
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+class ServerConfig(ConfigMixin):
+    preferred_url_scheme: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Verbose / logging
+# ---------------------------------------------------------------------------
+
+
+class VerboseConfig(ConfigMixin):
+    level: str = "DEBUG"
+
+
+# ---------------------------------------------------------------------------
+# Prompts (file name mapping)
+# ---------------------------------------------------------------------------
+
+
+class PromptsConfig(ConfigMixin):
+    sys_prompt: str = "sys_prompt_tmpl.txt"
+    query_contextualizer: str = "query_contextualizer_tmpl.txt"
+    chunk_contextualizer: str = "chunk_contextualizer_tmpl.txt"
+    image_describer: str = "image_captioning_tmpl.txt"
+    spoken_style_answer: str = "spoken_style_answer_tmpl.txt"
+    hyde: str = "hyde.txt"
+    multi_query: str = "multi_query_pmpt_tmpl.txt"

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -1,0 +1,282 @@
+"""Configuration loader — reads YAML defaults, merges env var overrides, validates with Pydantic.
+
+Copied from config/loader.py. The original will be updated to re-export
+from here for backward compatibility.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openrag.core.config.root import Settings
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONF_DIR = Path(__file__).resolve().parent.parent.parent.parent / "conf"
+
+# ---------------------------------------------------------------------------
+# Env var mappings: {env_var_name: dotted.config.path}
+# ---------------------------------------------------------------------------
+_ENV_OVERRIDES: list[tuple[str, str, type]] = [
+    # LLM
+    ("BASE_URL", "llm.base_url", str),
+    ("MODEL", "llm.model", str),
+    ("API_KEY", "llm.api_key", str),
+    # VLM
+    ("VLM_BASE_URL", "vlm.base_url", str),
+    ("VLM_MODEL", "vlm.model", str),
+    ("VLM_API_KEY", "vlm.api_key", str),
+    # Semaphore
+    ("LLM_SEMAPHORE", "semaphore.llm_semaphore", int),
+    ("VLM_SEMAPHORE", "semaphore.vlm_semaphore", int),
+    # Embedder
+    ("EMBEDDER_MODEL_NAME", "embedder.model_name", str),
+    ("EMBEDDER_BASE_URL", "embedder.base_url", str),
+    ("EMBEDDER_API_KEY", "embedder.api_key", str),
+    ("MAX_MODEL_LEN", "embedder.max_model_len", int),
+    # VectorDB
+    ("VDB_HOST", "vectordb.host", str),
+    ("VDB_iPORT", "vectordb.port", int),
+    ("VDB_PORT", "vectordb.port", int),
+    ("VDB_CONNECTOR_NAME", "vectordb.connector_name", str),
+    ("VDB_COLLECTION_NAME", "vectordb.collection_name", str),
+    ("VDB_HYBRID_SEARCH", "vectordb.hybrid_search", bool),
+    ("VDB_ENABLE_INSERTION", "vectordb.enable", bool),
+    # RDB (Postgres)
+    ("POSTGRES_HOST", "rdb.host", str),
+    ("POSTGRES_PORT", "rdb.port", int),
+    ("POSTGRES_USER", "rdb.user", str),
+    ("POSTGRES_PASSWORD", "rdb.password", str),
+    ("DEFAULT_FILE_QUOTA", "rdb.default_file_quota", int),
+    # Reranker
+    ("RERANKER_PROVIDER", "reranker.provider", str),
+    ("RERANKER_ENABLED", "reranker.enabled", bool),
+    ("RERANKER_MODEL", "reranker.model_name", str),
+    ("RERANKER_TOP_K", "reranker.top_k", int),
+    ("RERANKER_BASE_URL", "reranker.base_url", str),
+    ("RERANKER_API_KEY", "reranker.api_key", str),
+    ("RERANKER_TIMEOUT", "reranker.timeout", float),
+    ("RERANKER_SEMAPHORE", "reranker.semaphore", int),
+    # Map-Reduce
+    ("MAP_REDUCE_INITIAL_BATCH_SIZE", "map_reduce.initial_batch_size", int),
+    ("MAP_REDUCE_EXPANSION_BATCH_SIZE", "map_reduce.expansion_batch_size", int),
+    ("MAP_REDUCE_MAX_TOTAL_DOCUMENTS", "map_reduce.max_total_documents", int),
+    ("MAP_REDUCE_DEBUG", "map_reduce.debug", bool),
+    # Verbose
+    ("LOG_LEVEL", "verbose.level", str),
+    # Server
+    ("PREFERRED_URL_SCHEME", "server.preferred_url_scheme", str),
+    # LLM Context
+    ("MAX_LLM_CONTEXT_SIZE", "llm_context.max_llm_context_size", int),
+    ("MAX_OUTPUT_TOKENS", "llm_context.max_output_tokens", int),
+    # Paths
+    ("PROMPTS_DIR", "paths.prompts_dir", str),
+    ("DATA_DIR", "paths.data_dir", str),
+    ("DB_DIR", "paths.db_dir", str),
+    ("LOG_DIR", "paths.log_dir", str),
+    # Loader
+    ("IMAGE_CAPTIONING", "loader.image_captioning", bool),
+    ("IMAGE_CAPTIONING_URL", "loader.image_captioning_url", bool),
+    ("SAVE_MARKDOWN", "loader.save_markdown", bool),
+    ("PDFLoader", "loader.file_loaders.pdf", str),
+    ("AUDIOLOADER", "loader.file_loaders.wav", str),
+    ("MARKER_MAX_TASKS_PER_CHILD", "loader.marker_max_tasks_per_child", int),
+    ("MARKER_POOL_SIZE", "loader.marker_pool_size", int),
+    ("MARKER_MAX_PROCESSES", "loader.marker_max_processes", int),
+    ("MARKER_NUM_GPUS", "loader.marker_num_gpus", float),
+    ("MARKER_TIMEOUT", "loader.marker_timeout", int),
+    ("MARKER_PDFTEXT_WORKERS", "loader.marker_pdftext_workers", int),
+    ("MARKER_CHUNK_SIZE", "loader.marker_chunk_size", int),
+    ("DOCLING_NUM_GPUS", "loader.docling_num_gpus", float),
+    ("DOCLING_POOL_SIZE", "loader.docling_pool_size", int),
+    ("DOCLING_MAX_TASKS_PER_WORKER", "loader.docling_max_tasks_per_worker", int),
+    ("WHISPER_MODEL", "loader.local_whisper.model", str),
+    ("WHISPER_N_WORKERS", "loader.local_whisper.whisper_n_workers", int),
+    ("WHISPER_NUM_GPUS", "loader.local_whisper.whisper_num_gpus", float),
+    ("WHISPER_CONCURRENCY_PER_WORKER", "loader.local_whisper.whisper_concurrency_per_worker", int),
+    ("TRANSCRIBER_BASE_URL", "loader.transcriber.base_url", str),
+    ("TRANSCRIBER_API_KEY", "loader.transcriber.api_key", str),
+    ("TRANSCRIBER_MODEL", "loader.transcriber.model_name", str),
+    ("TRANSCRIBER_TIMEOUT", "loader.transcriber.timeout", int),
+    ("TRANSCRIBER_MAX_CONCURRENT_CHUNKS", "loader.transcriber.max_concurrent_chunks", int),
+    ("USE_WHISPER_LANG_DETECTOR", "loader.transcriber.use_whisper_lang_detector", bool),
+    ("OPENAI_LOADER_BASE_URL", "loader.openai.base_url", str),
+    ("OPENAI_LOADER_API_KEY", "loader.openai.api_key", str),
+    ("OPENAI_LOADER_MODEL", "loader.openai.model", str),
+    ("OPENAI_LOADER_TEMPERATURE", "loader.openai.temperature", float),
+    ("OPENAI_LOADER_TIMEOUT", "loader.openai.timeout", int),
+    ("OPENAI_LOADER_MAX_RETRIES", "loader.openai.max_retries", int),
+    ("OPENAI_LOADER_TOP_P", "loader.openai.top_p", float),
+    ("OPENAI_LOADER_CONCURRENCY_LIMIT", "loader.openai.concurrency_limit", int),
+    # Ray
+    ("RAY_NUM_GPUS", "ray.num_gpus", float),
+    ("RAY_POOL_SIZE", "ray.pool_size", int),
+    ("RAY_MAX_TASKS_PER_WORKER", "ray.max_tasks_per_worker", int),
+    ("RAY_MAX_TASK_RETRIES", "ray.indexer.max_task_retries", int),
+    ("INDEXER_SERIALIZE_TIMEOUT", "ray.indexer.serialize_timeout", int),
+    ("VECTORDB_TIMEOUT", "ray.indexer.vectordb_timeout", int),
+    ("INDEXER_DEFAULT_CONCURRENCY", "ray.indexer.concurrency_groups.default", int),
+    ("INDEXER_UPDATE_CONCURRENCY", "ray.indexer.concurrency_groups.update", int),
+    ("INDEXER_SEARCH_CONCURRENCY", "ray.indexer.concurrency_groups.search", int),
+    ("INDEXER_DELETE_CONCURRENCY", "ray.indexer.concurrency_groups.delete", int),
+    ("INDEXER_SERIALIZE_CONCURRENCY", "ray.indexer.concurrency_groups.serialize", int),
+    ("INDEXER_CHUNK_CONCURRENCY", "ray.indexer.concurrency_groups.chunk", int),
+    ("INDEXER_INSERT_CONCURRENCY", "ray.indexer.concurrency_groups.insert", int),
+    ("RAY_SEMAPHORE_CONCURRENCY", "ray.semaphore.concurrency", int),
+    ("ENABLE_RAY_SERVE", "ray.serve.enable", bool),
+    ("RAY_SERVE_NUM_REPLICAS", "ray.serve.num_replicas", int),
+    ("RAY_SERVE_HOST", "ray.serve.host", str),
+    ("RAY_SERVE_PORT", "ray.serve.port", int),
+    ("CHAINLIT_PORT", "ray.serve.chainlit_port", int),
+    # Chunker
+    ("CHUNKER", "chunker.name", str),
+    ("CONTEXTUAL_RETRIEVAL", "chunker.contextual_retrieval", bool),
+    ("CONTEXTUALIZATION_TIMEOUT", "chunker.contextualization_timeout", int),
+    ("MAX_CONCURRENT_CONTEXTUALIZATION", "chunker.max_concurrent_contextualization", int),
+    ("CHUNK_SIZE", "chunker.chunk_size", int),
+    ("CHUNK_OVERLAP_RATE", "chunker.chunk_overlap_rate", float),
+    # Retriever
+    ("RETRIEVER_TYPE", "retriever.type", str),
+    ("RETRIEVER_TOP_K", "retriever.top_k", int),
+    ("SIMILARITY_THRESHOLD", "retriever.similarity_threshold", float),
+    ("WITH_SURROUNDING_CHUNKS", "retriever.with_surrounding_chunks", bool),
+    ("INCLUDE_RELATED", "retriever.include_related", bool),
+    ("INCLUDE_ANCESTORS", "retriever.include_ancestors", bool),
+    ("RELATED_LIMIT", "retriever.related_limit", int),
+    ("MAX_DEPTH", "retriever.max_ancestor_depth", int),
+    # RAG
+    ("RAG_MODE", "rag.mode", str),
+    # WebSearch
+    ("WEBSEARCH_PROVIDER", "websearch.provider", str),
+    ("WEBSEARCH_API_TOKEN", "websearch.api_token", str),
+    ("WEBSEARCH_BASE_URL", "websearch.base_url", str),
+    ("WEBSEARCH_TOP_K", "websearch.top_k", int),
+    ("WEBSEARCH_LANG", "websearch.lang", str),
+    ("WEBSEARCH_MAX_TOKENS", "websearch.max_tokens", int),
+    ("WEBSEARCH_FETCH_CONTENT", "websearch.fetch_content", bool),
+    ("WEBSEARCH_FETCH_MAX_RESULTS", "websearch.fetch_max_results", int),
+    ("WEBSEARCH_FETCH_TIMEOUT", "websearch.fetch_timeout", float),
+    ("WEBSEARCH_FETCH_MAX_TOKENS", "websearch.fetch_max_tokens", int),
+    ("WEBSEARCH_FETCH_VERIFY_SSL", "websearch.fetch_verify_ssl", bool),
+]
+
+_AUDIO_EXTENSIONS = ("mp3", "flac", "ogg", "aac", "flv", "wma", "mp4")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file, returning empty dict if not found."""
+    if not path.exists():
+        logger.warning("Config file not found: %s — using defaults", path)
+        return {}
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base."""
+    merged = base.copy()
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _set_nested(data: dict, dotted_path: str, value: Any) -> None:
+    """Set a value in a nested dict using a dotted path."""
+    keys = dotted_path.split(".")
+    current = data
+    for key in keys[:-1]:
+        current = current.setdefault(key, {})
+    current[keys[-1]] = value
+
+
+def _coerce(value: str, target_type: type, env_var: str = "") -> Any:
+    """Coerce a string env var value to the target type."""
+    if target_type is bool:
+        lower = value.lower()
+        if lower in ("true", "1", "yes"):
+            return True
+        if lower in ("false", "0", "no"):
+            return False
+        raise ValueError(f"Invalid value for {env_var}: expected bool, got {value!r}")
+    try:
+        if target_type is int:
+            return int(value)
+        if target_type is float:
+            return float(value)
+    except ValueError:
+        raise ValueError(f"Invalid value for {env_var}: expected {target_type.__name__}, got {value!r}")
+    return value
+
+
+def _apply_env_overrides(data: dict) -> dict:
+    """Apply environment variable overrides to the config dict."""
+    for env_var, dotted_path, target_type in _ENV_OVERRIDES:
+        value = os.environ.get(env_var)
+        if value is not None and value != "":
+            _set_nested(data, dotted_path, _coerce(value, target_type, env_var))
+
+    semaphore = os.environ.get("SEMAPHORE")
+    if semaphore:
+        sem_value = _coerce(semaphore, int, "SEMAPHORE")
+        sem = data.setdefault("semaphore", {})
+        sem.setdefault("llm_semaphore", sem_value)
+        sem.setdefault("vlm_semaphore", sem_value)
+
+    audio_loader = os.environ.get("AUDIOLOADER")
+    if audio_loader:
+        file_loaders = data.setdefault("loader", {}).setdefault("file_loaders", {})
+        for ext in _AUDIO_EXTENSIONS:
+            file_loaders[ext] = audio_loader
+
+    return data
+
+
+def load_config(
+    conf_dir: Path | str | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> Settings:
+    """Load configuration: YAML defaults -> env var overrides -> Pydantic validation.
+
+    Args:
+        conf_dir: Path to the configuration directory. Defaults to ``conf/``
+                  at the project root, overridable via ``OPENRAG_CONF_DIR``.
+        overrides: Programmatic overrides (useful for tests).
+    """
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    env_conf_dir = os.environ.get("OPENRAG_CONF_DIR")
+    if conf_dir:
+        conf_dir = Path(conf_dir)
+    elif env_conf_dir:
+        conf_dir = Path(env_conf_dir)
+    else:
+        conf_dir = _DEFAULT_CONF_DIR
+
+    data = _load_yaml(conf_dir / "config.yaml")
+    data = {k: v for k, v in data.items() if not k.startswith("_")}
+    data = _apply_env_overrides(data)
+
+    reranker = data.get("reranker")
+    if isinstance(reranker, dict) and not reranker.get("base_url"):
+        reranker.pop("base_url", None)
+
+    if overrides:
+        data = _deep_merge(data, overrides)
+
+    paths = data.get("paths", {})
+    for key in ("prompts_dir", "data_dir", "db_dir", "log_dir"):
+        if key in paths and paths[key]:
+            paths[key] = str(Path(paths[key]).resolve())
+
+    return Settings(**data)

--- a/openrag/core/config/retrieval.py
+++ b/openrag/core/config/retrieval.py
@@ -1,0 +1,129 @@
+"""Retrieval, reranker, RAG mode, map-reduce, and web search configuration."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from openrag.core.config.base import ConfigMixin
+
+# ---------------------------------------------------------------------------
+# Reranker
+# ---------------------------------------------------------------------------
+
+
+class _BaseRerankerConfig(ConfigMixin):
+    model_name: str = "Alibaba-NLP/gte-multilingual-reranker-base"
+    top_k: int = 10
+    api_key: str = Field(default="EMPTY", repr=False)
+    timeout: float = 60.0
+    semaphore: int = 5
+    enabled: bool = True
+
+
+class InfinityRerankerConfig(_BaseRerankerConfig):
+    provider: Literal["infinity"] = "infinity"
+    base_url: str = "http://reranker:7997"
+
+
+class OpenAIRerankerConfig(_BaseRerankerConfig):
+    provider: Literal["openai"] = "openai"
+    base_url: str = "http://reranker:8000/v1"
+
+
+RerankerConfig = Annotated[
+    InfinityRerankerConfig | OpenAIRerankerConfig,
+    Field(discriminator="provider"),
+]
+
+
+def _default_reranker_config() -> InfinityRerankerConfig:
+    return InfinityRerankerConfig()
+
+
+# ---------------------------------------------------------------------------
+# Retriever
+# ---------------------------------------------------------------------------
+
+
+class _BaseRetrieverConfig(ConfigMixin):
+    top_k: int = 50
+    similarity_threshold: float = 0.6
+    with_surrounding_chunks: bool = False
+    include_related: bool = True
+    include_ancestors: bool = True
+    related_limit: int = 10
+    max_ancestor_depth: int = 10
+
+
+class SingleRetrieverConfig(_BaseRetrieverConfig):
+    type: Literal["single"] = "single"
+
+
+class MultiQueryRetrieverConfig(_BaseRetrieverConfig):
+    type: Literal["multiQuery"] = "multiQuery"
+    k_queries: int = 3
+
+
+class HydeRetrieverConfig(_BaseRetrieverConfig):
+    type: Literal["hyde"] = "hyde"
+    combine: bool = False
+
+
+RetrieverConfig = Annotated[
+    SingleRetrieverConfig | MultiQueryRetrieverConfig | HydeRetrieverConfig,
+    Field(discriminator="type"),
+]
+
+
+# ---------------------------------------------------------------------------
+# RAG
+# ---------------------------------------------------------------------------
+
+
+class RAGConfig(ConfigMixin):
+    mode: str = "ChatBotRag"
+    chat_history_depth: int = 4
+    max_contextualized_query_len: int = 512
+
+
+# ---------------------------------------------------------------------------
+# Map-Reduce
+# ---------------------------------------------------------------------------
+
+
+class MapReduceConfig(ConfigMixin):
+    initial_batch_size: int = 10
+    expansion_batch_size: int = 5
+    max_total_documents: int = 20
+    debug: bool = False
+
+
+# ---------------------------------------------------------------------------
+# WebSearch
+# ---------------------------------------------------------------------------
+
+
+class _BaseWebSearchConfig(ConfigMixin):
+    base_url: str
+    api_token: str = Field(default="", repr=False)
+    top_k: int = 5
+    lang: str = "fr-FR"
+    max_tokens: int = 2000
+    fetch_content: bool = True
+    fetch_max_results: int = 3
+    fetch_timeout: float = 1.0
+    fetch_max_tokens: int = 500
+    fetch_verify_ssl: bool = False
+
+
+class StaanWebSearchConfig(_BaseWebSearchConfig):
+    provider: Literal["staan"] = "staan"
+    base_url: str = "https://api.staan.ai/search/web"
+
+
+WebSearchConfig = Annotated[
+    StaanWebSearchConfig,
+    Field(discriminator="provider"),
+]

--- a/openrag/core/config/root.py
+++ b/openrag/core/config/root.py
@@ -1,0 +1,63 @@
+"""Root configuration — composes all sub-models into a single Settings object."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from openrag.core.config.base import ConfigMixin
+from openrag.core.config.chunking import ChunkerConfig
+from openrag.core.config.endpoints import (
+    EmbedderConfig,
+    LLMConfig,
+    LLMContextConfig,
+    SemaphoreConfig,
+    VLMConfig,
+)
+from openrag.core.config.indexation import LoaderConfig
+from openrag.core.config.infrastructure import (
+    PathsConfig,
+    PromptsConfig,
+    RayConfig,
+    RDBConfig,
+    ServerConfig,
+    VectorDBConfig,
+    VerboseConfig,
+)
+from openrag.core.config.retrieval import (
+    MapReduceConfig,
+    RAGConfig,
+    RerankerConfig,
+    RetrieverConfig,
+    SingleRetrieverConfig,
+    StaanWebSearchConfig,
+    WebSearchConfig,
+    _default_reranker_config,
+)
+
+
+class Settings(ConfigMixin):
+    """Root configuration.
+
+    Defaults here are fallbacks only. In production, values come from
+    conf/config.yaml merged with environment variable overrides.
+    """
+
+    llm: LLMConfig = Field(default_factory=LLMConfig)
+    vlm: VLMConfig = Field(default_factory=VLMConfig)
+    semaphore: SemaphoreConfig = Field(default_factory=SemaphoreConfig)
+    embedder: EmbedderConfig = Field(default_factory=EmbedderConfig)
+    vectordb: VectorDBConfig = Field(default_factory=VectorDBConfig)
+    rdb: RDBConfig = Field(default_factory=RDBConfig)
+    reranker: RerankerConfig = Field(default_factory=_default_reranker_config)
+    map_reduce: MapReduceConfig = Field(default_factory=MapReduceConfig)
+    verbose: VerboseConfig = Field(default_factory=VerboseConfig)
+    server: ServerConfig = Field(default_factory=ServerConfig)
+    llm_context: LLMContextConfig = Field(default_factory=LLMContextConfig)
+    paths: PathsConfig = Field(default_factory=PathsConfig)
+    prompts: PromptsConfig = Field(default_factory=PromptsConfig)
+    loader: LoaderConfig = Field(default_factory=LoaderConfig)
+    ray: RayConfig = Field(default_factory=RayConfig)
+    chunker: ChunkerConfig = Field(default_factory=ChunkerConfig)
+    retriever: RetrieverConfig = Field(default_factory=SingleRetrieverConfig)
+    rag: RAGConfig = Field(default_factory=RAGConfig)
+    websearch: WebSearchConfig = Field(default_factory=StaanWebSearchConfig)


### PR DESCRIPTION
## Summary

Splits the monolithic `config/models.py` into domain-focused files in `core/config/`:

- `base.py` — ConfigMixin (frozen Pydantic + dict-like compat)
- `endpoints.py` — LLM, VLM, embedder, semaphore, LLM context
- `chunking.py` — ChunkerConfig
- `retrieval.py` — reranker, retriever, RAG, map-reduce, websearch
- `indexation.py` — LoaderConfig + all nested configs
- `infrastructure.py` — VectorDB, Postgres, Ray, paths, server, verbose, prompts
- `auth.py` — OIDCConfig
- `root.py` — Settings composing all sections
- `loader.py` — load_config() (YAML + env overrides + Pydantic validation)

Old `config/__init__.py` re-exports from core for backward compatibility.

## Verification

- Layer guard: OK
- Legacy imports (`from config import load_config`) still work
- New imports (`from openrag.core.config.loader import load_config`) work