### PR TITLE
fix(audio): bind tmp_wav before try in OpenAI transcribe() (#366)

### DIFF
--- a/openrag/components/indexer/loaders/audio/test_openai.py
+++ b/openrag/components/indexer/loaders/audio/test_openai.py
@@ -276,3 +276,41 @@ class TestAudioChunking:
         # Chunks should be contiguous
         for i in range(len(chunks) - 1):
             assert chunks[i][1] == chunks[i + 1][0]
+
+
+class TestTranscribeFinallyCleanup:
+    """Regression test for the UnboundLocalError in transcribe()'s finally clause.
+
+    The transcribe() method previously bound ``tmp_wav`` only inside the
+    if/else block, so if ``AudioSegment.from_file`` raised at the very top
+    of the try, the finally clause crashed with ``UnboundLocalError`` and
+    masked the real exception. We mirror the buggy / fixed control flow here
+    without pulling in the heavy real dependencies (ray, openai, etc.).
+    """
+
+    @staticmethod
+    def _buggy_transcribe():
+        try:
+            # Simulate AudioSegment.from_file raising before tmp_wav is set.
+            raise RuntimeError("audio decode failed")
+            tmp_wav = None  # noqa: F841  (unreachable, matches old code)
+        finally:
+            if tmp_wav:  # noqa: F821  (deliberately exercises the bug)
+                pass
+
+    @staticmethod
+    def _fixed_transcribe():
+        tmp_wav = None
+        try:
+            raise RuntimeError("audio decode failed")
+        finally:
+            if tmp_wav:
+                pass
+
+    def test_buggy_pattern_masks_original_error(self):
+        with pytest.raises(UnboundLocalError):
+            self._buggy_transcribe()
+
+    def test_fixed_pattern_propagates_original_error(self):
+        with pytest.raises(RuntimeError, match="audio decode failed"):
+            self._fixed_transcribe()

--- a/openrag/components/indexer/loaders/audio/test_openai.py
+++ b/openrag/components/indexer/loaders/audio/test_openai.py
@@ -279,19 +279,9 @@ class TestAudioChunking:
 
 
 class TestTranscribeFinallyCleanup:
-    """Regression test for the UnboundLocalError in transcribe()'s finally clause.
-
-    The transcribe() method previously bound ``tmp_wav`` only inside the
-    if/else block, so if ``AudioSegment.from_file`` raised at the very top
-    of the try, the finally clause crashed with ``UnboundLocalError`` and
-    masked the real exception. We mirror the buggy / fixed control flow here
-    without pulling in the heavy real dependencies (ray, openai, etc.).
-    """
-
     @staticmethod
     def _buggy_transcribe():
         try:
-            # Simulate AudioSegment.from_file raising before tmp_wav is set.
             raise RuntimeError("audio decode failed")
             tmp_wav = None  # noqa: F841  (unreachable, matches old code)
         finally:


### PR DESCRIPTION
Fixes #366.

`AudioTranscriber.transcribe()` only assigned `tmp_wav` inside the if/else block, so when `AudioSegment.from_file` raised before that point, the `finally` clause hit `UnboundLocalError` and masked the real decode failure.

Move `tmp_wav = None` ahead of the try so the cleanup branch always sees the name; the real exception now propagates to the caller. Added a small regression test that mirrors the buggy / fixed control flow without pulling in the heavy ray / openai dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test suite for audio transcription error handling, covering edge cases in control flow where variable initialization timing affects exception propagation. Test cases validate both problematic patterns that inadvertently mask errors and corrected patterns that ensure audio processing failures are properly reported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/392)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->