### PR TITLE
feat(auth): redirect unauthenticated browser hits on /chainlit/* to /auth/login

### DIFF
--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -128,6 +128,27 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # --- Bypass list (docs, health, /auth/* callbacks, chainlit).
         path = request.url.path
         if is_bypass_path(path):
+            # Special case: browser HTML page-loads on /chainlit/* without an
+            # active session can't be served usefully — Chainlit configures no
+            # in-app auth provider when headerAuth is used, so the SPA shows
+            # a dead-end "Login to access the app" screen with no actionable
+            # button. Redirect those to /auth/login so the OIDC flow takes
+            # over. API/asset/WebSocket requests (Accept != text/html) keep
+            # the bypass so Chainlit's own headerAuth callback can validate.
+            if (
+                auth_mode == "oidc"
+                and path.startswith("/chainlit")
+                and "text/html" in request.headers.get("accept", "").lower()
+                and not request.cookies.get(SESSION_COOKIE_NAME)
+                and not request.headers.get("authorization", "").lower().startswith("bearer ")
+            ):
+                next_path = path
+                if request.url.query:
+                    next_path = f"{path}?{request.url.query}"
+                return RedirectResponse(
+                    url=f"/auth/login?next={quote(next_path, safe='')}",
+                    status_code=302,
+                )
             return await call_next(request)
 
         user = None


### PR DESCRIPTION
## Summary

Currently `/chainlit/*` is unconditionally bypassed by `AuthMiddleware` so Chainlit can enforce its own `headerAuth` callback. The downside: when a browser hits `/chainlit/` or `/chainlit/login` without a valid `openrag_session` cookie, the SPA shows a dead-end **"Login to access the app"** screen with no actionable button — because the typical Chainlit-with-OpenRAG deployment configures no in-app auth provider (`oauthProviders=[]`, `passwordAuth=false`, only `headerAuth=true`).

Common ways to land there:
- Bookmark on `/chainlit/login` after the cookie has expired
- Cross-domain redirect (e.g. canonical swap) where the cookie was on the previous host and isn't forwarded after the 301
- Logging in via Open WebUI / external propagated token then visiting `/chainlit/` directly without going through `/auth/login` first

## Fix

When `AUTH_MODE=oidc`, the middleware now **302s HTML page-loads** (`Accept: text/html`) on `/chainlit/*` to `/auth/login?next=<original>` if there's no session cookie and no Bearer token. API/asset/WebSocket requests (`Accept != text/html`) keep the bypass so Chainlit's `headerAuth` callback continues to handle authenticated SPA traffic exactly as before.

The heuristic is intentional: it avoids enumerating Chainlit's page-load routes (`/chainlit/`, `/chainlit/login`, `/chainlit/readme`, `/chainlit/element/*`, `/chainlit/thread/*`) and won't break if Chainlit adds new ones — they all carry `Accept: text/html`.

```diff
+ if (
+     auth_mode == "oidc"
+     and path.startswith("/chainlit")
+     and "text/html" in request.headers.get("accept", "").lower()
+     and not request.cookies.get(SESSION_COOKIE_NAME)
+     and not request.headers.get("authorization", "").lower().startswith("bearer ")
+ ):
+     # 302 to /auth/login?next=<original>
```

## Test plan

Validated end-to-end on a production deployment behind Caddy + Keycloak:

- [x] Browser `GET /chainlit/login` (no cookie) → 302 to `/auth/login?next=%2Fchainlit%2Flogin`
- [x] Browser `GET /chainlit/` (no cookie) → 302 to `/auth/login?next=%2Fchainlit%2F`
- [x] SPA fetch `GET /chainlit/auth/config` (Accept: application/json) → 200 (bypass kept)
- [x] SPA load `GET /chainlit/assets/index-*.js` → 200 (bypass kept)
- [x] WebSocket `/chainlit/ws/socket.io/...` → still bypassed
- [x] Authenticated browser hit on `/chainlit/` → cookie present → bypass branch's redirect check skipped → SPA loads

No behavior change for `AUTH_MODE=token` deployments (the redirect is gated on `oidc` mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OIDC authentication enforcement for protected pages. Users without valid authentication will now be properly redirected to the login flow instead of bypassing security checks, and will be returned to their originally requested page after successful authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->