### PR TITLE
fix(audio): use module logger in LocalWhisperLoader error path

### DIFF
--- a/openrag/components/indexer/loaders/audio/local_whisper.py
+++ b/openrag/components/indexer/loaders/audio/local_whisper.py
@@ -117,5 +117,5 @@ class LocalWhisperLoader(BaseLoader):
                 self.save_content(content, str(file_path))
             return doc
         except Exception as e:
-            self.logger.error("Error loading document", error=str(e))
-            raise e
+            logger.error("Error loading document", error=str(e))
+            raise


### PR DESCRIPTION
Fixes #367.

`LocalWhisperLoader.aload_document` calls `self.logger.error(...)` in its except branch, but neither `LocalWhisperLoader.__init__` nor `BaseLoader.__init__` ever assigns a `logger` attribute. Any failure inside `whisper_actor.transcribe.remote(...)` therefore raises `AttributeError: 'LocalWhisperLoader' object has no attribute 'logger'` and hides the original cause. Switch the call to the module-level `logger` (already imported from `utils.logger`), matching the pattern used elsewhere in this package (e.g. `base.py`, `pdf_loaders/marker.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling for audio transcription: error events are now logged consistently and exceptions are re-raised to preserve original tracebacks, aiding diagnostics.

---

*No user-facing features or bug fixes in this release.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/391)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->