### PR TITLE
fix(audio): bind tmp_wav before try in OpenAI transcribe() (#366)

### DIFF
--- a/openrag/components/indexer/loaders/audio/openai.py
+++ b/openrag/components/indexer/loaders/audio/openai.py
@@ -41,12 +41,12 @@ class AudioTranscriber:
         # size inflation from WAV conversion (Scaleway cap: 100 MB; OpenAI: 25 MB).
         # Everything else falls back to WAV for vLLM/libsndfile deployments.
 
+        tmp_wav = None
         try:
             logger.bind(file=file_path.name)
             suffix = file_path.suffix.lower()
             if suffix in self.direct_upload_suffixes:
                 wav_path = file_path
-                tmp_wav = None
                 # We still need to load the audio so language detection can
                 # extract its 30-second sample. ``AudioSegment.from_file``
                 # uses ffmpeg under the hood, so it handles every format.


### PR DESCRIPTION
Completes #392, which added the regression test but did not modify `transcribe()`.

On `dev`, `tmp_wav` is only assigned inside the if/else branches of the `try`. If `AudioSegment.from_file` raises in the else path before `tmp_wav` is bound, the `finally` clause hits `UnboundLocalError` and masks the real decode failure.

Move `tmp_wav = None` ahead of the `try` so cleanup always sees the name.

Fixes #366. Pairs with #392 (regression test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of audio transcription processing by enhancing temporary file cleanup handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->