### PR TITLE
fix(audio): skip WAV conversion for already-supported formats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ EMBEDDER_MODEL_NAME=jinaai/jina-embeddings-v3 # or other embedder from huggingfa
 RERANKER_ENABLED=true # deactivate the reranker if your CPU is not powerful enough
 RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base # or jinaai/jina-reranker-v2-base-multilingual
 
+# Audio transcription
+# Pipe-separated list of file extensions sent directly to the transcription endpoint
+# without converting to WAV first. Defaults cover all formats the OpenAI Whisper
+# API accepts natively. Override to restrict (e.g. to ".wav" only for vLLM deployments).
+# TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES=.wav|.flac|.ogg|.mp3|.mp4|.m4a|.webm|.mpeg|.mpga
+
 # Prompts
 PROMPTS_DIR=../prompts/example1
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -207,7 +207,8 @@ loader:
   docling_retry_base_delay: 2.0
 
   # Env: TRANSCRIBER_BASE_URL, TRANSCRIBER_API_KEY, TRANSCRIBER_MODEL,
-  #      TRANSCRIBER_TIMEOUT, TRANSCRIBER_MAX_CONCURRENT_CHUNKS, USE_WHISPER_LANG_DETECTOR
+  #      TRANSCRIBER_TIMEOUT, TRANSCRIBER_MAX_CONCURRENT_CHUNKS, USE_WHISPER_LANG_DETECTOR,
+  #      TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES (pipe-separated, e.g. ".mp3|.mp4|.wav")
   transcriber:
     base_url: http://transcriber:8000/v1
     api_key: EMPTY
@@ -215,6 +216,7 @@ loader:
     timeout: 3600
     max_concurrent_chunks: 20
     use_whisper_lang_detector: true
+    direct_upload_suffixes: ".wav|.flac|.ogg|.mp3|.mp4|.m4a|.webm|.mpeg|.mpga"
 
   # Env: OPENAI_LOADER_BASE_URL, OPENAI_LOADER_API_KEY, OPENAI_LOADER_MODEL,
   #      OPENAI_LOADER_TEMPERATURE, OPENAI_LOADER_TIMEOUT, OPENAI_LOADER_MAX_RETRIES,

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -117,6 +117,7 @@ Here are some other variables related to openai-compatible endpoint.
 | `TRANSCRIBER_MODEL` | `str` | `openai/whisper-large-v3-turbo` | Whisper model identifier served by VLLM for speech-to-text conversion. Other options: `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc.|
 | `TRANSCRIBER_MAX_CONCURRENT_CHUNKS` | `int` | `20` | Maximum number of audio chunks processed simultaneously. Increasing this value improves throughput when sufficient GPU resources are available. |
 | `TRANSCRIBER_TIMEOUT` | `int` | `3600` | Maximum duration in seconds allowed for a single transcription request. |
+| `TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES` | `str` | `.wav\|.flac\|.ogg\|.mp3\|.mp4\|.m4a\|.webm\|.mpeg\|.mpga` | Pipe-delimited list of audio file suffixes uploaded to the transcriber as-is (no WAV conversion). Other formats are re-encoded to WAV before upload. Trim this list when your transcriber backend (e.g. vLLM/libsndfile) only accepts a subset. |
 | `USE_WHISPER_LANG_DETECTOR` | `bool` | `true` | When enabled, uses a local Whisper-based language detector to identify the source audio language before transcription. |
 
 </div>

--- a/openrag/components/indexer/loaders/audio/openai.py
+++ b/openrag/components/indexer/loaders/audio/openai.py
@@ -16,6 +16,17 @@ logger = get_logger()
 # Duration of the audio sample used for language detection
 LANG_DETECT_SAMPLE_MS = 30_000  # 30 s
 
+# Audio container formats that the OpenAI ``/v1/audio/transcriptions`` family
+# accepts directly (Whisper API, vLLM-served Whisper, Scaleway Generative
+# whisper-large-v3, etc.). For these we skip the WAV conversion and send the
+# file as-is — converting an already-compressed input to uncompressed WAV
+# inflates size by ~10×, which trips per-request size limits enforced
+# server-side (Scaleway: 100 MB; OpenAI: 25 MB).
+DIRECT_UPLOAD_SUFFIXES = {
+    ".wav", ".flac", ".ogg", ".mp3", ".mp4", ".m4a",
+    ".webm", ".mpeg", ".mpga",
+}
+
 
 class AudioTranscriber:
     """Transcribes audio in a single request (no chunking).
@@ -35,18 +46,27 @@ class AudioTranscriber:
         self.use_whisper_lang_detector = config.loader.transcriber.get("use_whisper_lang_detector", True)
 
     async def transcribe(self, file_path: Path) -> str:
-        # vLLM uses soundfile/libsndfile internally, which only supports WAV/FLAC/OGG.
-        # mp3, mp4, m4a, etc. raise "Format not recognised", so convert to WAV first.
+        # The default OpenAI / Whisper API contract (and Scaleway, which mirrors
+        # it) accepts the common compressed formats directly. We only fall back
+        # to a WAV conversion for exotic containers — see DIRECT_UPLOAD_SUFFIXES
+        # above. Sending the compressed file as-is keeps mp3/m4a/mp4 well below
+        # the 25-100 MB request-size cap enforced by these endpoints.
+        # vLLM-only deployments that use libsndfile (which doesn't decode mp3)
+        # will still work via the conversion fallback for .flv/.wma/etc.
 
         try:
             logger.bind(file=file_path.name)
-            if file_path.suffix.lower() == ".wav":
+            suffix = file_path.suffix.lower()
+            if suffix in DIRECT_UPLOAD_SUFFIXES:
                 wav_path = file_path
                 tmp_wav = None
-                sound = await asyncio.to_thread(AudioSegment.from_file, wav_path)
+                # We still need to load the audio so language detection can
+                # extract its 30-second sample. ``AudioSegment.from_file``
+                # uses ffmpeg under the hood, so it handles every format.
+                sound = await asyncio.to_thread(AudioSegment.from_file, file_path)
             else:
                 sound = await asyncio.to_thread(AudioSegment.from_file, file_path)
-                logger.info("Converting audio to WAV", duration_s=f"{len(sound) / 1000:.1f}")
+                logger.info("Converting audio to WAV (unsupported container)", duration_s=f"{len(sound) / 1000:.1f}")
                 tmp_wav = file_path.with_suffix(".wav")
                 await asyncio.to_thread(sound.export, tmp_wav, format="wav")
                 wav_path = tmp_wav

--- a/openrag/components/indexer/loaders/audio/openai.py
+++ b/openrag/components/indexer/loaders/audio/openai.py
@@ -16,18 +16,6 @@ logger = get_logger()
 # Duration of the audio sample used for language detection
 LANG_DETECT_SAMPLE_MS = 30_000  # 30 s
 
-_DEFAULT_DIRECT_UPLOAD_SUFFIXES = {
-    ".wav",
-    ".flac",
-    ".ogg",
-    ".mp3",
-    ".mp4",
-    ".m4a",
-    ".webm",
-    ".mpeg",
-    ".mpga",
-}
-
 
 class AudioTranscriber:
     """Transcribes audio in a single request (no chunking).
@@ -44,12 +32,8 @@ class AudioTranscriber:
             timeout=config.loader.transcriber.timeout,
         )
         self.model_name = config.loader.transcriber.model_name
-        self.use_whisper_lang_detector = config.loader.transcriber.get("use_whisper_lang_detector", True)
-        raw = config.loader.transcriber.get("direct_upload_suffixes", "")
-        if raw:
-            self.direct_upload_suffixes = {s.strip() for s in raw.split("|") if s.strip()}
-        else:
-            self.direct_upload_suffixes = _DEFAULT_DIRECT_UPLOAD_SUFFIXES
+        self.use_whisper_lang_detector = config.loader.transcriber.use_whisper_lang_detector
+        self.direct_upload_suffixes = config.loader.transcriber.direct_upload_suffixes
 
     async def transcribe(self, file_path: Path) -> str:
         # Formats in self.direct_upload_suffixes (configurable via

--- a/openrag/components/indexer/loaders/audio/openai.py
+++ b/openrag/components/indexer/loaders/audio/openai.py
@@ -16,15 +16,16 @@ logger = get_logger()
 # Duration of the audio sample used for language detection
 LANG_DETECT_SAMPLE_MS = 30_000  # 30 s
 
-# Audio container formats that the OpenAI ``/v1/audio/transcriptions`` family
-# accepts directly (Whisper API, vLLM-served Whisper, Scaleway Generative
-# whisper-large-v3, etc.). For these we skip the WAV conversion and send the
-# file as-is — converting an already-compressed input to uncompressed WAV
-# inflates size by ~10×, which trips per-request size limits enforced
-# server-side (Scaleway: 100 MB; OpenAI: 25 MB).
-DIRECT_UPLOAD_SUFFIXES = {
-    ".wav", ".flac", ".ogg", ".mp3", ".mp4", ".m4a",
-    ".webm", ".mpeg", ".mpga",
+_DEFAULT_DIRECT_UPLOAD_SUFFIXES = {
+    ".wav",
+    ".flac",
+    ".ogg",
+    ".mp3",
+    ".mp4",
+    ".m4a",
+    ".webm",
+    ".mpeg",
+    ".mpga",
 }
 
 
@@ -44,20 +45,22 @@ class AudioTranscriber:
         )
         self.model_name = config.loader.transcriber.model_name
         self.use_whisper_lang_detector = config.loader.transcriber.get("use_whisper_lang_detector", True)
+        raw = config.loader.transcriber.get("direct_upload_suffixes", "")
+        if raw:
+            self.direct_upload_suffixes = {s.strip() for s in raw.split("|") if s.strip()}
+        else:
+            self.direct_upload_suffixes = _DEFAULT_DIRECT_UPLOAD_SUFFIXES
 
     async def transcribe(self, file_path: Path) -> str:
-        # The default OpenAI / Whisper API contract (and Scaleway, which mirrors
-        # it) accepts the common compressed formats directly. We only fall back
-        # to a WAV conversion for exotic containers — see DIRECT_UPLOAD_SUFFIXES
-        # above. Sending the compressed file as-is keeps mp3/m4a/mp4 well below
-        # the 25-100 MB request-size cap enforced by these endpoints.
-        # vLLM-only deployments that use libsndfile (which doesn't decode mp3)
-        # will still work via the conversion fallback for .flv/.wma/etc.
+        # Formats in self.direct_upload_suffixes (configurable via
+        # TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES) are sent as-is to avoid the ~10x
+        # size inflation from WAV conversion (Scaleway cap: 100 MB; OpenAI: 25 MB).
+        # Everything else falls back to WAV for vLLM/libsndfile deployments.
 
         try:
             logger.bind(file=file_path.name)
             suffix = file_path.suffix.lower()
-            if suffix in DIRECT_UPLOAD_SUFFIXES:
+            if suffix in self.direct_upload_suffixes:
                 wav_path = file_path
                 tmp_wav = None
                 # We still need to load the audio so language detection can

--- a/openrag/config/loader.py
+++ b/openrag/config/loader.py
@@ -105,6 +105,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("TRANSCRIBER_TIMEOUT", "loader.transcriber.timeout", int),
     ("TRANSCRIBER_MAX_CONCURRENT_CHUNKS", "loader.transcriber.max_concurrent_chunks", int),
     ("USE_WHISPER_LANG_DETECTOR", "loader.transcriber.use_whisper_lang_detector", bool),
+    ("TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES", "loader.transcriber.direct_upload_suffixes", str),
     ("OPENAI_LOADER_BASE_URL", "loader.openai.base_url", str),
     ("OPENAI_LOADER_API_KEY", "loader.openai.api_key", str),
     ("OPENAI_LOADER_MODEL", "loader.openai.model", str),

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +216,18 @@ class PromptsConfig(ConfigMixin):
 # ---------------------------------------------------------------------------
 # Transcriber (nested under loader)
 # ---------------------------------------------------------------------------
+_DEFAULT_DIRECT_UPLOAD_SUFFIXES = frozenset(
+    {".wav", ".flac", ".ogg", ".mp3", ".mp4", ".m4a", ".webm", ".mpeg", ".mpga"}
+)
+
+
+def _normalize_suffix(s: str) -> str:
+    s = s.strip().lower()
+    if not s:
+        return ""
+    return s if s.startswith(".") else f".{s}"
+
+
 class TranscriberConfig(ConfigMixin):
     base_url: str = "http://transcriber:8000/v1"
     api_key: str = Field(default="EMPTY", repr=False)
@@ -223,6 +235,14 @@ class TranscriberConfig(ConfigMixin):
     timeout: int = 3600
     max_concurrent_chunks: int = 20
     use_whisper_lang_detector: bool = True
+    direct_upload_suffixes: set[str] = Field(default_factory=lambda: set(_DEFAULT_DIRECT_UPLOAD_SUFFIXES))
+
+    @field_validator("direct_upload_suffixes", mode="before")
+    @classmethod
+    def _split_suffixes(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            return {n for raw in v.split("|") if (n := _normalize_suffix(raw))}
+        return v
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces #342. Same content plus one follow-up fix for review feedback.

`OpenAIAudioLoader` was converting every non-WAV input to uncompressed WAV before sending it to the transcription endpoint. The conversion inflates a typical mp3 by ~10x, so a 30-min mp3 (11.7 MB) becomes 124 MB and trips the per-request size cap on hosted Whisper endpoints (Scaleway 100 MB, OpenAI 25 MB).

Fix: skip the conversion when the suffix is one of the formats every OpenAI-compat Whisper accepts (mp3, m4a, mp4, mpeg, mpga, wav, webm, flac, ogg). Other suffixes (`.flv`, `.wma`, ...) still go through the WAV fallback for vLLM/libsndfile deployments.

## Changes vs #342

- `51711b6` - move the suffix list into config (`loader.transcriber.direct_upload_suffixes`), overridable via `TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES`, addressing CodeRabbit's note about the hard-coded module-level whitelist

## Test plan

- 30-min mp3 that previously failed on Scaleway with `Maximum file size exceeded`: uploads and returns a transcript
- WAV/FLAC inputs unchanged (no conversion)
- `.flv` and other exotic containers still go through the WAV fallback for vLLM
- Default suffix list matches the previous hard-coded set, no regression with default config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for direct audio file uploads to the transcriber without format conversion for supported file types.
  * New environment variable configuration option to specify which audio/video formats bypass conversion.

* **Documentation**
  * Updated configuration documentation with guidance on audio file format handling and codec compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->