### PR TITLE
feat(auth): redirect unauthenticated browser hits on /chainlit/* to /auth/login

### DIFF
--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -128,6 +128,27 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # --- Bypass list (docs, health, /auth/* callbacks, chainlit).
         path = request.url.path
         if is_bypass_path(path):
+            # Special case: browser HTML page-loads on /chainlit/* without an
+            # active session can't be served usefully — Chainlit configures no
+            # in-app auth provider when headerAuth is used, so the SPA shows
+            # a dead-end "Login to access the app" screen with no actionable
+            # button. Redirect those to /auth/login so the OIDC flow takes
+            # over. API/asset/WebSocket requests (Accept != text/html) keep
+            # the bypass so Chainlit's own headerAuth callback can validate.
+            if (
+                auth_mode == "oidc"
+                and path.startswith("/chainlit")
+                and "text/html" in request.headers.get("accept", "").lower()
+                and not request.cookies.get(SESSION_COOKIE_NAME)
+                and not request.headers.get("authorization", "").lower().startswith("bearer ")
+            ):
+                next_path = path
+                if request.url.query:
+                    next_path = f"{path}?{request.url.query}"
+                return RedirectResponse(
+                    url=f"/auth/login?next={quote(next_path, safe='')}",
+                    status_code=302,
+                )
             return await call_next(request)
 
         user = None

--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -139,16 +139,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 auth_mode == "oidc"
                 and path.startswith("/chainlit")
                 and "text/html" in request.headers.get("accept", "").lower()
-                and not request.cookies.get(SESSION_COOKIE_NAME)
                 and not request.headers.get("authorization", "").lower().startswith("bearer ")
             ):
-                next_path = path
-                if request.url.query:
-                    next_path = f"{path}?{request.url.query}"
-                return RedirectResponse(
-                    url=f"/auth/login?next={quote(next_path, safe='')}",
-                    status_code=302,
-                )
+                cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
+                session_valid = False
+                if cookie_token:
+                    session = await vectordb.get_oidc_session_by_token.remote(cookie_token)
+                    session_valid = session is not None
+                if not session_valid:
+                    next_path = path
+                    if request.url.query:
+                        next_path = f"{path}?{request.url.query}"
+                    return RedirectResponse(
+                        url=f"/auth/login?next={quote(next_path, safe='')}",
+                        status_code=302,
+                    )
             return await call_next(request)
 
         user = None


### PR DESCRIPTION
Replaces #343. Same content plus one follow-up fix for the stale-cookie bypass bug.

`/chainlit/*` is unconditionally bypassed by `AuthMiddleware` so Chainlit can run its own `headerAuth` callback. When a browser hits `/chainlit/` without a valid `openrag_session` cookie (expired session, cross-domain redirect, jumping in from Open WebUI without going through `/auth/login`), the SPA shows a dead-end "Login to access the app" screen with no actionable button.

Fix: in `AUTH_MODE=oidc`, 302 HTML page-loads on `/chainlit/*` to `/auth/login?next=<original>` when the request has no valid session and no Bearer token. API/asset/WebSocket traffic (`Accept != text/html`) keeps the bypass so Chainlit's `headerAuth` callback continues to work for authenticated SPA fetches.

## Changes vs #343

- `53555fc` - validate the cookie against the DB via `get_oidc_session_by_token` before deciding to bypass the redirect. The original check only tested cookie presence, so an expired/revoked cookie was still bypassed and produced the same dead-end screen.

## Test plan

- Browser `GET /chainlit/login` with no cookie: 302 to `/auth/login?next=%2Fchainlit%2Flogin`
- Browser `GET /chainlit/` with expired/revoked cookie: 302 (was wrongly bypassed before the fix commit)
- SPA fetch `GET /chainlit/auth/config` (Accept: application/json): 200, bypass kept
- WebSocket `/chainlit/ws/socket.io/...`: still bypassed
- `AUTH_MODE=token` deployments unchanged