### PR TITLE
feat(inference): add ollama provider flexibility

### DIFF
--- a/.env.ollama
+++ b/.env.ollama
@@ -24,7 +24,8 @@ RERANKER_ENABLED=false
 MAX_OUTPUT_TOKENS=2048
 
 # App Settings
-SHARED_ENV=/home/hedi/Documents/workspace/openrag/.env.ollama
+# Docker Compose expands PWD from the shell; customize if your shell does not set it.
+SHARED_ENV=${PWD}/.env.ollama
 APP_PORT=8002
 CHAINLIT_PORT=8090
 DEFAULT_LANGUAGE=en-US

--- a/.env.ollama
+++ b/.env.ollama
@@ -1,0 +1,48 @@
+# LLM
+BASE_URL=http://host.docker.internal:11434/v1
+API_KEY=ollama
+MODEL=qwen2.5:0.5b
+LLM_SEMAPHORE=1
+TIMEOUT=300
+
+# VLM (Vision support)
+VLM_BASE_URL=http://host.docker.internal:11434/v1
+VLM_API_KEY=ollama
+VLM_MODEL=qwen3-vl:2b
+VLM_SEMAPHORE=1
+
+# EMBEDDER
+EMBEDDER_MODEL_NAME=dengcao/Qwen3-Embedding-0.6B:Q8_0
+EMBEDDER_BASE_URL=http://host.docker.internal:11434/v1
+EMBEDDER_API_KEY=ollama
+MAX_MODEL_LEN=2048
+
+# RAG CONFIG
+RAG_MODE=SimpleRag
+CONTEXTUAL_RETRIEVAL=false
+RERANKER_ENABLED=false
+MAX_OUTPUT_TOKENS=2048
+
+# App Settings
+SHARED_ENV=/home/hedi/Documents/workspace/openrag/.env.ollama
+APP_PORT=8002
+CHAINLIT_PORT=8090
+DEFAULT_LANGUAGE=en-US
+INDEXERUI_PORT=8060
+
+# Chainlit conversation history (SQLAlchemy -> existing rdb PostgreSQL)
+CHAINLIT_DATABASE_URL=postgresql+asyncpg://root:root_password@rdb:5432/chainlit
+DATABASE_URL=postgresql://root:root_password@rdb:5432/chainlit
+CHAINLIT_AUTH_SECRET=openrag_local_dev_secret_2026
+
+# RAY & System
+RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+RAY_NUM_GPUS=0
+RAY_DASHBOARD_PORT=8265
+RAY_memory_usage_threshold=0.99
+RAY_memory_monitor_refresh_ms=0
+SUPER_ADMIN_MODE=true
+AUTH_TOKEN=sk-1234
+SAVE_UPLOADED_FILES=true
+PDFLoader=PyMuPDFLoader
+WHISPER_N_WORKERS=0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -136,6 +136,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-root}
     volumes:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
+      - ./scripts/postgres-init:/docker-entrypoint-initdb.d:ro
     expose:
       - 5432
 
@@ -181,4 +182,3 @@ services:
     # For details see https://github.com/vllm-project/vllm/issues/21179
     profiles:
       - "cpu"
-

--- a/openrag/services/inference/__init__.py
+++ b/openrag/services/inference/__init__.py
@@ -8,6 +8,7 @@ so they can be created via ``registry.create("name", **kwargs)``.
 from ._circuit_breaker import get_breaker, with_circuit_breaker
 from ._retry import with_retry
 from .distributed_semaphore import DistributedSemaphore, DistributedSemaphoreActor
+from .ollama_client import OllamaClient, OllamaEmbedder
 from .reranker_clients import InfinityReranker, OpenAIReranker
 from .vllm_client import VLLMClient, VLLMEmbedder, VLLMVision
 
@@ -15,6 +16,8 @@ __all__ = [
     "DistributedSemaphore",
     "DistributedSemaphoreActor",
     "InfinityReranker",
+    "OllamaClient",
+    "OllamaEmbedder",
     "OpenAIReranker",
     "VLLMClient",
     "VLLMEmbedder",

--- a/openrag/services/inference/ollama_client.py
+++ b/openrag/services/inference/ollama_client.py
@@ -1,0 +1,222 @@
+"""Ollama inference clients.
+
+Ollama exposes an OpenAI-compatible ``/v1`` API since v0.1.24, so these
+clients are thin wrappers over the vLLM clients with Ollama-specific defaults
+and without vLLM-only fields (``truncate_prompt_tokens``).
+
+* ``OllamaClient``   → ``LLM``      (chat completions via /v1/chat/completions)
+* ``OllamaEmbedder`` → ``Embedder``  (embeddings via /v1/embeddings)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+from core.embeddings import Embedder, embedder_registry
+from core.llm import LLM, llm_registry
+from core.utils.exceptions import (
+    EmbeddingAPIError,
+    EmbeddingResponseError,
+    InferenceConnectionError,
+    InferenceError,
+    InferenceTimeoutError,
+)
+from utils.logger import get_logger
+
+from ._circuit_breaker import with_circuit_breaker
+from ._retry import with_retry
+from .vllm_client import _parse_response
+
+logger = get_logger()
+_ERROR_SNIPPET_LIMIT = 500
+
+
+def _error_snippet(text: str) -> str:
+    snippet = " ".join(text.split())[:_ERROR_SNIPPET_LIMIT]
+    if len(text) > _ERROR_SNIPPET_LIMIT:
+        return f"{snippet}...(truncated)"
+    return snippet
+
+
+# ---------------------------------------------------------------------------
+# LLM
+# ---------------------------------------------------------------------------
+
+
+@llm_registry.register("ollama")
+class OllamaClient(LLM):
+    """Ollama LLM client using the OpenAI-compatible /v1 API.
+
+    *endpoint* should point to the Ollama server root or include the ``/v1``
+    prefix, e.g. ``http://localhost:11434/v1``.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        model_name: str,
+        *,
+        timeout: float = 240.0,
+        **kwargs,
+    ) -> None:
+        self._endpoint = endpoint.rstrip("/")
+        if not self._endpoint.endswith("/v1"):
+            self._endpoint = f"{self._endpoint}/v1"
+        self._model = model_name
+        self._defaults: dict = kwargs
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={"Content-Type": "application/json"},
+        )
+
+    @with_circuit_breaker("llm")
+    @with_retry(max_attempts=3)
+    async def generate(self, prompt: str, **kwargs) -> dict:
+        payload = {**self._defaults, **kwargs, "model": self._model, "prompt": prompt}
+        payload.pop("metadata", None)
+        try:
+            resp = await self._client.post(f"{self._endpoint}/completions", json=payload)
+            resp.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise InferenceConnectionError(f"Cannot reach Ollama at {self._endpoint}") from exc
+        except httpx.TimeoutException as exc:
+            raise InferenceTimeoutError(f"Ollama request timed out at {self._endpoint}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise InferenceError(
+                f"Ollama error ({exc.response.status_code}): {exc.response.text[:500]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        return _parse_response(resp)
+
+    @with_circuit_breaker("llm")
+    @with_retry(max_attempts=3)
+    async def chat(self, messages: list[dict[str, str]], **kwargs) -> dict:
+        payload = {**self._defaults, **kwargs, "model": self._model, "messages": messages, "stream": False}
+        payload.pop("metadata", None)
+        try:
+            resp = await self._client.post(f"{self._endpoint}/chat/completions", json=payload)
+            resp.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise InferenceConnectionError(f"Cannot reach Ollama at {self._endpoint}") from exc
+        except httpx.TimeoutException as exc:
+            raise InferenceTimeoutError(f"Ollama request timed out at {self._endpoint}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise InferenceError(
+                f"Ollama error ({exc.response.status_code}): {exc.response.text[:500]}",
+                status_code=exc.response.status_code,
+            ) from exc
+        return _parse_response(resp)
+
+    async def stream_chat(self, messages: list[dict[str, str]], **kwargs) -> AsyncIterator[str]:
+        payload = {**self._defaults, **kwargs, "model": self._model, "messages": messages, "stream": True}
+        payload.pop("metadata", None)
+        try:
+            async with self._client.stream(
+                "POST", f"{self._endpoint}/chat/completions", json=payload
+            ) as resp:
+                if resp.status_code >= 400:
+                    await resp.aread()
+                    raise InferenceError(
+                        f"Ollama streaming error ({resp.status_code}): {resp.text[:500]}",
+                        status_code=resp.status_code,
+                    )
+                async for line in resp.aiter_lines():
+                    yield line
+        except httpx.ConnectError as exc:
+            raise InferenceConnectionError(f"Cannot reach Ollama at {self._endpoint}") from exc
+        except httpx.TimeoutException as exc:
+            raise InferenceTimeoutError(f"Ollama streaming request timed out at {self._endpoint}") from exc
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Embedder
+# ---------------------------------------------------------------------------
+
+
+@embedder_registry.register("ollama")
+class OllamaEmbedder(Embedder):
+    """Ollama embedding client using the OpenAI-compatible /v1/embeddings API."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        model_name: str,
+        *,
+        dimension: int | None = None,
+        timeout: float = 60.0,
+        **_kwargs,
+    ) -> None:
+        self._endpoint = endpoint.rstrip("/")
+        if not self._endpoint.endswith("/v1"):
+            self._endpoint = f"{self._endpoint}/v1"
+        self._model = model_name
+        self._dimension: int | None = dimension
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    @with_circuit_breaker("embedder")
+    @with_retry(max_attempts=3)
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        body = {"model": self._model, "input": texts}
+        try:
+            resp = await self._client.post(f"{self._endpoint}/embeddings", json=body)
+            resp.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise EmbeddingAPIError(
+                f"Cannot reach Ollama embedder at {self._endpoint}",
+                model_name=self._model,
+                base_url=self._endpoint,
+                error=str(exc),
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise EmbeddingAPIError(
+                f"Ollama embedder request timed out at {self._endpoint}",
+                model_name=self._model,
+                base_url=self._endpoint,
+                error=str(exc),
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise EmbeddingAPIError(
+                f"Ollama embedder API error ({exc.response.status_code})",
+                model_name=self._model,
+                base_url=self._endpoint,
+                error=_error_snippet(exc.response.text),
+            ) from exc
+
+        try:
+            data = resp.json()["data"]
+            embeddings = [item["embedding"] for item in sorted(data, key=lambda x: x["index"])]
+        except (ValueError, KeyError, IndexError, TypeError) as exc:
+            raise EmbeddingResponseError(
+                "Unexpected Ollama embedding response format",
+                model_name=self._model,
+                base_url=self._endpoint,
+                error=str(exc),
+            ) from exc
+
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+        return embeddings
+
+    async def embed_single(self, text: str) -> list[float]:
+        result = await self.embed([text])
+        if not result:
+            raise EmbeddingResponseError(
+                "Empty Ollama embedding response",
+                model_name=self._model,
+                base_url=self._endpoint,
+                error="No vectors returned",
+            )
+        return result[0]
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is None:
+            raise RuntimeError("Embedding dimension unknown — call embed() first")
+        return self._dimension
+
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/openrag/services/inference/test_ollama_client.py
+++ b/openrag/services/inference/test_ollama_client.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from core.utils.exceptions import (
+    EmbeddingAPIError,
+    EmbeddingResponseError,
+    InferenceConnectionError,
+    InferenceError,
+    InferenceTimeoutError,
+)
+from services.inference._circuit_breaker import _breakers
+
+from .ollama_client import OllamaClient, OllamaEmbedder
+
+
+@pytest.fixture(autouse=True)
+def _clean_breakers():
+    yield
+    for breaker in _breakers.values():
+        breaker.close()
+    _breakers.clear()
+
+
+def _make_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def _chat_response(content: str = "hello") -> httpx.Response:
+    return httpx.Response(200, json={"choices": [{"message": {"content": content}}]})
+
+
+def _completions_response(text: str = "result") -> httpx.Response:
+    return httpx.Response(200, json={"choices": [{"text": text}]})
+
+
+def _embed_response(vectors: list[list[float]] | None = None) -> httpx.Response:
+    vectors = vectors or [[0.1, 0.2, 0.3]]
+    data = [{"index": i, "embedding": v} for i, v in enumerate(vectors)]
+    return httpx.Response(200, json={"data": data})
+
+
+# ---------------------------------------------------------------------------
+# OllamaClient (LLM)
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaClient:
+    def _make_client(self, handler, endpoint="http://ollama:11434", **kwargs):
+        client = OllamaClient(endpoint=endpoint, model_name="llama3", **kwargs)
+        client._client = httpx.AsyncClient(transport=_make_transport(handler))
+        return client
+
+    @pytest.mark.asyncio
+    async def test_chat_returns_full_response(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "/v1/chat/completions" in str(request.url)
+            assert body["model"] == "llama3"
+            assert body["stream"] is False
+            return _chat_response("world")
+
+        result = await self._make_client(handler).chat([{"role": "user", "content": "hi"}])
+        assert result["choices"][0]["message"]["content"] == "world"
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_full_response(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "/v1/completions" in str(request.url)
+            assert "/chat/" not in str(request.url)
+            assert body["prompt"] == "say something"
+            return _completions_response("done")
+
+        result = await self._make_client(handler).generate("say something")
+        assert result["choices"][0]["text"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_yields_raw_sse_lines(self):
+        sse_body = (
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}\n'
+            'data: {"choices":[{"delta":{"content":" world"}}]}\n'
+            "data: [DONE]\n"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content)["stream"] is True
+            return httpx.Response(200, text=sse_body)
+
+        client = self._make_client(handler)
+        lines = [line async for line in client.stream_chat([{"role": "user", "content": "hi"}])]
+        assert 'data: {"choices":[{"delta":{"content":"Hello"}}]}' in lines
+        assert 'data: {"choices":[{"delta":{"content":" world"}}]}' in lines
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_error_raises(self):
+        client = self._make_client(lambda req: httpx.Response(503, text="unavailable"))
+        with pytest.raises(InferenceError):
+            async for _ in client.stream_chat([{"role": "user", "content": "hi"}]):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_chat_connection_error(self):
+        async def fail(*a, **kw):
+            raise httpx.ConnectError("refused")
+
+        client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
+        client._client = AsyncMock()
+        client._client.post = fail
+        with pytest.raises(InferenceConnectionError):
+            await client.chat([{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_timeout(self):
+        async def fail(*a, **kw):
+            raise httpx.TimeoutException("timeout")
+
+        client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
+        client._client = AsyncMock()
+        client._client.post = fail
+        with pytest.raises(InferenceTimeoutError):
+            await client.chat([{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_http_error_raises_inference_error(self):
+        client = self._make_client(lambda req: httpx.Response(500, text="server error"))
+        with pytest.raises(InferenceError):
+            await client.chat([{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_defaults_forwarded(self):
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        await self._make_client(capture, temperature=0.7).chat([{"role": "user", "content": "hi"}])
+        assert captured["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_per_request_kwargs_override_defaults(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["temperature"] == 0.1
+            assert body["max_tokens"] == 256
+            return _chat_response()
+
+        await self._make_client(handler, temperature=0.9).chat(
+            [{"role": "user", "content": "hi"}], temperature=0.1, max_tokens=256
+        )
+
+    @pytest.mark.asyncio
+    async def test_metadata_stripped_from_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "metadata" not in body
+            return _chat_response()
+
+        await self._make_client(handler).chat(
+            [{"role": "user", "content": "hi"}], metadata={"llm_override": {}}
+        )
+
+    @pytest.mark.asyncio
+    async def test_metadata_default_stripped_from_generate_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "metadata" not in body
+            return _completions_response()
+
+        await self._make_client(handler, metadata={"llm_override": {}}).generate("hi")
+
+    @pytest.mark.asyncio
+    async def test_metadata_default_stripped_from_chat_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "metadata" not in body
+            return _chat_response()
+
+        await self._make_client(handler, metadata={"llm_override": {}}).chat(
+            [{"role": "user", "content": "hi"}]
+        )
+
+    @pytest.mark.asyncio
+    async def test_metadata_default_stripped_from_stream_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "metadata" not in body
+            return httpx.Response(200, text="data: [DONE]\n")
+
+        client = self._make_client(handler, metadata={"llm_override": {}})
+        lines = [line async for line in client.stream_chat([{"role": "user", "content": "hi"}])]
+        assert lines == ["data: [DONE]"]
+
+    def test_endpoint_v1_appended_when_missing(self):
+        client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
+        assert client._endpoint == "http://ollama:11434/v1"
+
+    def test_endpoint_v1_not_doubled(self):
+        client = OllamaClient(endpoint="http://ollama:11434/v1", model_name="llama3")
+        assert client._endpoint == "http://ollama:11434/v1"
+
+    def test_trailing_slash_stripped(self):
+        client = OllamaClient(endpoint="http://ollama:11434/v1/", model_name="llama3")
+        assert client._endpoint == "http://ollama:11434/v1"
+
+    def test_no_auth_header_sent_by_default(self):
+        client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
+        assert "Authorization" not in client._client.headers
+
+    @pytest.mark.asyncio
+    async def test_aclose(self):
+        client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
+        client._client = AsyncMock()
+        await client.aclose()
+        client._client.aclose.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# OllamaEmbedder
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaEmbedder:
+    def _make_embedder(self, handler, endpoint="http://ollama:11434", **kwargs):
+        embedder = OllamaEmbedder(endpoint=endpoint, model_name="nomic-embed-text", **kwargs)
+        embedder._client = httpx.AsyncClient(transport=_make_transport(handler))
+        return embedder
+
+    @pytest.mark.asyncio
+    async def test_embed_returns_sorted_vectors(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["model"] == "nomic-embed-text"
+            assert body["input"] == ["hello", "world"]
+            return httpx.Response(
+                200,
+                json={"data": [{"index": 1, "embedding": [0.3, 0.4]}, {"index": 0, "embedding": [0.1, 0.2]}]},
+            )
+
+        result = await self._make_embedder(handler).embed(["hello", "world"])
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+    @pytest.mark.asyncio
+    async def test_embed_single(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.5, 0.6, 0.7]}]})
+
+        result = await self._make_embedder(handler).embed_single("test")
+        assert result == [0.5, 0.6, 0.7]
+
+    @pytest.mark.asyncio
+    async def test_dimension_auto_detected(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]})
+
+        embedder = self._make_embedder(handler)
+
+        with pytest.raises(RuntimeError, match="unknown"):
+            _ = embedder.dimension
+
+        await embedder.embed(["test"])
+        assert embedder.dimension == 3
+
+    def test_dimension_from_init(self):
+        assert OllamaEmbedder(endpoint="http://ollama:11434", model_name="m", dimension=768).dimension == 768
+
+    @pytest.mark.asyncio
+    async def test_no_truncate_prompt_tokens_in_payload(self):
+        """Ollama doesn't support truncate_prompt_tokens — must never be sent."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "truncate_prompt_tokens" not in json.loads(request.content)
+            return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1]}]})
+
+        await self._make_embedder(handler).embed(["test"])
+
+    @pytest.mark.asyncio
+    async def test_embed_connection_error(self):
+        async def fail(*a, **kw):
+            raise httpx.ConnectError("refused")
+
+        embedder = OllamaEmbedder(endpoint="http://ollama:11434", model_name="nomic-embed-text")
+        embedder._client = AsyncMock()
+        embedder._client.post = fail
+        with pytest.raises(EmbeddingAPIError):
+            await embedder.embed(["text"])
+
+    @pytest.mark.asyncio
+    async def test_embed_timeout(self):
+        async def fail(*a, **kw):
+            raise httpx.TimeoutException("timeout")
+
+        embedder = OllamaEmbedder(endpoint="http://ollama:11434", model_name="nomic-embed-text")
+        embedder._client = AsyncMock()
+        embedder._client.post = fail
+        with pytest.raises(EmbeddingAPIError):
+            await embedder.embed(["text"])
+
+    @pytest.mark.asyncio
+    async def test_embed_http_error_raises_embedding_api_error(self):
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="service unavailable")
+
+        with pytest.raises(EmbeddingAPIError):
+            await self._make_embedder(handler).embed(["text"])
+
+    @pytest.mark.asyncio
+    async def test_embed_http_error_truncates_response_body(self):
+        body = "secret-token " + ("x" * 1000)
+
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text=body)
+
+        with pytest.raises(EmbeddingAPIError) as exc_info:
+            await self._make_embedder(handler).embed(["text"])
+
+        error = exc_info.value.extra["error"]
+        assert len(error) < len(body)
+        assert error.endswith("...(truncated)")
+
+    @pytest.mark.asyncio
+    async def test_embed_bad_response_format(self):
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"wrong": "shape"})
+
+        with pytest.raises(EmbeddingResponseError):
+            await self._make_embedder(handler).embed(["text"])
+
+    @pytest.mark.asyncio
+    async def test_embed_single_empty_response_raises_embedding_response_error(self):
+        def handler(_req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": []})
+
+        with pytest.raises(EmbeddingResponseError, match="Empty Ollama embedding response"):
+            await self._make_embedder(handler).embed_single("text")
+
+    def test_endpoint_v1_appended_when_missing(self):
+        embedder = OllamaEmbedder(endpoint="http://ollama:11434", model_name="m")
+        assert embedder._endpoint == "http://ollama:11434/v1"
+
+    def test_endpoint_v1_not_doubled(self):
+        embedder = OllamaEmbedder(endpoint="http://ollama:11434/v1", model_name="m")
+        assert embedder._endpoint == "http://ollama:11434/v1"
+
+    @pytest.mark.asyncio
+    async def test_aclose(self):
+        embedder = OllamaEmbedder(endpoint="http://ollama:11434", model_name="m")
+        embedder._client = AsyncMock()
+        await embedder.aclose()
+        embedder._client.aclose.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    def test_llm_registered(self):
+        from core.llm import llm_registry
+
+        assert "ollama" in llm_registry
+
+    def test_embedder_registered(self):
+        from core.embeddings import embedder_registry
+
+        assert "ollama" in embedder_registry

--- a/scripts/postgres-init/01-chainlit.sql
+++ b/scripts/postgres-init/01-chainlit.sql
@@ -1,0 +1,64 @@
+CREATE DATABASE chainlit;
+
+\connect chainlit
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS "User" (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    identifier text NOT NULL UNIQUE,
+    metadata text DEFAULT '{}'::text NOT NULL,
+    "createdAt" timestamptz DEFAULT now() NOT NULL,
+    "updatedAt" timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "Thread" (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    name text,
+    "userId" uuid REFERENCES "User"(id) ON DELETE SET NULL,
+    tags text[],
+    metadata text DEFAULT '{}'::text NOT NULL,
+    "createdAt" timestamptz DEFAULT now() NOT NULL,
+    "deletedAt" timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS "Step" (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    "threadId" uuid REFERENCES "Thread"(id) ON DELETE CASCADE,
+    "parentId" uuid,
+    input jsonb DEFAULT '{}'::jsonb,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    name text,
+    output jsonb DEFAULT '{}'::jsonb NOT NULL,
+    type text NOT NULL,
+    "startTime" timestamptz,
+    "endTime" timestamptz,
+    "showInput" text,
+    "isError" boolean,
+    "createdAt" timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS "Feedback" (
+    id text PRIMARY KEY,
+    "stepId" uuid NOT NULL REFERENCES "Step"(id) ON DELETE CASCADE,
+    name text DEFAULT 'user_feedback'::text NOT NULL,
+    value double precision NOT NULL,
+    comment text
+);
+
+CREATE TABLE IF NOT EXISTS "Element" (
+    id text PRIMARY KEY,
+    "threadId" uuid REFERENCES "Thread"(id) ON DELETE CASCADE,
+    "stepId" uuid REFERENCES "Step"(id) ON DELETE CASCADE,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    mime text,
+    name text NOT NULL,
+    "objectKey" text,
+    url text,
+    "chainlitKey" text,
+    display text,
+    size text,
+    language text,
+    page integer,
+    props jsonb DEFAULT '{}'::jsonb NOT NULL
+);

--- a/scripts/postgres-init/01-chainlit.sql
+++ b/scripts/postgres-init/01-chainlit.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS "Thread" (
 CREATE TABLE IF NOT EXISTS "Step" (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     "threadId" uuid REFERENCES "Thread"(id) ON DELETE CASCADE,
-    "parentId" uuid,
+    "parentId" uuid REFERENCES "Step"(id) ON DELETE SET NULL,
     input jsonb DEFAULT '{}'::jsonb,
     metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
     name text,


### PR DESCRIPTION
Context

Phase 6 moves external inference providers behind service-layer adapters and registry wiring. vLLM support already covered OpenAI-compatible inference, but Ollama needed its own provider entry so deployments can choose local Ollama models without coupling callers to provider-specific details.

Problem

Without a registered Ollama adapter, local Ollama deployments cannot be selected through the same inference abstraction as vLLM and rerankers. That keeps provider choice less flexible and makes local-model setups harder to validate.

What changed

This adds Ollama as a first-class LLM and embedding provider using its OpenAI-compatible API. It keeps Ollama-specific request differences contained inside the adapter, maps transport failures into OpenRAG domain errors, and registers the provider through the inference service package.

Validation

- 36 focused Ollama and inference DI tests pass.
- The layer import guard passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ollama inference integration: chat completions (including streaming) and embeddings with endpoint normalization and robust error handling.

* **Tests**
  * Extensive test coverage for Ollama clients: request/stream behavior, error mapping, payload validation, and registry integration.

* **Chores**
  * Added environment configuration for Ollama and app defaults, DB init scripts, and adjusted compose setup to load DB initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->