### PR TITLE
feat(auth): optional auto-provisioning of OIDC users on first login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,10 @@ PREFERRED_URL_SCHEME=https
 # Writable fields whitelist: display_name, email (never is_admin / external_user_id / file_quota / token).
 # Leave unset to keep user rows untouched after login.
 # OIDC_CLAIM_MAPPING=display_name:name,email:email
+# --- Optional auto-provisioning on first login ---
+# When the IdP returns a `sub` that isn't yet known to OpenRag, the callback
+# normally returns 403 "User not registered" — admins must pre-create every
+# user. Setting this to true makes the callback create a non-admin user on
+# the fly using the ID-token claims (display_name from `name`/`preferred_username`,
+# email from `email`). The new user inherits the default file quota.
+# OIDC_AUTO_PROVISION_LOGIN=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,10 +365,13 @@ OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environ
 | `OIDC_CLAIM_MAPPING` | (none) | CSV of `db_field:claim` pairs to sync IdP claims into the users row on every login (whitelist: `display_name`, `email`). Unset = no post-login update. |
 | `OIDC_SCOPES` | `openid email profile offline_access` | Space-separated scope list (include `offline_access` for refresh tokens) |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | — | URL the IdP sends the user to after RP-initiated logout. No default (an OpenRag URL would re-trigger OIDC login) |
+| `OIDC_AUTO_PROVISION_LOGIN` | `false` | When `true`, an unknown `sub` triggers on-the-fly creation of a non-admin user from the ID-token claims (`name`/`preferred_username` → `display_name`, `email` → `email`). Default keeps the strict admin-pre-provisioning policy below. |
 
 **User Matching & Provisioning**:
 
-When a user logs in via OIDC, matching is **exclusively** by `users.external_user_id == sub` (the stable OIDC claim). There is no email fallback and no auto-provisioning: if the `sub` is unknown, the callback returns `403 "User not registered"`. Admins MUST pre-create every user with the expected `external_user_id`.
+When a user logs in via OIDC, matching is **exclusively** by `users.external_user_id == sub` (the stable OIDC claim). There is no email fallback. If the `sub` is unknown, the callback either:
+- returns `403 "User not registered"` (default — admins must pre-create every user), or
+- creates a non-admin user from the ID-token claims when `OIDC_AUTO_PROVISION_LOGIN=true`. Auto-provisioned users inherit the default file quota; `is_admin` is **always** `false` (operators can promote afterwards via `/users/{id}` or `/users/`).
 
 Optionally, if `OIDC_CLAIM_MAPPING` is set, after a successful match the callback reads the configured claims (from the ID token or `/userinfo`, per `OIDC_CLAIM_SOURCE`) and updates the user row. The writable whitelist is strict — only `display_name` and `email` are allowed; `is_admin`, `external_user_id`, `file_quota`, `token` are never writable via claim mapping.
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -31,6 +31,7 @@ from components.auth import (
 )
 from fastapi import APIRouter, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
+from models.user import UserCreate
 from utils.dependencies import get_vectordb
 from utils.logger import get_logger
 
@@ -63,6 +64,40 @@ def _token_encryption_key() -> str:
 
 def _claim_source() -> str:
     return os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower()
+
+
+def _auto_provision_login() -> bool:
+    """Whether to auto-provision a non-admin user on first OIDC login.
+
+    Defaults to ``False`` — keeping the historical "admin pre-creates every
+    user" model. Set ``OIDC_AUTO_PROVISION_LOGIN=true`` to enable: when the
+    callback receives a ``sub`` that isn't yet mapped to an OpenRAG user,
+    a row is created on the fly using the ID-token claims (``name`` /
+    ``preferred_username`` for the display name, ``email`` if present).
+
+    Auto-provisioned users are **never** admin and inherit the default file
+    quota — operators can promote / adjust afterwards via ``/users/``.
+    """
+    return os.getenv("OIDC_AUTO_PROVISION_LOGIN", "false").strip().lower() == "true"
+
+
+def _display_name_from_claims(claims: dict[str, Any], sub: str) -> str:
+    """Pick a sensible display name from the standard OIDC claims.
+
+    Falls back to a short ``sub`` prefix when nothing readable is available
+    so the user row always has something printable for the UI.
+    """
+    for key in ("name", "preferred_username"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    given = claims.get("given_name") or ""
+    family = claims.get("family_name") or ""
+    composed = f"{given} {family}".strip()
+    if composed:
+        return composed
+    # Last-resort fallback — keep enough of the sub to be unique-ish in the UI.
+    return f"oidc-{sub[:8]}"
 
 
 def _claim_mapping() -> dict[str, str]:
@@ -308,12 +343,47 @@ async def callback(request: Request, code: str | None = None, state: str | None 
     vdb = get_vectordb()
     user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
     if user is None:
-        logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
-        return _json_error(
-            status.HTTP_403_FORBIDDEN,
-            "User not registered",
-            delete_state_cookie=True,
-        )
+        if not _auto_provision_login():
+            logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
+            return _json_error(
+                status.HTTP_403_FORBIDDEN,
+                "User not registered",
+                delete_state_cookie=True,
+            )
+
+        # Auto-provision: create a non-admin user from the ID-token claims.
+        # Email is best-effort — populated when the IdP exposes it on the
+        # ``email`` claim (typically via the ``email`` scope, which is in the
+        # default ``OIDC_SCOPES``). Display name falls back to the sub when
+        # the IdP exposes nothing readable.
+        display_name = _display_name_from_claims(bundle.claims, sub)
+        email = bundle.claims.get("email")
+        try:
+            user = await vdb.create_user.remote(
+                UserCreate(
+                    display_name=display_name,
+                    external_user_id=sub,
+                    email=email if isinstance(email, str) and email.strip() else None,
+                    is_admin=False,
+                )
+            )
+        except Exception as e:
+            # Race condition (concurrent first-login) or DB failure — try to
+            # recover by re-reading; if still missing, surface a 500 so the
+            # operator notices instead of silently masking the problem.
+            logger.exception(f"OIDC auto-provisioning failed for sub={sub!r}: {e}")
+            user = await vdb.get_user_by_external_id.remote(sub)
+            if user is None:
+                return _json_error(
+                    status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    "Failed to provision user",
+                    delete_state_cookie=True,
+                )
+        else:
+            logger.info(
+                f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, "
+                f"display_name={display_name!r})"
+            )
 
     # --- 5. Optional claim-mapping update --------------------------------------
     mapping = _claim_mapping()

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -143,11 +143,13 @@ class _StubVectorDB:
         self._sessions: dict[int, dict] = {}
         self._sessions_by_token: dict[str, int] = {}
         self._next_session_id = 1
+        self._next_user_id = 1000
         # Bind each underlying impl as an actor-style accessor.
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
         self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
+        self.create_user = _RayMethodStub("create_user", self._impl_create_user, self.calls)
         self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
         self.get_oidc_session_by_token = _RayMethodStub(
             "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
@@ -185,6 +187,30 @@ class _StubVectorDB:
 
     def _impl_get_user_by_external_id(self, external_user_id: str):
         return self._users_by_sub.get(external_user_id)
+
+    def _impl_create_user(self, body):
+        # Accept either UserCreate or a plain dict, like the real Ray method
+        # would (Pydantic instances are serializable).
+        if hasattr(body, "model_dump"):
+            data = body.model_dump()
+        else:
+            data = dict(body)
+        user_id = self._next_user_id
+        self._next_user_id += 1
+        user = {
+            "id": user_id,
+            "display_name": data.get("display_name"),
+            "external_user_id": data.get("external_user_id"),
+            "email": (data.get("email").strip().lower() if data.get("email") else None),
+            "is_admin": bool(data.get("is_admin", False)),
+            "file_quota": data.get("file_quota"),
+            "file_count": 0,
+            "token": "or-stub",
+        }
+        self._users_by_id[user_id] = user
+        if data.get("external_user_id"):
+            self._users_by_sub[data["external_user_id"]] = user
+        return user
 
     def _impl_update_user_fields(self, user_id: int, fields: dict):
         user = self._users_by_id.get(user_id)
@@ -458,7 +484,7 @@ def test_callback_success_by_external_id(client, fresh_stub_vectordb):
 
 
 def test_callback_user_not_registered(client, fresh_stub_vectordb):
-    """Unknown sub → 403 (no email fallback, no auto-provisioning)."""
+    """Unknown sub → 403 by default (no email fallback, no auto-provisioning)."""
     _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com"))
@@ -470,6 +496,83 @@ def test_callback_user_not_registered(client, fresh_stub_vectordb):
     )
     assert r.status_code == 403
     assert "not registered" in r.json()["detail"].lower()
+    # Without OIDC_AUTO_PROVISION_LOGIN, no user must have been created.
+    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
+
+
+def test_callback_auto_provisions_user_when_enabled(client, fresh_stub_vectordb, monkeypatch):
+    """OIDC_AUTO_PROVISION_LOGIN=true: unknown sub triggers user creation
+    from ID-token claims, never as admin, and login proceeds (302 + cookie)."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(
+            nonce,
+            sub="sub-new-user",
+            email="alice@example.com",
+            extra={"name": "Alice Liddell"},
+        )
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    assert "openrag_session" in r.cookies
+
+    # create_user was called exactly once with the IdP claims.
+    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
+    assert len(create_calls) == 1
+    body = create_calls[0][1][0]
+    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
+    assert data["external_user_id"] == "sub-new-user"
+    assert data["display_name"] == "Alice Liddell"
+    assert data["email"] == "alice@example.com"
+    assert data["is_admin"] is False  # auto-provisioned users are NEVER admin
+
+
+def test_callback_auto_provision_falls_back_to_sub_when_no_name(client, fresh_stub_vectordb, monkeypatch):
+    """When the IdP exposes no readable display name, a deterministic
+    ``oidc-<sub-prefix>`` placeholder is used so the UI always has something."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="abcdef0123456789", email=None, extra={})
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+
+    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
+    assert len(create_calls) == 1
+    body = create_calls[0][1][0]
+    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
+    assert data["display_name"] == "oidc-abcdef01"
+    assert data["email"] is None
+
+
+def test_callback_auto_provision_disabled_by_default(client, fresh_stub_vectordb, monkeypatch):
+    """Explicitly setting OIDC_AUTO_PROVISION_LOGIN=false (or unset) keeps the
+    historical 403 behaviour — non-breaking guard for existing deployments."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "false")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-x", email="x@example.com", extra={"name": "X"})
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
+    assert r.status_code == 403
+    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
 
 
 def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectordb, monkeypatch):


### PR DESCRIPTION
## Why

OpenRAG's OIDC flow today rejects unknown `sub` values with a hard `403 "User not registered"`. That works well for tightly controlled deployments but is painful at scale: every corporate user has to be manually pre-provisioned via `POST /users/` before they can use the platform, even when the IdP itself already enforces who can issue valid tokens.

This PR adds an opt-in flag that lets the callback create a non-admin user on the fly from the ID-token claims — same idea as the existing `OIDC_AUTO_PROVISION` in the bearer-JWT validator (`auth/oidc.py`), now mirrored in the interactive login flow.

**Default is unchanged.** `OIDC_AUTO_PROVISION_LOGIN` defaults to `false` → no behavioral regression for any existing deployment.

## What

When `OIDC_AUTO_PROVISION_LOGIN=true` and the callback receives an unknown `sub`:

| Field | Source |
|---|---|
| `external_user_id` | `sub` (always) |
| `display_name` | `name` → `preferred_username` → `<given_name> <family_name>` → `oidc-<8-char-sub-prefix>` |
| `email` | `email` claim if present, else `null` |
| `is_admin` | **always `false`** — operators must promote afterwards |
| `file_quota` | inherited from server default (same as `POST /users/`) |

A best-effort recovery handles concurrent first-login races (catches the create exception, retries `get_user_by_external_id`; surfaces 500 only if both still fail). An `INFO` log line is emitted on each auto-provisioning so audits can correlate IdP-driven account creations.

## Threat model

The flag is **opt-in** because it shifts the trust boundary: deployments that enable it must be comfortable trusting their IdP's user list as the source of truth for OpenRAG accounts. Operators who need a stricter "manual whitelist" workflow keep the existing 403 behavior by leaving the flag unset.

`is_admin` is hard-coded to `false` for auto-provisioned users — there is no path to grant admin via OIDC claims. Promotion still goes through the existing admin endpoints.

## Tests

- `test_callback_user_not_registered` (existing) — extended to also assert `create_user` is **not** called when the flag is unset.
- `test_callback_auto_provisions_user_when_enabled` — 302 + cookie + `create_user` called with the IdP claims and `is_admin=False`.
- `test_callback_auto_provision_falls_back_to_sub_when_no_name` — `oidc-<sub-prefix>` fallback when no readable name claim.
- `test_callback_auto_provision_disabled_by_default` — explicit `=false` keeps the historical 403.

`_StubVectorDB` grows a `create_user` impl matching the real Ray actor signature (`UserCreate` Pydantic in / dict out).

## Docs

- `.env.example` documents the flag with the exact semantics.
- `CLAUDE.md` updates the OIDC env-var table and the *User Matching & Provisioning* section to describe both flows.

## Files

\`\`\`
.env.example                        |   7 +++
CLAUDE.md                           |   5 +-
openrag/routers/auth.py             |  82 +++++++++++++++++++++++++---
openrag/routers/test_auth_router.py | 105 +++++++++++++++++++++++++++++++++++-
4 files changed, 191 insertions(+), 8 deletions(-)
\`\`\`

## Out of scope (could be follow-ups)

- Group/role sync from claims (already handled by `auth/oidc.py` for bearer JWT — could be unified later).
- Auto-provisioning hooks/callbacks (e.g. emit a webhook when a user is auto-created so external systems can react).

🤖 Generated with [Claude Code](https://claude.com/claude-code)