### PR TITLE
feat: add CORS_EXTRA_ORIGINS env var to extend allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ VLM_MODEL=
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234
+# Optional: semicolon-separated extra allowed origins
+# CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'  
 
 # SAVE_UPLOADED_FILES=true # usefull for chainlit (chat interface) source viewing
 

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -484,6 +484,7 @@ The following environment variables configure the FastAPI server and control acc
 | `DEFAULT_FILE_QUOTA` | `int` | `-1` | Default per-user file quota. `<0` disables quotas globally; `>=0` sets the default limit when a user has no explicit quota. |
 |`API_NUM_WORKERS`|`int`|1|Number of uvicorn workers|
 | `PREFERRED_URL_SCHEME` | `string` | `null` | URL scheme (`http` or `https`) used when generating URLs in API responses (e.g., `task_status_url`). When running behind a reverse proxy that terminates SSL, set this to `https` to ensure generated URLs use the correct scheme. If unset, the scheme from the incoming request is used. |
+| `CORS_EXTRA_ORIGINS` | `string` | _(unset)_ | Semicolon-separated list of additional origins allowed by CORS (e.g. `https://app.example.com;https://other.example.com`). Extends the default list without replacing it. |
 
 
 :::caution[Security Notice]

--- a/openrag/api.py
+++ b/openrag/api.py
@@ -84,6 +84,7 @@ class AppState:
 AUTH_TOKEN: str | None = os.getenv("AUTH_TOKEN")
 INDEXERUI_PORT: str | None = os.getenv("INDEXERUI_PORT", "3042")
 INDEXERUI_URL: str | None = os.getenv("INDEXERUI_URL", f"http://localhost:{INDEXERUI_PORT}")
+CORS_EXTRA_ORIGINS: list[str] = [o.strip() for o in os.getenv("CORS_EXTRA_ORIGINS", "").split(";") if o.strip()]
 WITH_CHAINLIT_UI: bool = os.getenv("WITH_CHAINLIT_UI", "true").lower() == "true"
 WITH_OPENAI_API: bool = os.getenv("WITH_OPENAI_API", "true").lower() == "true"
 
@@ -237,10 +238,13 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 
 # Add CORS middleware
+
+
 allow_origins = [
     "http://localhost:3042",
     "http://localhost:5173",
     INDEXERUI_URL,
+    *CORS_EXTRA_ORIGINS,
 ]
 
 app.add_middleware(


### PR DESCRIPTION
Introduces CORS_EXTRA_ORIGINS, a semicolon-separated env var that appends extra origins to the CORS allowlist at startup without replacing the defaults. Documented in env_vars.md (FastAPI & Indexer-UI sections) and .env.example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional CORS allowed origins via a new environment variable, which accepts a semicolon-separated list of origins. These additional origins augment rather than override the existing allowed origins, providing flexible cross-origin request configuration.

* **Documentation**
  * Added documentation for the new CORS configuration option, including format specifications and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->