### PR TITLE
Fix/rename api entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,8 @@ fi
 
 if [[ "${ENABLE_RAY_SERVE}" == "true" ]]; then
   echo "🔁 Starting with Ray Serve..."
-  uv run $ENV_ARG api.py
+  uv run $ENV_ARG main.py
 else
   echo "🚀 Starting with Uvicorn..."
-  uv run --no-dev $ENV_ARG uvicorn api:app --host 0.0.0.0 --port ${APP_iPORT:-8080} --reload --workers ${API_NUM_WORKERS:-1}
+  uv run --no-dev $ENV_ARG uvicorn main:app --host 0.0.0.0 --port ${APP_iPORT:-8080} --reload --workers ${API_NUM_WORKERS:-1}
 fi

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -342,4 +342,4 @@ if __name__ == "__main__":
             serve.run(OpenRagAPI.bind(), route_prefix="/", blocking=True)
 
     else:
-        uvicorn.run("api:app", host="0.0.0.0", port=8080, reload=True, proxy_headers=True)
+        uvicorn.run("main:app", host="0.0.0.0", port=8080, reload=True, proxy_headers=True)


### PR DESCRIPTION
On the refactor/hexagonal branch, the new **openrag/api/ package** (scaffolded as part of the hexagonal architecture) shadows the existing **openrag/api.py** entry point. Python always prefers a package over a same-named module, so `uvicorn api:app` was failing with `Attribute "app" not found in module "api"`.
See the CIs:

* https://github.com/linagora/openrag/actions/runs/24801467999/job/72584879775
* https://github.com/linagora/openrag/actions/runs/24780349551/job/72509477971
* https://github.com/linagora/openrag/actions/runs/24732602821/job/72350853867
* https://github.com/linagora/openrag/actions/runs/24726292618/job/72328132918

The rename of the entry point to **`main.py`** was originally scoped to **Phase 10 — API Layer Restructure (step 10E)**, where **`api/main.py`** becomes the new FastAPI app entry point wired with the DI container. 
**`It is pulled forward here as a hotfix to unblock the current branch.`**

Changes:

* `openrag/api.py` → `openrag/main.py`
* `entrypoint.sh: uvicorn api:app `→ `uvicorn main:app`
* `main.py: internal uvicorn.run("api:app"` → `uvicorn.run("main:app"`