### PR TITLE
Fix/core config missing filterless fallback

### DIFF
--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -149,6 +149,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("INCLUDE_ANCESTORS", "retriever.include_ancestors", bool),
     ("RELATED_LIMIT", "retriever.related_limit", int),
     ("MAX_DEPTH", "retriever.max_ancestor_depth", int),
+    ("RETRIEVER_ALLOW_FILTERLESS_FALLBACK", "retriever.allow_filterless_fallback", bool),
     # RAG
     ("RAG_MODE", "rag.mode", str),
     # WebSearch

--- a/openrag/core/config/retrieval.py
+++ b/openrag/core/config/retrieval.py
@@ -55,6 +55,7 @@ class _BaseRetrieverConfig(ConfigMixin):
     include_ancestors: bool = True
     related_limit: int = 10
     max_ancestor_depth: int = 10
+    allow_filterless_fallback: bool = True
 
 
 class SingleRetrieverConfig(_BaseRetrieverConfig):

--- a/openrag/utils/exceptions/vectordb.py
+++ b/openrag/utils/exceptions/vectordb.py
@@ -5,6 +5,7 @@ from openrag.core.utils.exceptions import (  # noqa: F401
     VDBConnectionError,
     VDBCreateOrLoadCollectionError,
     VDBDeleteError,
+    VDBError,
     VDBFileIDAlreadyExistsError,
     VDBFileNotFoundError,
     VDBInsertError,


### PR DESCRIPTION
## Summary

- `openrag/config/models.py:422` → `openrag/core/config/retrieval.py:58` — backfill `allow_filterless_fallback: bool = True` on `_BaseRetrieverConfig`
- `openrag/config/loader.py:152` → `openrag/core/config/loader.py:152` — backfill `RETRIEVER_ALLOW_FILTERLESS_FALLBACK` env override
- `openrag/utils/exceptions/vectordb.py` — add `VDBError` to shim re-exports

## Context

These entries existed in the old `openrag/config/` layer but were missed
during the migration to `openrag/core/config/`. Code reading from `core/config`
silently lost the env override and the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filterless retrieval fallback option when filters are unavailable (enabled by default)
  * New environment variable support for retriever configuration

* **Refactor**
  * Extended exception handling with additional error type exposure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->