### PR TITLE
fix(prompt): tighten citation rules to forbid inline source references

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -182,6 +182,3 @@ services:
     profiles:
       - "cpu"
 
-networks:
-  default:
-    name: openrag_default

--- a/prompts/example1/spoken_style_answer_tmpl.txt
+++ b/prompts/example1/spoken_style_answer_tmpl.txt
@@ -10,15 +10,18 @@ Your goal is to give short (1-2 sentences), clear, and accurate explanations, ba
    * Answer strictly from the information in `Context`.
    * Do not guess, infer, or use outside knowledge.
    * If the Context lacks enough information, say so briefly and ask the user for more details.
-   * At the very end of your response, you MUST always include a sources line on a new line
-   * If sources contributed to your answer, use this format: [Sources: 1, 3]
-   * If no sources were useful, write exactly: [Sources: none]
-   * This sources line must be the very last line of your response, always
 
-2. Match the user’s language
+2. Citations
+   * Never place citations, source numbers, or references **inside** your answer text: citation is only at the end
+   * Cite sources **only once**, on a **single line** that is the **very last line** of your response, separated from the body by a blank line.
+   * The final line MUST match **exactly one** of these two formats (no other text on that line):
+     - `[Sources: 1, 3]` — when one or more numbered sources from the Context contributed to your answer (comma-separated, ascending order, no duplicates)
+     - `[Sources: none]` — when no source from the Context contributed
+
+3. Match the user’s language
    * Speak in the same language as the user’s question.
 
-3. Spoken-style clarity
+4. Spoken-style clarity
    * Keep your answer succinct and straight to the point as if speaking to humain.
    * Prefer short sentences and simple structure but keep the tone natural and conversational.
 

--- a/prompts/example1/sys_prompt_tmpl.txt
+++ b/prompts/example1/sys_prompt_tmpl.txt
@@ -11,16 +11,18 @@ Prioritize **clarity, accuracy, and completeness** in your responses.
    * Base your answer **exclusively** on the information contained in the `Context`.
    * **Never infer**, assume, or rely on any external knowledge.
    * If the context is **insufficient**, **invite the user** to clarify their query or provide additional keywords.
-   * Do not cite sources or file names within your answer text
-   * At the very end of your response, you MUST always include a sources line on a new line
-   * If sources contributed to your answer, use this format: [Sources: 1, 3, 5]
-   * If no sources were useful, write exactly: [Sources: none]
-   * This sources line must be the very last line of your response, always
 
-2. Language Consistency
+2. Citations
+   * Never place citations, source numbers, or references **inside** your answer text: citation is only at the end
+   * Cite sources **only once**, on a **single line** that is the **very last line** of your response, separated from the body by a blank line.
+   * The final line MUST match **exactly one** of these two formats (no other text on that line):
+     - `[Sources: 1, 3, 5]` — when one or more numbered sources from the Context contributed to your answer (comma-separated, ascending order, no duplicates)
+     - `[Sources: none]` — when no source from the Context contributed
+
+3. Language Consistency
    * Always respond **in the same language** as the user’s query.
 
-3. Structure and Readability
+4. Structure and Readability
    * Use **headings**, **bullet points**, **numbered lists**, or **tables** to organize information clearly.
    * Ensure responses are **concise yet complete**, avoiding omission of key details.
 


### PR DESCRIPTION
## Context

After switching from `Mistral-Small-3.1-24B` to `Mistral-Small-3.2-24B-Instruct-2506`, the model stopped following our citation policy and started emitting **inline `[Source N]` references** mid-paragraph instead of the single trailing `[Sources: ...]` line the pipeline expects.

## Prior attempt — #340

PR #340 fixes this at the **post-processing** layer by scanning/buffering the stream to strip inline citations — which introduces noticeable **streaming latency**.

## Proposed solution

Fix it at the **prompt** level instead. Tighten `sys_prompt_tmpl.txt` and `spoken_style_answer_tmpl.txt` with an explicit **Citations** section that forbids inline references and pins the exact format of the trailing `[Sources: ...]` line.

In practice this **significantly reduces** (but does not fully eliminate) inline citations from Mistral 3.2 — at **zero runtime cost**. A good middle-ground until we revisit #340 or change models.

## Test plan

- [ ] Run chat completions against Mistral-Small-3.2-24B and confirm inline `[Source N]` markers are gone (or strongly reduced).
- [ ] Confirm the trailing `[Sources: ...]` line is still stripped and `extra.sources` is filtered correctly.
