### PR TITLE
fix: drop chat_template_kwargs for Mistral 3.2 compatibility

### DIFF
--- a/benchmarks/prompt_eval/eval_query_decomposition.py
+++ b/benchmarks/prompt_eval/eval_query_decomposition.py
@@ -200,8 +200,8 @@ def build_llm_messages(prompt: str, messages: list[dict]) -> list[dict]:
 def _model_kwargs(base_url: str) -> dict:
     """Return call-time kwargs; omit vLLM-specific extra_body for OpenAI endpoints."""
     kwargs: dict = {"max_completion_tokens": 512}
-    if "openai.com" not in base_url:
-        kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
+    # if "openai.com" not in base_url:
+    #     kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
     return kwargs
 
 

--- a/benchmarks/prompt_eval/eval_temporal_filter_generation.py
+++ b/benchmarks/prompt_eval/eval_temporal_filter_generation.py
@@ -229,8 +229,8 @@ def build_llm_messages(prompt: str, messages: list[dict]) -> list[dict]:
 def _model_kwargs(base_url: str) -> dict:
     """Return call-time kwargs; omit vLLM-specific extra_body for OpenAI endpoints."""
     kwargs: dict = {"max_completion_tokens": 512}
-    if "openai.com" not in base_url:
-        kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
+    # if "openai.com" not in base_url:
+    #     kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
     return kwargs
 
 

--- a/openrag/components/indexer/loaders/base.py
+++ b/openrag/components/indexer/loaders/base.py
@@ -42,7 +42,7 @@ class BaseLoader(ABC):
             "temperature": 0.2,
             "max_retries": 3,
             "timeout": 60,
-            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+            # "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
         }
         settings.update(model_settings)
 

--- a/openrag/components/pipeline.py
+++ b/openrag/components/pipeline.py
@@ -249,7 +249,7 @@ class RagPipeline:
 
                 model_kwargs = {
                     "max_completion_tokens": self.max_contextualized_query_len,
-                    "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+                    # "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
                 }
                 prompt = QUERY_CONTEXTUALIZER_PROMPT.format(
                     query_language=query_language,


### PR DESCRIPTION
## Summary

Mistral-Small-3.2-24B-Instruct-2506-FP8 ships native tokenizer files (`tekken.json` / `params.json`), causing vLLM to load `mistral_common` which rejects any `chat_template` field — including `chat_template_kwargs` in the request body (`ValueError: chat_template is not supported for Mistral tokenizers`).

Remove `extra_body: {"chat_template_kwargs": {"enable_thinking": False}}` from the pipeline, base loader, and benchmark scripts.

## Test plan

- [ ] `POST /v1/chat/completions` no longer raises the `ValueError`
- [ ] Tool calling and image captioning still work