### PR TITLE
feat(openai): inline sources in content (opt-in) for clients ignoring `extra`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ EMBEDDER_MODEL_NAME=jinaai/jina-embeddings-v3 # or other embedder from huggingfa
 # RETRIEVER
 # RETRIEVER_TOP_K=20 # number of top documents to retrieve, before reranking (lower (~10) is faster on CPU | on GPU, you can try to increase the value (~40) ).
 
+# INLINE SOURCES IN CONTENT — opt-in, default off
+# When true, OpenRAG appends a markdown source block (`**Sources :**` …) to the
+# assistant `content` of /v1/chat/completions and /v1/completions responses,
+# in addition to the structured `extra.sources` field that already exists.
+# Useful for clients that ignore the non-standard `extra` field at the
+# response top-level (Open WebUI, LibreChat, Continue, Cursor, vanilla curl).
+# Default `false` keeps the existing OpenAI-compat contract intact.
+# See linagora/openrag#344 for context.
+# INLINE_SOURCES_IN_CONTENT=false
+# INLINE_SOURCES_TOP_K=5
+# INLINE_SOURCES_MIN_SCORE=-inf
+
 # RERANKER
 RERANKER_ENABLED=true # deactivate the reranker if your CPU is not powerful enough
 RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base # or jinaai/jina-reranker-v2-base-multilingual

--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -6,6 +6,7 @@ import pytest
 from components.utils import (
     extract_and_strip_sources_block,
     filter_sources_by_citations,
+    format_sources_as_markdown,
     stream_with_source_filtering,
 )
 
@@ -241,3 +242,101 @@ class TestStreamWithSourceFiltering:
         result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
         assert _collect_content(result) == "Answer without any sources tag."
         assert _parse_finish_sources(result) == self.SOURCES
+
+
+class TestFormatSourcesAsMarkdown:
+    """Behavior of the markdown source block injected into content when
+    INLINE_SOURCES_IN_CONTENT=true.
+    """
+
+    SOURCES = [
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.9},
+        {"filename": "b.pdf", "title": "Doc B", "file_url": "https://x/b", "relevance_score": 0.7},
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.5},
+    ]
+
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("INLINE_SOURCES_IN_CONTENT", raising=False)
+        assert format_sources_as_markdown(self.SOURCES) == ""
+
+    def test_disabled_explicit(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "false")
+        assert format_sources_as_markdown(self.SOURCES) == ""
+
+    def test_enabled_basic(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "**Sources :**" in result
+        # Dedup on file_url: a.pdf appears twice in input, once in output (best score)
+        assert result.count("Doc A") == 1
+        assert result.count("Doc B") == 1
+        # Best score wins
+        assert "score 0.90" in result
+        assert "score 0.50" not in result
+        # Ranked: Doc A (0.9) before Doc B (0.7)
+        assert result.find("Doc A") < result.find("Doc B")
+        # URL is rendered as markdown link
+        assert "[Doc A](https://x/a)" in result
+
+    def test_empty_sources(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        assert format_sources_as_markdown([]) == ""
+
+    def test_min_score_filter(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        monkeypatch.setenv("INLINE_SOURCES_MIN_SCORE", "0.8")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "Doc A" in result  # score 0.9 ≥ 0.8
+        assert "Doc B" not in result  # score 0.7 < 0.8
+
+    def test_top_k_limit(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        monkeypatch.setenv("INLINE_SOURCES_TOP_K", "1")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "Doc A" in result
+        assert "Doc B" not in result  # capped at 1
+
+
+class TestStreamWithInlineSources:
+    """When INLINE_SOURCES_IN_CONTENT=true, the stream emits an extra delta
+    chunk carrying the markdown source block before the finish_reason chunk.
+    Pre-existing tests verify the off-default behavior remains intact.
+    """
+
+    SOURCES = [
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.9},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_inline_sources_appended_to_stream(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        lines = [
+            _make_chunk("The answer."),
+            _make_chunk("\n[Sources: 1]"),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        # Concatenated content should include the original answer + the
+        # markdown source block (no [Sources: 1] tag — stripped as before).
+        full_content = _collect_content(result)
+        assert "The answer." in full_content
+        assert "**Sources :**" in full_content
+        assert "[Doc A](https://x/a)" in full_content
+        assert "[Sources: 1]" not in full_content
+        # The structured `extra` field still reaches the finish chunk.
+        assert _parse_finish_sources(result) == self.SOURCES
+
+    @pytest.mark.asyncio
+    async def test_no_inline_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "false")
+        lines = [
+            _make_chunk("The answer."),
+            _make_chunk("\n[Sources: 1]"),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        full_content = _collect_content(result)
+        assert full_content == "The answer."
+        assert "**Sources :**" not in full_content

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import os
 import re
 import threading
 from collections import deque
@@ -214,6 +215,93 @@ def filter_sources_by_citations(sources: list, citations: set[int] | None) -> li
     return filtered if filtered else sources
 
 
+def inline_sources_enabled() -> bool:
+    """``INLINE_SOURCES_IN_CONTENT=true`` opts in to writing the source list
+    directly into the assistant message ``content`` as a markdown block,
+    in addition to the structured ``extra.sources`` field.
+
+    The default is ``false`` because it changes the visible content of the
+    response — opt-in keeps the existing OpenAI-compat contract intact for
+    clients that already consume ``extra``.
+    """
+    return os.getenv("INLINE_SOURCES_IN_CONTENT", "false").strip().lower() == "true"
+
+
+def _inline_sources_max_items() -> int:
+    try:
+        return max(0, int(os.getenv("INLINE_SOURCES_TOP_K", "5")))
+    except ValueError:
+        return 5
+
+
+def _inline_sources_min_score() -> float:
+    try:
+        return float(os.getenv("INLINE_SOURCES_MIN_SCORE", "-inf"))
+    except ValueError:
+        return float("-inf")
+
+
+def format_sources_as_markdown(sources: list) -> str:
+    """Render a deduplicated, ranked source list as a markdown block.
+
+    Returns ``""`` when ``INLINE_SOURCES_IN_CONTENT`` is not enabled or no
+    source survives the filters — callers can append unconditionally.
+
+    Why a flat ``Sources:`` list rather than inline ``[^N]`` footnote markers:
+    the LLM's content was generated without any awareness of the markers, so
+    inserting them after-the-fact would never match the actual claims in the
+    text. A trailing block is honest about that and renders cleanly in every
+    markdown client.
+    """
+    if not inline_sources_enabled() or not sources:
+        return ""
+
+    max_items = _inline_sources_max_items()
+    min_score = _inline_sources_min_score()
+
+    def _score(s: dict) -> float:
+        v = s.get("relevance_score")
+        try:
+            return float(v) if v is not None else float("-inf")
+        except (TypeError, ValueError):
+            return float("-inf")
+
+    # Dedup on (file_url|filename) — OpenRAG can return several chunks of the
+    # same file with different scores; show each file once with its best chunk.
+    seen: dict[str, dict] = {}
+    for s in sources:
+        key = s.get("file_url") or s.get("filename") or s.get("source") or ""
+        if not key:
+            continue
+        if _score(s) < min_score:
+            continue
+        if key not in seen or _score(s) > _score(seen[key]):
+            seen[key] = s
+
+    ranked = sorted(seen.values(), key=_score, reverse=True)[:max_items]
+    if not ranked:
+        return ""
+
+    def _label(s: dict) -> str:
+        title = s.get("title") or s.get("filename") or s.get("file_id") or "source"
+        page = s.get("page")
+        if page and str(page) not in {"0", "1"}:
+            return f"{title} (p. {page})"
+        return str(title)
+
+    lines = ["", "---", "**Sources :**", ""]
+    for i, s in enumerate(ranked, start=1):
+        url = s.get("file_url") or s.get("chunk_url") or ""
+        label = _label(s).replace("|", "\\|")
+        score = _score(s)
+        score_suffix = f" — score {score:.2f}" if score != float("-inf") else ""
+        if url:
+            lines.append(f"{i}. [{label}]({url}){score_suffix}")
+        else:
+            lines.append(f"{i}. {label}{score_suffix}")
+    return "\n".join(lines)
+
+
 async def stream_with_source_filtering(
     llm_stream,
     sources: list,
@@ -256,6 +344,17 @@ async def stream_with_source_filtering(
                     chunk["choices"][0]["delta"]["content"] = surviving
                 chunk["extra"] = filtered_json
                 yield f"data: {json.dumps(chunk)}\n\n"
+
+            # When INLINE_SOURCES_IN_CONTENT=true, emit one extra delta with
+            # the markdown source block. Sent before finish_reason so clients
+            # that buffer until finish (most do) see it as part of the content.
+            sources_md = format_sources_as_markdown(filtered)
+            if sources_md and last_chunk_template:
+                inline_chunk = copy.deepcopy(last_chunk_template)
+                inline_chunk["choices"][0]["delta"] = {"content": sources_md}
+                inline_chunk["choices"][0].pop("finish_reason", None)
+                inline_chunk["extra"] = filtered_json
+                yield f"data: {json.dumps(inline_chunk)}\n\n"
 
             if last_chunk_template:
                 # FIXME: race condition where clients missed sources because finish_reason

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -9,6 +9,7 @@ from components.pipeline import RagPipeline
 from components.utils import (
     extract_and_strip_sources_block,
     filter_sources_by_citations,
+    format_sources_as_markdown,
     get_num_tokens,
     stream_with_source_filtering,
 )
@@ -360,9 +361,14 @@ async def openai_chat_completion(
 
         content = chunk.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
         clean_content, citations = extract_and_strip_sources_block(content)
-        chunk["choices"][0]["message"]["content"] = clean_content
 
         filtered = filter_sources_by_citations(sources, citations)
+        # When INLINE_SOURCES_IN_CONTENT=true, append a markdown source block to
+        # the visible content for clients that ignore the non-standard `extra`
+        # field (Open WebUI, LibreChat, Continue, …). No-op otherwise.
+        clean_content += format_sources_as_markdown(filtered)
+        chunk["choices"][0]["message"]["content"] = clean_content
+
         chunk["extra"] = json.dumps({"sources": filtered})
         log.debug("Returning non-streaming completion chunk.")
         return JSONResponse(content=chunk)
@@ -435,9 +441,12 @@ async def openai_completion(
 
     text = complete_response.get("choices", [{}])[0].get("text", "") or ""
     clean_text, citations = extract_and_strip_sources_block(text)
-    complete_response["choices"][0]["text"] = clean_text
 
     filtered = filter_sources_by_citations(sources, citations)
+    # See note on /chat/completions about INLINE_SOURCES_IN_CONTENT.
+    clean_text += format_sources_as_markdown(filtered)
+    complete_response["choices"][0]["text"] = clean_text
+
     complete_response["extra"] = json.dumps({"sources": filtered})
     log.debug("Returning completion response.")
     return JSONResponse(content=complete_response)


### PR DESCRIPTION
Companion PR for #344.

## TL;DR

OpenRAG returns its source list in a non-standard `extra` field at the top of `/v1/chat/completions` responses. Vanilla OpenAI-compat clients (Open WebUI 0.9.2, LibreChat, Continue, Cursor, curl, …) silently drop it — the user sees the answer without sources. This PR adds an **opt-in** flag `INLINE_SOURCES_IN_CONTENT` that *also* writes the source list into the assistant message `content` as a markdown block, so any OpenAI-compat client renders it natively. The structured `extra` field is unchanged for clients that already consume it.

Default = `false` → no breaking change. See #344 for full context.

## Changes

| File | What |
|---|---|
| `components/utils.py` | `inline_sources_enabled()` (env-var read) + `format_sources_as_markdown(sources)` helper (dedup on `file_url`, ranked by `relevance_score`, capped by `INLINE_SOURCES_TOP_K`, filtered by `INLINE_SOURCES_MIN_SCORE`). Streaming path injects one extra delta chunk before `finish_reason`. |
| `routers/openai.py` | 3 call sites — append the markdown block right after `extract_and_strip_sources_block`/`filter_sources_by_citations`. |
| `components/test_source_filtering.py` | 5 new tests : on/off behavior, dedup, ranking, top_k, min_score, streaming with the extra delta chunk, no-inline when disabled. |
| `.env.example` | Documents the 3 knobs (`INLINE_SOURCES_IN_CONTENT`, `INLINE_SOURCES_TOP_K`, `INLINE_SOURCES_MIN_SCORE`). |

## Knobs

```bash
INLINE_SOURCES_IN_CONTENT=true     # default false — opt-in
INLINE_SOURCES_TOP_K=5              # default 5 — max sources rendered
INLINE_SOURCES_MIN_SCORE=0.65       # default -inf — filter weak chunks
```

## Sample output (with flag on)

```
…answer from the LLM…

---
**Sources :**

1. [Article L423-1 — Conditions de séjour](https://api.openrag.example.com/static/foo.md) — score 0.71
2. [Décret 2024-… — Procédure CESEDA](https://api.openrag.example.com/static/bar.pdf) — score 0.69
…
```

The block is dedup'd by `file_url` (OpenRAG can return multiple chunks of the same file with different scores ; we show each file once with its best chunk), ranked by relevance score desc, and capped at `INLINE_SOURCES_TOP_K`.

## Validation

Tested in production on a deployment serving the French Ministry of the Interior :

- **Non-streaming `/v1/chat/completions`** : block appears in `choices[0].message.content`, `extra.sources` unchanged.
- **Streaming `/v1/chat/completions`** : extra delta chunk emitted between content stream and `finish_reason` ; OWUI 0.9.2 buffers it correctly and renders the full message with the source block.
- **Non-streaming `/v1/completions`** : block appears in `choices[0].text`.
- **With flag off (default)** : exactly identical to current behavior, no regression.
- Open WebUI 0.9.2 user-side : sources visible as clickable markdown links inside the answer card. No client modification needed. The ecosystem-specific `pipe_openrag.py` (which emits OWUI native `citation` events) keeps working in parallel for operators who want richer UX — both can coexist.
- 5 new unit tests pass (`pytest components/test_source_filtering.py`).

## Why opt-in (not always-on)

- **Zero breaking change** for current deployments using clients that consume `extra` (the existing pipe, MyRAG bridge, programmatic agents).
- The decision belongs to the operator : some workflows want structured citations only (clean for downstream parsing), others want the visible-content fallback for vanilla clients.
- Easy to A/B compare.

## Alternatives considered & rejected

| Option | Rejected because |
|---|---|
| Push OWUI to read `extra` (PR upstream) | No traction (0 related PR on `open-webui/open-webui`), multi-month timeline, doesn't help LibreChat/Continue/curl. |
| Use `choices[0].message.annotations` (OpenAI 2024+) | OWUI doesn't render those either today. |
| Force every operator to install a Pipe Function | Non-trivial UX, doesn't scale to other OpenAI-compat clients. |
| Custom SSE event types | Format undocumented + version-dependent across OWUI versions. |

A trailing markdown block is the **minimum delta** that works in every OpenAI-compat client today, with zero client-side change.

## Test plan

- [x] `pytest components/test_source_filtering.py` — 5 new + existing tests green
- [x] Production VM (Open WebUI 0.9.2 talking to OpenRAG via vanilla `OPENAI_API_BASE_URLS`) : sources visible in chat
- [x] With flag off : output byte-identical to current behavior
- [x] `extra.sources` always present in response (rétrocompat for pipe_openrag.py and MyRAG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optional inline markdown sources now appear directly in assistant responses
  * Sources are ranked, filtered, and deduplicated for improved relevance
  * Configurable behavior to control source inclusion and filtering thresholds

* **Tests**
  * Added unit tests for source formatting and filtering functionality

* **Chores**
  * Extended environment configuration documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->