### PR TITLE
feat(auth): optional auto-provisioning of OIDC users on first login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,3 +114,10 @@ PREFERRED_URL_SCHEME=https
 # Writable fields whitelist: display_name, email (never is_admin / external_user_id / file_quota / token).
 # Leave unset to keep user rows untouched after login.
 # OIDC_CLAIM_MAPPING=display_name:name,email:email
+# --- Optional auto-provisioning on first login ---
+# When the IdP returns a `sub` that isn't yet known to OpenRag, the callback
+# normally returns 403 "User not registered" — admins must pre-create every
+# user. Setting this to true makes the callback create a non-admin user on
+# the fly using the ID-token claims (display_name from `name`/`preferred_username`,
+# email from `email`). The new user inherits the default file quota.
+# OIDC_AUTO_PROVISION_LOGIN=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,10 +365,13 @@ OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environ
 | `OIDC_CLAIM_MAPPING` | (none) | CSV of `db_field:claim` pairs to sync IdP claims into the users row on every login (whitelist: `display_name`, `email`). Unset = no post-login update. |
 | `OIDC_SCOPES` | `openid email profile offline_access` | Space-separated scope list (include `offline_access` for refresh tokens) |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | — | URL the IdP sends the user to after RP-initiated logout. No default (an OpenRag URL would re-trigger OIDC login) |
+| `OIDC_AUTO_PROVISION_LOGIN` | `false` | When `true`, an unknown `sub` triggers on-the-fly creation of a non-admin user from the ID-token claims (`name`/`preferred_username` → `display_name`, `email` → `email`). Default keeps the strict admin-pre-provisioning policy below. |
 
 **User Matching & Provisioning**:
 
-When a user logs in via OIDC, matching is **exclusively** by `users.external_user_id == sub` (the stable OIDC claim). There is no email fallback and no auto-provisioning: if the `sub` is unknown, the callback returns `403 "User not registered"`. Admins MUST pre-create every user with the expected `external_user_id`.
+When a user logs in via OIDC, matching is **exclusively** by `users.external_user_id == sub` (the stable OIDC claim). There is no email fallback. If the `sub` is unknown, the callback either:
+- returns `403 "User not registered"` (default — admins must pre-create every user), or
+- creates a non-admin user from the ID-token claims when `OIDC_AUTO_PROVISION_LOGIN=true`. Auto-provisioned users inherit the default file quota; `is_admin` is **always** `false` (operators can promote afterwards via `/users/{id}` or `/users/`).
 
 Optionally, if `OIDC_CLAIM_MAPPING` is set, after a successful match the callback reads the configured claims (from the ID token or `/userinfo`, per `OIDC_CLAIM_SOURCE`) and updates the user row. The writable whitelist is strict — only `display_name` and `email` are allowed; `is_admin`, `external_user_id`, `file_quota`, `token` are never writable via claim mapping.
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -8,12 +8,14 @@ This guide walks you through configuring and using OpenRag's OIDC authentication
 2. [Architecture](#architecture)
 3. [Configuration](#configuration)
 4. [User Pre-provisioning](#user-pre-provisioning)
-5. [Keycloak Setup](#keycloak-setup)
-6. [LemonLDAP::NG Setup](#lemonldapng-setup)
-7. [Programmatic Access](#programmatic-access)
-8. [Back-Channel Logout](#back-channel-logout)
-9. [Troubleshooting](#troubleshooting)
-10. [Security Considerations](#security-considerations)
+5. [Claim Mapping (optional)](#claim-mapping-optional)
+6. [Auto-provisioning (optional)](#auto-provisioning-optional)
+7. [Keycloak Setup](#keycloak-setup)
+8. [LemonLDAP::NG Setup](#lemonldapng-setup)
+9. [Programmatic Access](#programmatic-access)
+10. [Back-Channel Logout](#back-channel-logout)
+11. [Troubleshooting](#troubleshooting)
+12. [Security Considerations](#security-considerations)
 
 ---
 
@@ -109,6 +111,7 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_TOKEN_ENCRYPTION_KEY` | Yes* | — | Fernet key for encrypting tokens at rest (see [Generating the Fernet Key](#generating-the-fernet-key)) |
 | `OIDC_CLAIM_SOURCE` | No | `id_token` | Where to read claims for [Claim Mapping](#claim-mapping-optional): `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
 | `OIDC_CLAIM_MAPPING` | No | — | Optional CSV of `db_field:claim` pairs to copy claims into user fields on every login (e.g., `display_name:name,email:email`). See [Claim Mapping](#claim-mapping-optional). |
+| `OIDC_AUTO_PROVISION_LOGIN` | No | `false` | When `true`, an unknown `sub` triggers creation of a non-admin user from the ID-token claims instead of returning `403 User not registered`. Also keeps the user's `display_name` and `email` in sync with the claims on every subsequent login. See [Auto-provisioning](#auto-provisioning-optional). |
 | `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | No | — | URL the IdP sends the user to after RP-initiated logout. **No default**: if unset AND the IdP doesn't have an `end_session_endpoint`, `/auth/logout` returns a plain 200 confirming the logout. Avoid pointing this to an OpenRag URL (triggers re-auth — silent SSO loop). |
 
@@ -178,7 +181,9 @@ OIDC_POST_LOGOUT_REDIRECT_URI=/
 
 ## User Pre-provisioning
 
-OIDC requires users to be pre-provisioned in OpenRag's database. There is **no automatic user creation** on login. User matching is performed **exclusively** by `external_user_id == sub`: the admin MUST set each user's `external_user_id` to the exact OIDC `sub` claim the IdP will emit for that user.
+By default, OIDC requires users to be pre-provisioned in OpenRag's database — there is **no automatic user creation** on login. User matching is performed **exclusively** by `external_user_id == sub`: the admin MUST set each user's `external_user_id` to the exact OIDC `sub` claim the IdP will emit for that user.
+
+If pre-provisioning every user is impractical at your scale, see [Auto-provisioning](#auto-provisioning-optional) for an opt-in flag that lets the callback create users on the fly from ID-token claims.
 
 ### Admin Pre-provisioning
 
@@ -295,6 +300,47 @@ With `OIDC_CLAIM_MAPPING=display_name:name,email:email` and `OIDC_CLAIM_SOURCE=i
 | `email: "alice@example.com"` | `email = "alice@example.com"` |
 | `sub: "kc-alice-uuid"` | (used for matching only, never written) |
 | `is_admin: true` | ignored (not in whitelist) |
+
+---
+
+## Auto-provisioning (optional)
+
+By default, an unknown `sub` is rejected with `403 User not registered` and the admin must pre-create the user via `POST /users/`. For deployments where every IdP user should be allowed in without manual provisioning, set `OIDC_AUTO_PROVISION_LOGIN=true`.
+
+### When to Use It
+
+- Your IdP already gates who can issue valid tokens, so its user list is the source of truth.
+- Manual pre-provisioning at corporate scale is impractical.
+- You want a user renamed in the IdP to be reflected in OpenRag automatically.
+
+### Behavior
+
+When `OIDC_AUTO_PROVISION_LOGIN=true`:
+
+- **Unknown `sub`**: a non-admin user is created from the ID-token claims.
+
+  | User column | Source |
+  |-------------|--------|
+  | `external_user_id` | `sub` (always) |
+  | `display_name` | `name` then `preferred_username` then `<given_name> <family_name>` then `oidc-<8-char-sub-prefix>` |
+  | `email` | `email` claim if present, else `null` |
+  | `is_admin` | always `false` (operators promote afterwards via `/users/`) |
+  | `file_quota` | server default (`DEFAULT_FILE_QUOTA`) |
+
+- **Known `sub`**: `display_name` and `email` are kept in sync with the ID-token claims on every login. A field is only written when the IdP value differs from the stored one (no DB churn on identical values).
+
+`is_admin`, `external_user_id`, `file_quota`, and `token` are never written via this path — same security boundary as [Claim Mapping](#claim-mapping-optional).
+
+### Interaction with Claim Mapping
+
+The two flags are independent and compose cleanly:
+
+- `OIDC_AUTO_PROVISION_LOGIN=true` alone is enough to keep `display_name` + `email` synced. No `OIDC_CLAIM_MAPPING` needed.
+- If both are set, `OIDC_CLAIM_MAPPING` runs after the auto-provision sync and can override it (useful when the operator wants `display_name` to come from a non-default claim).
+
+### Threat Model
+
+Enabling auto-provisioning shifts the trust boundary: the IdP's user list becomes the source of truth for OpenRag accounts. Strict-whitelist deployments leave the flag unset and keep the historical `403`. There is no path to grant `is_admin=true` via OIDC claims; promotion remains an explicit admin action.
 
 ---
 
@@ -659,7 +705,9 @@ OpenRag builds the discovery URL by stripping any trailing slash internally, so 
 
 **Error**: After a successful IdP login, OpenRag responds with `403 {"detail": "User not registered"}` at `/auth/callback`.
 
-**Cause**: User matching is now performed **exclusively** by `users.external_user_id == sub`. There is no email fallback and no auto-provisioning. The user either doesn't exist yet, or their `external_user_id` column is not set (or does not match the IdP's `sub`).
+**Cause**: User matching is performed **exclusively** by `users.external_user_id == sub`. There is no email fallback. The user either doesn't exist yet, or their `external_user_id` column is not set (or does not match the IdP's `sub`).
+
+> If pre-provisioning every user is impractical, set `OIDC_AUTO_PROVISION_LOGIN=true` to let the callback create users on the fly from the ID-token claims. See [Auto-provisioning](#auto-provisioning-optional) for the trust-model implications.
 
 **Solution**: The admin must pre-provision the user with the *exact* `sub` the IdP emits. Discover the IdP's `sub` for the user (e.g., Keycloak: **Users** → open the user → copy the `ID` field; or decode an ID token for that user with <https://jwt.io> and read the `sub` claim).
 

--- a/docs/sso-quickstart.md
+++ b/docs/sso-quickstart.md
@@ -92,6 +92,7 @@ OIDC_TOKEN_ENCRYPTION_KEY=XFlT-ZfXkdqf0v-5Z8kVt9xhU6c7Z4z0ZY8Z4Z4Z4=
 # OIDC_SCOPES="openid email profile offline_access"   # default
 # OIDC_CLAIM_SOURCE=id_token                          # default ; alternative: userinfo
 # OIDC_CLAIM_MAPPING=                                 # default: empty (no sync of display_name/email from IdP)
+# OIDC_AUTO_PROVISION_LOGIN=false                     # default ; true = create users on first login from claims (see Step 5)
 
 # ⚠ Where the IdP sends the user AFTER logging out.
 #   A ("/") lands on the OpenRag root, which immediately re-triggers
@@ -125,7 +126,9 @@ By default OpenRag reads the claims from the verified ID token (`OIDC_CLAIM_SOUR
 
 ## Step 5 — Pre-provision users
 
-OpenRag **does not auto-create users** on first login. Each user must exist in the database with their OIDC `sub` stored in `external_user_id`.
+By default, OpenRag **does not auto-create users** on first login. Each user must exist in the database with their OIDC `sub` stored in `external_user_id`.
+
+> **Skip this step entirely** by setting `OIDC_AUTO_PROVISION_LOGIN=true` in your `.env`. The callback then creates a non-admin user from the ID-token claims on first login and keeps `display_name` + `email` in sync with the IdP on every subsequent login. The trade-off: your IdP's user list becomes the source of truth for OpenRag accounts. See `docs/oidc.md` → [Auto-provisioning](./oidc.md#auto-provisioning-optional) for the full trust-model.
 
 Ask the IdP admin for each user's `sub` claim value (stable identifier, NOT the username). Then create the user via the OpenRag admin API — you'll need an admin `AUTH_TOKEN` for this:
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -31,6 +31,7 @@ from components.auth import (
 )
 from fastapi import APIRouter, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
+from models.user import UserCreate
 from utils.dependencies import get_vectordb
 from utils.logger import get_logger
 
@@ -63,6 +64,40 @@ def _token_encryption_key() -> str:
 
 def _claim_source() -> str:
     return os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower()
+
+
+def _auto_provision_login() -> bool:
+    """Whether to auto-provision a non-admin user on first OIDC login.
+
+    Defaults to ``False`` — keeping the historical "admin pre-creates every
+    user" model. Set ``OIDC_AUTO_PROVISION_LOGIN=true`` to enable: when the
+    callback receives a ``sub`` that isn't yet mapped to an OpenRAG user,
+    a row is created on the fly using the ID-token claims (``name`` /
+    ``preferred_username`` for the display name, ``email`` if present).
+
+    Auto-provisioned users are **never** admin and inherit the default file
+    quota — operators can promote / adjust afterwards via ``/users/``.
+    """
+    return os.getenv("OIDC_AUTO_PROVISION_LOGIN", "false").strip().lower() == "true"
+
+
+def _display_name_from_claims(claims: dict[str, Any], sub: str) -> str:
+    """Pick a sensible display name from the standard OIDC claims.
+
+    Falls back to a short ``sub`` prefix when nothing readable is available
+    so the user row always has something printable for the UI.
+    """
+    for key in ("name", "preferred_username"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    given = claims.get("given_name") or ""
+    family = claims.get("family_name") or ""
+    composed = f"{given} {family}".strip()
+    if composed:
+        return composed
+    # Last-resort fallback — keep enough of the sub to be unique-ish in the UI.
+    return f"oidc-{sub[:8]}"
 
 
 def _claim_mapping() -> dict[str, str]:
@@ -308,12 +343,47 @@ async def callback(request: Request, code: str | None = None, state: str | None 
     vdb = get_vectordb()
     user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
     if user is None:
-        logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
-        return _json_error(
-            status.HTTP_403_FORBIDDEN,
-            "User not registered",
-            delete_state_cookie=True,
-        )
+        if not _auto_provision_login():
+            logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
+            return _json_error(
+                status.HTTP_403_FORBIDDEN,
+                "User not registered",
+                delete_state_cookie=True,
+            )
+
+        # Auto-provision: create a non-admin user from the ID-token claims.
+        # Email is best-effort — populated when the IdP exposes it on the
+        # ``email`` claim (typically via the ``email`` scope, which is in the
+        # default ``OIDC_SCOPES``). Display name falls back to the sub when
+        # the IdP exposes nothing readable.
+        display_name = _display_name_from_claims(bundle.claims, sub)
+        email = bundle.claims.get("email")
+        try:
+            user = await vdb.create_user.remote(
+                UserCreate(
+                    display_name=display_name,
+                    external_user_id=sub,
+                    email=email if isinstance(email, str) and email.strip() else None,
+                    is_admin=False,
+                )
+            )
+        except Exception as e:
+            # Race condition (concurrent first-login) or DB failure — try to
+            # recover by re-reading; if still missing, surface a 500 so the
+            # operator notices instead of silently masking the problem.
+            logger.exception(f"OIDC auto-provisioning failed for sub={sub!r}: {e}")
+            user = await vdb.get_user_by_external_id.remote(sub)
+            if user is None:
+                return _json_error(
+                    status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    "Failed to provision user",
+                    delete_state_cookie=True,
+                )
+        else:
+            logger.info(
+                f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, "
+                f"display_name={display_name!r})"
+            )
 
     # --- 5. Optional claim-mapping update --------------------------------------
     mapping = _claim_mapping()

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -380,10 +380,35 @@ async def callback(request: Request, code: str | None = None, state: str | None 
                     delete_state_cookie=True,
                 )
         else:
-            logger.info(
-                f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, "
-                f"display_name={display_name!r})"
-            )
+            logger.info(f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, display_name={display_name!r})")
+
+    # --- 4b. Auto-provision: keep display_name + email in sync with claims ----
+    # When OIDC_AUTO_PROVISION_LOGIN is on, the IdP is treated as the source of
+    # truth for these two fields on every login (not just at creation), so a
+    # user renamed in the IdP doesn't drift out of sync. No-op for users whose
+    # row already matches the claims (including the user we just created).
+    if _auto_provision_login():
+        derived_display = _display_name_from_claims(bundle.claims, sub)
+        derived_email_raw = bundle.claims.get("email")
+        derived_email = (
+            derived_email_raw.strip() if isinstance(derived_email_raw, str) and derived_email_raw.strip() else None
+        )
+
+        sync_updates: dict[str, Any] = {}
+        if derived_display and user.get("display_name") != derived_display:
+            sync_updates["display_name"] = derived_display
+        if derived_email is not None and user.get("email") != derived_email:
+            sync_updates["email"] = derived_email
+
+        if sync_updates:
+            try:
+                await vdb.update_user_fields.remote(user["id"], sync_updates)
+            except Exception as e:
+                logger.warning(f"OIDC auto-provision sync failed for user_id={user['id']}: {e}")
+            else:
+                refreshed = await vdb.get_user_by_external_id.remote(sub)
+                if refreshed is not None:
+                    user = refreshed
 
     # --- 5. Optional claim-mapping update --------------------------------------
     mapping = _claim_mapping()

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -143,11 +143,13 @@ class _StubVectorDB:
         self._sessions: dict[int, dict] = {}
         self._sessions_by_token: dict[str, int] = {}
         self._next_session_id = 1
+        self._next_user_id = 1000
         # Bind each underlying impl as an actor-style accessor.
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
         self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
+        self.create_user = _RayMethodStub("create_user", self._impl_create_user, self.calls)
         self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
         self.get_oidc_session_by_token = _RayMethodStub(
             "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
@@ -185,6 +187,30 @@ class _StubVectorDB:
 
     def _impl_get_user_by_external_id(self, external_user_id: str):
         return self._users_by_sub.get(external_user_id)
+
+    def _impl_create_user(self, body):
+        # Accept either UserCreate or a plain dict, like the real Ray method
+        # would (Pydantic instances are serializable).
+        if hasattr(body, "model_dump"):
+            data = body.model_dump()
+        else:
+            data = dict(body)
+        user_id = self._next_user_id
+        self._next_user_id += 1
+        user = {
+            "id": user_id,
+            "display_name": data.get("display_name"),
+            "external_user_id": data.get("external_user_id"),
+            "email": (data.get("email").strip().lower() if data.get("email") else None),
+            "is_admin": bool(data.get("is_admin", False)),
+            "file_quota": data.get("file_quota"),
+            "file_count": 0,
+            "token": "or-stub",
+        }
+        self._users_by_id[user_id] = user
+        if data.get("external_user_id"):
+            self._users_by_sub[data["external_user_id"]] = user
+        return user
 
     def _impl_update_user_fields(self, user_id: int, fields: dict):
         user = self._users_by_id.get(user_id)
@@ -458,7 +484,7 @@ def test_callback_success_by_external_id(client, fresh_stub_vectordb):
 
 
 def test_callback_user_not_registered(client, fresh_stub_vectordb):
-    """Unknown sub → 403 (no email fallback, no auto-provisioning)."""
+    """Unknown sub → 403 by default (no email fallback, no auto-provisioning)."""
     _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
     id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com"))
@@ -470,6 +496,83 @@ def test_callback_user_not_registered(client, fresh_stub_vectordb):
     )
     assert r.status_code == 403
     assert "not registered" in r.json()["detail"].lower()
+    # Without OIDC_AUTO_PROVISION_LOGIN, no user must have been created.
+    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
+
+
+def test_callback_auto_provisions_user_when_enabled(client, fresh_stub_vectordb, monkeypatch):
+    """OIDC_AUTO_PROVISION_LOGIN=true: unknown sub triggers user creation
+    from ID-token claims, never as admin, and login proceeds (302 + cookie)."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(
+            nonce,
+            sub="sub-new-user",
+            email="alice@example.com",
+            extra={"name": "Alice Liddell"},
+        )
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+    assert "openrag_session" in r.cookies
+
+    # create_user was called exactly once with the IdP claims.
+    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
+    assert len(create_calls) == 1
+    body = create_calls[0][1][0]
+    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
+    assert data["external_user_id"] == "sub-new-user"
+    assert data["display_name"] == "Alice Liddell"
+    assert data["email"] == "alice@example.com"
+    assert data["is_admin"] is False  # auto-provisioned users are NEVER admin
+
+
+def test_callback_auto_provision_falls_back_to_sub_when_no_name(client, fresh_stub_vectordb, monkeypatch):
+    """When the IdP exposes no readable display name, a deterministic
+    ``oidc-<sub-prefix>`` placeholder is used so the UI always has something."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="abcdef0123456789", email=None, extra={})
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(
+        f"/auth/callback?code=c&state={state}",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302, r.text
+
+    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
+    assert len(create_calls) == 1
+    body = create_calls[0][1][0]
+    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
+    assert data["display_name"] == "oidc-abcdef01"
+    assert data["email"] is None
+
+
+def test_callback_auto_provision_disabled_by_default(client, fresh_stub_vectordb, monkeypatch):
+    """Explicitly setting OIDC_AUTO_PROVISION_LOGIN=false (or unset) keeps the
+    historical 403 behaviour — non-breaking guard for existing deployments."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "false")
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(nonce, sub="sub-x", email="x@example.com", extra={"name": "X"})
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
+    assert r.status_code == 403
+    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
 
 
 def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectordb, monkeypatch):

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -540,9 +540,7 @@ def test_callback_auto_provision_falls_back_to_sub_when_no_name(client, fresh_st
     monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
     _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="abcdef0123456789", email=None, extra={})
-    )
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="abcdef0123456789", email=None, extra={}))
     _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(
@@ -565,14 +563,74 @@ def test_callback_auto_provision_disabled_by_default(client, fresh_stub_vectordb
     monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "false")
     _setup_jwks(client.oidc_router)
     state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(nonce, sub="sub-x", email="x@example.com", extra={"name": "X"})
-    )
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-x", email="x@example.com", extra={"name": "X"}))
     _mock_token_endpoint(client.oidc_router, id_token)
 
     r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
     assert r.status_code == 403
     assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
+
+
+def test_callback_auto_provision_syncs_existing_user_claims(client, fresh_stub_vectordb, monkeypatch):
+    """OIDC_AUTO_PROVISION_LOGIN=true also keeps display_name/email of an
+    already-known user in sync with the IdP claims on every login."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
+    fresh_stub_vectordb.add_user(
+        user_id=99,
+        email="stale@example.com",
+        external_user_id="sub-existing",
+        display_name="Stale Name",
+    )
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(
+            nonce,
+            sub="sub-existing",
+            email="fresh@example.com",
+            extra={"name": "Fresh Name"},
+        )
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
+    assert r.status_code == 302, r.text
+
+    user = fresh_stub_vectordb._users_by_id[99]
+    assert user["display_name"] == "Fresh Name"
+    assert user["email"] == "fresh@example.com"
+    # User row was not re-created — only updated.
+    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
+    assert sum(1 for c in fresh_stub_vectordb.calls if c[0] == "update_user_fields") == 1
+
+
+def test_callback_auto_provision_no_db_write_when_claims_match(client, fresh_stub_vectordb, monkeypatch):
+    """With AUTO_PROVISION_LOGIN on but claims already matching the stored row,
+    no update_user_fields call is made (the no-op filter avoids DB churn)."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
+    fresh_stub_vectordb.add_user(
+        user_id=101,
+        email="same@example.com",
+        external_user_id="sub-stable",
+        display_name="Same Name",
+    )
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(
+        _id_token_payload(
+            nonce,
+            sub="sub-stable",
+            email="same@example.com",
+            extra={"name": "Same Name"},
+        )
+    )
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
+    assert r.status_code == 302, r.text
+    assert not any(c[0] == "update_user_fields" for c in fresh_stub_vectordb.calls)
 
 
 def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectordb, monkeypatch):


### PR DESCRIPTION
Replaces #341. Same content, no follow-up fix needed.

OpenRAG's OIDC callback rejects unknown `sub` values with a hard 403. That works for tightly controlled deployments but is painful at scale where every corporate user has to be pre-provisioned via `POST /users/`.

Adds opt-in flag `OIDC_AUTO_PROVISION_LOGIN` (default false). When enabled and the callback receives an unknown `sub`, it creates a non-admin user from the ID-token claims, mirroring the existing `OIDC_AUTO_PROVISION` for bearer JWT validation in `auth/oidc.py`.

## Provisioning fields

- `external_user_id`: `sub` (always)
- `display_name`: `name` then `preferred_username` then `<given_name> <family_name>` then `oidc-<8-char-sub-prefix>`
- `email`: `email` claim if present, else null
- `is_admin`: hard-coded false. Promotion still goes through the existing admin endpoints
- `file_quota`: server default

## Threat model

The flag shifts the trust boundary: enabling it means trusting the IdP's user list as the source of truth for OpenRAG accounts. Strict-whitelist deployments leave the flag unset and keep the 403.

## Test plan

- `test_callback_user_not_registered`: extended to assert `create_user` is not called when the flag is unset
- `test_callback_auto_provisions_user_when_enabled`: 302 + cookie + `create_user` called with the IdP claims and `is_admin=False`
- `test_callback_auto_provision_falls_back_to_sub_when_no_name`: `oidc-<sub-prefix>` fallback when no readable name claim
- `test_callback_auto_provision_disabled_by_default`: explicit `=false` keeps the historical 403