### PR TITLE
chore(transcriber): upgrade vLLM to v0.19.1 and documentation

### DIFF
--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -121,10 +121,14 @@ Here are some other variables related to openai-compatible endpoint.
 
 </div>
 
-:::danger[About whisper with vLLM]
-As noted in [this PR](https://github.com/linagora/openrag/pull/134), the current vLLM implementation of Whisper can mis-detect the language and output English regardless of the source audio. For details, see [this vLLM issue](https://github.com/vllm-project/vllm/issues/14174).
+:::note[About whisper with vLLM and language detection]
+As noted in [this PR](https://github.com/linagora/openrag/pull/134), vLLM's Whisper implementation could mis-detect the language and output English regardless of the source audio. For details, see [this vLLM issue](https://github.com/vllm-project/vllm/issues/14174).
 
-To improve accuracy, we use a local Whisper-based language detector that is activated by default with the default setting (`USE_WHISPER_LANG_DETECTOR=true`). 
+This bug was fixed in **vLLM v0.17.0** ([PR #34342](https://github.com/vllm-project/vllm/pull/34342)). If you are running a vLLM version **older than v0.17.0**, set `USE_WHISPER_LANG_DETECTOR=true` to work around the issue: OpenRAG will use a local Whisper-based language detector to identify the source language and pass it explicitly to the transcription endpoint.
+
+If your deployment already uses vLLM ≥ v0.17.0, you can safely set `USE_WHISPER_LANG_DETECTOR=false` to skip the local detection step.
+
+The default OpenRAG transcriber stack now ships with **vLLM v0.19.1**, which includes the fix.
 :::
 
 ### Chunking

--- a/extern/transcriber.yaml
+++ b/extern/transcriber.yaml
@@ -20,6 +20,6 @@ services:
     command: >
       --model ${TRANSCRIBER_MODEL:-openai/whisper-large-v3-turbo}
       --trust-remote-code
-      --gpu_memory_utilization 0.3
+      --gpu_memory_utilization 0.2
     # ports:
     #   - ${TRANSCRIBER_PORT:-8002}:8000

--- a/extern/vllm/Dockerfile.transcriber
+++ b/extern/vllm/Dockerfile.transcriber
@@ -1,2 +1,2 @@
-FROM vllm/vllm-openai:v0.16.0
-RUN pip install --no-cache-dir "vllm[audio]"
+FROM vllm/vllm-openai:v0.19.1
+RUN pip install --no-cache-dir "vllm[audio]==0.19.1"


### PR DESCRIPTION
# chore(transcriber): upgrade vLLM to v0.19.1
* Bump transcriber image from v0.16.0 to v0.19.1
* Update docs: language detection bug fixed in v0.17.0 — USE_WHISPER_LANG_DETECTOR only needed for older deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworded language-detection guidance from a warning to a note, clarified default transcriber behavior, and added version-specific instructions for enabling or disabling the local Whisper language detector.

* **Chores**
  * Updated transcriber to ship with vLLM v0.19.1.
  * Reduced GPU memory utilization setting for the transcriber service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->