### PR TITLE
Feat/inline sources in content upstream

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ EMBEDDER_MODEL_NAME=jinaai/jina-embeddings-v3 # or other embedder from huggingfa
 # RETRIEVER
 # RETRIEVER_TOP_K=20 # number of top documents to retrieve, before reranking (lower (~10) is faster on CPU | on GPU, you can try to increase the value (~40) ).
 
+# INLINE SOURCES IN CONTENT — opt-in, default off
+# When true, OpenRAG appends a markdown source block (`**Sources :**` …) to the
+# assistant `content` of /v1/chat/completions and /v1/completions responses,
+# in addition to the structured `extra.sources` field that already exists.
+# Useful for clients that ignore the non-standard `extra` field at the
+# response top-level (Open WebUI, LibreChat, Continue, Cursor, vanilla curl).
+# Default `false` keeps the existing OpenAI-compat contract intact.
+# See linagora/openrag#344 for context.
+# INLINE_SOURCES_IN_CONTENT=false
+# INLINE_SOURCES_TOP_K=5
+# INLINE_SOURCES_MIN_SCORE=-inf
+
 # RERANKER
 RERANKER_ENABLED=true # deactivate the reranker if your CPU is not powerful enough
 RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base # or jinaai/jina-reranker-v2-base-multilingual

--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -6,6 +6,7 @@ import pytest
 from components.utils import (
     extract_and_strip_sources_block,
     filter_sources_by_citations,
+    format_sources_as_markdown,
     stream_with_source_filtering,
 )
 
@@ -241,3 +242,101 @@ class TestStreamWithSourceFiltering:
         result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
         assert _collect_content(result) == "Answer without any sources tag."
         assert _parse_finish_sources(result) == self.SOURCES
+
+
+class TestFormatSourcesAsMarkdown:
+    """Behavior of the markdown source block injected into content when
+    INLINE_SOURCES_IN_CONTENT=true.
+    """
+
+    SOURCES = [
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.9},
+        {"filename": "b.pdf", "title": "Doc B", "file_url": "https://x/b", "relevance_score": 0.7},
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.5},
+    ]
+
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("INLINE_SOURCES_IN_CONTENT", raising=False)
+        assert format_sources_as_markdown(self.SOURCES) == ""
+
+    def test_disabled_explicit(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "false")
+        assert format_sources_as_markdown(self.SOURCES) == ""
+
+    def test_enabled_basic(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "**Sources :**" in result
+        # Dedup on file_url: a.pdf appears twice in input, once in output (best score)
+        assert result.count("Doc A") == 1
+        assert result.count("Doc B") == 1
+        # Best score wins
+        assert "score 0.90" in result
+        assert "score 0.50" not in result
+        # Ranked: Doc A (0.9) before Doc B (0.7)
+        assert result.find("Doc A") < result.find("Doc B")
+        # URL is rendered as markdown link
+        assert "[Doc A](https://x/a)" in result
+
+    def test_empty_sources(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        assert format_sources_as_markdown([]) == ""
+
+    def test_min_score_filter(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        monkeypatch.setenv("INLINE_SOURCES_MIN_SCORE", "0.8")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "Doc A" in result  # score 0.9 ≥ 0.8
+        assert "Doc B" not in result  # score 0.7 < 0.8
+
+    def test_top_k_limit(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        monkeypatch.setenv("INLINE_SOURCES_TOP_K", "1")
+        result = format_sources_as_markdown(self.SOURCES)
+        assert "Doc A" in result
+        assert "Doc B" not in result  # capped at 1
+
+
+class TestStreamWithInlineSources:
+    """When INLINE_SOURCES_IN_CONTENT=true, the stream emits an extra delta
+    chunk carrying the markdown source block before the finish_reason chunk.
+    Pre-existing tests verify the off-default behavior remains intact.
+    """
+
+    SOURCES = [
+        {"filename": "a.pdf", "title": "Doc A", "file_url": "https://x/a", "relevance_score": 0.9},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_inline_sources_appended_to_stream(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        lines = [
+            _make_chunk("The answer."),
+            _make_chunk("\n[Sources: 1]"),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        # Concatenated content should include the original answer + the
+        # markdown source block (no [Sources: 1] tag — stripped as before).
+        full_content = _collect_content(result)
+        assert "The answer." in full_content
+        assert "**Sources :**" in full_content
+        assert "[Doc A](https://x/a)" in full_content
+        assert "[Sources: 1]" not in full_content
+        # The structured `extra` field still reaches the finish chunk.
+        assert _parse_finish_sources(result) == self.SOURCES
+
+    @pytest.mark.asyncio
+    async def test_no_inline_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "false")
+        lines = [
+            _make_chunk("The answer."),
+            _make_chunk("\n[Sources: 1]"),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        full_content = _collect_content(result)
+        assert full_content == "The answer."
+        assert "**Sources :**" not in full_content

--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -296,6 +296,29 @@ class TestFormatSourcesAsMarkdown:
         assert "Doc A" in result
         assert "Doc B" not in result  # capped at 1
 
+    def test_web_sources_included(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        sources = [
+            {
+                "source_type": "web",
+                "url": "https://example.com/page",
+                "title": "Web Result",
+                "snippet": "...",
+                "relevance_score": 0.8,
+            },
+            {"source_type": "document", "file_url": "https://x/doc.pdf", "title": "Doc", "relevance_score": 0.7},
+        ]
+        result = format_sources_as_markdown(sources)
+        assert "Web Result" in result
+        assert "[Web Result](https://example.com/page)" in result
+        assert "Doc" in result
+
+    def test_label_special_chars_escaped(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        sources = [{"file_url": "https://x/a", "title": "Report [draft] Q1|Q2", "relevance_score": 0.9}]
+        result = format_sources_as_markdown(sources)
+        assert "[Report \\[draft\\] Q1\\|Q2](https://x/a)" in result
+
 
 class TestStreamWithInlineSources:
     """When INLINE_SOURCES_IN_CONTENT=true, the stream emits an extra delta

--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -275,8 +275,8 @@ class TestFormatSourcesAsMarkdown:
         assert "score 0.50" not in result
         # Ranked: Doc A (0.9) before Doc B (0.7)
         assert result.find("Doc A") < result.find("Doc B")
-        # URL is rendered as markdown link
-        assert "[Doc A](https://x/a)" in result
+        # URL is rendered as markdown link (angle-bracket form)
+        assert "[Doc A](<https://x/a>)" in result
 
     def test_empty_sources(self, monkeypatch):
         monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
@@ -310,14 +310,35 @@ class TestFormatSourcesAsMarkdown:
         ]
         result = format_sources_as_markdown(sources)
         assert "Web Result" in result
-        assert "[Web Result](https://example.com/page)" in result
+        assert "[Web Result](<https://example.com/page>)" in result
         assert "Doc" in result
 
     def test_label_special_chars_escaped(self, monkeypatch):
         monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
         sources = [{"file_url": "https://x/a", "title": "Report [draft] Q1|Q2", "relevance_score": 0.9}]
         result = format_sources_as_markdown(sources)
-        assert "[Report \\[draft\\] Q1\\|Q2](https://x/a)" in result
+        assert "[Report \\[draft\\] Q1\\|Q2](<https://x/a>)" in result
+
+    def test_url_with_parens_and_spaces_uses_angle_brackets(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        sources = [
+            {
+                "file_url": "https://en.wikipedia.org/wiki/Foo_(bar) baz",
+                "title": "Wiki",
+                "relevance_score": 0.9,
+            }
+        ]
+        result = format_sources_as_markdown(sources)
+        # Bare-URL form would break on "(", ")", and " ". Angle-bracket form
+        # tolerates all three, so the destination must be wrapped.
+        assert "[Wiki](<https://en.wikipedia.org/wiki/Foo_(bar) baz>)" in result
+
+    def test_url_with_angle_brackets_percent_encoded(self, monkeypatch):
+        monkeypatch.setenv("INLINE_SOURCES_IN_CONTENT", "true")
+        sources = [{"file_url": "https://x/a<b>c", "title": "T", "relevance_score": 0.9}]
+        result = format_sources_as_markdown(sources)
+        # "<" / ">" close the angle-bracket destination prematurely; encode them.
+        assert "[T](<https://x/a%3Cb%3Ec>)" in result
 
 
 class TestStreamWithInlineSources:
@@ -345,7 +366,7 @@ class TestStreamWithInlineSources:
         full_content = _collect_content(result)
         assert "The answer." in full_content
         assert "**Sources :**" in full_content
-        assert "[Doc A](https://x/a)" in full_content
+        assert "[Doc A](<https://x/a>)" in full_content
         assert "[Sources: 1]" not in full_content
         # The structured `extra` field still reaches the finish chunk.
         assert _parse_finish_sources(result) == self.SOURCES

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import os
 import re
 import threading
 from collections import deque
@@ -214,6 +215,93 @@ def filter_sources_by_citations(sources: list, citations: set[int] | None) -> li
     return filtered if filtered else sources
 
 
+def inline_sources_enabled() -> bool:
+    """``INLINE_SOURCES_IN_CONTENT=true`` opts in to writing the source list
+    directly into the assistant message ``content`` as a markdown block,
+    in addition to the structured ``extra.sources`` field.
+
+    The default is ``false`` because it changes the visible content of the
+    response — opt-in keeps the existing OpenAI-compat contract intact for
+    clients that already consume ``extra``.
+    """
+    return os.getenv("INLINE_SOURCES_IN_CONTENT", "false").strip().lower() == "true"
+
+
+def _inline_sources_max_items() -> int:
+    try:
+        return max(0, int(os.getenv("INLINE_SOURCES_TOP_K", "5")))
+    except ValueError:
+        return 5
+
+
+def _inline_sources_min_score() -> float:
+    try:
+        return float(os.getenv("INLINE_SOURCES_MIN_SCORE", "-inf"))
+    except ValueError:
+        return float("-inf")
+
+
+def format_sources_as_markdown(sources: list) -> str:
+    """Render a deduplicated, ranked source list as a markdown block.
+
+    Returns ``""`` when ``INLINE_SOURCES_IN_CONTENT`` is not enabled or no
+    source survives the filters — callers can append unconditionally.
+
+    Why a flat ``Sources:`` list rather than inline ``[^N]`` footnote markers:
+    the LLM's content was generated without any awareness of the markers, so
+    inserting them after-the-fact would never match the actual claims in the
+    text. A trailing block is honest about that and renders cleanly in every
+    markdown client.
+    """
+    if not inline_sources_enabled() or not sources:
+        return ""
+
+    max_items = _inline_sources_max_items()
+    min_score = _inline_sources_min_score()
+
+    def _score(s: dict) -> float:
+        v = s.get("relevance_score")
+        try:
+            return float(v) if v is not None else float("-inf")
+        except (TypeError, ValueError):
+            return float("-inf")
+
+    # Dedup on (file_url|filename) — OpenRAG can return several chunks of the
+    # same file with different scores; show each file once with its best chunk.
+    seen: dict[str, dict] = {}
+    for s in sources:
+        key = s.get("file_url") or s.get("filename") or s.get("source") or ""
+        if not key:
+            continue
+        if _score(s) < min_score:
+            continue
+        if key not in seen or _score(s) > _score(seen[key]):
+            seen[key] = s
+
+    ranked = sorted(seen.values(), key=_score, reverse=True)[:max_items]
+    if not ranked:
+        return ""
+
+    def _label(s: dict) -> str:
+        title = s.get("title") or s.get("filename") or s.get("file_id") or "source"
+        page = s.get("page")
+        if page and str(page) not in {"0", "1"}:
+            return f"{title} (p. {page})"
+        return str(title)
+
+    lines = ["", "---", "**Sources :**", ""]
+    for i, s in enumerate(ranked, start=1):
+        url = s.get("file_url") or s.get("chunk_url") or ""
+        label = _label(s).replace("|", "\\|")
+        score = _score(s)
+        score_suffix = f" — score {score:.2f}" if score != float("-inf") else ""
+        if url:
+            lines.append(f"{i}. [{label}]({url}){score_suffix}")
+        else:
+            lines.append(f"{i}. {label}{score_suffix}")
+    return "\n".join(lines)
+
+
 async def stream_with_source_filtering(
     llm_stream,
     sources: list,
@@ -256,6 +344,17 @@ async def stream_with_source_filtering(
                     chunk["choices"][0]["delta"]["content"] = surviving
                 chunk["extra"] = filtered_json
                 yield f"data: {json.dumps(chunk)}\n\n"
+
+            # When INLINE_SOURCES_IN_CONTENT=true, emit one extra delta with
+            # the markdown source block. Sent before finish_reason so clients
+            # that buffer until finish (most do) see it as part of the content.
+            sources_md = format_sources_as_markdown(filtered)
+            if sources_md and last_chunk_template:
+                inline_chunk = copy.deepcopy(last_chunk_template)
+                inline_chunk["choices"][0]["delta"] = {"content": sources_md}
+                inline_chunk["choices"][0].pop("finish_reason", None)
+                inline_chunk["extra"] = filtered_json
+                yield f"data: {json.dumps(inline_chunk)}\n\n"
 
             if last_chunk_template:
                 # FIXME: race condition where clients missed sources because finish_reason

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -8,7 +8,6 @@ from collections import deque
 from typing import ClassVar
 
 import ray
-from components.indexer.utils.text_sanitizer import sanitize_text
 from config import load_config
 from fast_langdetect import LangDetectConfig, LangDetector
 from langchain_core.documents.base import Document
@@ -142,6 +141,8 @@ def format_web_context(
     """
     if not web_results:
         return "", [], 0
+
+    from components.indexer.utils.text_sanitizer import sanitize_text
 
     _length_function = get_num_tokens()
 

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -266,11 +266,12 @@ def format_sources_as_markdown(sources: list) -> str:
         except (TypeError, ValueError):
             return float("-inf")
 
-    # Dedup on (file_url|filename) — OpenRAG can return several chunks of the
-    # same file with different scores; show each file once with its best chunk.
+    # Dedup on best available identifier. Web sources use "url"; document
+    # sources use "file_url" or "filename". Show each source once at its
+    # best-scoring chunk.
     seen: dict[str, dict] = {}
     for s in sources:
-        key = s.get("file_url") or s.get("filename") or s.get("source") or ""
+        key = s.get("file_url") or s.get("url") or s.get("filename") or s.get("source") or ""
         if not key:
             continue
         if _score(s) < min_score:
@@ -291,8 +292,8 @@ def format_sources_as_markdown(sources: list) -> str:
 
     lines = ["", "---", "**Sources :**", ""]
     for i, s in enumerate(ranked, start=1):
-        url = s.get("file_url") or s.get("chunk_url") or ""
-        label = _label(s).replace("|", "\\|")
+        url = s.get("file_url") or s.get("url") or s.get("chunk_url") or ""
+        label = _label(s).replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]").replace("|", "\\|")
         score = _score(s)
         score_suffix = f" — score {score:.2f}" if score != float("-inf") else ""
         if url:

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -298,7 +298,11 @@ def format_sources_as_markdown(sources: list) -> str:
         score = _score(s)
         score_suffix = f" — score {score:.2f}" if score != float("-inf") else ""
         if url:
-            lines.append(f"{i}. [{label}]({url}){score_suffix}")
+            # Angle-bracket destination tolerates spaces, "(", ")" — characters
+            # that break the bare-URL form. Percent-encode the only two chars
+            # that could close the destination prematurely.
+            url_safe = url.replace("<", "%3C").replace(">", "%3E")
+            lines.append(f"{i}. [{label}](<{url_safe}>){score_suffix}")
         else:
             lines.append(f"{i}. {label}{score_suffix}")
     return "\n".join(lines)

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -9,6 +9,7 @@ from components.pipeline import RagPipeline
 from components.utils import (
     extract_and_strip_sources_block,
     filter_sources_by_citations,
+    format_sources_as_markdown,
     get_num_tokens,
     stream_with_source_filtering,
 )
@@ -360,9 +361,14 @@ async def openai_chat_completion(
 
         content = chunk.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
         clean_content, citations = extract_and_strip_sources_block(content)
-        chunk["choices"][0]["message"]["content"] = clean_content
 
         filtered = filter_sources_by_citations(sources, citations)
+        # When INLINE_SOURCES_IN_CONTENT=true, append a markdown source block to
+        # the visible content for clients that ignore the non-standard `extra`
+        # field (Open WebUI, LibreChat, Continue, …). No-op otherwise.
+        clean_content += format_sources_as_markdown(filtered)
+        chunk["choices"][0]["message"]["content"] = clean_content
+
         chunk["extra"] = json.dumps({"sources": filtered})
         log.debug("Returning non-streaming completion chunk.")
         return JSONResponse(content=chunk)
@@ -435,9 +441,12 @@ async def openai_completion(
 
     text = complete_response.get("choices", [{}])[0].get("text", "") or ""
     clean_text, citations = extract_and_strip_sources_block(text)
-    complete_response["choices"][0]["text"] = clean_text
 
     filtered = filter_sources_by_citations(sources, citations)
+    # See note on /chat/completions about INLINE_SOURCES_IN_CONTENT.
+    clean_text += format_sources_as_markdown(filtered)
+    complete_response["choices"][0]["text"] = clean_text
+
     complete_response["extra"] = json.dumps({"sources": filtered})
     log.debug("Returning completion response.")
     return JSONResponse(content=complete_response)


### PR DESCRIPTION
Replaces #345 with two follow-up fixes on top of etiquet's commit.

OpenRAG returns sources in a non-standard `extra` field. Most OpenAI-compat clients (Open WebUI, LibreChat, Continue) drop it, so users see the answer without sources. This adds an opt-in `INLINE_SOURCES_IN_CONTENT` flag that also writes a markdown source block into the assistant `content`. Default off, no breaking change.

## Knobs

- `INLINE_SOURCES_IN_CONTENT` (default false): enable the content block
- `INLINE_SOURCES_TOP_K` (default 5): cap on rendered sources
- `INLINE_SOURCES_MIN_SCORE` (default -inf): filter weak chunks

## Changes vs #345

- `cfea199` - include web sources in the inline block, escape `\`, `[`, `]`, `|` in labels (review feedback from #345)
- `f5e59e1` - move `sanitize_text` import inside `format_web_context` to break a circular import that surfaced when `components.utils` is imported from a test