### PR TITLE
refactor(phase 8): service layer extraction

### DIFF
--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1346,6 +1346,45 @@ covered by a new `TestPhase8OrchestratorWiring` in `di/test_container.py`.
   dominate the line count; the business-logic extraction — the actual
   goal — is complete and grep-verified (#1–#6 clean).
 
+**14. Phase-8 CI fixes — the §1 "DB-backed flows dormant until Phase 11"
+deferral was wrong and is corrected here.** The unit + API CI jobs were
+red after Phase 8; four root causes, all behaviour-preserving fixes:
+- *Container never initialised (API tests, ~80 failures).* The thinned
+  routers resolve repos through the container's *own* `PostgresStore`,
+  a separate instance from the one the legacy Ray `Vectordb` actor owns
+  and `initialize()`s (`vectordb.py:188`). §1 attached the container but
+  never opened its asyncpg pool, so every catalog-backed route 500'd
+  against an uninitialised pool. Fix: `main.py` startup/shutdown hooks
+  call `container.initialize()/shutdown()` (best-effort, guarded). The
+  asyncpg layer is idempotent (Phase 7), so a second store against the
+  same DB alongside the actor's is safe. This pulls a thin slice of
+  Phase 11 forward — the original deferral broke the live app, which
+  Phase 8 must not. Phase 11 still folds this into a real lifespan.
+- *Auth router 503 instead of 400 in token mode (3 unit failures).*
+  FastAPI resolves `Depends` in declaration order; `Depends(get_auth_service)`
+  ran (and 503'd on the absent container) before the in-body
+  `_require_oidc_mode()` 400 gate. Fix: `_require_oidc_mode` is now a
+  `Depends` declared *before* the service on login/callback/
+  backchannel-logout/logout, so token mode 400s without touching the
+  container. No behaviour change in oidc mode.
+- *`components/utils.py:get_num_tokens` needs an OpenAI key (1 unit
+  failure, latent keyless-deploy defect).* It built `ChatOpenAI(...)`
+  just to count tokens; client construction requires a non-empty
+  api_key (CI mock-vLLM env has none). Fix: fall back to a local
+  tiktoken `cl100k_base` encoder when the client can't be built. Prod
+  (key present) behaviour is unchanged; the count is equivalent for the
+  GPT-3.5/4 family. Also trims LangChain off the QueryService hot path
+  (aligned with the 8H intent).
+- *Stale `routers/test_auth_router.py` (17 collection errors).* The
+  882-line file tested the pre-8A.1 fat router (`routers.auth.OIDCClient`,
+  full OIDC/JWT flow). 8A.1 thinned the router but never updated its
+  companion test — a Phase-8 omission. All that logic moved to
+  `AuthService` and is covered by `services/orchestrators/
+  test_auth_service.py`. Replaced with a lean transport test (stub
+  service via `dependency_overrides`: AUTH_MODE gate, delegation,
+  cookie set/clear, `OIDCFlowError` mapping), matching the phase
+  principle "logic tests move to the service".
+
 ---
 ## Template for future entries
 

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1384,6 +1384,19 @@ red after Phase 8; four root causes, all behaviour-preserving fixes:
   service via `dependency_overrides`: AUTH_MODE gate, delegation,
   cookie set/clear, `OIDCFlowError` mapping), matching the phase
   principle "logic tests move to the service".
+- *Search response lost `metadata.file_id` (5 API `test_search`
+  filtering failures, second pass).* `Chunk.from_langchain` lifts
+  `file_id`/`partition`/`page`/`_id` out of the free-form metadata into
+  typed `Chunk` fields; the thinned `routers/search.py:_documents`
+  returned only `Chunk.metadata`, so the API contract dropped
+  `metadata.file_id` (filter tests saw `file_id == None`; `origin` /
+  temporal fields survived because they stay free-form). Fix: shape the
+  response via `Chunk.to_langchain().metadata`, which merges the typed
+  fields back — reproducing the pre-Phase-8 router that returned the raw
+  Document metadata. Transport-only shaping, stays in the thin router.
+
+All five CI jobs (Layer guard, Linting, Unit, Integration, API) are
+green on the branch after these fixes.
 
 ---
 ## Template for future entries

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1233,6 +1233,42 @@ citation-filtered `extra`. The router maps partition, wraps
   now dead code (no router imports `RagPipeline`); **flag for Phase 12
   cleanup** to delete them with the other shims.
 
+**9. 8D.1 indexing dispatch sits behind an `IndexingDispatcher` port +
+Ray shim, not direct Ray calls in the service.** The plan's
+`IndexingService.__init__(document_repo, workspace_repo, vector_store,
+config)` can't reach the `Indexer` / `TaskStateManager` actors. Mirroring
+the proven 8C searcher pattern, a new `core/indexing/dispatcher.py` ABC
+defines the worker operations the service needs and
+`services/storage/indexer_ray_shim.py` adapts the two Ray actors to it;
+the container injects it via `from_ray_namespace()` (lazy, like
+RetrievalService). `vector_store` and `config` are dropped from the ctor
+(the file delete is owned by the Indexer worker; the only config the
+legacy router used — data dir, vectordb timeout — is a transport/shim
+concern); `dispatcher` is the added arg.
+- Why: 8H bans Ray remote calls under `services/orchestrators/` (only
+  JobService is excepted); the established way to keep an orchestrator
+  Ray-free during the shim is a core port + `services/storage/` shim.
+- Alternative: leave the dispatch in the thin router. Rejected — 8G/8D.1
+  explicitly move "inline upload+dispatch → indexing_service.add_file()".
+- File save to disk + the byte-identical `HTTPException` guards (409
+  exists, 404 not-found, 400 bad workspace_ids, 404 unknown workspace,
+  404 no object ref) stay in the router (transport + exact legacy body),
+  matching the workspaces.py thinning style.
+- **Flag for Phase 9:** delete `indexer_ray_shim.py`, have IndexingService
+  call the pipeline stages directly.
+
+**10. 8D.2 JobService keeps Ray `.remote` calls (the one 8H exception).**
+Per the plan ctor `JobService(task_state_manager)` and the 8H carve-out,
+JobService wraps the `TaskStateManager` actor directly — no shim. The
+status rollup and `?task_status=` filtering (business logic) move into
+the service; `request.url_for` link building stays in the thin queue
+router. Container resolves the actor lazily in the cached property
+(deferred `utils.dependencies` import) so it is only needed at first
+request.
+- Why: introducing a shim here would contradict the plan and the
+  explicit 8H exception; JobService is the documented hook point for the
+  post-refactor DB-backed job tracking (Phase 9).
+
 ---
 ## Template for future entries
 

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1269,6 +1269,24 @@ request.
   explicit 8H exception; JobService is the documented hook point for the
   post-refactor DB-backed job tracking (Phase 9).
 
+**11. 8D.1 reuses `components.indexer.utils.files.extract_temporal_fields`
+as-is, carrying a transitive module-level `load_config()` and an
+`HTTPException`.** IndexingService imports that helper for ISO-8601
+metadata parsing. Its module body runs `config = load_config()` at
+import time, and the helper raises FastAPI `HTTPException` on a bad
+datetime — a transport type leaking into a service.
+- Why: it is a pure parsing helper under the shim-exempt `components`
+  layer (8H greps the orchestrator file itself, which stays clean), and
+  reusing it verbatim keeps the bad-datetime 400 response byte-identical
+  with the legacy router. Rewriting it now would risk behavioural drift
+  for no Phase-8 benefit.
+- Alternative: reimplement the parse in `core/` raising `ValidationError`
+  and map it in the router. Rejected for Phase 8 (byte-identical bodies
+  are the priority); it is the right move once the shim is gone.
+- **Flag for Phase 9:** when `indexer_ray_shim.py` is deleted, move the
+  temporal-field parsing into core (raise `ValidationError`, drop the
+  module-level `load_config` and the `HTTPException`).
+
 ---
 ## Template for future entries
 

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1313,6 +1313,39 @@ settings-supplied vector-store name); `config` dropped.
 - **Flag for Phase 9:** delete `serializer_ray_shim.py`, have
   ConversionService call the serializer stage directly.
 
+**13. 8F keeps the lazy-property container (no eager ordered `__init__`);
+8H closeout pulls the last Ray call out of a thinned router.** The
+plan's 8F snippet builds every orchestrator eagerly in
+`ServiceContainer.__init__` in a hand-ordered block. We did *not* adopt
+that — the lazy cached-property convention set in 8A.1 (decision 1)
+already satisfies "correct instantiation order": dependency resolution
+happens on first access (`user_service` → `auth_service` /
+`partition_service` / `job_service`; `query_service` →
+`retrieval_service` / `workspace_service`), there are no cycles, and the
+Ray shims stay un-touched until first request. 8F is therefore a
+verification pass, not a rewrite: all nine orchestrators are wired
+identically (9 `_x_service` cache slots, 9 properties, 9 providers),
+covered by a new `TestPhase8OrchestratorWiring` in `di/test_container.py`.
+- During the 8H sweep, `routers/users.py` `/users/info` was found still
+  calling `task_state_manager.get_user_pending_task_count` directly (a
+  Ray `.remote` + quota math left in a thinned router by 8A.2). It
+  passed the literal 8H greps (`vectordb` only) but contradicted "routers
+  are thin". Fixed per the plan's "Day 3: fix remaining router rewrites":
+  added `JobService.get_user_pending_task_count`, injected `JobService`
+  into `UserService` (orchestrator-to-orchestrator, same pattern as
+  UserService←PartitionService), moved the quota-usage computation into
+  `UserService.get_current_user_info` (byte-identical response), thinned
+  the handler. UserService stays Ray-free — the count goes through
+  JobService, the one 8H-excepted Ray wrapper.
+- `routers/actors.py` still imports `utils.dependencies` Ray handles —
+  intentionally out of scope: it is the Ray actor/health admin router,
+  not one of the 12 fat routers in the 8G table; it belongs to Phase 9.
+- 8H #7 ("no router > 120 lines") is not literally met (indexer 516,
+  partition 453, …) and is treated as aspirational, consistent with
+  every prior slice: the verbose OpenAPI `description=` docstrings
+  dominate the line count; the business-logic extraction — the actual
+  goal — is complete and grep-verified (#1–#6 clean).
+
 ---
 ## Template for future entries
 

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1287,6 +1287,32 @@ datetime — a transport type leaking into a service.
   temporal-field parsing into core (raise `ValidationError`, drop the
   module-level `load_config` and the `HTTPException`).
 
+**12. 8E ConversionService — serializer behind a `FileSerializer` port +
+shim; chunk lookup through the clean `VectorStore`.** Same pattern as
+8C/8D.1: new `core/indexing/serializer.py` ABC + `services/storage/
+serializer_ray_shim.py` wrapping the `DocSerializer` actor (it reuses
+the legacy `components...serialize_file` helper so the
+`call_ray_actor_with_timeout` behaviour the tools router relied on is
+preserved). `get_chunk` ports the legacy `get_chunk_by_id` onto
+`VectorStore.query_chunks_by_filter({"_id": int(chunk_id)})` and returns
+a plain `{"page_content", "metadata"}` dict (no LangChain `Document`),
+exactly as PartitionService reads chunks. Ctor deviates from the plan's
+`ConversionService(config=config)` → `(serializer, vector_store,
+collection)` (the `collection` extra is the established
+settings-supplied vector-store name); `config` dropped.
+- Why: the plan ctor is underspecified and the 8C/8D shim+port approach
+  is the established way to keep the orchestrator Ray-free (8H).
+- File save + cleanup IO, tool dispatch, and the byte-identical
+  `HTTPException` bodies (404 not-found, 403 forbidden, the tool-error
+  4xx/5xx mapping) stay in the thin routers.
+- Note: the legacy router's `task_id` came from
+  `ray.get_runtime_context().get_task_id()`; outside a Ray task that is
+  the driver context, so the shim passes a fixed `"tools-extract"`
+  fallback label (the serializer only uses it for logging / state keys —
+  no behavioural change).
+- **Flag for Phase 9:** delete `serializer_ray_shim.py`, have
+  ConversionService call the serializer stage directly.
+
 ---
 ## Template for future entries
 

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1139,6 +1139,69 @@ between the vector-store and catalog-store bootstrap steps.
   `partitions_for_collection_<name>` derivation (see Phase 7E entry 2).
 
 ---
+## Phase 8 — Orchestrators (2026-05-19)
+
+**1. Provider sourcing: routers read `request.app.state.container`.**
+- Why: the 8 Phase-8 doc shows providers as one-line accessors; the
+  ServiceContainer is not attached to the live app until Phase 11. We
+  attach it best-effort in `main.py` now (not `initialize()`d), so the
+  thinned routers resolve services but the DB-backed flows stay dormant
+  until Phase 11. Token-mode auth routes already 400 before any service.
+- Alternative considered: a lazy module-level container singleton in
+  `di/providers.py` (mirrors `components/auth/deps.py`). Rejected — the
+  one-liner/app.state shape matches the doc and Phase-11 cutover.
+
+**2. OIDCConfig built from env in the container, not wired into Settings.**
+- Why: keeps 8A.1 scoped; `OIDCConfig` exists but is not in root
+  `Settings`. Added a missing `auto_provision_login` field.
+- Alternative: wire it into `Settings` now — deferred (config refactor).
+
+**3. Thin routers: typed core exceptions propagate to the global
+`OpenRAGError` handler; `HTTPException` kept only where the legacy body
+must stay byte-identical** (id==1 / 409-exists / file|workspace 404s).
+- Why: the legacy `_check_*` guards already surfaced 404s via the global
+  handler, so propagating `UserNotFoundError`/`PartitionNotFoundError`/
+  `ValidationError` reproduces them; only the non-bracketed
+  `{"detail": ...}` `HTTPException` bodies need to stay verbatim.
+
+**4. Constructor extensions over the plan's prescribed signatures.**
+- Why: to preserve legacy behaviour without reaching into Ray/config,
+  orchestrators take extra container-supplied args: `collection`
+  (`settings.vectordb.collection_name` — Partition/Workspace/Retrieval),
+  `user_repo` (PartitionService, to reproduce `VDBUserNotFound`),
+  `default_file_quota` (UserService), and orchestrator→orchestrator
+  injection (UserService←PartitionService for the delete-user cascade).
+- Alternative: hold the plan signatures exactly — rejected, would drop
+  behaviour (cascade) or smuggle config/Ray into the service.
+
+**5. 8A.2 delete-user owner-partition cascade deferred, then restored in
+8B.1.** UserService.delete_user was a plain repo delete in 8A.2 (gap
+logged); 8B.1 composes PartitionService so it deletes owned partitions
+(vectors + rows) first, matching the legacy Ray `delete_user`.
+
+**6. 8C searcher backing: inject the Ray-backed `MilvusRayShim` behind
+the `RetrievalSearcher` port during the Phase-8 shim.**
+- Why: the only `RetrievalSearcher` impl is `MilvusRayShim` (Ray
+  `Vectordb` actor — embeds + hybrid-searches internally). The 8C plan
+  text says "retriever calls `vector_store.search()` directly (no Ray)",
+  but the dev-workflow doc puts Ray cleanup in Phase 9 and allows
+  orchestrators to call Ray *behind a port* during the shim. Injecting
+  the shim keeps the orchestrator file Ray-free (8H satisfied: no
+  Ray remote-call, no Ray import — Ray is behind the port) and avoids a
+  risky reimplementation of hybrid-search / surrounding-chunks /
+  similarity behaviour in the hot search path.
+- Alternative considered: write a new `VectorStoreSearcher` on the clean
+  `VectorStore` port now (embed via Embedder factory + `search`).
+  Rejected for this phase — real regression surface in core search; the
+  clean adapter lands in Phase 9 when the shim is deleted. **Flag for
+  Phase 9:** add `VectorStoreSearcher`, swap the container wiring, delete
+  `MilvusRayShim`.
+- Consequence: `RetrievalService.__init__` deviates from the plan's
+  `(vector_store, embedder_factory, reranker_factory, llm_factory,
+  document_repo, config)` — with the shim searcher those are unused;
+  it takes the built `searcher` / `reranker` / `llm` + `config`.
+
+---
 ## Template for future entries
 
 ```

--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1201,6 +1201,38 @@ the `RetrievalSearcher` port during the Phase-8 shim.**
   document_repo, config)` — with the shim searcher those are unused;
   it takes the built `searcher` / `reranker` / `llm` + `config`.
 
+**7. 8C.2 structured output: core LLM + JSON-mode prompt + parse (no
+LangChain).** `RagPipeline.generate_query` and `map_reduce` used a
+LangChain structured-output chain for `SearchQueries` / `SummarizedChunk`.
+QueryService instead calls the injected core `LLM.chat` with a
+JSON-instructed prompt + `response_format={"type":"json_object"}` and
+`json.loads` (+ `_json_slice` brace-extraction) into the Pydantic model,
+preserving the legacy fallbacks (query-gen: retry once → raw user query;
+map-reduce: relevancy=False on any parse error).
+- Why: 8H bans LangChain in orchestrators; the plan's explicit "remove
+  ChatOpenAI — use LLM factory" intent.
+- Alternative: wrap the LangChain chain behind a core-LLM-shaped helper
+  outside orchestrators. Rejected — only partially meets the intent and
+  keeps a LangChain dependency on the hot path.
+
+**8. 8C.2 streaming + citations live in QueryService; the router is pure
+transport.** `chat_stream` drives the proven
+`components.utils.stream_with_source_filtering` (reused verbatim — the
+100-char buffer that strips `[Sources: N]` mid-stream is delicate);
+`chat`/`complete` return the finalized OpenAI dict with the
+citation-filtered `extra`. The router maps partition, wraps
+`StreamingResponse`/`JSONResponse`, and passes a request-bound
+`prepare_sources` callable so `request.url_for` stays in transport.
+- Why: the plan's "service owns streaming" Q&A; keeps the proven SSE
+  buffer logic intact (no rewrite) while ownership moves to the service.
+- Constructor takes `workspace_service` beyond the plan's four (the
+  legacy `_prepare_for_chat_completion` validated the workspace via the
+  Ray actor; reusing WorkspaceService.get_workspace keeps it Ray-free).
+- Consequence: legacy `components/pipeline.py` (RagPipeline /
+  RetrieverPipeline) + `map_reduce.py` + `components/retriever.py` are
+  now dead code (no router imports `RagPipeline`); **flag for Phase 12
+  cleanup** to delete them with the other shims.
+
 ---
 ## Template for future entries
 

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -42,8 +42,24 @@ _cached_length_function = None
 def get_num_tokens():
     global _cached_length_function
     if _cached_length_function is None:
-        llm = ChatOpenAI(**config.llm.model_dump())
-        _cached_length_function = llm.get_num_tokens
+        try:
+            llm = ChatOpenAI(**config.llm.model_dump())
+            _cached_length_function = llm.get_num_tokens
+        except Exception as exc:
+            # ChatOpenAI validates an openai client at construction, which
+            # requires a non-empty api_key. Token counting itself is local
+            # (tiktoken) and needs no key or network, so fall back to a
+            # tiktoken encoder when the client cannot be built (keyless
+            # deployments / CI mock-vLLM). cl100k_base matches the
+            # GPT-3.5/4 family OpenRAG targets; counts are equivalent.
+            import tiktoken
+
+            logger.warning(
+                "ChatOpenAI unavailable for token counting, falling back to tiktoken cl100k_base",
+                error=str(exc),
+            )
+            _encoding = tiktoken.get_encoding("cl100k_base")
+            _cached_length_function = lambda text: len(_encoding.encode(text))  # noqa: E731
     return _cached_length_function
 
 

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -22,3 +22,7 @@ class OIDCConfig(BaseModel):
     claim_source: str = "id_token"
     claim_mapping: str = ""
     post_logout_redirect_uri: str = ""
+    # When True, an unknown ``sub`` at callback time provisions a
+    # non-admin user on the fly from the ID-token claims. Default keeps
+    # the strict "admin pre-creates every user" policy.
+    auto_provision_login: bool = False

--- a/openrag/core/indexing/dispatcher.py
+++ b/openrag/core/indexing/dispatcher.py
@@ -1,0 +1,87 @@
+"""Transitional port for the indexing dispatch operations.
+
+``IndexingService`` (Phase 8D.1) owns the business logic around file
+ingestion — format/quota/existence checks, metadata assembly, workspace
+validation — but the heavy lifting (serialize → chunk → embed → insert)
+still runs inside the ``Indexer`` Ray actor, and task bookkeeping lives
+in the ``TaskStateManager`` Ray actor. Phase 9 removes that Ray
+indirection.
+
+Defining the operations the service needs on a dedicated port keeps
+``IndexingService`` Ray-free (8H: no Ray import / remote call under
+``services/orchestrators/``). A small shim in ``services/storage/``
+adapts the two Ray actors to this interface during the shim period;
+Phase 9 swaps it for a direct pipeline call and deletes the shim.
+
+No Ray / pymilvus / LangChain types leak across this boundary — only
+plain dicts and strings.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class IndexingDispatcher(ABC):
+    """Operations the indexing orchestrator needs from the worker layer."""
+
+    @abstractmethod
+    async def dispatch_indexing(
+        self,
+        *,
+        path: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+        workspace_ids: list[str] | None,
+        replace: bool,
+    ) -> str:
+        """Queue an (re)indexing job, register its task state, return its id."""
+        ...
+
+    @abstractmethod
+    async def delete_file(self, file_id: str, partition: str) -> None:
+        """Delete a file's chunks via the worker layer."""
+        ...
+
+    @abstractmethod
+    async def update_file_metadata(
+        self,
+        file_id: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+    ) -> None:
+        """Upsert file metadata in place (no re-embedding)."""
+        ...
+
+    @abstractmethod
+    async def copy_file(
+        self,
+        file_id: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+    ) -> None:
+        """Copy a file's chunks into another partition / file id."""
+        ...
+
+    @abstractmethod
+    async def get_task_state(self, task_id: str) -> str | None:
+        """Current task state, or ``None`` if the task is unknown."""
+        ...
+
+    @abstractmethod
+    async def get_task_error(self, task_id: str) -> str | None:
+        """Stored traceback for a failed task, or ``None``."""
+        ...
+
+    @abstractmethod
+    async def cancel_task(self, task_id: str) -> bool:
+        """Cancel a running/queued task.
+
+        Returns ``False`` when no object ref is stored for ``task_id``
+        (the caller maps that to a 404), ``True`` once the cancel signal
+        has been sent.
+        """
+        ...

--- a/openrag/core/indexing/serializer.py
+++ b/openrag/core/indexing/serializer.py
@@ -1,0 +1,26 @@
+"""Transitional port for the document-serialization operation.
+
+``ConversionService`` (Phase 8E) exposes the ``extractText`` tool —
+serialize an uploaded file to raw text. The work runs in the
+``DocSerializer`` Ray actor; defining it on a dedicated port keeps the
+orchestrator Ray-free (8H: no Ray import / remote call under
+``services/orchestrators/``). A small shim in ``services/storage/``
+adapts the actor to this interface during the shim period; Phase 9
+swaps it for a direct serializer call and deletes the shim.
+
+No Ray / LangChain types leak across this boundary — the serialized
+document is returned as its plain text content.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class FileSerializer(ABC):
+    """The single serialize operation the conversion orchestrator needs."""
+
+    @abstractmethod
+    async def serialize(self, path: str, metadata: dict) -> str:
+        """Serialize the file at ``path`` and return its raw text content."""
+        ...

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
+    from services.orchestrators.retrieval_service import RetrievalService
     from services.orchestrators.user_service import UserService
     from services.orchestrators.workspace_service import WorkspaceService
 
@@ -105,6 +106,7 @@ class ServiceContainer:
         self._user_service: UserService | None = None
         self._partition_service: PartitionService | None = None
         self._workspace_service: WorkspaceService | None = None
+        self._retrieval_service: RetrievalService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -287,6 +289,45 @@ class ServiceContainer:
                 collection=self._settings.vectordb.collection_name,
             )
         return self._workspace_service
+
+    @property
+    def retrieval_service(self) -> RetrievalService:
+        """RetrievalService — lazily built, cached for the container's lifetime.
+
+        The ``RetrievalSearcher`` is the Ray-backed ``MilvusRayShim``
+        during the Phase-8 shim period (Ray cleanup is Phase 9); it is
+        resolved lazily so the ``Vectordb`` actor only needs to exist at
+        first request, not at container construction.
+        """
+        if self._retrieval_service is None:
+            from services.orchestrators.retrieval_service import RetrievalService
+            from services.storage.milvus_ray_shim import from_ray_namespace
+
+            llm_cfg = self._settings.llm.model_dump()
+            llm = self.create_llm(
+                "vllm",
+                endpoint=llm_cfg["base_url"],
+                model_name=llm_cfg["model"],
+                api_key=llm_cfg.get("api_key", ""),
+                **{k: v for k, v in llm_cfg.items() if k not in ("base_url", "model", "api_key")},
+            )
+            reranker = None
+            rcfg = self._settings.reranker
+            if rcfg.enabled:
+                reranker = self.create_reranker(
+                    rcfg.provider,
+                    endpoint=rcfg.base_url,
+                    model_name=rcfg.model_name,
+                    api_key=rcfg.api_key,
+                    timeout=rcfg.timeout,
+                )
+            self._retrieval_service = RetrievalService(
+                searcher=from_ray_namespace(),
+                reranker=reranker,
+                llm=llm,
+                config=self._settings,
+            )
+        return self._retrieval_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -20,6 +20,7 @@ queries.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from core.embeddings import embedder_registry
@@ -53,12 +54,36 @@ if TYPE_CHECKING:
     from core.ports.user_repo import UserRepository
     from core.ports.workspace_repo import WorkspaceRepository
     from core.vector_stores import VectorStore
+    from services.orchestrators.auth_service import AuthService
 
 
 _NO_SETTINGS_MESSAGE = (
     "ServiceContainer was constructed without a Settings instance — "
     "pass Settings to ServiceContainer(...) to wire storage adapters."
 )
+
+
+def _oidc_config_from_env():
+    """Build :class:`OIDCConfig` from the same env vars ``main.py`` validates.
+
+    Phase 8A.1 keeps OIDC config env-sourced (it is not yet wired into the
+    root :class:`Settings`); ``enabled`` mirrors ``AUTH_MODE=oidc``.
+    """
+    from core.config.auth import OIDCConfig
+
+    return OIDCConfig(
+        enabled=os.getenv("AUTH_MODE", "token").strip().lower() == "oidc",
+        issuer_url=os.getenv("OIDC_ENDPOINT", "") or "",
+        client_id=os.getenv("OIDC_CLIENT_ID", "") or "",
+        client_secret=os.getenv("OIDC_CLIENT_SECRET", "") or "",
+        redirect_uri=os.getenv("OIDC_REDIRECT_URI", "") or "",
+        scopes=os.getenv("OIDC_SCOPES", "openid email profile offline_access"),
+        token_encryption_key=os.getenv("OIDC_TOKEN_ENCRYPTION_KEY", "") or "",
+        claim_source=os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower(),
+        claim_mapping=os.getenv("OIDC_CLAIM_MAPPING", "").strip(),
+        post_logout_redirect_uri=os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "") or "",
+        auto_provision_login=os.getenv("OIDC_AUTO_PROVISION_LOGIN", "false").strip().lower() == "true",
+    )
 
 
 class ServiceContainer:
@@ -73,6 +98,7 @@ class ServiceContainer:
         self._settings = settings
         self._catalog_store: CatalogStore | None = create_catalog_store(settings) if settings is not None else None
         self._vector_store: VectorStore | None = create_vector_store(settings) if settings is not None else None
+        self._auth_service: AuthService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -180,6 +206,36 @@ class ServiceContainer:
     @property
     def preset_repo(self) -> PresetRepository:
         return self.catalog_store.preset_repo
+
+    # ------------------------------------------------------------------
+    # Orchestrators (Phase 8)
+    # ------------------------------------------------------------------
+
+    @property
+    def auth_service(self) -> AuthService:
+        """AuthService — lazily built, cached for the container's lifetime.
+
+        The OIDC client is only constructed in ``AUTH_MODE=oidc`` (it reads
+        required env vars and would raise otherwise); in token mode it is
+        ``None`` and the OIDC flow methods refuse cleanly.
+        """
+        if self._auth_service is None:
+            from services.orchestrators.auth_service import AuthService
+
+            cfg = _oidc_config_from_env()
+            client = None
+            if cfg.enabled:
+                from components.auth import get_oidc_client
+
+                client = get_oidc_client()
+            self._auth_service = AuthService(
+                user_repo=self.user_repo,
+                oidc_session_repo=self.oidc_session_repo,
+                membership_repo=self.membership_repo,
+                oidc_client=client,
+                config=cfg,
+            )
+        return self._auth_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -265,6 +265,7 @@ class ServiceContainer:
                 default_file_quota=self._settings.rdb.default_file_quota,
                 partition_service=self.partition_service,
                 membership_repo=self.membership_repo,
+                job_service=self.job_service,
             )
         return self._user_service
 

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     from core.ports.workspace_repo import WorkspaceRepository
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.indexing_service import IndexingService
+    from services.orchestrators.job_service import JobService
     from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.query_service import QueryService
     from services.orchestrators.retrieval_service import RetrievalService
@@ -109,6 +111,8 @@ class ServiceContainer:
         self._workspace_service: WorkspaceService | None = None
         self._retrieval_service: RetrievalService | None = None
         self._query_service: QueryService | None = None
+        self._indexing_service: IndexingService | None = None
+        self._job_service: JobService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -360,6 +364,41 @@ class ServiceContainer:
                 workspace_service=self.workspace_service,
             )
         return self._query_service
+
+    @property
+    def indexing_service(self) -> IndexingService:
+        """IndexingService — lazily built, cached for the container's lifetime.
+
+        The dispatcher is the Ray-backed ``IndexerRayShim`` during the
+        Phase-8 shim period (Ray cleanup is Phase 9); it is resolved
+        lazily so the ``Indexer`` / ``TaskStateManager`` actors only need
+        to exist at first request, not at container construction.
+        """
+        if self._indexing_service is None:
+            from services.orchestrators.indexing_service import IndexingService
+            from services.storage.indexer_ray_shim import from_ray_namespace
+
+            self._indexing_service = IndexingService(
+                document_repo=self.document_repo,
+                workspace_repo=self.workspace_repo,
+                dispatcher=from_ray_namespace(),
+            )
+        return self._indexing_service
+
+    @property
+    def job_service(self) -> JobService:
+        """JobService — lazily built, cached for the container's lifetime.
+
+        Wraps the ``TaskStateManager`` Ray actor directly (8H excepts
+        JobService); resolved lazily so the actor only needs to exist at
+        first request.
+        """
+        if self._job_service is None:
+            from services.orchestrators.job_service import JobService
+            from utils.dependencies import get_task_state_manager
+
+            self._job_service = JobService(task_state_manager=get_task_state_manager())
+        return self._job_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -116,6 +116,18 @@ class ServiceContainer:
         self._job_service: JobService | None = None
         self._conversion_service: ConversionService | None = None
 
+    def _require_settings(self) -> Settings:
+        """Settings guard for the settings-dependent service properties.
+
+        Without this, ``ServiceContainer()`` (no-settings legacy path)
+        fails with a bare ``AttributeError`` on ``self._settings.x`` —
+        inconsistent with the ``catalog_store`` / ``vector_store``
+        contract, which raises ``RuntimeError(_NO_SETTINGS_MESSAGE)``.
+        """
+        if self._settings is None:
+            raise RuntimeError(_NO_SETTINGS_MESSAGE)
+        return self._settings
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -259,10 +271,11 @@ class ServiceContainer:
         if self._user_service is None:
             from services.orchestrators.user_service import UserService
 
+            settings = self._require_settings()
             self._user_service = UserService(
                 user_repo=self.user_repo,
                 auth_service=self.auth_service,
-                default_file_quota=self._settings.rdb.default_file_quota,
+                default_file_quota=settings.rdb.default_file_quota,
                 partition_service=self.partition_service,
                 membership_repo=self.membership_repo,
                 job_service=self.job_service,
@@ -275,13 +288,14 @@ class ServiceContainer:
         if self._partition_service is None:
             from services.orchestrators.partition_service import PartitionService
 
+            settings = self._require_settings()
             self._partition_service = PartitionService(
                 partition_repo=self.partition_repo,
                 membership_repo=self.membership_repo,
                 document_repo=self.document_repo,
                 vector_store=self.vector_store,
                 user_repo=self.user_repo,
-                collection=self._settings.vectordb.collection_name,
+                collection=settings.vectordb.collection_name,
             )
         return self._partition_service
 
@@ -291,11 +305,12 @@ class ServiceContainer:
         if self._workspace_service is None:
             from services.orchestrators.workspace_service import WorkspaceService
 
+            settings = self._require_settings()
             self._workspace_service = WorkspaceService(
                 workspace_repo=self.workspace_repo,
                 document_repo=self.document_repo,
                 vector_store=self.vector_store,
-                collection=self._settings.vectordb.collection_name,
+                collection=settings.vectordb.collection_name,
             )
         return self._workspace_service
 
@@ -312,7 +327,8 @@ class ServiceContainer:
             from services.orchestrators.retrieval_service import RetrievalService
             from services.storage.milvus_ray_shim import from_ray_namespace
 
-            llm_cfg = self._settings.llm.model_dump()
+            settings = self._require_settings()
+            llm_cfg = settings.llm.model_dump()
             llm = self.create_llm(
                 "vllm",
                 endpoint=llm_cfg["base_url"],
@@ -321,7 +337,7 @@ class ServiceContainer:
                 **{k: v for k, v in llm_cfg.items() if k not in ("base_url", "model", "api_key")},
             )
             reranker = None
-            rcfg = self._settings.reranker
+            rcfg = settings.reranker
             if rcfg.enabled:
                 reranker = self.create_reranker(
                     rcfg.provider,
@@ -334,7 +350,7 @@ class ServiceContainer:
                 searcher=from_ray_namespace(),
                 reranker=reranker,
                 llm=llm,
-                config=self._settings,
+                config=settings,
             )
         return self._retrieval_service
 
@@ -351,7 +367,8 @@ class ServiceContainer:
             from components.websearch import WebSearchFactory
             from services.orchestrators.query_service import QueryService
 
-            llm_cfg = self._settings.llm.model_dump()
+            settings = self._require_settings()
+            llm_cfg = settings.llm.model_dump()
             llm = self.create_llm(
                 "vllm",
                 endpoint=llm_cfg["base_url"],
@@ -362,8 +379,8 @@ class ServiceContainer:
             self._query_service = QueryService(
                 retrieval_service=self.retrieval_service,
                 llm=llm,
-                config=self._settings,
-                web_search_service=WebSearchFactory.create_service(self._settings),
+                config=settings,
+                web_search_service=WebSearchFactory.create_service(settings),
                 workspace_service=self.workspace_service,
             )
         return self._query_service
@@ -415,10 +432,11 @@ class ServiceContainer:
             from services.orchestrators.conversion_service import ConversionService
             from services.storage.serializer_ray_shim import from_ray_namespace
 
+            settings = self._require_settings()
             self._conversion_service = ConversionService(
                 serializer=from_ray_namespace(),
                 vector_store=self.vector_store,
-                collection=self._settings.vectordb.collection_name,
+                collection=settings.vectordb.collection_name,
             )
         return self._conversion_service
 

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from core.ports.workspace_repo import WorkspaceRepository
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.conversion_service import ConversionService
     from services.orchestrators.indexing_service import IndexingService
     from services.orchestrators.job_service import JobService
     from services.orchestrators.partition_service import PartitionService
@@ -113,6 +114,7 @@ class ServiceContainer:
         self._query_service: QueryService | None = None
         self._indexing_service: IndexingService | None = None
         self._job_service: JobService | None = None
+        self._conversion_service: ConversionService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -399,6 +401,25 @@ class ServiceContainer:
 
             self._job_service = JobService(task_state_manager=get_task_state_manager())
         return self._job_service
+
+    @property
+    def conversion_service(self) -> ConversionService:
+        """ConversionService — lazily built, cached for the container's lifetime.
+
+        The serializer is the Ray-backed ``SerializerRayShim`` during the
+        Phase-8 shim period (Ray cleanup is Phase 9); the DocSerializer
+        actor is resolved lazily per call inside the shim.
+        """
+        if self._conversion_service is None:
+            from services.orchestrators.conversion_service import ConversionService
+            from services.storage.serializer_ray_shim import from_ray_namespace
+
+            self._conversion_service = ConversionService(
+                serializer=from_ray_namespace(),
+                vector_store=self.vector_store,
+                collection=self._settings.vectordb.collection_name,
+            )
+        return self._conversion_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from core.ports.workspace_repo import WorkspaceRepository
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.user_service import UserService
 
 
 _NO_SETTINGS_MESSAGE = (
@@ -99,6 +100,7 @@ class ServiceContainer:
         self._catalog_store: CatalogStore | None = create_catalog_store(settings) if settings is not None else None
         self._vector_store: VectorStore | None = create_vector_store(settings) if settings is not None else None
         self._auth_service: AuthService | None = None
+        self._user_service: UserService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -236,6 +238,19 @@ class ServiceContainer:
                 config=cfg,
             )
         return self._auth_service
+
+    @property
+    def user_service(self) -> UserService:
+        """UserService — lazily built, cached for the container's lifetime."""
+        if self._user_service is None:
+            from services.orchestrators.user_service import UserService
+
+            self._user_service = UserService(
+                user_repo=self.user_repo,
+                auth_service=self.auth_service,
+                default_file_quota=self._settings.rdb.default_file_quota,
+            )
+        return self._user_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
+    from services.orchestrators.query_service import QueryService
     from services.orchestrators.retrieval_service import RetrievalService
     from services.orchestrators.user_service import UserService
     from services.orchestrators.workspace_service import WorkspaceService
@@ -107,6 +108,7 @@ class ServiceContainer:
         self._partition_service: PartitionService | None = None
         self._workspace_service: WorkspaceService | None = None
         self._retrieval_service: RetrievalService | None = None
+        self._query_service: QueryService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -328,6 +330,36 @@ class ServiceContainer:
                 config=self._settings,
             )
         return self._retrieval_service
+
+    @property
+    def query_service(self) -> QueryService:
+        """QueryService — lazily built, cached for the container's lifetime.
+
+        Shares the same core LLM construction as ``retrieval_service``
+        (built from ``settings.llm``); the web-search service comes from
+        the legacy ``WebSearchFactory`` (provider is ``None`` when
+        ``WEBSEARCH_API_TOKEN`` is unset — web search silently disabled).
+        """
+        if self._query_service is None:
+            from components.websearch import WebSearchFactory
+            from services.orchestrators.query_service import QueryService
+
+            llm_cfg = self._settings.llm.model_dump()
+            llm = self.create_llm(
+                "vllm",
+                endpoint=llm_cfg["base_url"],
+                model_name=llm_cfg["model"],
+                api_key=llm_cfg.get("api_key", ""),
+                **{k: v for k, v in llm_cfg.items() if k not in ("base_url", "model", "api_key")},
+            )
+            self._query_service = QueryService(
+                retrieval_service=self.retrieval_service,
+                llm=llm,
+                config=self._settings,
+                web_search_service=WebSearchFactory.create_service(self._settings),
+                workspace_service=self.workspace_service,
+            )
+        return self._query_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.user_service import UserService
+    from services.orchestrators.workspace_service import WorkspaceService
 
 
 _NO_SETTINGS_MESSAGE = (
@@ -103,6 +104,7 @@ class ServiceContainer:
         self._auth_service: AuthService | None = None
         self._user_service: UserService | None = None
         self._partition_service: PartitionService | None = None
+        self._workspace_service: WorkspaceService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -271,6 +273,20 @@ class ServiceContainer:
                 collection=self._settings.vectordb.collection_name,
             )
         return self._partition_service
+
+    @property
+    def workspace_service(self) -> WorkspaceService:
+        """WorkspaceService — lazily built, cached for the container's lifetime."""
+        if self._workspace_service is None:
+            from services.orchestrators.workspace_service import WorkspaceService
+
+            self._workspace_service = WorkspaceService(
+                workspace_repo=self.workspace_repo,
+                document_repo=self.document_repo,
+                vector_store=self.vector_store,
+                collection=self._settings.vectordb.collection_name,
+            )
+        return self._workspace_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from core.ports.workspace_repo import WorkspaceRepository
     from core.vector_stores import VectorStore
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.user_service import UserService
 
 
@@ -101,6 +102,7 @@ class ServiceContainer:
         self._vector_store: VectorStore | None = create_vector_store(settings) if settings is not None else None
         self._auth_service: AuthService | None = None
         self._user_service: UserService | None = None
+        self._partition_service: PartitionService | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -249,8 +251,26 @@ class ServiceContainer:
                 user_repo=self.user_repo,
                 auth_service=self.auth_service,
                 default_file_quota=self._settings.rdb.default_file_quota,
+                partition_service=self.partition_service,
+                membership_repo=self.membership_repo,
             )
         return self._user_service
+
+    @property
+    def partition_service(self) -> PartitionService:
+        """PartitionService — lazily built, cached for the container's lifetime."""
+        if self._partition_service is None:
+            from services.orchestrators.partition_service import PartitionService
+
+            self._partition_service = PartitionService(
+                partition_repo=self.partition_repo,
+                membership_repo=self.membership_repo,
+                document_repo=self.document_repo,
+                vector_store=self.vector_store,
+                user_repo=self.user_repo,
+                collection=self._settings.vectordb.collection_name,
+            )
+        return self._partition_service
 
     # ------------------------------------------------------------------
     # Registry-based inference factories (Phase 6)

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.user_service import UserService
+    from services.orchestrators.workspace_service import WorkspaceService
 
 
 def get_container(request: Request) -> ServiceContainer:
@@ -42,3 +43,7 @@ def get_user_service(request: Request) -> UserService:
 
 def get_partition_service(request: Request) -> PartitionService:
     return get_container(request).partition_service
+
+
+def get_workspace_service(request: Request) -> WorkspaceService:
+    return get_container(request).workspace_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
+    from services.orchestrators.retrieval_service import RetrievalService
     from services.orchestrators.user_service import UserService
     from services.orchestrators.workspace_service import WorkspaceService
 
@@ -47,3 +48,7 @@ def get_partition_service(request: Request) -> PartitionService:
 
 def get_workspace_service(request: Request) -> WorkspaceService:
     return get_container(request).workspace_service
+
+
+def get_retrieval_service(request: Request) -> RetrievalService:
+    return get_container(request).retrieval_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
     from services.orchestrators.partition_service import PartitionService
+    from services.orchestrators.query_service import QueryService
     from services.orchestrators.retrieval_service import RetrievalService
     from services.orchestrators.user_service import UserService
     from services.orchestrators.workspace_service import WorkspaceService
@@ -52,3 +53,7 @@ def get_workspace_service(request: Request) -> WorkspaceService:
 
 def get_retrieval_service(request: Request) -> RetrievalService:
     return get_container(request).retrieval_service
+
+
+def get_query_service(request: Request) -> QueryService:
+    return get_container(request).query_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException, Request, status
 if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.user_service import UserService
 
 
@@ -37,3 +38,7 @@ def get_auth_service(request: Request) -> AuthService:
 
 def get_user_service(request: Request) -> UserService:
     return get_container(request).user_service
+
+
+def get_partition_service(request: Request) -> PartitionService:
+    return get_container(request).partition_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException, Request, status
 if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.conversion_service import ConversionService
     from services.orchestrators.indexing_service import IndexingService
     from services.orchestrators.job_service import JobService
     from services.orchestrators.partition_service import PartitionService
@@ -67,3 +68,7 @@ def get_indexing_service(request: Request) -> IndexingService:
 
 def get_job_service(request: Request) -> JobService:
     return get_container(request).job_service
+
+
+def get_conversion_service(request: Request) -> ConversionService:
+    return get_container(request).conversion_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -1,0 +1,34 @@
+"""FastAPI dependency providers.
+
+Thin accessors over the request-scoped :class:`ServiceContainer` that
+``main.py`` attaches at ``app.state.container``. Phase 8 keeps these as
+one-liners — the container (``di/container.py``) is the composition
+root. Phase 11 moves the attachment into a proper FastAPI lifespan and
+wires ``container.initialize()``; until then the OIDC flow that needs
+the asyncpg pool is dormant (token-mode auth routes already short-circuit
+before reaching a service).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, Request, status
+
+if TYPE_CHECKING:
+    from di.container import ServiceContainer
+    from services.orchestrators.auth_service import AuthService
+
+
+def get_container(request: Request) -> ServiceContainer:
+    container = getattr(request.app.state, "container", None)
+    if container is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service container is not available.",
+        )
+    return container
+
+
+def get_auth_service(request: Request) -> AuthService:
+    return get_container(request).auth_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException, Request, status
 if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.user_service import UserService
 
 
 def get_container(request: Request) -> ServiceContainer:
@@ -32,3 +33,7 @@ def get_container(request: Request) -> ServiceContainer:
 
 def get_auth_service(request: Request) -> AuthService:
     return get_container(request).auth_service
+
+
+def get_user_service(request: Request) -> UserService:
+    return get_container(request).user_service

--- a/openrag/di/providers.py
+++ b/openrag/di/providers.py
@@ -18,6 +18,8 @@ from fastapi import HTTPException, Request, status
 if TYPE_CHECKING:
     from di.container import ServiceContainer
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.indexing_service import IndexingService
+    from services.orchestrators.job_service import JobService
     from services.orchestrators.partition_service import PartitionService
     from services.orchestrators.query_service import QueryService
     from services.orchestrators.retrieval_service import RetrievalService
@@ -57,3 +59,11 @@ def get_retrieval_service(request: Request) -> RetrievalService:
 
 def get_query_service(request: Request) -> QueryService:
     return get_container(request).query_service
+
+
+def get_indexing_service(request: Request) -> IndexingService:
+    return get_container(request).indexing_service
+
+
+def get_job_service(request: Request) -> JobService:
+    return get_container(request).job_service

--- a/openrag/di/test_container.py
+++ b/openrag/di/test_container.py
@@ -174,3 +174,50 @@ class TestRepositoriesFactory:
         create_catalog_store(s)
         # The factory uses model_copy with an update — the source must stay None.
         assert s.rdb.database == original_database
+
+
+# Phase 8F — every orchestrator is a lazy cached property on the
+# container and is reachable through a one-liner provider. Keyed by the
+# container property name; value is the matching provider function.
+_ORCHESTRATORS = [
+    ("auth_service", "get_auth_service"),
+    ("user_service", "get_user_service"),
+    ("partition_service", "get_partition_service"),
+    ("workspace_service", "get_workspace_service"),
+    ("retrieval_service", "get_retrieval_service"),
+    ("query_service", "get_query_service"),
+    ("indexing_service", "get_indexing_service"),
+    ("job_service", "get_job_service"),
+    ("conversion_service", "get_conversion_service"),
+]
+
+
+class TestPhase8OrchestratorWiring:
+    """8F: all nine orchestrators wired consistently (container + providers)."""
+
+    @pytest.mark.parametrize("prop,_provider", _ORCHESTRATORS)
+    def test_property_is_lazy_and_cache_slot_starts_none(self, prop, _provider):
+        # The public accessor is a property (lazy), not an eager attribute.
+        assert isinstance(getattr(ServiceContainer, prop), property)
+        # The cache slot exists and is None before first access (no
+        # settings needed — the legacy no-arg path must keep working).
+        assert getattr(ServiceContainer(), f"_{prop}") is None
+
+    @pytest.mark.parametrize("prop,provider", _ORCHESTRATORS)
+    def test_provider_delegates_to_container_property(self, prop, provider):
+        from types import SimpleNamespace
+
+        from di import providers
+
+        sentinel = object()
+        fake_container = SimpleNamespace(**{prop: sentinel})
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(container=fake_container)))
+
+        resolved = getattr(providers, provider)(request)
+        assert resolved is sentinel
+
+    def test_no_orchestrator_is_missing_a_provider(self):
+        from di import providers
+
+        wired = {name for name in vars(providers) if name.startswith("get_") and name.endswith("_service")}
+        assert wired == {p for _, p in _ORCHESTRATORS}

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -266,8 +266,12 @@ try:
     from di.container import ServiceContainer
 
     app.state.container = ServiceContainer(config)
-except Exception as _container_exc:  # pragma: no cover - defensive boot guard
-    logger.warning(f"ServiceContainer wiring skipped: {_container_exc}")
+except Exception:  # pragma: no cover - defensive boot guard
+    # Best-effort by design (a Milvus/PG hiccup must not block boot, and
+    # di/providers.py serves a 503 while the container is absent), but log
+    # at exception level with a full traceback so an unexpected failure
+    # (import/syntax/misconfig) is loud rather than a one-line warning.
+    logger.exception("ServiceContainer wiring skipped")
     app.state.container = None
 
 
@@ -288,8 +292,8 @@ async def _initialize_container() -> None:
         return
     try:
         await container.initialize()
-    except Exception as exc:  # pragma: no cover - defensive boot guard
-        logger.warning(f"ServiceContainer.initialize skipped: {exc}")
+    except Exception:  # pragma: no cover - defensive boot guard
+        logger.exception("ServiceContainer.initialize skipped")
 
 
 @app.on_event("shutdown")
@@ -299,8 +303,8 @@ async def _shutdown_container() -> None:
         return
     try:
         await container.shutdown()
-    except Exception as exc:  # pragma: no cover - defensive shutdown guard
-        logger.warning(f"ServiceContainer.shutdown skipped: {exc}")
+    except Exception:  # pragma: no cover - defensive shutdown guard
+        logger.exception("ServiceContainer.shutdown skipped")
 
 
 app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -293,7 +293,11 @@ async def _initialize_container() -> None:
     try:
         await container.initialize()
     except Exception:  # pragma: no cover - defensive boot guard
-        logger.exception("ServiceContainer.initialize skipped")
+        # A half-initialised container (e.g. asyncpg pool never opened)
+        # would route requests into broken repos and 500. Drop it so
+        # di/providers.py serves the intended degraded 503 instead.
+        logger.exception("ServiceContainer.initialize failed; serving degraded (503)")
+        app.state.container = None
 
 
 @app.on_event("shutdown")

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -256,6 +256,20 @@ app.add_middleware(
 )
 
 app.state.app_state = AppState(config)
+
+# Phase 8 composition root. Attached here as minimal wiring so the thinned
+# routers can resolve services via di.providers; Phase 11 moves this into a
+# FastAPI lifespan and calls ``await container.initialize()``. Construction
+# is best-effort: a Milvus/PG hiccup at import must not stop the app from
+# booting (the providers raise 503 if the container is absent).
+try:
+    from di.container import ServiceContainer
+
+    app.state.container = ServiceContainer(config)
+except Exception as _container_exc:  # pragma: no cover - defensive boot guard
+    logger.warning(f"ServiceContainer wiring skipped: {_container_exc}")
+    app.state.container = None
+
 app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")
 
 

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -259,9 +259,9 @@ app.state.app_state = AppState(config)
 
 # Phase 8 composition root. Attached here as minimal wiring so the thinned
 # routers can resolve services via di.providers; Phase 11 moves this into a
-# FastAPI lifespan and calls ``await container.initialize()``. Construction
-# is best-effort: a Milvus/PG hiccup at import must not stop the app from
-# booting (the providers raise 503 if the container is absent).
+# proper FastAPI lifespan. Construction is best-effort: a Milvus/PG hiccup at
+# import must not stop the app from booting (the providers raise 503 if the
+# container is absent).
 try:
     from di.container import ServiceContainer
 
@@ -269,6 +269,39 @@ try:
 except Exception as _container_exc:  # pragma: no cover - defensive boot guard
     logger.warning(f"ServiceContainer wiring skipped: {_container_exc}")
     app.state.container = None
+
+
+@app.on_event("startup")
+async def _initialize_container() -> None:
+    """Open the container's asyncpg pool + run idempotent migrations.
+
+    The thinned Phase-8 routers resolve repositories through the container's
+    own :class:`PostgresStore`, which is a *separate* instance from the one
+    the legacy Ray ``Vectordb`` actor owns. Without this the catalog-backed
+    routes raise (uninitialised pool). The asyncpg layer (Phase 7) is
+    idempotent, so initialising alongside the actor's store is safe. Phase 11
+    folds this into a lifespan; the deferral originally logged in the Phase-8
+    decision log (§1) is corrected here because it broke the live app.
+    """
+    container = getattr(app.state, "container", None)
+    if container is None:
+        return
+    try:
+        await container.initialize()
+    except Exception as exc:  # pragma: no cover - defensive boot guard
+        logger.warning(f"ServiceContainer.initialize skipped: {exc}")
+
+
+@app.on_event("shutdown")
+async def _shutdown_container() -> None:
+    container = getattr(app.state, "container", None)
+    if container is None:
+        return
+    try:
+        await container.shutdown()
+    except Exception as exc:  # pragma: no cover - defensive shutdown guard
+        logger.warning(f"ServiceContainer.shutdown skipped: {exc}")
+
 
 app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -89,9 +89,9 @@ def _json_error(status_code: int, detail: str, *, delete_state_cookie: bool = Fa
 async def login(
     request: Request,
     next: str | None = None,
+    _oidc: None = Depends(_require_oidc_mode),
     service: AuthService = Depends(get_auth_service),
 ):
-    _require_oidc_mode()
     try:
         result = await service.start_oidc_login(next)
     except OIDCFlowError as e:
@@ -120,9 +120,9 @@ async def callback(
     request: Request,
     code: str | None = None,
     state: str | None = None,
+    _oidc: None = Depends(_require_oidc_mode),
     service: AuthService = Depends(get_auth_service),
 ):
-    _require_oidc_mode()
     try:
         result = await service.handle_oidc_callback(
             code=code,
@@ -154,13 +154,13 @@ async def callback(
 @router.post("/auth/backchannel-logout", include_in_schema=False)
 async def backchannel_logout(
     logout_token: str = Form(...),
+    _oidc: None = Depends(_require_oidc_mode),
     service: AuthService = Depends(get_auth_service),
 ):
     """IdP-initiated logout per OIDC Back-Channel Logout spec.
 
     Content-Type: ``application/x-www-form-urlencoded`` with field ``logout_token``.
     """
-    _require_oidc_mode()
     try:
         await service.handle_backchannel_logout(logout_token)
     except OIDCFlowError as e:
@@ -187,9 +187,9 @@ async def backchannel_logout(
 @router.get("/auth/logout", include_in_schema=False)
 async def logout(
     request: Request,
+    _oidc: None = Depends(_require_oidc_mode),
     service: AuthService = Depends(get_auth_service),
 ):
-    _require_oidc_mode()
     redirect_target = await service.logout(request.cookies.get(SESSION_COOKIE_NAME))
 
     if redirect_target:

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -1,4 +1,4 @@
-"""OIDC authentication routes — phase 4 of the OIDC integration.
+"""OIDC authentication routes — thin HTTP layer over :class:`AuthService`.
 
 Routes exposed (all bypassed by ``AuthMiddleware``):
   - ``GET  /auth/login``              — start Authorization Code + PKCE flow
@@ -11,43 +11,35 @@ One more route sits *behind* the middleware:
 
 All routes return ``400`` when ``AUTH_MODE != "oidc"`` — the feature is dormant
 in ``token`` mode.
+
+Phase 8A.1: every business decision (PKCE/state generation, code exchange,
+user lookup / provisioning, session creation, logout-URL construction) now
+lives in :class:`services.orchestrators.auth_service.AuthService`. This
+module only does HTTP transport: the ``AUTH_MODE`` gate, cookie set/clear,
+the Secure-flag heuristic, and mapping :class:`OIDCFlowError` to responses.
 """
 
 from __future__ import annotations
 
 import os
-from datetime import datetime, timedelta
-from typing import Any
-from urllib.parse import urlencode, urlparse
 
-from components.auth import (
-    OIDCClient,
-    StateCookiePayload,
-    StateCookieSerializer,
-    decrypt_token,
-    encrypt_token,
-    get_oidc_client,
-    issue_session_token,
-)
-from fastapi import APIRouter, Form, HTTPException, Request, Response, status
+from components.auth import StateCookieSerializer
+from di.providers import get_auth_service
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
-from models.user import UserCreate
-from utils.dependencies import get_vectordb
+from services.orchestrators.auth_service import (
+    SESSION_COOKIE_NAME,
+    AuthService,
+    OIDCFlowError,
+)
 from utils.logger import get_logger
-
-# Whitelist mirrors ``api._OIDC_CLAIM_MAPPING_ALLOWED_FIELDS`` — kept in sync
-# at the DB layer too (``PartitionFileManager.update_user_fields``).
-_OIDC_CLAIM_MAPPING_ALLOWED_FIELDS = {"display_name", "email"}
 
 logger = get_logger()
 router = APIRouter()
 
 
-SESSION_COOKIE_NAME = "openrag_session"
-
-
 # ---------------------------------------------------------------------------
-# Env helpers — read lazily so tests can monkeypatch os.environ
+# HTTP-transport helpers (kept in the router by design)
 # ---------------------------------------------------------------------------
 
 
@@ -55,94 +47,7 @@ def _auth_mode() -> str:
     return os.getenv("AUTH_MODE", "token").strip().lower()
 
 
-def _token_encryption_key() -> str:
-    key = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY")
-    if not key:
-        raise RuntimeError("OIDC_TOKEN_ENCRYPTION_KEY is not set")
-    return key
-
-
-def _claim_source() -> str:
-    return os.getenv("OIDC_CLAIM_SOURCE", "id_token").strip().lower()
-
-
-def _auto_provision_login() -> bool:
-    """Whether to auto-provision a non-admin user on first OIDC login.
-
-    Defaults to ``False`` — keeping the historical "admin pre-creates every
-    user" model. Set ``OIDC_AUTO_PROVISION_LOGIN=true`` to enable: when the
-    callback receives a ``sub`` that isn't yet mapped to an OpenRAG user,
-    a row is created on the fly using the ID-token claims (``name`` /
-    ``preferred_username`` for the display name, ``email`` if present).
-
-    Auto-provisioned users are **never** admin and inherit the default file
-    quota — operators can promote / adjust afterwards via ``/users/``.
-    """
-    return os.getenv("OIDC_AUTO_PROVISION_LOGIN", "false").strip().lower() == "true"
-
-
-def _display_name_from_claims(claims: dict[str, Any], sub: str) -> str:
-    """Pick a sensible display name from the standard OIDC claims.
-
-    Falls back to a short ``sub`` prefix when nothing readable is available
-    so the user row always has something printable for the UI.
-    """
-    for key in ("name", "preferred_username"):
-        value = claims.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    given = claims.get("given_name") or ""
-    family = claims.get("family_name") or ""
-    composed = f"{given} {family}".strip()
-    if composed:
-        return composed
-    # Last-resort fallback — keep enough of the sub to be unique-ish in the UI.
-    return f"oidc-{sub[:8]}"
-
-
-def _claim_mapping() -> dict[str, str]:
-    """Parse ``OIDC_CLAIM_MAPPING`` at request time so tests can monkeypatch it.
-
-    Shares the validation rules with ``api._parse_oidc_claim_mapping``: entries
-    whose ``db_field`` is not whitelisted are silently dropped here because the
-    hard-failure path belongs to the startup validator in ``api.py`` — at login
-    time we prefer to log and continue rather than break the flow on a
-    misconfiguration the operator has already been warned about.
-    """
-    raw = os.getenv("OIDC_CLAIM_MAPPING", "").strip()
-    if not raw:
-        return {}
-    mapping: dict[str, str] = {}
-    for pair in raw.split(","):
-        pair = pair.strip()
-        if not pair or ":" not in pair:
-            continue
-        db_field, claim = pair.split(":", 1)
-        db_field = db_field.strip()
-        claim = claim.strip()
-        if db_field not in _OIDC_CLAIM_MAPPING_ALLOWED_FIELDS or not claim:
-            continue
-        mapping[db_field] = claim
-    return mapping
-
-
-def _post_logout_redirect_uri() -> str | None:
-    """Return the configured post-logout redirect URI, or None if unset.
-
-    No default is provided: a default of "/" would land the user back on
-    OpenRag's root which immediately re-triggers OIDC login (silent re-auth
-    if the IdP session is still alive, or a loop on the IdP form if not).
-    Operators deliberately choose a URL outside OpenRag (corporate intranet,
-    a static 'you are logged out' page, the IdP's own post-logout page).
-    """
-    return os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI")
-
-
-def _oidc_client_id() -> str:
-    return os.environ["OIDC_CLIENT_ID"]
-
-
-def _require_oidc_mode():
+def _require_oidc_mode() -> None:
     if _auth_mode() != "oidc":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -153,70 +58,19 @@ def _require_oidc_mode():
 def _is_request_secure(request: Request) -> bool:
     """True if the client-observed scheme is HTTPS.
 
-    Checks multiple indicators:
-    1. ``PREFERRED_URL_SCHEME`` env var (set when behind a TLS-terminating proxy)
-    2. ``X-Forwarded-Proto`` header (set by reverse proxies like Traefik/Nginx)
-    3. ``request.url.scheme`` (accounts for proxy_headers=True in uvicorn)
+    Checks ``PREFERRED_URL_SCHEME``, the ``X-Forwarded-Proto`` header
+    (client-most hop when comma-separated), then ``request.url.scheme``.
     """
     if os.environ.get("PREFERRED_URL_SCHEME", "").lower() == "https":
         return True
-    # X-Forwarded-Proto can be comma-separated when chained through multiple
-    # proxies (e.g. "https, http"); the client-most hop is the first entry.
     xfp = request.headers.get("x-forwarded-proto", "")
     if xfp.split(",", 1)[0].strip().lower() == "https":
         return True
     return request.url.scheme == "https"
 
 
-def _state_serializer() -> StateCookieSerializer:
-    return StateCookieSerializer(secret_key=_token_encryption_key())
-
-
-def _allowed_next_origins() -> set[str]:
-    """Origins (scheme://host[:port]) accepted as redirect targets after login.
-
-    Mirrors the CORS allow_origins from ``api.py``: localhost dev ports plus
-    ``INDEXERUI_URL`` so that the indexer-ui (served on a different port) can
-    receive the user back after the OIDC flow completes.
-    """
-    origins = {"http://localhost:3042", "http://localhost:5173"}
-    indexer_ui = os.getenv("INDEXERUI_URL")
-    if indexer_ui:
-        origins.add(indexer_ui.rstrip("/"))
-    return origins
-
-
-def _sanitize_next_url(next_url: str | None) -> str:
-    """Accept either a same-origin relative path (``/...`` but not ``//...``)
-    or an absolute URL whose origin is explicitly whitelisted (indexer-ui,
-    dev-only localhost). Fall back to ``/`` on any mismatch — protects against
-    open-redirect attacks.
-    """
-    if not next_url:
-        return "/"
-    if next_url.startswith("/") and not next_url.startswith("//"):
-        return next_url
-    # Absolute URL: only allow whitelisted origins.
-    parsed = urlparse(next_url)
-    if parsed.scheme in ("http", "https") and parsed.netloc:
-        origin = f"{parsed.scheme}://{parsed.netloc}"
-        if origin in _allowed_next_origins():
-            return next_url
-    return "/"
-
-
-def _utcnow() -> datetime:
-    # DB-side timestamps are naive local time (models' default is ``datetime.now``),
-    # and every read site compares against ``datetime.now()``. Using ``datetime.now()``
-    # here keeps newly-issued sessions from appearing pre-expired on non-UTC hosts.
-    return datetime.now()
-
-
 def _delete_state_cookie(response: Response) -> None:
-    response.delete_cookie(
-        key=StateCookieSerializer.COOKIE_NAME,
-        path="/",
-    )
+    response.delete_cookie(key=StateCookieSerializer.COOKIE_NAME, path="/")
 
 
 def _json_error(status_code: int, detail: str, *, delete_state_cookie: bool = False) -> JSONResponse:
@@ -232,35 +86,22 @@ def _json_error(status_code: int, detail: str, *, delete_state_cookie: bool = Fa
 
 
 @router.get("/auth/login", include_in_schema=False)
-async def login(request: Request, next: str | None = None):
+async def login(
+    request: Request,
+    next: str | None = None,
+    service: AuthService = Depends(get_auth_service),
+):
     _require_oidc_mode()
-    client: OIDCClient = get_oidc_client()
-
-    state, nonce = OIDCClient.generate_state_and_nonce()
-    code_verifier, code_challenge = OIDCClient.generate_pkce_pair()
-
     try:
-        auth_url = await client.build_authorization_url(state=state, nonce=nonce, code_challenge=code_challenge)
-    except Exception as e:
-        logger.error(f"Failed to build OIDC authorization URL: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="OIDC discovery failed — see server logs.",
-        ) from e
+        result = await service.start_oidc_login(next)
+    except OIDCFlowError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message) from e
 
-    payload = StateCookiePayload(
-        state=state,
-        nonce=nonce,
-        code_verifier=code_verifier,
-        next_url=_sanitize_next_url(next),
-    )
-    cookie_value = _state_serializer().dumps(payload)
-
-    response = RedirectResponse(url=auth_url, status_code=302)
+    response = RedirectResponse(url=result.authorization_url, status_code=302)
     response.set_cookie(
-        key=StateCookieSerializer.COOKIE_NAME,
-        value=cookie_value,
-        max_age=StateCookieSerializer.DEFAULT_TTL_SECONDS,
+        key=result.state_cookie_name,
+        value=result.state_cookie_value,
+        max_age=result.state_cookie_max_age,
         httponly=True,
         secure=_is_request_secure(request),
         samesite="lax",
@@ -275,224 +116,33 @@ async def login(request: Request, next: str | None = None):
 
 
 @router.get("/auth/callback", include_in_schema=False)
-async def callback(request: Request, code: str | None = None, state: str | None = None):
+async def callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    service: AuthService = Depends(get_auth_service),
+):
     _require_oidc_mode()
-
-    if not code or not state:
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "Missing 'code' or 'state' query parameter.",
-            delete_state_cookie=True,
-        )
-
-    # --- 1. Parse state cookie -------------------------------------------------
-    cookie_raw = request.cookies.get(StateCookieSerializer.COOKIE_NAME)
-    if not cookie_raw:
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "OIDC state cookie missing.",
-            delete_state_cookie=True,
-        )
-
     try:
-        payload = _state_serializer().loads(cookie_raw)
-    except ValueError as e:
-        logger.warning(f"Invalid OIDC state cookie: {e}")
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "Invalid or expired OIDC state cookie.",
-            delete_state_cookie=True,
-        )
-
-    # --- 2. CSRF check --------------------------------------------------------
-    if state != payload.state:
-        logger.warning("OIDC state mismatch between query and cookie")
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "OIDC state mismatch.",
-            delete_state_cookie=True,
-        )
-
-    # --- 3. Exchange code ------------------------------------------------------
-    client: OIDCClient = get_oidc_client()
-    try:
-        bundle = await client.exchange_code(
+        result = await service.handle_oidc_callback(
             code=code,
-            code_verifier=payload.code_verifier,
-            expected_nonce=payload.nonce,
+            state=state,
+            state_cookie_raw=request.cookies.get(StateCookieSerializer.COOKIE_NAME),
         )
-    except Exception:
-        # Log full exception for operators; return a generic message so IdP
-        # URLs / stack-adjacent internals don't leak via the HTTP response.
-        logger.exception("OIDC code exchange failed")
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "OIDC code exchange failed",
-            delete_state_cookie=True,
-        )
+    except OIDCFlowError as e:
+        return _json_error(e.status_code, e.message, delete_state_cookie=True)
 
-    # --- 4. Extract sub and match user ----------------------------------------
-    sub = bundle.claims.get("sub")
-    if not sub:
-        return _json_error(
-            status.HTTP_400_BAD_REQUEST,
-            "ID token missing 'sub' claim.",
-            delete_state_cookie=True,
-        )
-
-    vdb = get_vectordb()
-    user: dict[str, Any] | None = await vdb.get_user_by_external_id.remote(sub)
-    if user is None:
-        if not _auto_provision_login():
-            logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
-            return _json_error(
-                status.HTTP_403_FORBIDDEN,
-                "User not registered",
-                delete_state_cookie=True,
-            )
-
-        # Auto-provision: create a non-admin user from the ID-token claims.
-        # Email is best-effort — populated when the IdP exposes it on the
-        # ``email`` claim (typically via the ``email`` scope, which is in the
-        # default ``OIDC_SCOPES``). Display name falls back to the sub when
-        # the IdP exposes nothing readable.
-        display_name = _display_name_from_claims(bundle.claims, sub)
-        email = bundle.claims.get("email")
-        try:
-            user = await vdb.create_user.remote(
-                UserCreate(
-                    display_name=display_name,
-                    external_user_id=sub,
-                    email=email if isinstance(email, str) and email.strip() else None,
-                    is_admin=False,
-                )
-            )
-        except Exception as e:
-            # Race condition (concurrent first-login) or DB failure — try to
-            # recover by re-reading; if still missing, surface a 500 so the
-            # operator notices instead of silently masking the problem.
-            logger.exception(f"OIDC auto-provisioning failed for sub={sub!r}: {e}")
-            user = await vdb.get_user_by_external_id.remote(sub)
-            if user is None:
-                return _json_error(
-                    status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    "Failed to provision user",
-                    delete_state_cookie=True,
-                )
-        else:
-            logger.info(f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, display_name={display_name!r})")
-
-    # --- 4b. Auto-provision: keep display_name + email in sync with claims ----
-    # When OIDC_AUTO_PROVISION_LOGIN is on, the IdP is treated as the source of
-    # truth for these two fields on every login (not just at creation), so a
-    # user renamed in the IdP doesn't drift out of sync. No-op for users whose
-    # row already matches the claims (including the user we just created).
-    if _auto_provision_login():
-        derived_display = _display_name_from_claims(bundle.claims, sub)
-        derived_email_raw = bundle.claims.get("email")
-        derived_email = (
-            derived_email_raw.strip() if isinstance(derived_email_raw, str) and derived_email_raw.strip() else None
-        )
-
-        sync_updates: dict[str, Any] = {}
-        if derived_display and user.get("display_name") != derived_display:
-            sync_updates["display_name"] = derived_display
-        if derived_email is not None and user.get("email") != derived_email:
-            sync_updates["email"] = derived_email
-
-        if sync_updates:
-            try:
-                await vdb.update_user_fields.remote(user["id"], sync_updates)
-            except Exception as e:
-                logger.warning(f"OIDC auto-provision sync failed for user_id={user['id']}: {e}")
-            else:
-                refreshed = await vdb.get_user_by_external_id.remote(sub)
-                if refreshed is not None:
-                    user = refreshed
-
-    # --- 5. Optional claim-mapping update --------------------------------------
-    mapping = _claim_mapping()
-    if mapping:
-        if _claim_source() == "userinfo":
-            try:
-                claims_for_mapping: dict[str, Any] = await client.fetch_userinfo(bundle.access_token)
-            except Exception as e:
-                logger.warning(f"OIDC userinfo fetch failed: {e}")
-                return _json_error(
-                    status.HTTP_400_BAD_REQUEST,
-                    "Failed to fetch userinfo from IdP.",
-                    delete_state_cookie=True,
-                )
-        else:
-            claims_for_mapping = bundle.claims
-
-        updates: dict[str, Any] = {}
-        for db_field, claim in mapping.items():
-            value = claims_for_mapping.get(claim)
-            if value is None:
-                continue
-            # No-op filter: skip fields already matching, so we don't churn the DB.
-            if user.get(db_field) == value:
-                continue
-            updates[db_field] = value
-
-        if updates:
-            try:
-                await vdb.update_user_fields.remote(user["id"], updates)
-            except Exception as e:
-                logger.warning(f"update_user_fields failed for user_id={user['id']}: {e}")
-            else:
-                # Refresh the user dict so anything downstream sees the new values.
-                refreshed = await vdb.get_user_by_external_id.remote(sub)
-                if refreshed is not None:
-                    user = refreshed
-
-    # --- 6. Timestamps ---------------------------------------------------------
-    now = _utcnow()
-    expires_in = max(int(bundle.expires_in or 0), 60)
-    access_token_expires_at = now + timedelta(seconds=expires_in)
-    if bundle.refresh_token:
-        session_expires_at = now + timedelta(days=7)
-    else:
-        session_expires_at = access_token_expires_at
-
-    # --- 7. Issue session & encrypt ------------------------------------------
-    plain, _hashed = issue_session_token()
-    key = _token_encryption_key()
-    id_token_encrypted = encrypt_token(bundle.id_token, key=key)
-    access_token_encrypted = encrypt_token(bundle.access_token, key=key)
-    refresh_token_encrypted = encrypt_token(bundle.refresh_token, key=key)
-    sid = bundle.claims.get("sid")
-
-    await vdb.create_oidc_session.remote(
-        user_id=user["id"],
-        sub=sub,
-        sid=sid,
-        session_token_plain=plain,
-        id_token_encrypted=id_token_encrypted,
-        access_token_encrypted=access_token_encrypted,
-        refresh_token_encrypted=refresh_token_encrypted,
-        access_token_expires_at=access_token_expires_at,
-        session_expires_at=session_expires_at,
-    )
-
-    # --- 8. Build redirect: clear state cookie, set session cookie -----------
-    next_url = _sanitize_next_url(payload.next_url)
-    redirect = RedirectResponse(url=next_url, status_code=302)
+    redirect = RedirectResponse(url=result.next_url, status_code=302)
     _delete_state_cookie(redirect)
-
-    max_age = max(int((session_expires_at - now).total_seconds()), 1)
     redirect.set_cookie(
-        key=SESSION_COOKIE_NAME,
-        value=plain,
-        max_age=max_age,
+        key=result.session_cookie_name,
+        value=result.session_cookie_value,
+        max_age=result.session_cookie_max_age,
         httponly=True,
         secure=_is_request_secure(request),
         samesite="lax",
         path="/",
     )
-
-    logger.info(f"OIDC login success — user_id={user['id']}, sid={sid!r}, next={next_url!r}")
     return redirect
 
 
@@ -502,42 +152,25 @@ async def callback(request: Request, code: str | None = None, state: str | None 
 
 
 @router.post("/auth/backchannel-logout", include_in_schema=False)
-async def backchannel_logout(logout_token: str = Form(...)):
+async def backchannel_logout(
+    logout_token: str = Form(...),
+    service: AuthService = Depends(get_auth_service),
+):
     """IdP-initiated logout per OIDC Back-Channel Logout spec.
 
     Content-Type: ``application/x-www-form-urlencoded`` with field ``logout_token``.
     """
     _require_oidc_mode()
-
-    client: OIDCClient = get_oidc_client()
-
     try:
-        claims = await client.verify_logout_token(logout_token)
-    except ValueError as e:
-        logger.warning(f"Invalid back-channel logout token: {e}")
+        await service.handle_backchannel_logout(logout_token)
+    except OIDCFlowError as e:
+        content: dict[str, str] = {"error": "invalid_request"}
+        if e.error_description:
+            content["error_description"] = e.error_description
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={"error": "invalid_request", "error_description": str(e)},
+            content=content,
             headers={"Cache-Control": "no-store"},
-        )
-    except Exception as e:
-        logger.warning(f"Back-channel logout token verification failed: {e}")
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={"error": "invalid_request"},
-            headers={"Cache-Control": "no-store"},
-        )
-
-    if claims.sid:
-        vdb = get_vectordb()
-        count = await vdb.revoke_oidc_sessions_by_sid.remote(claims.sid)
-        logger.info(f"Back-channel logout revoked sessions — sid={claims.sid!r}, count={count}")
-    else:
-        # Plan §2 #10 limits back-channel logout scope to sid only.
-        # Still return 200 to keep the IdP happy.
-        logger.warning(
-            f"Received sid-less back-channel logout token — not supported; "
-            f"ignoring per implementation policy (sub={claims.sub!r})"
         )
 
     return Response(
@@ -552,52 +185,17 @@ async def backchannel_logout(logout_token: str = Form(...)):
 
 
 @router.get("/auth/logout", include_in_schema=False)
-async def logout(request: Request):
+async def logout(
+    request: Request,
+    service: AuthService = Depends(get_auth_service),
+):
     _require_oidc_mode()
-
-    vdb = get_vectordb()
-    client: OIDCClient = get_oidc_client()
-
-    # Look up & revoke the session; keep the id_token to forward as id_token_hint.
-    id_token_hint: str | None = None
-    cookie_value = request.cookies.get(SESSION_COOKIE_NAME)
-    if cookie_value:
-        session = await vdb.get_oidc_session_by_token.remote(cookie_value)
-        if session:
-            enc = session.get("id_token_encrypted")
-            if enc:
-                try:
-                    id_token_hint = decrypt_token(enc, key=_token_encryption_key())
-                except ValueError as e:
-                    logger.warning(f"Failed to decrypt id_token for logout: {e}")
-            try:
-                await vdb.revoke_oidc_session_by_id.remote(session["id"])
-            except Exception as e:
-                logger.warning(f"Failed to revoke oidc_session during logout: {e}")
-
-    # Build redirect target: IdP end_session if discovery provides one,
-    # otherwise the configured post-logout URL. If neither is available
-    # we return a plain 200 with the cookie deleted — better than a 302
-    # loop through the root.
-    local_target = _post_logout_redirect_uri()
-    redirect_target: str | None = local_target
-    try:
-        meta = await client.discover()
-        end_session = meta.get("end_session_endpoint")
-        if end_session:
-            params: dict[str, str] = {"client_id": _oidc_client_id()}
-            if local_target:
-                params["post_logout_redirect_uri"] = local_target
-            if id_token_hint:
-                params["id_token_hint"] = id_token_hint
-            redirect_target = f"{end_session}?{urlencode(params)}"
-    except Exception as e:
-        logger.warning(f"OIDC discovery failed during logout, skipping IdP redirect: {e}")
+    redirect_target = await service.logout(request.cookies.get(SESSION_COOKIE_NAME))
 
     if redirect_target:
-        response = RedirectResponse(url=redirect_target, status_code=302)
+        response: Response = RedirectResponse(url=redirect_target, status_code=302)
     else:
-        # No IdP end_session and no local post-logout URL → just confirm the
+        # No IdP end_session and no local post-logout URL → confirm the
         # logout in-place. The cookie deletion below still takes effect.
         response = JSONResponse(status_code=200, content={"detail": "Logged out"})
     response.delete_cookie(key=SESSION_COOKIE_NAME, path="/")
@@ -623,7 +221,6 @@ async def me(request: Request):
     if oidc_session and oidc_session.get("session_expires_at"):
         exp = oidc_session["session_expires_at"]
         try:
-            # naive datetime → iso str
             session_expires_at = exp.isoformat()
         except AttributeError:
             session_expires_at = str(exp)

--- a/openrag/routers/extract.py
+++ b/openrag/routers/extract.py
@@ -62,7 +62,13 @@ async def get_extract(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Extract '{extract_id}' not found.",
         )
-    chunk_partition = chunk["metadata"]["partition"]
+    chunk_partition = chunk.get("metadata", {}).get("partition")
+    if not chunk_partition:
+        log.warning("Extract metadata missing partition.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Extract '{extract_id}' not found.",
+        )
     log.info(f"User partitions: {user_partitions}, Chunk partition: {chunk_partition}")
     if chunk_partition not in user_partitions and user_partitions != ["all"]:
         log.warning("User does not have access to this extract.")

--- a/openrag/routers/extract.py
+++ b/openrag/routers/extract.py
@@ -1,13 +1,23 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+"""Extract route — thin HTTP layer over :class:`ConversionService`.
+
+Phase 8E: the chunk-by-id lookup moved to
+``services.orchestrators.conversion_service.ConversionService`` (clean
+``VectorStore`` port, no Ray). This module keeps HTTP transport only:
+the request-scoped partition authorization and the not-found / forbidden
+guards whose exact ``{"detail": ...}`` body the legacy endpoint
+returned via ``HTTPException``.
+"""
+
+from di.providers import get_conversion_service
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
-from utils.dependencies import get_vectordb
+from services.orchestrators.conversion_service import ConversionService
 from utils.logger import get_logger
 
 from .utils import current_user_or_admin_partitions_list
 
 logger = get_logger()
 
-# Create an APIRouter instance
 router = APIRouter()
 
 
@@ -39,21 +49,20 @@ View detailed content of a specific chunk from search results.
 """,
 )
 async def get_extract(
-    request: Request,
     extract_id: str,
-    vectordb=Depends(get_vectordb),
     user_partitions=Depends(current_user_or_admin_partitions_list),
+    service: ConversionService = Depends(get_conversion_service),
 ):
     log = logger.bind(extract_id=extract_id)
 
-    chunk = await vectordb.get_chunk_by_id.remote(extract_id)
+    chunk = await service.get_chunk(extract_id)
     if chunk is None:
         log.warning("Extract not found.")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Extract '{extract_id}' not found.",
         )
-    chunk_partition = chunk.metadata["partition"]
+    chunk_partition = chunk["metadata"]["partition"]
     log.info(f"User partitions: {user_partitions}, Chunk partition: {chunk_partition}")
     if chunk_partition not in user_partitions and user_partitions != ["all"]:
         log.warning("User does not have access to this extract.")
@@ -65,5 +74,5 @@ async def get_extract(
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content={"page_content": chunk.page_content, "metadata": chunk.metadata},
+        content={"page_content": chunk["page_content"], "metadata": chunk["metadata"]},
     )

--- a/openrag/routers/indexer.py
+++ b/openrag/routers/indexer.py
@@ -1,11 +1,23 @@
+"""Indexing routes — thin HTTP layer over :class:`IndexingService`.
+
+Phase 8D.1: metadata assembly, existence/workspace checks and task
+dispatch moved to
+``services.orchestrators.indexing_service.IndexingService`` (the Ray
+``Indexer`` / ``TaskStateManager`` actors now sit behind the
+``IndexingDispatcher`` port). This module keeps HTTP transport only:
+the saved-file IO, ``request.url_for`` link building, the shared
+``Depends`` auth wrappers, and the conflict / not-found / bad-input
+guards whose exact non-bracketed ``{"detail": ...}`` body the legacy
+endpoints returned via ``HTTPException``.
+"""
+
 import json
 from pathlib import Path
 from typing import Any
 
-import ray
-from components.indexer.utils.files import extract_temporal_fields, sanitize_filename, save_file_to_disk
-from components.ray_utils import call_ray_actor_with_timeout
+from components.indexer.utils.files import sanitize_filename, save_file_to_disk
 from config import load_config
+from di.providers import get_indexing_service
 from fastapi import (
     APIRouter,
     Depends,
@@ -17,14 +29,13 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from utils.dependencies import get_indexer, get_task_state_manager, get_vectordb
+from services.orchestrators.indexing_service import IndexingService
 from utils.logger import get_logger
 
 from .utils import (
     check_user_file_quota,
     current_user_partitions,
     ensure_partition_role,
-    human_readable_size,
     require_partition_editor,
     require_task_owner,
     validate_file_format,
@@ -32,26 +43,17 @@ from .utils import (
     validate_metadata,
 )
 
-# load logger
 logger = get_logger()
 
-# load config
 config = load_config()
 DATA_DIR = config.paths.data_dir
-VECTORDB_TIMEOUT = config.ray.indexer.vectordb_timeout
-
-FORBIDDEN_CHARS_IN_FILE_ID = set("/")  # set('"<>#%{}|\\^`[]')
 LOG_FILE = Path(config.paths.log_dir or "logs") / "app.json"
 
 # supported file formats or mimetypes
 ACCEPTED_FILE_FORMATS = config.loader.file_loaders.model_dump().keys()
 DICT_MIMETYPES = config.loader.mimetypes.to_dict()
 
-# URL scheme configuration
 PREFERRED_URL_SCHEME = config.server.preferred_url_scheme
-
-# DATETIME FIELDS: Fields provided by the client
-TEMPORAL_FIELDS = ["created_at"]
 
 
 def build_url(request: Request, route_name: str, **path_params) -> str:
@@ -62,7 +64,6 @@ def build_url(request: Request, route_name: str, **path_params) -> str:
     return str(url)
 
 
-# Create an APIRouter instance
 router = APIRouter()
 
 
@@ -83,9 +84,7 @@ async def get_supported_types():
         - `extensions`: List of supported file extensions.
         - `mimetypes`: List of supported MIME types.
     """
-    list_extensions = list(ACCEPTED_FILE_FORMATS)
-    list_mimetypes = list(DICT_MIMETYPES)
-    resp = {"extensions": list_extensions, "mimetypes": list_mimetypes}
+    resp = {"extensions": list(ACCEPTED_FILE_FORMATS), "mimetypes": list(DICT_MIMETYPES)}
     return JSONResponse(content=resp)
 
 
@@ -129,23 +128,20 @@ async def add_file(
     file: UploadFile = Depends(validate_file_format),
     metadata: dict = Depends(validate_metadata),
     workspace_ids: str | None = Form(None, description="JSON array of workspace IDs to add the file to"),
-    indexer=Depends(get_indexer),
-    task_state_manager=Depends(get_task_state_manager),
-    vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),
     _quota_check=Depends(check_user_file_quota),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    if await vectordb.file_exists.remote(file_id, partition):
+    if await service.file_exists(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"File '{file_id}' already exists in partition {partition}",
         )
 
-    save_dir = Path(DATA_DIR)
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
     try:
-        file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
+        file_path = await save_file_to_disk(file, Path(DATA_DIR), with_random_prefix=True)
     except Exception as e:
         logger.exception("Failed to save file to disk.", error=str(e))
         raise HTTPException(
@@ -153,24 +149,6 @@ async def add_file(
             detail=str(e),
         )
 
-    metadata.update(
-        {
-            "source": str(file_path),
-            "filename": file.filename,
-            "original_filename": original_filename,
-        }
-    )
-    file_stat = Path(file_path).stat()
-
-    # Append extra metadata
-    metadata["file_size"] = human_readable_size(file_stat.st_size)
-    metadata["file_id"] = file_id
-
-    ## Add temporal fields to metadata, using provided values if available, otherwise extracting from file system
-    temporal_fields = extract_temporal_fields(metadata, temporal_fields=TEMPORAL_FIELDS)
-    metadata.update(temporal_fields)
-
-    # Validate and parse workspace_ids
     parsed_workspace_ids = None
     if workspace_ids:
         try:
@@ -183,27 +161,27 @@ async def add_file(
                 detail="workspace_ids must be a JSON array of strings",
             )
         for ws_id in parsed_workspace_ids:
-            ws = await call_ray_actor_with_timeout(
-                vectordb.get_workspace.remote(ws_id),
-                timeout=VECTORDB_TIMEOUT,
-                task_description=f"get_workspace({ws_id})",
-            )
+            ws = await service.get_workspace(ws_id)
             if not ws or ws["partition_name"] != partition:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=f"Workspace '{ws_id}' not found in partition '{partition}'",
                 )
 
-    # Indexing the file (workspace association happens inside add_file after successful indexing)
-    task = indexer.add_file.remote(
-        path=file_path, metadata=metadata, partition=partition, user=user, workspace_ids=parsed_workspace_ids
+    task_id = await service.add_file(
+        file_path=str(file_path),
+        file_id=file_id,
+        partition=partition,
+        metadata=metadata,
+        sanitized_filename=file.filename,
+        original_filename=original_filename,
+        user=user,
+        workspace_ids=parsed_workspace_ids,
     )
-    await task_state_manager.set_state.remote(task.task_id().hex(), "QUEUED")
-    await task_state_manager.set_object_ref.remote(task.task_id().hex(), {"ref": task})
 
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
-        content={"task_status_url": build_url(request, "get_task_status", task_id=task.task_id().hex())},
+        content={"task_status_url": build_url(request, "get_task_status", task_id=task_id)},
     )
 
 
@@ -222,16 +200,15 @@ Returns 204 No Content on successful deletion.
 async def delete_file(
     partition: str,
     file_id: str,
-    indexer=Depends(get_indexer),
-    vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    if not await vectordb.file_exists.remote(file_id, partition):
+    if not await service.file_exists(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"'{file_id}' not found in partition '{partition}'",
         )
-    await indexer.delete_file.remote(file_id, partition)
+    await service.delete_file(file_id, partition)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -275,12 +252,10 @@ async def put_file(
     file_id: str = Depends(validate_file_id),
     file: UploadFile = Depends(validate_file_format),
     metadata: dict = Depends(validate_metadata),
-    indexer=Depends(get_indexer),
-    task_state_manager=Depends(get_task_state_manager),
-    vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    if not await vectordb.file_exists.remote(file_id, partition):
+    if not await service.file_exists(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"'{file_id}' not found in partition '{partition}'",
@@ -289,45 +264,24 @@ async def put_file(
     # No Milvus deletion here. The Indexer's add_file(replace=True) flow uses
     # insert-before-delete: it snapshots old chunk IDs, inserts new chunks,
     # then deletes old ones — so the file is never left in a half-replaced state.
-
-    save_dir = Path(DATA_DIR)
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
-    file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
+    file_path = await save_file_to_disk(file, Path(DATA_DIR), with_random_prefix=True)
 
-    metadata.update(
-        {
-            "source": str(file_path),
-            "filename": file.filename,
-            "original_filename": original_filename,
-        }
-    )
-
-    file_stat = Path(file_path).stat()
-
-    # Append extra metadata
-    metadata["file_size"] = human_readable_size(file_stat.st_size)
-    metadata["file_id"] = file_id
-
-    ## Add temporal fields to metadata, using provided values if available, otherwise extracting from file system
-    temporal_fields = extract_temporal_fields(metadata, temporal_fields=TEMPORAL_FIELDS)
-    metadata.update(temporal_fields)
-
-    # Re-index: serialize → chunk → embed → insert into Milvus + update PG row in-place.
-    # replace=True tells add_file to update the existing PG File row rather than creating a new one.
-    task = indexer.add_file.remote(
-        path=file_path,
-        metadata=metadata,
+    task_id = await service.add_file(
+        file_path=str(file_path),
+        file_id=file_id,
         partition=partition,
+        metadata=metadata,
+        sanitized_filename=file.filename,
+        original_filename=original_filename,
         user=user,
         replace=True,
     )
-    await task_state_manager.set_state.remote(task.task_id().hex(), "QUEUED")
-    await task_state_manager.set_object_ref.remote(task.task_id().hex(), {"ref": task})
 
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,
-        content={"task_status_url": build_url(request, "get_task_status", task_id=task.task_id().hex())},
+        content={"task_status_url": build_url(request, "get_task_status", task_id=task_id)},
     )
 
 
@@ -353,12 +307,10 @@ async def patch_file(
     partition: str,
     file_id: str = Depends(validate_file_id),
     metadata: Any | None = Depends(validate_metadata),
-    indexer=Depends(get_indexer),
     user=Depends(require_partition_editor),
     user_partitions=Depends(current_user_partitions),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    metadata["file_id"] = file_id
-
     # Make sure partition role is valid if partition is being changed
     if "partition" in metadata:
         await ensure_partition_role(
@@ -368,7 +320,7 @@ async def patch_file(
             required_role="editor",
         )
 
-    await indexer.update_file_metadata.remote(file_id, metadata, partition, user=user)
+    await service.update_metadata(file_id, metadata, partition, user)
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content={"message": f"Metadata for file '{file_id}' successfully updated."},
@@ -400,22 +352,27 @@ async def copy_file_between_partitions(
     metadata: Any | None = Depends(validate_metadata),
     source_partition: str = Form(...),
     source_file_id: str = Form(...),
-    indexer=Depends(get_indexer),
     user=Depends(require_partition_editor),
     user_partitions=Depends(current_user_partitions),
     _quota_check=Depends(check_user_file_quota),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    # Make sure user has access to destination partition
+    # Make sure user has access to the source partition
     await ensure_partition_role(
         partition=source_partition,
         user=user,
         user_partitions=user_partitions,
         required_role="viewer",
     )
-    metadata["file_id"] = file_id
-    metadata["partition"] = partition
 
-    await indexer.copy_file.remote(file_id=source_file_id, metadata=metadata, partition=source_partition, user=user)
+    await service.copy_file(
+        source_file_id=source_file_id,
+        source_partition=source_partition,
+        target_file_id=file_id,
+        target_partition=partition,
+        metadata=metadata,
+        user=user,
+    )
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
         content={"message": "File copied successfully."},
@@ -440,18 +397,16 @@ Returns task status information including:
 async def get_task_status(
     request: Request,
     task_id: str,
-    task_state_manager=Depends(get_task_state_manager),
     task_details=Depends(require_task_owner),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    # fetch task state
-    state = await task_state_manager.get_state.remote(task_id)
+    state = await service.get_task_state(task_id)
     if state is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Task '{task_id}' not found.",
         )
 
-    # format the response
     content: dict[str, Any] = {
         "task_id": task_id,
         "task_state": state,
@@ -481,10 +436,10 @@ Returns error information including:
 )
 async def get_task_error(
     task_id: str,
-    task_state_manager=Depends(get_task_state_manager),
     task_details=Depends(require_task_owner),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    error = await task_state_manager.get_error.remote(task_id)
+    error = await service.get_task_error(task_id)
     if error is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -552,15 +507,10 @@ Returns confirmation message that cancellation signal was sent.
 )
 async def cancel_task(
     task_id: str,
-    task_state_manager=Depends(get_task_state_manager),
     task_details=Depends(require_task_owner),
+    service: IndexingService = Depends(get_indexing_service),
 ):
-    obj_ref = await task_state_manager.get_object_ref.remote(task_id)
-    if obj_ref is None:
+    cancelled = await service.cancel_task(task_id)
+    if not cancelled:
         raise HTTPException(404, f"No ObjectRef stored for task {task_id}")
-
-    ray.cancel(obj_ref["ref"], recursive=True)
-    current_state = await task_state_manager.get_state.remote(task_id)
-    if current_state not in {"COMPLETED", "FAILED"}:
-        await task_state_manager.set_state.remote(task_id, "CANCELLED")
     return {"message": f"Cancellation signal sent for task {task_id}"}

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -1,3 +1,16 @@
+"""OpenAI-compatible RAG endpoints — thin HTTP layer over QueryService.
+
+Phase 8C.2: the RAG flow (query generation, retrieval, web search,
+map-reduce, context/prompt assembly, streaming, and the
+``[Sources: N]`` citation filtering) moved to
+``services.orchestrators.query_service.QueryService``. This module keeps
+HTTP transport only: model→partition resolution, token-limit validation,
+the OpenAI ``/models`` listing, request-bound source-link building
+(``__prepare_sources`` uses ``request.url_for`` so it stays here and is
+handed to the service as a callable), and ``StreamingResponse`` /
+``JSONResponse`` wrapping with the SSE error envelope.
+"""
+
 import asyncio
 import json
 from pathlib import Path
@@ -5,19 +18,14 @@ from urllib.parse import quote, urlparse
 
 import consts
 from components.indexer.utils.text_sanitizer import sanitize_text
-from components.pipeline import RagPipeline
-from components.utils import (
-    extract_and_strip_sources_block,
-    filter_sources_by_citations,
-    get_num_tokens,
-    stream_with_source_filtering,
-)
+from components.utils import get_num_tokens
 from config import load_config
+from di.providers import get_partition_service, get_query_service
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
-from langchain_core.documents.base import Document
 from models.openai import OpenAIChatCompletionRequest, OpenAICompletionRequest
-from utils.dependencies import get_vectordb
+from services.orchestrators.partition_service import PartitionService
+from services.orchestrators.query_service import QueryService
 from utils.exceptions.base import OpenRAGError
 from utils.logger import get_logger
 
@@ -35,8 +43,6 @@ logger = get_logger()
 config = load_config()
 router = APIRouter()
 
-ragpipe = RagPipeline()
-
 # Cached max model token limit, populated at startup
 _max_model_tokens: int | None = None
 
@@ -49,14 +55,7 @@ async def _cache_max_model_tokens():
 
 def _make_sse_error(message: str, code: str) -> str:
     """Format an error as an SSE data chunk for streaming responses."""
-    chunk = {
-        "error": {
-            "message": message,
-            "type": "error",
-            "param": None,
-            "code": code,
-        }
-    }
+    chunk = {"error": {"message": message, "type": "error", "param": None, "code": code}}
     return f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n"
 
 
@@ -81,37 +80,27 @@ Returns models in OpenAI-compatible format with:
     response_description="A list of available models in OpenAI format",
 )
 async def list_models(
-    vectordb=Depends(get_vectordb),
     user_partitions=Depends(current_user_or_admin_partitions),
+    partitions: PartitionService = Depends(get_partition_service),
 ):
     if [p["partition"] for p in user_partitions] == ["all"]:
-        user_partitions = await vectordb.list_partitions.remote()
+        user_partitions = await partitions.list_partitions()
     logger.debug("Listing models", partition_count=len(user_partitions))
 
-    models = []
-    for partition in user_partitions:
-        model_id = f"{consts.PARTITION_PREFIX}{partition['partition']}"
-        models.append(
-            {
-                "id": model_id,
-                "object": "model",
-                "created": partition["created_at"],
-                "owned_by": "OpenRAG",
-            }
-        )
-
-    models.append(
+    models = [
         {
-            "id": f"{consts.PARTITION_PREFIX}all",
+            "id": f"{consts.PARTITION_PREFIX}{partition['partition']}",
             "object": "model",
-            "created": 0,
+            "created": partition["created_at"],
             "owned_by": "OpenRAG",
         }
-    )
+        for partition in user_partitions
+    ]
+    models.append({"id": f"{consts.PARTITION_PREFIX}all", "object": "model", "created": 0, "owned_by": "OpenRAG"})
     return JSONResponse(content={"object": "list", "data": models})
 
 
-def __prepare_sources(request: Request, docs: list[Document], web_results: list | None = None):
+def __prepare_sources(request: Request, docs: list, web_results: list | None = None):
     links = []
     for doc in docs:
         doc_metadata = dict(doc.metadata)
@@ -144,18 +133,14 @@ def __prepare_sources(request: Request, docs: list[Document], web_results: list 
 def is_direct_llm_model(
     request: OpenAIChatCompletionRequest | OpenAICompletionRequest,
 ) -> bool:
-    """Check if request should use direct LLM (no RAG partition).
-
-    Returns True if model is None, empty, or matches the configured default model.
-    """
+    """True if the request should use the LLM directly (no RAG partition)."""
     return request.model is None or request.model == "" or request.model == config.llm.model
 
 
 async def _fetch_max_model_tokens() -> int:
-    """Fetch the maximum model token limit from vLLM's OpenAI server.
+    """Fetch the max model token limit from vLLM's OpenAI server.
 
-    Queries `/v1/models` and looks for `max_model_len` for the configured LLM model.
-    Falls back to `config.llm_context.max_llm_context_size` (default 8192) if unavailable.
+    Falls back to ``config.llm_context.max_llm_context_size`` if unavailable.
     """
     default_limit = int(config.llm_context.max_llm_context_size)
     model_id = config.llm.model
@@ -165,17 +150,13 @@ async def _fetch_max_model_tokens() -> int:
         if model is None:
             logger.warning(f"No model found for {model_id}. Using default context size.")
             return default_limit
-
         model_data = model.model_dump() if hasattr(model, "model_dump") else model.dict()
         max_len = model_data.get("max_model_len") or model_data.get("model_extra", {}).get("max_model_len")
-
         if max_len is None:
             logger.warning(f"max_model_len not found for {model_id}. Using default context size.")
             return default_limit
-
         logger.info("Fetched max_model_len from vLLM at startup", model=model_id, max_model_len=int(max_len))
         return int(max_len)
-
     except Exception as e:
         logger.warning("Failed to query /v1/models for max_model_len; using default", error=str(e))
         return default_limit
@@ -192,15 +173,7 @@ def validate_tokens_limit(
     request: OpenAIChatCompletionRequest | OpenAICompletionRequest,
     max_tokens_allowed: int,
 ) -> tuple[bool, str]:
-    """Validate if the request respects the maximum token limit.
-
-    Args:
-        request: The OpenAI request object
-        max_tokens_allowed: Maximum allowed tokens for the request.
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
+    """Validate if the request respects the maximum token limit."""
     try:
         _length_function = get_num_tokens()
 
@@ -209,15 +182,6 @@ def validate_tokens_limit(
             default_output_tokens = int(config.llm_context.max_output_tokens)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = message_tokens + requested_tokens
-
-            logger.debug(
-                "Token validation for chat completion",
-                message_tokens=message_tokens,
-                requested_tokens=requested_tokens,
-                total_tokens=total_tokens_needed,
-                max_allowed=max_tokens_allowed,
-            )
-
             if total_tokens_needed > max_tokens_allowed:
                 return False, (
                     f"Request exceeds maximum token limit. "
@@ -232,15 +196,6 @@ def validate_tokens_limit(
             default_output_tokens = int(config.llm_context.max_output_tokens)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = prompt_tokens + requested_tokens
-
-            logger.debug(
-                "Token validation for completion",
-                prompt_tokens=prompt_tokens,
-                requested_tokens=requested_tokens,
-                total_tokens=total_tokens_needed,
-                max_allowed=max_tokens_allowed,
-            )
-
             if total_tokens_needed > max_tokens_allowed:
                 return False, (
                     f"Request exceeds maximum token limit. "
@@ -251,7 +206,6 @@ def validate_tokens_limit(
                 )
 
         return True, ""
-
     except Exception as e:
         logger.warning("Error during token validation, skipping check", error=str(e))
         return True, ""
@@ -262,8 +216,7 @@ def check_tokens_limit(
     log,
 ):
     """Validate token limit and raise HTTPException(413) if exceeded."""
-    max_tokens_allowed = get_max_model_tokens()
-    is_valid, error_message = validate_tokens_limit(request, max_tokens_allowed=max_tokens_allowed)
+    is_valid, error_message = validate_tokens_limit(request, max_tokens_allowed=get_max_model_tokens())
     if not is_valid:
         log.info("Request exceeds token limit", detail=error_message)
         raise HTTPException(
@@ -289,12 +242,6 @@ Accepts OpenAI-compatible chat completion requests with:
 - `stream`: Optional streaming response (true/false)
 - Standard OpenAI parameters (temperature, max_tokens, etc.)
 
-**RAG Process:**
-1. Extracts query from conversation
-2. Retrieves relevant documents from specified partition(s)
-3. Enriches prompt with document context
-4. Generates completion using LLM
-
 **Response:**
 Returns OpenAI-compatible response with additional `extra` field containing:
 - `sources`: Array of source documents with metadata and URLs
@@ -309,6 +256,7 @@ async def openai_chat_completion(
     user=Depends(current_user),
     user_partitions=Depends(current_user_or_admin_partitions_list),
     _: None = Depends(check_llm_model_availability),
+    service: QueryService = Depends(get_query_service),
 ):
     model_name = request.model or config.llm.model
     log = logger.bind(model=model_name, endpoint="/chat/completions")
@@ -320,10 +268,7 @@ async def openai_chat_completion(
             detail="The last message must be a non-empty user message",
         )
 
-    log.debug(
-        "Received chat completion request with messages: {}",
-        truncate(str(request.messages)),
-    )
+    log.debug("Received chat completion request with messages: {}", truncate(str(request.messages)))
 
     if is_direct_llm_model(request):
         check_tokens_limit(request, log)
@@ -332,16 +277,19 @@ async def openai_chat_completion(
         partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
         log.debug(f"Using partitions: {partitions}")
 
-    llm_output, docs, web_results = await ragpipe.chat_completion(partition=partitions, payload=request.model_dump())
-    log.debug("RAG chat completion pipeline executed.")
-
-    sources = __prepare_sources(request2, docs, web_results=web_results)
+    def prep(docs, web):
+        return __prepare_sources(request2, docs, web)
 
     if request.stream:
 
         async def stream_response():
             try:
-                async for sse_line in stream_with_source_filtering(llm_output, sources, model_name):
+                async for sse_line in service.chat_stream(
+                    partitions=partitions,
+                    payload=request.model_dump(),
+                    prepare_sources=prep,
+                    model_name=model_name,
+                ):
                     yield sse_line
             except asyncio.CancelledError:
                 log.info("Client disconnected during streaming")
@@ -354,18 +302,15 @@ async def openai_chat_completion(
                 yield _make_sse_error("An unexpected error occurred during streaming", "UNEXPECTED_ERROR")
 
         return StreamingResponse(stream_response(), media_type="text/event-stream")
-    else:
-        chunk = await llm_output.__anext__()
-        chunk["model"] = model_name
 
-        content = chunk.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
-        clean_content, citations = extract_and_strip_sources_block(content)
-        chunk["choices"][0]["message"]["content"] = clean_content
-
-        filtered = filter_sources_by_citations(sources, citations)
-        chunk["extra"] = json.dumps({"sources": filtered})
-        log.debug("Returning non-streaming completion chunk.")
-        return JSONResponse(content=chunk)
+    chunk = await service.chat(
+        partitions=partitions,
+        payload=request.model_dump(),
+        prepare_sources=prep,
+        model_name=model_name,
+    )
+    log.debug("Returning non-streaming completion chunk.")
+    return JSONResponse(content=chunk)
 
 
 @router.post(
@@ -384,11 +329,6 @@ Accepts OpenAI-compatible completion requests with:
 - `model`: Model/partition to use
 - Standard OpenAI parameters (temperature, max_tokens, etc.)
 
-**RAG Process:**
-1. Retrieves relevant documents from specified partition(s)
-2. Enriches prompt with document context
-3. Generates completion using LLM
-
 **Response:**
 Returns OpenAI-compatible response with additional `extra` field containing:
 - `sources`: Array of source documents with metadata and URLs
@@ -402,16 +342,14 @@ async def openai_completion(
     user=Depends(current_user),
     user_partitions=Depends(current_user_or_admin_partitions_list),
     _: None = Depends(check_llm_model_availability),
+    service: QueryService = Depends(get_query_service),
 ):
     model_name = request.model or config.llm.model
     log = logger.bind(model=model_name, endpoint="/completions")
 
     if not request.prompt:
         log.warning("Prompt is missing.")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The prompt is required",
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The prompt is required")
 
     if request.stream:
         log.warning("Streaming not supported for this endpoint.")
@@ -426,18 +364,10 @@ async def openai_completion(
     else:
         partitions = await get_partition_name(model_name, user_partitions, is_admin=user["is_admin"])
 
-    llm_output, docs = await ragpipe.completions(partition=partitions, payload=request.model_dump())
-    log.debug("RAG completion pipeline executed.")
-
-    sources = __prepare_sources(request2, docs)
-
-    complete_response = await llm_output.__anext__()
-
-    text = complete_response.get("choices", [{}])[0].get("text", "") or ""
-    clean_text, citations = extract_and_strip_sources_block(text)
-    complete_response["choices"][0]["text"] = clean_text
-
-    filtered = filter_sources_by_citations(sources, citations)
-    complete_response["extra"] = json.dumps({"sources": filtered})
+    resp = await service.complete(
+        partitions=partitions,
+        payload=request.model_dump(),
+        prepare_sources=lambda docs, _web: __prepare_sources(request2, docs),
+    )
     log.debug("Returning completion response.")
-    return JSONResponse(content=complete_response)
+    return JSONResponse(content=resp)

--- a/openrag/routers/partition.py
+++ b/openrag/routers/partition.py
@@ -1,9 +1,22 @@
+"""Partition routes — thin HTTP layer over :class:`PartitionService`.
+
+Phase 8B.1: partition CRUD, membership, file/chunk reads and the
+relationship queries moved to
+``services.orchestrators.partition_service.PartitionService``. This
+module keeps HTTP transport only: request-scoped authorization (the
+shared ``Depends`` wrappers in ``routers/utils.py``), ``request.url_for``
+link building, and the conflict / not-found guards whose exact
+non-bracketed ``{"detail": ...}`` body the legacy endpoints returned via
+``HTTPException``.
+"""
+
 from typing import Literal
 from urllib.parse import quote
 
+from di.providers import get_partition_service
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
-from utils.dependencies import get_vectordb
+from services.orchestrators.partition_service import PartitionService
 from utils.logger import get_logger
 
 from .utils import (
@@ -37,11 +50,11 @@ Returns a list of partitions you have access to, including:
 """,
 )
 async def list_existant_partitions(
-    vectordb=Depends(get_vectordb),
     partitions=Depends(partitions_with_details),
+    service: PartitionService = Depends(get_partition_service),
 ):
     if len(partitions) == 1 and partitions[0]["partition"] == "all":
-        partitions = await vectordb.list_partitions.remote()
+        partitions = await service.list_partitions()
     logger.debug("Returned list of existing partitions.", partition_count=len(partitions))
     return JSONResponse(status_code=status.HTTP_200_OK, content={"partitions": partitions})
 
@@ -65,11 +78,10 @@ Returns 204 No Content on successful deletion.
 )
 async def delete_partition(
     partition: str,
-    vectordb=Depends(get_vectordb),
     partition_owner=Depends(require_partition_owner),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    await vectordb.delete_partition.remote(partition)
-    logger.debug("Partition successfully deleted.")
+    await service.delete_partition(partition)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -96,13 +108,10 @@ async def list_files(
     request: Request,
     partition: str,
     limit: int | None = None,
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    log = logger.bind(partition=partition)
-    file_obj_l = await vectordb.list_partition_files.remote(partition=partition, limit=limit)
-    file_dicts = file_obj_l.get("files", [])
-    log.debug("Listed files in partition", file_count=len(file_dicts))
+    file_dicts = await service.list_files(partition, limit)
 
     def process_file(file_dict):
         return {
@@ -145,19 +154,17 @@ async def get_file(
     partition: str,
     file_id: str,
     limit: int = 2000,
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    if not await vectordb.file_exists.remote(file_id, partition):
+    if not await service.file_exists(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"'{file_id}' not found in partition '{partition}'",
         )
-    results = await vectordb.get_file_chunks.remote(partition=partition, file_id=file_id, include_id=True, limit=limit)
-
-    documents = [{"link": str(request.url_for("get_extract", extract_id=doc.metadata["_id"]))} for doc in results]
-
-    metadata = {k: v for k, v in results[0].metadata.items() if k != "_id"} if results else {}
+    rows = await service.get_file_chunks(partition=partition, file_id=file_id, limit=limit)
+    documents = [{"link": str(request.url_for("get_extract", extract_id=row["_id"]))} for row in rows]
+    metadata = {k: v for k, v in rows[0].items() if k != "_id"} if rows else {}
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,
@@ -190,17 +197,17 @@ async def list_all_chunks(
     request: Request,
     partition: str,
     include_embedding: bool = True,
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    chunks = await vectordb.list_all_chunk.remote(partition=partition, include_embedding=include_embedding)
+    items = await service.list_all_chunks(partition=partition, include_embedding=include_embedding)
     chunks = [
         {
-            "link": str(request.url_for("get_extract", extract_id=chunk.metadata["_id"])),
-            "content": chunk.page_content,
-            "metadata": chunk.metadata,
+            "link": str(request.url_for("get_extract", extract_id=it["metadata"]["_id"])),
+            "content": it["content"],
+            "metadata": it["metadata"],
         }
-        for chunk in chunks
+        for it in items
     ]
     return JSONResponse(status_code=status.HTTP_200_OK, content={"chunks": chunks})
 
@@ -224,14 +231,18 @@ Returns 201 Created on successful creation.
 Returns 409 Conflict if partition already exists.
 """,
 )
-async def create_partition(request: Request, partition: str, vectordb=Depends(get_vectordb)):
-    if await vectordb.partition_exists.remote(partition):
+async def create_partition(
+    request: Request,
+    partition: str,
+    service: PartitionService = Depends(get_partition_service),
+):
+    if await service.partition_exists(partition):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Partition '{partition}' already exists.",
         )
     user_id = request.state.user["id"]
-    await vectordb.create_partition.remote(partition=partition, user_id=user_id)
+    await service.create_partition(partition=partition, user_id=user_id)
     return Response(status_code=status.HTTP_201_CREATED)
 
 
@@ -259,17 +270,11 @@ Returns list of partition members with:
 )
 async def list_partition_users(
     partition: str,
-    vectordb=Depends(get_vectordb),
     partition_owner=Depends(require_partition_owner),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    """
-    List all users who are members of the given partition.
-    """
-    log = logger.bind(partition=partition)
-
-    members = await vectordb.list_partition_members.remote(partition=partition)
-
-    log.debug("Returned list of partition members.", member_count=len(members))
+    """List all users who are members of the given partition."""
+    members = await service.list_members(partition=partition)
     return JSONResponse(status_code=status.HTTP_200_OK, content={"members": members})
 
 
@@ -298,17 +303,11 @@ async def add_partition_user(
     partition: str,
     user_id: int = Form(...),
     role: RoleType = Form("viewer"),
-    vectordb=Depends(get_vectordb),
     partition_owner=Depends(require_partition_owner),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    """
-    Add a user as a member of the given partition.
-    """
-    log = logger.bind(partition=partition, user_id=user_id)
-
-    await vectordb.add_partition_member.remote(partition=partition, user_id=user_id, role=role)
-
-    log.debug("User added to partition successfully")
+    """Add a user as a member of the given partition."""
+    await service.add_member(partition=partition, user_id=user_id, role=role)
     return Response(status_code=status.HTTP_201_CREATED)
 
 
@@ -335,17 +334,11 @@ Returns 204 No Content on successful removal.
 async def remove_partition_user(
     partition: str,
     user_id: int,
-    vectordb=Depends(get_vectordb),
     partition_owner=Depends(require_partition_owner),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    """
-    Remove a user from the given partition.
-    """
-    log = logger.bind(partition=partition, user_id=user_id)
-
-    await vectordb.remove_partition_member.remote(partition=partition, user_id=user_id)
-
-    log.debug("User removed from partition successfully")
+    """Remove a user from the given partition."""
+    await service.remove_member(partition=partition, user_id=user_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -374,17 +367,11 @@ async def update_partition_user_role(
     partition: str,
     user_id: int,
     role: RoleType = Form(...),
-    vectordb=Depends(get_vectordb),
     partition_owner=Depends(require_partition_owner),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    """
-    Update a user's role in the given partition.
-    """
-    log = logger.bind(partition=partition, user_id=user_id, role=role)
-
-    await vectordb.update_partition_member_role.remote(partition=partition, user_id=user_id, new_role=role)
-
-    log.debug("User role updated successfully")
+    """Update a user's role in the given partition."""
+    await service.update_role(partition=partition, user_id=user_id, new_role=role)
     return Response(status_code=status.HTTP_200_OK)
 
 
@@ -413,19 +400,13 @@ Returns all files that share the same relationship_id:
 """,
 )
 async def get_related_files(
-    request: Request,
     partition: str,
     relationship_id: str,
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    log = logger.bind(partition=partition, relationship_id=relationship_id)
-    files = await vectordb.get_files_by_relationship.remote(partition=partition, relationship_id=relationship_id)
-    log.debug("Listed related files", file_count=len(files))
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content={"files": files},
-    )
+    files = await service.get_related_files(partition=partition, relationship_id=relationship_id)
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"files": files})
 
 
 @router.get(
@@ -455,26 +436,18 @@ For email threads with parallel branches, each branch has its own ancestor path.
 """,
 )
 async def get_file_ancestors(
-    request: Request,
     partition: str,
     file_id: str,
-    max_ancestor_depth: int | None = None,  # Optional limit on ancestor depth
-    vectordb=Depends(get_vectordb),
+    max_ancestor_depth: int | None = None,
     partition_viewer=Depends(require_partition_viewer),
+    service: PartitionService = Depends(get_partition_service),
 ):
-    log = logger.bind(partition=partition, file_id=file_id)
-
-    if not await vectordb.file_exists.remote(file_id, partition):
+    if not await service.file_exists(file_id, partition):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"'{file_id}' not found in partition '{partition}'",
         )
-
-    ancestors = await vectordb.get_file_ancestors.remote(
+    ancestors = await service.get_file_ancestors(
         partition=partition, file_id=file_id, max_ancestor_depth=max_ancestor_depth
     )
-    log.debug("Listed file ancestors", ancestor_count=len(ancestors))
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content={"ancestors": ancestors},
-    )
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"ancestors": ancestors})

--- a/openrag/routers/queue.py
+++ b/openrag/routers/queue.py
@@ -1,28 +1,19 @@
-from collections import Counter
+"""Queue routes — thin HTTP layer over :class:`JobService`.
 
-from config import load_config
+Phase 8D.2: queue aggregation and the ``?task_status=`` filtering moved
+to ``services.orchestrators.job_service.JobService``. This module keeps
+HTTP transport only: the shared admin/current-user ``Depends`` wrappers
+and the ``request.url_for`` link building.
+"""
+
+from di.providers import get_job_service
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import JSONResponse
-from utils.dependencies import get_task_state_manager
+from services.orchestrators.job_service import JobService
 
 from .utils import current_user, require_admin
 
-# load config
-config = load_config()
-
-# Create an APIRouter instance
 router = APIRouter()
-
-
-def _format_pool_info(worker_info: dict[str, int]) -> dict[str, int]:
-    """
-    Convert SerializerQueue.pool_info() output into a concise dict for the API.
-    """
-    return {
-        "total_slots": worker_info["total_capacity"],
-        "pool_size": worker_info["pool_size"],
-        "max_per_actor": worker_info["max_tasks_per_worker"],
-    }
 
 
 @router.get(
@@ -51,25 +42,11 @@ Returns system status including:
 Monitor system load and worker utilization.
 """,
 )
-async def get_queue_info(admin=Depends(require_admin), task_state_manager=Depends(get_task_state_manager)):
-    all_states: dict = await task_state_manager.get_all_states.remote()
-    status_counts = Counter(all_states.values())
-
-    active_statuses = ["QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"]
-    active = {s: status_counts.get(s, 0) for s in active_statuses}
-
-    task_summary = {
-        "active": sum(active.values()),
-        "active_statuses": active,
-        "total_cancelled": status_counts.get("CANCELLED", 0),
-        "total_completed": status_counts.get("COMPLETED", 0),
-        "total_failed": status_counts.get("FAILED", 0),
-    }
-
-    worker_info = await task_state_manager.get_pool_info.remote()
-    workers_block = _format_pool_info(worker_info)
-
-    return {"workers": workers_block, "tasks": task_summary}
+async def get_queue_info(
+    admin=Depends(require_admin),
+    service: JobService = Depends(get_job_service),
+):
+    return await service.get_queue_info()
 
 
 @router.get(
@@ -111,40 +88,30 @@ Returns list of tasks with:
 async def list_tasks(
     request: Request,
     task_status: str | None = None,
-    task_state_manager=Depends(get_task_state_manager),
     user=Depends(current_user),
+    service: JobService = Depends(get_job_service),
 ):
     """
     - ?task_status=active  → QUEUED | SERIALIZING | CHUNKING | INSERTING
     - ?task_status=<exact> → exact match (case-insensitive)
     - (none)               → all tasks
     """
-    # fetch task info
-    if user.get("is_admin"):
-        all_info: dict[str, dict] = await task_state_manager.get_all_info.remote()
-    else:
-        all_info: dict[str, dict] = await task_state_manager.get_all_user_info.remote(user.get("id"))
+    rows = await service.list_tasks(
+        is_admin=bool(user.get("is_admin")),
+        user_id=user.get("id"),
+        task_status=task_status,
+    )
 
-    if task_status is None:
-        filtered = all_info.items()
-    else:
-        if task_status.lower() == "active":
-            active_states = {"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"}
-            filtered = [(tid, info) for tid, info in all_info.items() if info["state"] in active_states]
-        else:
-            filtered = [(tid, info) for tid, info in all_info.items() if info["state"].lower() == task_status.lower()]
-
-    # format the response
     tasks = []
-    for task_id, info in filtered:
+    for row in rows:
+        task_id = row["task_id"]
         item = {
             "task_id": task_id,
-            "state": info["state"],
-            "details": info["details"],
-            # include an error URL if applicable
+            "state": row["state"],
+            "details": row["details"],
             **(
                 {"error_url": str(request.url_for("get_task_error", task_id=task_id))}
-                if info["state"] == "FAILED"
+                if row["state"] == "FAILED"
                 else {}
             ),
             "url": str(request.url_for("get_task_status", task_id=task_id)),

--- a/openrag/routers/search.py
+++ b/openrag/routers/search.py
@@ -67,14 +67,22 @@ class CommonSearchParams:
 
 
 def _documents(request: Request, chunks) -> list[dict]:
-    return [
-        {
-            "link": str(request.url_for("get_extract", extract_id=c.metadata.get("_id") or c.id)),
-            "metadata": c.metadata,
-            "content": c.text,
-        }
-        for c in chunks
-    ]
+    docs: list[dict] = []
+    for c in chunks:
+        # Restore the legacy response metadata shape. Chunk.from_langchain
+        # lifts file_id / partition / page / _id out of the free-form
+        # metadata into typed Chunk fields; to_langchain merges them back so
+        # the API contract (metadata.file_id, _id, …) matches the
+        # pre-Phase-8 router that returned the raw Document metadata.
+        meta = c.to_langchain().metadata
+        docs.append(
+            {
+                "link": str(request.url_for("get_extract", extract_id=meta.get("_id") or c.id)),
+                "metadata": meta,
+                "content": c.text,
+            }
+        )
+    return docs
 
 
 @router.get(

--- a/openrag/routers/search.py
+++ b/openrag/routers/search.py
@@ -1,11 +1,21 @@
+"""Semantic search routes — thin HTTP layer over RetrievalService.
+
+Phase 8C.1: the retrieval call (was ``indexer.asearch.remote`` + the
+legacy ``_expand_with_related_chunks``) moved to
+``services.orchestrators.retrieval_service.RetrievalService.search``.
+This module keeps HTTP transport only: request-scoped authorization,
+partition resolution from the authenticated user, the byte-identical
+workspace-not-found 404 guard, ``request.url_for`` links, and response
+shaping (domain ``Chunk`` → ``{link, metadata, content}``).
+"""
+
 from typing import Annotated
 
-from components.ray_utils import call_ray_actor_with_timeout
-from components.retriever import _expand_with_related_chunks
-from config import load_config
+from di.providers import get_retrieval_service, get_workspace_service
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
-from utils.dependencies import get_indexer, get_vectordb
+from services.orchestrators.retrieval_service import RetrievalService
+from services.orchestrators.workspace_service import WorkspaceService
 from utils.logger import get_logger
 
 from .utils import (
@@ -13,9 +23,6 @@ from .utils import (
     require_partition_viewer,
     require_partitions_viewer,
 )
-
-_config = load_config()
-VECTORDB_TIMEOUT = _config.ray.indexer.vectordb_timeout
 
 logger = get_logger()
 
@@ -57,6 +64,17 @@ class CommonSearchParams:
         self.top_k = top_k
         self.similarity_threshold = similarity_threshold
         self.filter = filter
+
+
+def _documents(request: Request, chunks) -> list[dict]:
+    return [
+        {
+            "link": str(request.url_for("get_extract", extract_id=c.metadata.get("_id") or c.id)),
+            "metadata": c.metadata,
+            "content": c.text,
+        }
+        for c in chunks
+    ]
 
 
 @router.get(
@@ -114,12 +132,11 @@ async def search_multiple_partitions(
     related_params: Annotated[RelatedDocSearchParams, Depends()],
     partitions: list[str] | None = Query(default=["all"], description="List of partitions to search"),
     workspace: str | None = Query(None, description="Workspace ID to filter results"),
-    indexer=Depends(get_indexer),
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partitions_viewer),
     user_partitions=Depends(current_user_or_admin_partitions_list),
+    service: RetrievalService = Depends(get_retrieval_service),
+    workspaces: WorkspaceService = Depends(get_workspace_service),
 ):
-    # Fetch user partitions if "all" is specified, or all partitions if super admin
     if partitions == ["all"]:
         partitions = user_partitions
 
@@ -134,53 +151,29 @@ async def search_multiple_partitions(
 
     filter_params = None
     if workspace:
-        ws = await call_ray_actor_with_timeout(
-            vectordb.get_workspace.remote(workspace),
-            timeout=VECTORDB_TIMEOUT,
-            task_description=f"get_workspace({workspace})",
-        )
+        ws = await workspaces.get_workspace(workspace)
         if not ws or ws["partition_name"] not in partitions:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
-
         filter_params = {"workspace_id": workspace}
 
-    results = await indexer.asearch.remote(
-        query=search_params.text,
+    results = await service.search(
+        text=search_params.text,
+        partitions=partitions,
         top_k=search_params.top_k,
         similarity_threshold=search_params.similarity_threshold,
-        partition=partitions,
         filter=search_params.filter,
         filter_params=filter_params,
+        include_related=related_params.include_related,
+        include_ancestors=related_params.include_ancestors,
+        related_limit=related_params.related_limit,
+        max_ancestor_depth=related_params.max_ancestor_depth,
     )
-    log.info(
-        "Semantic search on multiple partitions completed.",
-        result_count=len(results),
+    log.info("Semantic search on multiple partitions completed.", result_count=len(results))
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"documents": _documents(request, results)},
     )
-
-    # Expand with related/ancestor chunks if requested
-    if related_params.include_related or related_params.include_ancestors:
-        results = await _expand_with_related_chunks(
-            results=results,
-            db=vectordb,
-            include_related=related_params.include_related,
-            include_ancestors=related_params.include_ancestors,
-            related_limit=related_params.related_limit,
-            max_ancestor_depth=related_params.max_ancestor_depth,
-        )
-        log.info(
-            "Expanded results with related/ancestor chunks.",
-            expanded_count=len(results),
-        )
-
-    documents = [
-        {
-            "link": str(request.url_for("get_extract", extract_id=doc.metadata["_id"])),
-            "metadata": doc.metadata,
-            "content": doc.page_content,
-        }
-        for doc in results
-    ]
-    return JSONResponse(status_code=status.HTTP_200_OK, content={"documents": documents})
 
 
 @router.get(
@@ -229,9 +222,9 @@ async def search_one_partition(
     search_params: Annotated[CommonSearchParams, Depends()],
     related_params: Annotated[RelatedDocSearchParams, Depends()],
     workspace: str | None = Query(None, description="Workspace ID to filter results"),
-    indexer=Depends(get_indexer),
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: RetrievalService = Depends(get_retrieval_service),
+    workspaces: WorkspaceService = Depends(get_workspace_service),
 ):
     log = logger.bind(
         partition=partition,
@@ -243,51 +236,29 @@ async def search_one_partition(
     )
     filter_params = None
     if workspace:
-        ws = await call_ray_actor_with_timeout(
-            vectordb.get_workspace.remote(workspace),
-            timeout=VECTORDB_TIMEOUT,
-            task_description=f"get_workspace({workspace})",
-        )
+        ws = await workspaces.get_workspace(workspace)
         if not ws or ws["partition_name"] != partition:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
-
         filter_params = {"workspace_id": workspace}
 
-    results = await indexer.asearch.remote(
-        query=search_params.text,
+    results = await service.search(
+        text=search_params.text,
+        partitions=partition,
         top_k=search_params.top_k,
         similarity_threshold=search_params.similarity_threshold,
-        partition=partition,
         filter=search_params.filter,
         filter_params=filter_params,
+        include_related=related_params.include_related,
+        include_ancestors=related_params.include_ancestors,
+        related_limit=related_params.related_limit,
+        max_ancestor_depth=related_params.max_ancestor_depth,
     )
-
     log.info("Semantic search on single partition completed.", result_count=len(results))
 
-    # Expand with related/ancestor chunks if requested
-    if related_params.include_related or related_params.include_ancestors:
-        results = await _expand_with_related_chunks(
-            results=results,
-            db=vectordb,
-            include_related=related_params.include_related,
-            include_ancestors=related_params.include_ancestors,
-            related_limit=related_params.related_limit,
-            max_ancestor_depth=related_params.max_ancestor_depth,
-        )
-        log.info(
-            "Expanded results with related/ancestor chunks.",
-            expanded_count=len(results),
-        )
-
-    documents = [
-        {
-            "link": str(request.url_for("get_extract", extract_id=doc.metadata["_id"])),
-            "metadata": doc.metadata,
-            "content": doc.page_content,
-        }
-        for doc in results
-    ]
-    return JSONResponse(status_code=status.HTTP_200_OK, content={"documents": documents})
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"documents": _documents(request, results)},
+    )
 
 
 @router.get(
@@ -331,31 +302,25 @@ async def search_file(
     partition: str,
     file_id: str,
     search_params: Annotated[CommonSearchParams, Depends()],
-    indexer=Depends(get_indexer),
-    vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
+    service: RetrievalService = Depends(get_retrieval_service),
 ):
     log = logger.bind(partition=partition, file_id=file_id, query=search_params.text, top_k=search_params.top_k)
 
     filter = "file_id == {_file_id}" + (f" AND {search_params.filter}" if search_params.filter else "")
     params = {"_file_id": file_id}
 
-    results = await indexer.asearch.remote(
-        query=search_params.text,
+    results = await service.search(
+        text=search_params.text,
+        partitions=partition,
         top_k=search_params.top_k,
         similarity_threshold=search_params.similarity_threshold,
-        partition=partition,
         filter=filter,
         filter_params=params,
     )
     log.info("Semantic search on specific file completed.", result_count=len(results))
 
-    documents = [
-        {
-            "link": str(request.url_for("get_extract", extract_id=doc.metadata["_id"])),
-            "metadata": doc.metadata,
-            "content": doc.page_content,
-        }
-        for doc in results
-    ]
-    return JSONResponse(status_code=status.HTTP_200_OK, content={"documents": documents})
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"documents": _documents(request, results)},
+    )

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -1,284 +1,42 @@
-"""Integration tests for the OIDC auth router.
+"""Transport tests for the thin OIDC auth router (Phase 8A.1).
 
-The router transitively imports ``utils.dependencies``, which spins up Ray
-actors at import time (indexer, marker pool, semaphores, …). To avoid that
-in a unit-test context, we stub ``utils.dependencies`` in ``sys.modules``
-*before* importing the router, then drive it via FastAPI's ``TestClient``.
+Every OIDC business decision (PKCE/state generation, code exchange, user
+lookup/provisioning, session creation, logout-URL construction, JWT
+verification) now lives in :class:`services.orchestrators.auth_service.
+AuthService` and is covered end-to-end by
+``services/orchestrators/test_auth_service.py``.
 
-IdP interactions are mocked end-to-end with ``respx`` using a real RSA key
-pair so the router exercises actual JWT verification.
+This module only asserts what the router still owns: the ``AUTH_MODE``
+gate, delegation to the injected service, cookie set/clear, and the
+``OIDCFlowError`` → HTTP-response mapping. The service is stubbed via
+``dependency_overrides`` so no container / Ray / IdP is needed.
+
+The router transitively imports ``utils.dependencies`` (Ray actors at
+import time) through its dependency graph, so we stub that module in
+``sys.modules`` before importing the router.
 """
 
 from __future__ import annotations
 
 import sys
-import time
 import types
-from typing import Any
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# pytest sometimes initialises warning filters before we run — tolerate it.
-# ---------------------------------------------------------------------------
-
-pytest.importorskip("respx")
-pytest.importorskip("httpx")
-pytest.importorskip("authlib")
 pytest.importorskip("fastapi")
-pytest.importorskip("itsdangerous")
-pytest.importorskip("cryptography")
+pytest.importorskip("httpx")
 
-import httpx  # noqa: E402
-import respx  # noqa: E402
-from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
-from cryptography.fernet import Fernet  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-
-# ---------------------------------------------------------------------------
-# Constants — align with the existing auth unit tests
-# ---------------------------------------------------------------------------
-
-ISSUER = "https://idp.example.com/realms/openrag"
-CLIENT_ID = "openrag-client"
-CLIENT_SECRET = "test-secret"
-REDIRECT_URI = "https://openrag.example.com/auth/callback"
-SCOPES = "openid email profile offline_access"
-
-DISCOVERY_DOC = {
-    "issuer": ISSUER,
-    "authorization_endpoint": f"{ISSUER}/protocol/openid-connect/auth",
-    "token_endpoint": f"{ISSUER}/protocol/openid-connect/token",
-    "userinfo_endpoint": f"{ISSUER}/protocol/openid-connect/userinfo",
-    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
-    "end_session_endpoint": f"{ISSUER}/protocol/openid-connect/logout",
-}
-
-
-def _make_rsa_key_pair():
-    private = JsonWebKey.generate_key("RSA", 2048, is_private=True)
-    return private, private.as_dict(is_private=True), private.as_dict()
-
-
-_RSA_PRIVATE, _RSA_PRIVATE_JWK, _RSA_PUBLIC_JWK = _make_rsa_key_pair()
-_RSA_PUBLIC_JWK["use"] = "sig"
-_RSA_PUBLIC_JWK["alg"] = "RS256"
-_RSA_PUBLIC_JWK["kid"] = "test-key-1"
-_RSA_PRIVATE_JWK["kid"] = "test-key-1"
-
-JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
-
-
-def _sign_jwt(payload: dict) -> str:
-    header = {"alg": "RS256", "kid": "test-key-1"}
-    # Authlib >=1.0 requires the allowed-algorithms list on JsonWebToken.
-    jwt = JsonWebToken(["RS256"])
-    token = jwt.encode(header, payload, _RSA_PRIVATE)
-    return token.decode() if isinstance(token, bytes) else token
-
-
-def _id_token_payload(
-    nonce: str, *, sub: str = "sub-abc", email: str | None = "user@example.com", extra: dict | None = None
-) -> dict:
-    now = int(time.time())
-    payload = {
-        "iss": ISSUER,
-        "sub": sub,
-        "aud": CLIENT_ID,
-        "exp": now + 300,
-        "iat": now,
-        "nonce": nonce,
-    }
-    if email is not None:
-        payload["email"] = email
-    if extra:
-        payload.update(extra)
-    return payload
-
-
-def _logout_token_payload(*, sid: str | None = None, sub: str | None = None) -> dict:
-    now = int(time.time())
-    payload: dict[str, Any] = {
-        "iss": ISSUER,
-        "aud": CLIENT_ID,
-        "iat": now,
-        "jti": "lt-001",
-        "events": {"http://schemas.openid.net/event/backchannel-logout": {}},
-    }
-    if sid is not None:
-        payload["sid"] = sid
-    if sub is not None:
-        payload["sub"] = sub
-    return payload
-
 
 # ---------------------------------------------------------------------------
 # Stub heavy dependencies BEFORE importing the router
 # ---------------------------------------------------------------------------
 
-_FERNET_KEY = Fernet.generate_key().decode()
 
-
-class _RayMethodStub:
-    """Mimics a Ray actor method: ``method.remote(...)`` returns an awaitable."""
-
-    def __init__(self, name: str, fn, call_log: list):
-        self._name = name
-        self._fn = fn
-        self._call_log = call_log
-
-    async def remote(self, *args, **kwargs):
-        self._call_log.append((self._name, args, kwargs))
-        return self._fn(*args, **kwargs)
-
-
-class _StubVectorDB:
-    """Minimal Ray-actor stand-in — exposes ``.method.remote(...)`` awaitables."""
-
-    def __init__(self):
-        self.calls: list[tuple[str, tuple, dict]] = []
-        self._users_by_sub: dict[str, dict] = {}
-        self._users_by_id: dict[int, dict] = {}
-        self._sessions: dict[int, dict] = {}
-        self._sessions_by_token: dict[str, int] = {}
-        self._next_session_id = 1
-        self._next_user_id = 1000
-        # Bind each underlying impl as an actor-style accessor.
-        self.get_user_by_external_id = _RayMethodStub(
-            "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
-        )
-        self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
-        self.create_user = _RayMethodStub("create_user", self._impl_create_user, self.calls)
-        self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
-        self.get_oidc_session_by_token = _RayMethodStub(
-            "get_oidc_session_by_token", self._impl_get_oidc_session_by_token, self.calls
-        )
-        self.revoke_oidc_session_by_id = _RayMethodStub(
-            "revoke_oidc_session_by_id", self._impl_revoke_oidc_session_by_id, self.calls
-        )
-        self.revoke_oidc_sessions_by_sid = _RayMethodStub(
-            "revoke_oidc_sessions_by_sid", self._impl_revoke_oidc_sessions_by_sid, self.calls
-        )
-
-    # Test-only helpers -----------------------------------------------------
-
-    def add_user(
-        self,
-        *,
-        user_id: int,
-        email: str | None = None,
-        external_user_id: str | None = None,
-        display_name: str | None = None,
-    ) -> dict:
-        user = {
-            "id": user_id,
-            "email": email,
-            "external_user_id": external_user_id,
-            "is_admin": False,
-            "display_name": display_name or f"user-{user_id}",
-        }
-        self._users_by_id[user_id] = user
-        if external_user_id:
-            self._users_by_sub[external_user_id] = user
-        return user
-
-    # Impls ------------------------------------------------------------------
-
-    def _impl_get_user_by_external_id(self, external_user_id: str):
-        return self._users_by_sub.get(external_user_id)
-
-    def _impl_create_user(self, body):
-        # Accept either UserCreate or a plain dict, like the real Ray method
-        # would (Pydantic instances are serializable).
-        if hasattr(body, "model_dump"):
-            data = body.model_dump()
-        else:
-            data = dict(body)
-        user_id = self._next_user_id
-        self._next_user_id += 1
-        user = {
-            "id": user_id,
-            "display_name": data.get("display_name"),
-            "external_user_id": data.get("external_user_id"),
-            "email": (data.get("email").strip().lower() if data.get("email") else None),
-            "is_admin": bool(data.get("is_admin", False)),
-            "file_quota": data.get("file_quota"),
-            "file_count": 0,
-            "token": "or-stub",
-        }
-        self._users_by_id[user_id] = user
-        if data.get("external_user_id"):
-            self._users_by_sub[data["external_user_id"]] = user
-        return user
-
-    def _impl_update_user_fields(self, user_id: int, fields: dict):
-        user = self._users_by_id.get(user_id)
-        if user is None:
-            raise ValueError(f"User {user_id} not found")
-        _ALLOWED = {"display_name", "email"}
-        bad = set(fields) - _ALLOWED
-        if bad:
-            raise ValueError(f"Cannot update non-whitelisted user fields: {sorted(bad)}")
-        for k, v in fields.items():
-            if v is None:
-                continue
-            if k == "email" and isinstance(v, str):
-                v = v.strip().lower()
-            user[k] = v
-
-    def _impl_create_oidc_session(self, **kwargs):
-        sid = self._next_session_id
-        self._next_session_id += 1
-        row = {
-            "id": sid,
-            "session_expires_at": kwargs["session_expires_at"],
-            "id_token_encrypted": kwargs["id_token_encrypted"],
-            **{k: v for k, v in kwargs.items() if k != "session_token_plain"},
-        }
-        self._sessions[sid] = row
-        self._sessions_by_token[kwargs["session_token_plain"]] = sid
-        return row
-
-    def _impl_get_oidc_session_by_token(self, session_token_plain: str):
-        # Mirror PartitionFileManager.get_oidc_session_by_token semantics:
-        # reject revoked rows AND rows whose session_expires_at is in the past
-        # relative to datetime.now(). The expiry check is what makes this stub
-        # a faithful regression target for the M2 timezone fix.
-        from datetime import datetime as _dt
-
-        sid = self._sessions_by_token.get(session_token_plain)
-        if sid is None:
-            return None
-        row = self._sessions[sid]
-        if row.get("revoked_at"):
-            return None
-        exp = row.get("session_expires_at")
-        if isinstance(exp, _dt) and exp < _dt.now():
-            return None
-        return row
-
-    def _impl_revoke_oidc_session_by_id(self, session_id: int):
-        row = self._sessions.get(session_id)
-        if row:
-            row["revoked_at"] = time.time()
-
-    def _impl_revoke_oidc_sessions_by_sid(self, sid: str) -> int:
-        count = 0
-        for row in self._sessions.values():
-            if row.get("sid") == sid and not row.get("revoked_at"):
-                row["revoked_at"] = time.time()
-                count += 1
-        return count
-
-
-_stub_vectordb_singleton = _StubVectorDB()
-
-
-def _install_dependencies_stub():
-    """Replace ``utils.dependencies`` with a stub providing only ``get_vectordb``."""
+def _install_dependencies_stub() -> None:
     stub = types.ModuleType("utils.dependencies")
-    stub.get_vectordb = lambda: _stub_vectordb_singleton
+    stub.get_vectordb = lambda: None
     stub.get_task_state_manager = lambda: None
     stub.get_serializer = lambda: None
     stub.get_indexer = lambda: None
@@ -288,91 +46,115 @@ def _install_dependencies_stub():
 
 _install_dependencies_stub()
 
+from di.providers import get_auth_service  # noqa: E402
+from routers.auth import router as auth_router  # noqa: E402
+from services.orchestrators.auth_service import (  # noqa: E402
+    SESSION_COOKIE_NAME,
+    CallbackResult,
+    LoginRedirect,
+    OIDCFlowError,
+)
 
-# Now we can import the router.
-import importlib  # noqa: E402
-
-# Reset the OIDC client singleton between tests — important when env changes.
-from components.auth import deps as _auth_deps  # noqa: E402
-
-# Import the router module, forcing a fresh import.
-sys.modules.pop("routers.auth", None)
-_auth_router_module = importlib.import_module("routers.auth")
-auth_router = _auth_router_module.router
+STATE_COOKIE_NAME = "openrag_oidc_state"
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Stub AuthService
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def env_oidc(monkeypatch):
-    monkeypatch.setenv("AUTH_MODE", "oidc")
-    monkeypatch.setenv("OIDC_ENDPOINT", ISSUER)
-    monkeypatch.setenv("OIDC_CLIENT_ID", CLIENT_ID)
-    monkeypatch.setenv("OIDC_CLIENT_SECRET", CLIENT_SECRET)
-    monkeypatch.setenv("OIDC_REDIRECT_URI", REDIRECT_URI)
-    monkeypatch.setenv("OIDC_SCOPES", SCOPES)
-    monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", _FERNET_KEY)
-    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "id_token")
-    monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
-    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
-    _auth_deps.reset_oidc_client()
+class StubAuthService:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.login_result = LoginRedirect(
+            authorization_url="https://idp.example.com/auth?response_type=code",
+            state_cookie_name=STATE_COOKIE_NAME,
+            state_cookie_value="state-val",
+            state_cookie_max_age=600,
+        )
+        self.callback_result = CallbackResult(
+            session_cookie_name=SESSION_COOKIE_NAME,
+            session_cookie_value="sess-plain",
+            session_cookie_max_age=300,
+            next_url="/next",
+        )
+        self.logout_target: str | None = "https://idp.example.com/logout"
+        self.raise_on: dict[str, OIDCFlowError] = {}
+
+    async def start_oidc_login(self, next_url):
+        self.calls.append(("start_oidc_login", next_url))
+        if "login" in self.raise_on:
+            raise self.raise_on["login"]
+        return self.login_result
+
+    async def handle_oidc_callback(self, *, code, state, state_cookie_raw):
+        self.calls.append(("handle_oidc_callback", code, state, state_cookie_raw))
+        if "callback" in self.raise_on:
+            raise self.raise_on["callback"]
+        return self.callback_result
+
+    async def handle_backchannel_logout(self, logout_token):
+        self.calls.append(("handle_backchannel_logout", logout_token))
+        if "bcl" in self.raise_on:
+            raise self.raise_on["bcl"]
+        return 1
+
+    async def logout(self, session_cookie_value):
+        self.calls.append(("logout", session_cookie_value))
+        return self.logout_target
+
+
+def _set_cookies(response) -> list[str]:
+    return [v for k, v in response.headers.multi_items() if k.lower() == "set-cookie"]
 
 
 @pytest.fixture
-def env_token(monkeypatch):
-    monkeypatch.setenv("AUTH_MODE", "token")
-    _auth_deps.reset_oidc_client()
+def stub() -> StubAuthService:
+    return StubAuthService()
 
 
 @pytest.fixture
-def fresh_stub_vectordb():
-    global _stub_vectordb_singleton
-    # Re-create so tests see a clean state.
-    _stub_vectordb_singleton.__init__()
-    return _stub_vectordb_singleton
-
-
-@pytest.fixture
-def client(env_oidc, fresh_stub_vectordb):
-    """TestClient for the minimal FastAPI app.
-
-    The OIDCClient singleton uses a shared respx-mocked transport so every
-    IdP route can be stubbed per-test via ``mock.router.get(...)``.
-    """
+def client(stub: StubAuthService) -> TestClient:
     app = FastAPI()
     app.include_router(auth_router)
+    app.dependency_overrides[get_auth_service] = lambda: stub
+    return TestClient(app)
 
-    # Replace the OIDCClient's internal httpx client with one backed by respx.
-    # respx >= 0.22 removed the top-level MockTransport; use MockRouter +
-    # httpx.MockTransport(router.handler) instead.
-    router = respx.MockRouter(assert_all_called=False)
-    http = httpx.AsyncClient(transport=httpx.MockTransport(router.handler))
 
-    # Force singleton creation using our mocked http client.
-    _auth_deps.reset_oidc_client()
-    _auth_deps._client = _auth_router_module.OIDCClient(
-        issuer=ISSUER,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
-        redirect_uri=REDIRECT_URI,
-        scopes=SCOPES,
-        http_client=http,
-    )
+@pytest.fixture
+def oidc_env(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "oidc")
 
+
+@pytest.fixture
+def token_env(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "token")
+
+
+# ---------------------------------------------------------------------------
+# AUTH_MODE gate — token mode must 400 *before* the service is resolved.
+# Regression: previously these returned 503 because Depends(get_auth_service)
+# resolved (and failed on a missing container) before the gate ran.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/auth/login", {}),
+        ("get", "/auth/callback?code=x&state=y", {}),
+        ("post", "/auth/backchannel-logout", {"data": {"logout_token": "x"}}),
+        ("get", "/auth/logout", {}),
+    ],
+)
+def test_routes_rejected_in_token_mode(token_env, method, path, kwargs):
+    """No service override and no container — must still be a clean 400."""
+    app = FastAPI()
+    app.include_router(auth_router)
     c = TestClient(app)
-    c.oidc_router = router  # type: ignore[attr-defined]
-    yield c
-
-
-def _setup_discovery(router):
-    router.get(f"{ISSUER}/.well-known/openid-configuration").mock(return_value=httpx.Response(200, json=DISCOVERY_DOC))
-
-
-def _setup_jwks(router):
-    router.get(f"{ISSUER}/protocol/openid-connect/certs").mock(return_value=httpx.Response(200, json=JWKS_RESPONSE))
+    r = getattr(c, method)(path, follow_redirects=False, **kwargs)
+    assert r.status_code == 400
+    assert "AUTH_MODE" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -380,359 +162,47 @@ def _setup_jwks(router):
 # ---------------------------------------------------------------------------
 
 
-def test_login_rejected_in_token_mode(env_token, fresh_stub_vectordb):
-    app = FastAPI()
-    app.include_router(auth_router)
-    c = TestClient(app)
-    r = c.get("/auth/login", follow_redirects=False)
-    assert r.status_code == 400
-
-
-def test_login_redirects_to_idp_with_pkce(client):
-    _setup_discovery(client.oidc_router)
-    r = client.get("/auth/login", follow_redirects=False)
+def test_login_redirects_and_sets_state_cookie(oidc_env, client, stub):
+    r = client.get("/auth/login?next=/dashboard", follow_redirects=False)
     assert r.status_code == 302
-    loc = r.headers["location"]
-    assert loc.startswith(f"{ISSUER}/protocol/openid-connect/auth")
-    assert "code_challenge_method=S256" in loc
-    assert "state=" in loc
-    assert "nonce=" in loc
-    assert "code_challenge=" in loc
-    # State cookie set
-    assert "openrag_oidc_state" in r.cookies
+    assert r.headers["location"] == stub.login_result.authorization_url
+    assert stub.calls == [("start_oidc_login", "/dashboard")]
+    assert any(STATE_COOKIE_NAME in c for c in _set_cookies(r))
 
 
-# ---------------------------------------------------------------------------
-# GET /auth/callback — failure paths
-# ---------------------------------------------------------------------------
-
-
-def test_callback_rejected_in_token_mode(env_token, fresh_stub_vectordb):
-    app = FastAPI()
-    app.include_router(auth_router)
-    c = TestClient(app)
-    r = c.get("/auth/callback?code=x&state=y", follow_redirects=False)
-    assert r.status_code == 400
-
-
-def test_callback_missing_state_cookie(client):
-    r = client.get("/auth/callback?code=x&state=y", follow_redirects=False)
-    assert r.status_code == 400
-    assert "state cookie" in r.json()["detail"].lower()
-
-
-def test_callback_state_mismatch(client):
-    _setup_discovery(client.oidc_router)
-    # First, obtain a legitimate state cookie via /auth/login.
-    login_resp = client.get("/auth/login", follow_redirects=False)
-    assert login_resp.status_code == 302
-
-    # Now call /auth/callback with a *different* state in the query.
-    r = client.get(
-        "/auth/callback?code=x&state=WRONG",
-        follow_redirects=False,
-    )
-    assert r.status_code == 400
-    assert "state" in r.json()["detail"].lower()
-
-
-# ---------------------------------------------------------------------------
-# GET /auth/callback — success paths
-# ---------------------------------------------------------------------------
-
-
-def _begin_login_and_extract_state(client) -> tuple[str, str]:
-    """Call /auth/login and return (state, nonce) values from the redirect query."""
-    _setup_discovery(client.oidc_router)
+def test_login_flow_error_maps_to_http(oidc_env, client, stub):
+    stub.raise_on["login"] = OIDCFlowError("boom", status_code=502)
     r = client.get("/auth/login", follow_redirects=False)
+    assert r.status_code == 502
+    assert r.json()["detail"] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/callback
+# ---------------------------------------------------------------------------
+
+
+def test_callback_success_sets_session_clears_state(oidc_env, client, stub):
+    r = client.get(
+        "/auth/callback?code=ac&state=st",
+        cookies={STATE_COOKIE_NAME: "raw-state"},
+        follow_redirects=False,
+    )
     assert r.status_code == 302
-    loc = r.headers["location"]
-    from urllib.parse import parse_qs, urlparse
-
-    qs = parse_qs(urlparse(loc).query)
-    return qs["state"][0], qs["nonce"][0]
-
-
-def _mock_token_endpoint(router, id_token: str, *, refresh_token: str | None = "rt-1"):
-    payload = {
-        "id_token": id_token,
-        "access_token": "at-1",
-        "expires_in": 300,
-        "token_type": "Bearer",
-    }
-    if refresh_token is not None:
-        payload["refresh_token"] = refresh_token
-    router.post(f"{ISSUER}/protocol/openid-connect/token").mock(return_value=httpx.Response(200, json=payload))
+    assert r.headers["location"] == "/next"
+    assert stub.calls == [("handle_oidc_callback", "ac", "st", "raw-state")]
+    cookies = _set_cookies(r)
+    assert any(SESSION_COOKIE_NAME in c for c in cookies)
+    # State cookie is cleared (deletion emits a Set-Cookie with Max-Age=0).
+    assert any(STATE_COOKIE_NAME in c and ("Max-Age=0" in c or "expires=" in c.lower()) for c in cookies)
 
 
-def test_callback_success_by_external_id(client, fresh_stub_vectordb):
-    fresh_stub_vectordb.add_user(user_id=42, email="user@example.com", external_user_id="sub-abc")
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-abc"))
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=authcode&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    assert r.headers["location"] == "/"
-    assert "openrag_session" in r.cookies
-    # At least one create_oidc_session call recorded.
-    assert any(c[0] == "create_oidc_session" for c in fresh_stub_vectordb.calls)
-
-
-def test_callback_user_not_registered(client, fresh_stub_vectordb):
-    """Unknown sub → 403 by default (no email fallback, no auto-provisioning)."""
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-unknown", email="ghost@example.com"))
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 403
-    assert "not registered" in r.json()["detail"].lower()
-    # Without OIDC_AUTO_PROVISION_LOGIN, no user must have been created.
-    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
-
-
-def test_callback_auto_provisions_user_when_enabled(client, fresh_stub_vectordb, monkeypatch):
-    """OIDC_AUTO_PROVISION_LOGIN=true: unknown sub triggers user creation
-    from ID-token claims, never as admin, and login proceeds (302 + cookie)."""
-    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(
-            nonce,
-            sub="sub-new-user",
-            email="alice@example.com",
-            extra={"name": "Alice Liddell"},
-        )
-    )
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    assert "openrag_session" in r.cookies
-
-    # create_user was called exactly once with the IdP claims.
-    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
-    assert len(create_calls) == 1
-    body = create_calls[0][1][0]
-    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
-    assert data["external_user_id"] == "sub-new-user"
-    assert data["display_name"] == "Alice Liddell"
-    assert data["email"] == "alice@example.com"
-    assert data["is_admin"] is False  # auto-provisioned users are NEVER admin
-
-
-def test_callback_auto_provision_falls_back_to_sub_when_no_name(client, fresh_stub_vectordb, monkeypatch):
-    """When the IdP exposes no readable display name, a deterministic
-    ``oidc-<sub-prefix>`` placeholder is used so the UI always has something."""
-    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(_id_token_payload(nonce, sub="abcdef0123456789", email=None, extra={}))
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-
-    create_calls = [c for c in fresh_stub_vectordb.calls if c[0] == "create_user"]
-    assert len(create_calls) == 1
-    body = create_calls[0][1][0]
-    data = body.model_dump() if hasattr(body, "model_dump") else dict(body)
-    assert data["display_name"] == "oidc-abcdef01"
-    assert data["email"] is None
-
-
-def test_callback_auto_provision_disabled_by_default(client, fresh_stub_vectordb, monkeypatch):
-    """Explicitly setting OIDC_AUTO_PROVISION_LOGIN=false (or unset) keeps the
-    historical 403 behaviour — non-breaking guard for existing deployments."""
-    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "false")
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-x", email="x@example.com", extra={"name": "X"}))
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
-    assert r.status_code == 403
-    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
-
-
-def test_callback_auto_provision_syncs_existing_user_claims(client, fresh_stub_vectordb, monkeypatch):
-    """OIDC_AUTO_PROVISION_LOGIN=true also keeps display_name/email of an
-    already-known user in sync with the IdP claims on every login."""
-    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
-    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
-    fresh_stub_vectordb.add_user(
-        user_id=99,
-        email="stale@example.com",
-        external_user_id="sub-existing",
-        display_name="Stale Name",
-    )
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(
-            nonce,
-            sub="sub-existing",
-            email="fresh@example.com",
-            extra={"name": "Fresh Name"},
-        )
-    )
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
-    assert r.status_code == 302, r.text
-
-    user = fresh_stub_vectordb._users_by_id[99]
-    assert user["display_name"] == "Fresh Name"
-    assert user["email"] == "fresh@example.com"
-    # User row was not re-created — only updated.
-    assert not any(c[0] == "create_user" for c in fresh_stub_vectordb.calls)
-    assert sum(1 for c in fresh_stub_vectordb.calls if c[0] == "update_user_fields") == 1
-
-
-def test_callback_auto_provision_no_db_write_when_claims_match(client, fresh_stub_vectordb, monkeypatch):
-    """With AUTO_PROVISION_LOGIN on but claims already matching the stored row,
-    no update_user_fields call is made (the no-op filter avoids DB churn)."""
-    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
-    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
-    fresh_stub_vectordb.add_user(
-        user_id=101,
-        email="same@example.com",
-        external_user_id="sub-stable",
-        display_name="Same Name",
-    )
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(
-            nonce,
-            sub="sub-stable",
-            email="same@example.com",
-            extra={"name": "Same Name"},
-        )
-    )
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
-    assert r.status_code == 302, r.text
-    assert not any(c[0] == "update_user_fields" for c in fresh_stub_vectordb.calls)
-
-
-def test_callback_applies_claim_mapping_from_id_token(client, fresh_stub_vectordb, monkeypatch):
-    """With OIDC_CLAIM_MAPPING set, claims from the ID token update the user row."""
-    monkeypatch.setenv("OIDC_CLAIM_MAPPING", "display_name:name,email:email")
-    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "id_token")
-    fresh_stub_vectordb.add_user(
-        user_id=42,
-        email="old@example.com",
-        external_user_id="sub-abc",
-        display_name="Old Name",
-    )
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(
-            nonce,
-            sub="sub-abc",
-            email="dwho@badwolf.org",
-            extra={"name": "Doctor Who"},
-        )
-    )
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    user = fresh_stub_vectordb._users_by_id[42]
-    assert user["display_name"] == "Doctor Who"
-    # email lowercased by update_user_fields stub
-    assert user["email"] == "dwho@badwolf.org"
-    # update_user_fields was called exactly once
-    assert sum(1 for c in fresh_stub_vectordb.calls if c[0] == "update_user_fields") == 1
-
-
-def test_callback_applies_claim_mapping_from_userinfo(client, fresh_stub_vectordb, monkeypatch):
-    """With OIDC_CLAIM_SOURCE=userinfo the claim fetch goes to /userinfo."""
-    monkeypatch.setenv("OIDC_CLAIM_MAPPING", "display_name:name,email:email")
-    monkeypatch.setenv("OIDC_CLAIM_SOURCE", "userinfo")
-    fresh_stub_vectordb.add_user(
-        user_id=55,
-        email=None,
-        external_user_id="sub-ui",
-        display_name="legacy",
-    )
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    # ID token carries no name/email — the router must pull them from /userinfo.
-    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-ui", email=None))
-    _mock_token_endpoint(client.oidc_router, id_token)
-    userinfo_route = client.oidc_router.get(f"{ISSUER}/protocol/openid-connect/userinfo").mock(
-        return_value=httpx.Response(
-            200,
-            json={"sub": "sub-ui", "name": "UI User", "email": "ui@example.com"},
-        )
-    )
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    assert userinfo_route.called
-    user = fresh_stub_vectordb._users_by_id[55]
-    assert user["display_name"] == "UI User"
-    assert user["email"] == "ui@example.com"
-
-
-def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypatch):
-    """Without OIDC_CLAIM_MAPPING the user row is not touched."""
-    monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
-    fresh_stub_vectordb.add_user(
-        user_id=77,
-        email="tester@example.com",
-        external_user_id="sub-plain",
-        display_name="Initial",
-    )
-    _setup_jwks(client.oidc_router)
-    state, nonce = _begin_login_and_extract_state(client)
-    id_token = _sign_jwt(
-        _id_token_payload(
-            nonce,
-            sub="sub-plain",
-            email="different@example.com",
-            extra={"name": "Should Be Ignored"},
-        )
-    )
-    _mock_token_endpoint(client.oidc_router, id_token)
-
-    r = client.get(
-        f"/auth/callback?code=c&state={state}",
-        follow_redirects=False,
-    )
-    assert r.status_code == 302, r.text
-    user = fresh_stub_vectordb._users_by_id[77]
-    # Untouched by the callback when OIDC_CLAIM_MAPPING is empty
-    assert user["display_name"] == "Initial"
-    assert user["email"] == "tester@example.com"
-    # update_user_fields was never called
-    assert not any(c[0] == "update_user_fields" for c in fresh_stub_vectordb.calls)
+def test_callback_flow_error_returns_json_and_clears_state(oidc_env, client, stub):
+    stub.raise_on["callback"] = OIDCFlowError("bad state", status_code=400)
+    r = client.get("/auth/callback?code=c&state=s", follow_redirects=False)
+    assert r.status_code == 400
+    assert r.json()["detail"] == "bad state"
+    assert any(STATE_COOKIE_NAME in c for c in _set_cookies(r))
 
 
 # ---------------------------------------------------------------------------
@@ -740,34 +210,21 @@ def test_callback_skips_mapping_when_unset(client, fresh_stub_vectordb, monkeypa
 # ---------------------------------------------------------------------------
 
 
-def test_backchannel_logout_rejects_invalid_token(client):
-    _setup_discovery(client.oidc_router)
-    _setup_jwks(client.oidc_router)
-    r = client.post(
-        "/auth/backchannel-logout",
-        data={"logout_token": "not-a-jwt"},
-    )
-    assert r.status_code == 400
-
-
-def test_backchannel_logout_revokes_by_sid(client, fresh_stub_vectordb):
-    _setup_jwks(client.oidc_router)
-    _setup_discovery(client.oidc_router)
-
-    # Seed a session to be revoked
-    fresh_stub_vectordb._sessions[1] = {
-        "id": 1,
-        "sid": "sid-target",
-        "revoked_at": None,
-    }
-    token = _sign_jwt(_logout_token_payload(sid="sid-target"))
-    r = client.post(
-        "/auth/backchannel-logout",
-        data={"logout_token": token},
-    )
+def test_backchannel_logout_success(oidc_env, client, stub):
+    r = client.post("/auth/backchannel-logout", data={"logout_token": "lt"})
     assert r.status_code == 200
-    # The stub increments revoked_at on matching sid
-    assert fresh_stub_vectordb._sessions[1]["revoked_at"] is not None
+    assert r.headers["cache-control"] == "no-store"
+    assert stub.calls == [("handle_backchannel_logout", "lt")]
+
+
+def test_backchannel_logout_error_emits_invalid_request(oidc_env, client, stub):
+    stub.raise_on["bcl"] = OIDCFlowError("nope", error_description="token expired")
+    r = client.post("/auth/backchannel-logout", data={"logout_token": "lt"})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"] == "invalid_request"
+    assert body["error_description"] == "token expired"
+    assert r.headers["cache-control"] == "no-store"
 
 
 # ---------------------------------------------------------------------------
@@ -775,108 +232,21 @@ def test_backchannel_logout_revokes_by_sid(client, fresh_stub_vectordb):
 # ---------------------------------------------------------------------------
 
 
-def test_logout_revokes_session_and_deletes_cookie(client, fresh_stub_vectordb):
-    _setup_discovery(client.oidc_router)
-    # Seed a session & cookie
-    session_token = "sess-logout-tok"
-    fresh_stub_vectordb._sessions[1] = {
-        "id": 1,
-        "sid": "sid-1",
-        "id_token_encrypted": None,  # skip decrypt path
-        "session_expires_at": time.time() + 3600,
-        "revoked_at": None,
-    }
-    fresh_stub_vectordb._sessions_by_token[session_token] = 1
-
+def test_logout_redirects_to_idp_and_clears_session(oidc_env, client, stub):
     r = client.get(
         "/auth/logout",
-        cookies={"openrag_session": session_token},
+        cookies={SESSION_COOKIE_NAME: "sess"},
         follow_redirects=False,
     )
     assert r.status_code == 302
-    # Session marked revoked
-    assert fresh_stub_vectordb._sessions[1]["revoked_at"] is not None
-    # Cookie cleared in response (max-age=0 or Expires=past)
-    set_cookie_headers = r.headers.get_list("set-cookie")
-    assert any("openrag_session=" in h and ("Max-Age=0" in h or "expires=" in h.lower()) for h in set_cookie_headers)
+    assert r.headers["location"] == stub.logout_target
+    assert stub.calls == [("logout", "sess")]
+    assert any(SESSION_COOKIE_NAME in c and ("Max-Age=0" in c or "expires=" in c.lower()) for c in _set_cookies(r))
 
 
-def test_logout_rejected_in_token_mode(env_token, fresh_stub_vectordb):
-    app = FastAPI()
-    app.include_router(auth_router)
-    c = TestClient(app)
-    r = c.get("/auth/logout", follow_redirects=False)
-    assert r.status_code == 400
-
-
-# ---------------------------------------------------------------------------
-# Skips — scenarios we can add once the full middleware stack is wired (phase 5)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.skip(reason="requires phase-5 middleware for cookie-based auth on /auth/me")
-def test_me_returns_user_info_with_valid_cookie():
-    pass
-
-
-# ---------------------------------------------------------------------------
-# M2: timezone-consistency regression test
-#
-# Before the fix, routers/auth.py wrote ``access_token_expires_at`` /
-# ``session_expires_at`` via ``datetime.utcnow()`` while every read site
-# compared against ``datetime.now()``. On a host whose TZ is east of UTC
-# (e.g. Europe/Paris), a newly-issued session thus appeared "already
-# expired" by tz_offset hours and ``get_oidc_session_by_token`` returned
-# None immediately after the callback.
-# ---------------------------------------------------------------------------
-
-
-def test_callback_session_not_prematurely_expired_under_nonutc_tz(client, fresh_stub_vectordb, monkeypatch):
-    """Callback in a non-UTC timezone must produce an immediately usable session."""
-    import os as _os
-
-    # Force a non-UTC timezone for the duration of this test. If the platform
-    # doesn't support ``time.tzset`` (e.g. Windows CI runners), skip gracefully.
-    tzset = getattr(time, "tzset", None)
-    if tzset is None:
-        pytest.skip("time.tzset not available on this platform; cannot force TZ")
-
-    original_tz = _os.environ.get("TZ")
-    monkeypatch.setenv("TZ", "Europe/Paris")
-    tzset()
-    try:
-        # Teach the stub to back get_oidc_session_by_token with the same dict we
-        # created in create_oidc_session (the default stub already does).
-        fresh_stub_vectordb.add_user(user_id=77, email="tz@example.com", external_user_id="sub-tz")
-        _setup_jwks(client.oidc_router)
-        state, nonce = _begin_login_and_extract_state(client)
-        id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-tz", email="tz@example.com"))
-        _mock_token_endpoint(client.oidc_router, id_token)
-
-        r = client.get(
-            f"/auth/callback?code=c&state={state}",
-            follow_redirects=False,
-        )
-        assert r.status_code == 302, r.text
-
-        # Pull the session cookie value from the response and look it up via
-        # the stub — this exercises the same staleness comparison the real
-        # middleware uses at request time.
-        session_cookie = r.cookies.get("openrag_session")
-        assert session_cookie, "callback did not set openrag_session cookie"
-
-        fetched = fresh_stub_vectordb._impl_get_oidc_session_by_token(session_cookie)
-        assert fetched is not None, "Session appeared expired IMMEDIATELY after creation — tz bug (M2)"
-
-        # Additional sanity: session_expires_at must be strictly in the future
-        # from the perspective of datetime.now() (the read-site clock).
-        from datetime import datetime as _dt
-
-        session_exp = fetched["session_expires_at"]
-        assert session_exp > _dt.now(), f"session_expires_at={session_exp} is not in the future vs datetime.now()"
-    finally:
-        if original_tz is None:
-            _os.environ.pop("TZ", None)
-        else:
-            _os.environ["TZ"] = original_tz
-        tzset()
+def test_logout_without_idp_target_confirms_in_place(oidc_env, client, stub):
+    stub.logout_target = None
+    r = client.get("/auth/logout", follow_redirects=False)
+    assert r.status_code == 200
+    assert r.json()["detail"] == "Logged out"
+    assert any(SESSION_COOKIE_NAME in c for c in _set_cookies(r))

--- a/openrag/routers/tools.py
+++ b/openrag/routers/tools.py
@@ -1,13 +1,24 @@
+"""Tools routes — thin HTTP layer over :class:`ConversionService`.
+
+Phase 8E: the ``extractText`` serialization moved to
+``services.orchestrators.conversion_service.ConversionService`` (the Ray
+``DocSerializer`` actor now sits behind the ``FileSerializer`` port).
+This module keeps HTTP transport only: the saved-file IO + cleanup,
+tool validation/dispatch, and the 4xx/5xx error mapping whose exact
+``{"detail": ...}`` body the legacy endpoint returned via
+``HTTPException``.
+"""
+
 import json
 from pathlib import Path
 
-import ray
-from components.indexer.utils.files import save_file_to_disk, serialize_file
-from components.indexer.utils.text_sanitizer import sanitize_extracted_text
+from components.indexer.utils.files import save_file_to_disk
 from config import load_config
+from di.providers import get_conversion_service
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from services.orchestrators.conversion_service import ConversionService
 from utils.logger import get_logger
 
 from .utils import (
@@ -92,22 +103,20 @@ async def execute_tool(
     file: UploadFile = Depends(validate_file_format),
     tool: str = Depends(validate_tool),
     metadata: dict = Depends(validate_metadata),
+    service: ConversionService = Depends(get_conversion_service),
 ):
-    save_dir = Path(data_dir)
     file_path = None
     try:
         if tool["name"] == "extractText":
-            file_path = await save_file_to_disk(file, save_dir, with_random_prefix=True)
-            metadata.update({"source": str(file_path), "filename": file.filename})
+            file_path = await save_file_to_disk(file, Path(data_dir), with_random_prefix=True)
 
-            task_id = ray.get_runtime_context().get_task_id()
-
-            logger.debug(f"Execute tool extractText for task {task_id} with file {file.filename}")
-            doc = await serialize_file(task_id, path=file_path, metadata=metadata)
-            logger.debug(f"extractText done for task {task_id}")
-
-            # Sanitize the extracted text to remove useless characters and improve quality
-            sanitized_content = sanitize_extracted_text(doc.page_content)
+            logger.debug(f"Execute tool extractText with file {file.filename}")
+            sanitized_content = await service.serialize_file(
+                file_path=str(file_path),
+                filename=file.filename,
+                metadata=metadata,
+            )
+            logger.debug("extractText done")
 
             return JSONResponse(
                 status_code=status.HTTP_200_OK,

--- a/openrag/routers/users.py
+++ b/openrag/routers/users.py
@@ -1,7 +1,24 @@
+"""User management routes — thin HTTP layer over :class:`UserService`.
+
+Phase 8A.2: business logic (validation, default-quota rule, existence /
+not-found semantics, repo delegation) moved to
+``services.orchestrators.user_service.UserService``. This module keeps
+HTTP transport only: request-scoped authorization (the shared FastAPI
+``Depends`` wrappers in ``routers/utils.py``, retired in a later phase),
+the two ``id == 1`` guard rules whose exact ``{"detail": ...}`` body the
+legacy endpoints returned via ``HTTPException``, and response shaping.
+
+``GET /users/info`` stays here unchanged — it computes effective quota
+from the ``TaskStateManager`` Ray actor, which orchestrators must not
+touch (Phase 8H); it will move to a service once the queue is de-Ray'd.
+"""
+
+from di.providers import get_user_service
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from models.user import UserCreate, UserPublic, UserUpdate
-from utils.dependencies import get_task_state_manager, get_vectordb
+from services.orchestrators.user_service import UserService
+from utils.dependencies import get_task_state_manager
 from utils.logger import get_logger
 
 from .utils import DEFAULT_FILE_QUOTA, current_user, require_admin, require_admin_or_self
@@ -28,9 +45,11 @@ Returns list of all users with:
 **Note:** User tokens are not included in the response.
 """,
 )
-async def list_users(vectordb=Depends(get_vectordb), admin_user=Depends(require_admin)):
-    users = await vectordb.list_users.remote()
-    logger.debug("Returned list of users.", user_count=len(users))
+async def list_users(
+    admin_user=Depends(require_admin),
+    service: UserService = Depends(get_user_service),
+):
+    users = await service.list_users()
     return JSONResponse(status_code=status.HTTP_200_OK, content={"users": users})
 
 
@@ -125,14 +144,11 @@ Returns created user including:
 )
 async def create_user(
     body: UserCreate,
-    vectordb=Depends(get_vectordb),
     admin_user=Depends(require_admin),
+    service: UserService = Depends(get_user_service),
 ):
-    """
-    Create a new user and generate a token.
-    """
-    user = await vectordb.create_user.remote(body)
-    logger.info("Created new user", user_id=user["id"])
+    """Create a new user and generate a token."""
+    user = await service.create_user(body)
     return JSONResponse(status_code=status.HTTP_201_CREATED, content=user)
 
 
@@ -157,11 +173,13 @@ Returns user details including:
 **Note:** User token is not included in the response.
 """,
 )
-async def get_user(user_id: int, vectordb=Depends(get_vectordb), admin_user=Depends(require_admin)):
-    """
-    Get details of a specific user (without exposing token).
-    """
-    user = await vectordb.get_user.remote(user_id)
+async def get_user(
+    user_id: int,
+    admin_user=Depends(require_admin),
+    service: UserService = Depends(get_user_service),
+):
+    """Get details of a specific user (without exposing token)."""
+    user = await service.get_user(user_id)
     return JSONResponse(status_code=status.HTTP_200_OK, content=user)
 
 
@@ -186,16 +204,18 @@ Returns 204 No Content on successful deletion.
 **Note:** Cannot delete the default admin user (ID: 1).
 """,
 )
-async def delete_user(user_id: int, vectordb=Depends(get_vectordb), admin_user=Depends(require_admin)):
-    """
-    Delete a user.
-    """
+async def delete_user(
+    user_id: int,
+    admin_user=Depends(require_admin),
+    service: UserService = Depends(get_user_service),
+):
+    """Delete a user."""
     if user_id == 1:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot delete default admin user.",
         )
-    await vectordb.delete_user.remote(user_id)
+    await service.delete_user(user_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -225,19 +245,11 @@ Returns user details including the new token:
 )
 async def regenerate_user_token(
     user_id: int,
-    vectordb=Depends(get_vectordb),
     _auth=Depends(require_admin_or_self),
+    service: UserService = Depends(get_user_service),
 ):
-    """
-    Regenerate a user's token.
-    """
-    user = await vectordb.regenerate_user_token.remote(user_id)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"User '{user_id}' not found",
-        )
-    logger.info("Regenerated user token", user_id=user_id)
+    """Regenerate a user's token."""
+    user = await service.regenerate_token(user_id)
     return JSONResponse(status_code=status.HTTP_200_OK, content=user)
 
 
@@ -274,18 +286,14 @@ Returns updated user details including:
 async def update_user(
     user_id: int,
     body: UserUpdate,
-    vectordb=Depends(get_vectordb),
     admin_user=Depends(require_admin),
+    service: UserService = Depends(get_user_service),
 ) -> UserPublic:
-    """
-    Update a user's profile fields.
-    """
-    # Only block if is_admin was explicitly set to False in the request
+    """Update a user's profile fields."""
+    # Only block if is_admin was explicitly set to False in the request.
     if user_id == 1 and "is_admin" in body.model_fields_set and body.is_admin is False:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot revoke admin privileges from the default admin user.",
         )
-    user = await vectordb.update_user.remote(user_id, body)
-    logger.info("Updated user info", user_id=user_id)
-    return user
+    return await service.update_user(user_id, body)

--- a/openrag/routers/users.py
+++ b/openrag/routers/users.py
@@ -18,10 +18,9 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from models.user import UserCreate, UserPublic, UserUpdate
 from services.orchestrators.user_service import UserService
-from utils.dependencies import get_task_state_manager
 from utils.logger import get_logger
 
-from .utils import DEFAULT_FILE_QUOTA, current_user, require_admin, require_admin_or_self
+from .utils import current_user, require_admin, require_admin_or_self
 
 logger = get_logger()
 router = APIRouter()
@@ -78,40 +77,12 @@ Returns current user details including:
 )
 async def get_current_user_info(
     user=Depends(current_user),
-    task_state_manager=Depends(get_task_state_manager),
+    service: UserService = Depends(get_user_service),
 ):
     """Get current authenticated user info"""
-
-    user_id = user.get("id")
-    is_admin = user.get("is_admin", False)
-
-    if is_admin:
-        user_quota = float("inf")
-    elif DEFAULT_FILE_QUOTA < 0:
-        user_quota = float("inf")
-    else:
-        user_quota = user.get("file_quota", None)
-        if user_quota is None:
-            user_quota = DEFAULT_FILE_QUOTA
-        elif user_quota < 0:
-            user_quota = float("inf")
-
-    file_count = user.get("file_count", 0)  # Get indexed file count from user info
-    pending_count = await task_state_manager.get_user_pending_task_count.remote(
-        user_id
-    )  # Get pending task count from task manager
-
-    total = file_count + pending_count
-
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content={
-            **user,
-            "file_count": file_count,
-            "pending_files": pending_count,
-            "total_files": total,
-            "file_quota": -1 if user_quota == float("inf") else user_quota,
-        },
+        content=await service.get_current_user_info(user),
     )
 
 

--- a/openrag/routers/workspaces.py
+++ b/openrag/routers/workspaces.py
@@ -1,22 +1,27 @@
-"""Workspace management endpoints."""
+"""Workspace management endpoints — thin HTTP layer over WorkspaceService.
 
-import asyncio
+Phase 8B.2: workspace CRUD, file association and the cross-cutting
+delete-with-orphan-cleanup moved to
+``services.orchestrators.workspace_service.WorkspaceService``. This
+module keeps HTTP transport only: request-scoped authorization, request
+schema validation, and the guards whose exact non-bracketed
+``{"detail": ...}`` body the legacy endpoints returned via
+``HTTPException`` (409 duplicate, the workspace-in-partition 404, the
+unknown/missing-file 404s, the not-removed 404).
+"""
+
 import re
 
-from components.ray_utils import call_ray_actor_with_timeout
-from config import load_config
+from di.providers import get_workspace_service
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, field_validator
-from utils.dependencies import get_vectordb
+from services.orchestrators.workspace_service import WorkspaceService
 from utils.logger import get_logger
 
 from .utils import require_partition_editor, require_partition_owner, require_partition_viewer
 
 router = APIRouter()
 logger = get_logger()
-
-_config = load_config()
-VECTORDB_TIMEOUT = _config.ray.indexer.vectordb_timeout
 
 _WORKSPACE_ID_RE = re.compile(r"[a-zA-Z0-9_-]+")
 
@@ -43,13 +48,13 @@ class AddFilesRequest(BaseModel):
     file_ids: list[str]
 
 
-async def require_workspace_in_partition(partition: str, workspace_id: str, vectordb=Depends(get_vectordb)) -> dict:
+async def require_workspace_in_partition(
+    partition: str,
+    workspace_id: str,
+    service: WorkspaceService = Depends(get_workspace_service),
+) -> dict:
     """Validate that a workspace exists and belongs to the given partition."""
-    ws = await call_ray_actor_with_timeout(
-        vectordb.get_workspace.remote(workspace_id),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"get_workspace({workspace_id})",
-    )
+    ws = await service.get_workspace(workspace_id)
     if not ws or ws["partition_name"] != partition:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
     return ws
@@ -63,27 +68,18 @@ async def create_workspace(
     partition: str,
     body: CreateWorkspaceRequest,
     user=Depends(require_partition_editor),
-    vectordb=Depends(get_vectordb),
+    service: WorkspaceService = Depends(get_workspace_service),
 ):
-    existing = await call_ray_actor_with_timeout(
-        vectordb.get_workspace.remote(body.workspace_id),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"get_workspace({body.workspace_id})",
-    )
-    if existing:
+    if await service.get_workspace(body.workspace_id):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Workspace '{body.workspace_id}' already exists.",
         )
-    await call_ray_actor_with_timeout(
-        vectordb.create_workspace.remote(
-            workspace_id=body.workspace_id,
-            partition=partition,
-            user_id=user["id"],
-            display_name=body.display_name,
-        ),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"create_workspace({body.workspace_id})",
+    await service.create_workspace(
+        workspace_id=body.workspace_id,
+        partition=partition,
+        user_id=user["id"],
+        display_name=body.display_name,
     )
     return {"status": "created", "workspace_id": body.workspace_id}
 
@@ -92,13 +88,11 @@ async def create_workspace(
     "/partition/{partition}/workspaces",
     dependencies=[Depends(require_partition_viewer)],
 )
-async def list_workspaces(partition: str, vectordb=Depends(get_vectordb)):
-    workspaces = await call_ray_actor_with_timeout(
-        vectordb.list_workspaces.remote(partition),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"list_workspaces({partition})",
-    )
-    return {"workspaces": workspaces}
+async def list_workspaces(
+    partition: str,
+    service: WorkspaceService = Depends(get_workspace_service),
+):
+    return {"workspaces": await service.list_workspaces(partition)}
 
 
 @router.get(
@@ -114,38 +108,13 @@ async def get_workspace(ws=Depends(require_workspace_in_partition)):
     dependencies=[Depends(require_partition_owner)],
 )
 async def delete_workspace(
-    partition: str, workspace_id: str, vectordb=Depends(get_vectordb), _ws=Depends(require_workspace_in_partition)
+    partition: str,
+    workspace_id: str,
+    _ws=Depends(require_workspace_in_partition),
+    service: WorkspaceService = Depends(get_workspace_service),
 ):
-    orphaned = await call_ray_actor_with_timeout(
-        vectordb.delete_workspace.remote(workspace_id),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"delete_workspace({workspace_id})",
-    )
-    deleted_count = 0
-    failed_file_ids: list[str] = []
-    if orphaned:
-        results = await asyncio.gather(
-            *[
-                call_ray_actor_with_timeout(
-                    vectordb.delete_file.remote(file_id, partition),
-                    timeout=VECTORDB_TIMEOUT,
-                    task_description=f"delete_file({file_id})",
-                )
-                for file_id in orphaned
-            ],
-            return_exceptions=True,
-        )
-        for file_id, result in zip(orphaned, results):
-            if isinstance(result, Exception):
-                logger.warning("Failed to delete orphaned file from Milvus", file_id=file_id, error=str(result))
-                failed_file_ids.append(file_id)
-            else:
-                deleted_count += 1
-    return {
-        "status": "deleted",
-        "orphaned_files_deleted": deleted_count,
-        "orphaned_files_failed": failed_file_ids,
-    }
+    result = await service.delete_workspace(partition, workspace_id)
+    return {"status": "deleted", **result}
 
 
 @router.post(
@@ -156,25 +125,17 @@ async def add_files_to_workspace(
     partition: str,
     workspace_id: str,
     body: AddFilesRequest,
-    vectordb=Depends(get_vectordb),
     _ws=Depends(require_workspace_in_partition),
+    service: WorkspaceService = Depends(get_workspace_service),
 ):
-    existing_ids = await call_ray_actor_with_timeout(
-        vectordb.get_existing_file_ids.remote(partition, body.file_ids),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"get_existing_file_ids({partition})",
-    )
+    existing_ids = await service.get_existing_file_ids(partition, body.file_ids)
     unknown_ids = sorted(set(body.file_ids) - set(existing_ids))
     if unknown_ids:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"File IDs not found in partition '{partition}': {unknown_ids}",
         )
-    missing = await call_ray_actor_with_timeout(
-        vectordb.add_files_to_workspace.remote(workspace_id, body.file_ids),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"add_files_to_workspace({workspace_id})",
-    )
+    missing = await service.add_files(workspace_id, body.file_ids)
     if missing:
         # TOCTOU: files were deleted between the pre-check and the insert.
         raise HTTPException(
@@ -189,26 +150,23 @@ async def add_files_to_workspace(
     dependencies=[Depends(require_partition_viewer)],
 )
 async def list_workspace_files(
-    workspace_id: str, vectordb=Depends(get_vectordb), _ws=Depends(require_workspace_in_partition)
+    workspace_id: str,
+    _ws=Depends(require_workspace_in_partition),
+    service: WorkspaceService = Depends(get_workspace_service),
 ):
-    file_ids = await call_ray_actor_with_timeout(
-        vectordb.list_workspace_files.remote(workspace_id),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"list_workspace_files({workspace_id})",
-    )
-    return {"file_ids": file_ids}
+    return {"file_ids": await service.list_files(workspace_id)}
 
 
 @router.get(
     "/partition/{partition}/files/{file_id}/workspaces",
     dependencies=[Depends(require_partition_viewer)],
 )
-async def list_file_workspaces(partition: str, file_id: str, vectordb=Depends(get_vectordb)):
-    workspace_ids = await call_ray_actor_with_timeout(
-        vectordb.get_file_workspaces.remote(file_id, partition),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"get_file_workspaces({file_id})",
-    )
+async def list_file_workspaces(
+    partition: str,
+    file_id: str,
+    service: WorkspaceService = Depends(get_workspace_service),
+):
+    workspace_ids = await service.get_file_workspaces(file_id, partition)
     return {"file_id": file_id, "workspace_ids": workspace_ids}
 
 
@@ -217,13 +175,12 @@ async def list_file_workspaces(partition: str, file_id: str, vectordb=Depends(ge
     dependencies=[Depends(require_partition_editor)],
 )
 async def remove_file_from_workspace(
-    workspace_id: str, file_id: str, vectordb=Depends(get_vectordb), _ws=Depends(require_workspace_in_partition)
+    workspace_id: str,
+    file_id: str,
+    _ws=Depends(require_workspace_in_partition),
+    service: WorkspaceService = Depends(get_workspace_service),
 ):
-    removed = await call_ray_actor_with_timeout(
-        vectordb.remove_file_from_workspace.remote(workspace_id, file_id),
-        timeout=VECTORDB_TIMEOUT,
-        task_description=f"remove_file_from_workspace({workspace_id}, {file_id})",
-    )
+    removed = await service.remove_file(workspace_id, file_id)
     if not removed:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found in workspace")
     return {"status": "removed"}

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -366,6 +366,11 @@ class AuthService:
             )
 
         user_role = membership.get("role")
+        if user_role not in cls.ROLE_HIERARCHY:
+            raise AuthError(
+                f"Access to partition '{partition}' forbidden",
+                status_code=403,
+            )
         if cls.ROLE_HIERARCHY[user_role] < cls.ROLE_HIERARCHY[required_role]:
             raise AuthError(
                 f"{required_role.capitalize()} role required for partition '{partition}'",

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -1,0 +1,599 @@
+"""AuthService — OIDC flow + auth-policy orchestration (Phase 8A.1).
+
+Business logic extracted from ``routers/auth.py`` and the auth helpers in
+``routers/utils.py``. The router keeps HTTP transport only (cookies,
+redirects, JSON error shaping, the ``AUTH_MODE`` gate); every decision
+lives here and is unit-testable with fake repos / OIDC client.
+
+Compared to the legacy router this service talks to the Phase 7 domain
+repositories (``UserRepository``, ``OIDCSessionRepository``) instead of
+the Ray ``vectordb`` actor, so it deals in :class:`User` /
+:class:`OIDCSession` models rather than ad-hoc dicts.
+
+The cryptographic / cookie primitives (``OIDCClient``, the state-cookie
+serializer, Fernet token (de)encryption, opaque session-token issuance)
+still come from ``components.auth`` during the Phase-8 shim period —
+those are infrastructure adapters scheduled to move under
+``services/auth`` in Phase 9.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode, urlparse
+
+from components.auth import (
+    OIDCClient,
+    StateCookiePayload,
+    StateCookieSerializer,
+    decrypt_token,
+    encrypt_token,
+    hash_session_token,
+    issue_session_token,
+)
+from core.models.user import OIDCSession, User
+from core.utils.exceptions import AuthError, OpenRAGError
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.config.auth import OIDCConfig
+    from core.ports.oidc_session_repo import OIDCSessionRepository
+    from core.ports.partition_membership_repo import PartitionMembershipRepository
+    from core.ports.user_repo import UserRepository
+
+logger = get_logger()
+
+SESSION_COOKIE_NAME = "openrag_session"
+
+
+class OIDCFlowError(OpenRAGError):
+    """Raised for any recoverable failure inside the OIDC flow.
+
+    Carries the exact ``status_code`` the legacy router used so the thin
+    router can reproduce the previous HTTP responses verbatim.
+    ``error_description`` is only set for back-channel logout, where the
+    OIDC spec wants an ``error_description`` field in the JSON body.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 400,
+        error_description: str | None = None,
+    ) -> None:
+        super().__init__(message, code="OIDC_FLOW_ERROR", status_code=status_code)
+        self.error_description = error_description
+
+
+@dataclass
+class LoginRedirect:
+    """Everything the router needs to start the Authorization Code flow."""
+
+    authorization_url: str
+    state_cookie_name: str
+    state_cookie_value: str
+    state_cookie_max_age: int
+
+
+@dataclass
+class CallbackResult:
+    """Everything the router needs to finish login (set session cookie)."""
+
+    session_cookie_name: str
+    session_cookie_value: str  # plaintext — only the SHA-256 hash is stored
+    session_cookie_max_age: int
+    next_url: str
+
+
+def _utcnow() -> datetime:
+    """Naive local ``now`` — matches the DB columns.
+
+    The ``oidc_sessions`` timestamp columns are ``TIMESTAMP WITHOUT TIME
+    ZONE`` and every read site compares against ``datetime.now()``; using a
+    tz-aware value here would make freshly-issued sessions look pre-expired
+    on non-UTC hosts (and asyncpg refuses tz-aware against tz-naive).
+    """
+    return datetime.now()
+
+
+class AuthService:
+    """Owns the OIDC Authorization-Code + PKCE flow and auth policy."""
+
+    ROLE_HIERARCHY: dict[str, int] = {"viewer": 1, "editor": 2, "owner": 3}
+
+    # Defence-in-depth: an IdP claim mapping may only ever write these two
+    # columns. Mirrors the startup validator and the repo whitelist.
+    _OIDC_CLAIM_MAPPING_ALLOWED_FIELDS = frozenset({"display_name", "email"})
+
+    def __init__(
+        self,
+        *,
+        user_repo: UserRepository,
+        oidc_session_repo: OIDCSessionRepository,
+        membership_repo: PartitionMembershipRepository,
+        oidc_client: OIDCClient | None,
+        config: OIDCConfig,
+    ) -> None:
+        self._user_repo = user_repo
+        self._oidc_session_repo = oidc_session_repo
+        # Retained for the role/membership helpers that later phases will
+        # route through this service (8B onward); the OIDC flow itself
+        # does not touch it.
+        self._membership_repo = membership_repo
+        self._oidc_client = oidc_client
+        self._config = config
+
+    # ------------------------------------------------------------------
+    # OIDC flow
+    # ------------------------------------------------------------------
+
+    async def start_oidc_login(self, next_url: str | None) -> LoginRedirect:
+        """Generate PKCE + state/nonce and build the IdP authorization URL."""
+        client = self._require_client()
+        state, nonce = OIDCClient.generate_state_and_nonce()
+        code_verifier, code_challenge = OIDCClient.generate_pkce_pair()
+
+        try:
+            auth_url = await client.build_authorization_url(
+                state=state,
+                nonce=nonce,
+                code_challenge=code_challenge,
+            )
+        except Exception as e:
+            logger.error(f"Failed to build OIDC authorization URL: {e}")
+            raise OIDCFlowError(
+                "OIDC discovery failed — see server logs.",
+                status_code=502,
+            ) from e
+
+        payload = StateCookiePayload(
+            state=state,
+            nonce=nonce,
+            code_verifier=code_verifier,
+            next_url=self.sanitize_next_url(next_url),
+        )
+        cookie_value = self._state_serializer().dumps(payload)
+        return LoginRedirect(
+            authorization_url=auth_url,
+            state_cookie_name=StateCookieSerializer.COOKIE_NAME,
+            state_cookie_value=cookie_value,
+            state_cookie_max_age=StateCookieSerializer.DEFAULT_TTL_SECONDS,
+        )
+
+    async def handle_oidc_callback(
+        self,
+        *,
+        code: str | None,
+        state: str | None,
+        state_cookie_raw: str | None,
+    ) -> CallbackResult:
+        """Validate the IdP redirect, resolve the user, create a session."""
+        client = self._require_client()
+
+        if not code or not state:
+            raise OIDCFlowError("Missing 'code' or 'state' query parameter.")
+        if not state_cookie_raw:
+            raise OIDCFlowError("OIDC state cookie missing.")
+
+        try:
+            payload = self._state_serializer().loads(state_cookie_raw)
+        except ValueError as e:
+            logger.warning(f"Invalid OIDC state cookie: {e}")
+            raise OIDCFlowError("Invalid or expired OIDC state cookie.") from e
+
+        # CSRF: the query ``state`` must match the signed cookie.
+        if state != payload.state:
+            logger.warning("OIDC state mismatch between query and cookie")
+            raise OIDCFlowError("OIDC state mismatch.")
+
+        try:
+            bundle = await client.exchange_code(
+                code=code,
+                code_verifier=payload.code_verifier,
+                expected_nonce=payload.nonce,
+            )
+        except Exception as e:
+            # Generic message — IdP URLs / internals must not leak via HTTP.
+            logger.exception("OIDC code exchange failed")
+            raise OIDCFlowError("OIDC code exchange failed") from e
+
+        sub = bundle.claims.get("sub")
+        if not sub:
+            raise OIDCFlowError("ID token missing 'sub' claim.")
+
+        user = await self._resolve_user(sub, bundle.claims)
+        user = await self._sync_auto_provisioned(user, sub, bundle.claims)
+        user = await self._apply_claim_mapping(user, bundle)
+
+        now = _utcnow()
+        expires_in = max(int(bundle.expires_in or 0), 60)
+        access_token_expires_at = now + timedelta(seconds=expires_in)
+        session_expires_at = now + timedelta(days=7) if bundle.refresh_token else access_token_expires_at
+
+        plain, token_hash = issue_session_token()
+        key = self._config.token_encryption_key
+        await self._oidc_session_repo.create_session(
+            OIDCSession(
+                session_token_hash=token_hash,
+                user_id=user.id,
+                sub=sub,
+                sid=bundle.claims.get("sid"),
+                id_token_encrypted=encrypt_token(bundle.id_token, key=key),
+                access_token_encrypted=encrypt_token(bundle.access_token, key=key),
+                refresh_token_encrypted=encrypt_token(bundle.refresh_token, key=key),
+                access_token_expires_at=access_token_expires_at,
+                session_expires_at=session_expires_at,
+                created_at=now,
+            )
+        )
+
+        next_url = self.sanitize_next_url(payload.next_url)
+        max_age = max(int((session_expires_at - now).total_seconds()), 1)
+        logger.info(f"OIDC login success — user_id={user.id}, sid={bundle.claims.get('sid')!r}, next={next_url!r}")
+        return CallbackResult(
+            session_cookie_name=SESSION_COOKIE_NAME,
+            session_cookie_value=plain,
+            session_cookie_max_age=max_age,
+            next_url=next_url,
+        )
+
+    async def handle_backchannel_logout(self, logout_token: str) -> int:
+        """Verify an IdP logout token and revoke the named session(s)."""
+        client = self._require_client()
+        try:
+            claims = await client.verify_logout_token(logout_token)
+        except ValueError as e:
+            logger.warning(f"Invalid back-channel logout token: {e}")
+            raise OIDCFlowError(str(e), error_description=str(e)) from e
+        except Exception as e:
+            logger.warning(f"Back-channel logout token verification failed: {e}")
+            raise OIDCFlowError("invalid_request") from e
+
+        if claims.sid:
+            count = await self._oidc_session_repo.revoke_by_sid(claims.sid)
+            logger.info(f"Back-channel logout revoked sessions — sid={claims.sid!r}, count={count}")
+            return count
+
+        # Policy: sid-less logout tokens are out of scope (still 200 to the
+        # IdP so it doesn't retry).
+        logger.warning(
+            f"Received sid-less back-channel logout token — not supported; "
+            f"ignoring per implementation policy (sub={claims.sub!r})"
+        )
+        return 0
+
+    async def logout(self, session_cookie_value: str | None) -> str | None:
+        """Revoke the local session and build the IdP end-session redirect.
+
+        Returns the redirect target, or ``None`` when neither an IdP
+        ``end_session_endpoint`` nor a configured post-logout URL exists
+        (the router then just confirms the logout in place).
+        """
+        client = self._require_client()
+
+        id_token_hint: str | None = None
+        if session_cookie_value:
+            session = await self._oidc_session_repo.get_by_token_hash(
+                hash_session_token(session_cookie_value),
+            )
+            if session:
+                if session.id_token_encrypted:
+                    try:
+                        id_token_hint = decrypt_token(
+                            session.id_token_encrypted,
+                            key=self._config.token_encryption_key,
+                        )
+                    except ValueError as e:
+                        logger.warning(f"Failed to decrypt id_token for logout: {e}")
+                try:
+                    await self._oidc_session_repo.revoke_session(session.id)
+                except Exception as e:
+                    logger.warning(f"Failed to revoke oidc_session during logout: {e}")
+
+        local_target = self._config.post_logout_redirect_uri or None
+        redirect_target: str | None = local_target
+        try:
+            meta = await client.discover()
+            end_session = meta.get("end_session_endpoint")
+            if end_session:
+                params: dict[str, str] = {"client_id": self._config.client_id}
+                if local_target:
+                    params["post_logout_redirect_uri"] = local_target
+                if id_token_hint:
+                    params["id_token_hint"] = id_token_hint
+                redirect_target = f"{end_session}?{urlencode(params)}"
+        except Exception as e:
+            logger.warning(f"OIDC discovery failed during logout, skipping IdP redirect: {e}")
+
+        return redirect_target
+
+    # ------------------------------------------------------------------
+    # Auth policy — pure helpers (no I/O)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _uget(user: Any, key: str, default: Any = None) -> Any:
+        """Read a user attribute whether ``user`` is a dict or :class:`User`.
+
+        The legacy middleware binds ``request.state.user`` as a dict; the
+        new repos return :class:`User`. Both shapes flow through these
+        helpers during the shim period.
+        """
+        if isinstance(user, dict):
+            return user.get(key, default)
+        return getattr(user, key, default)
+
+    @classmethod
+    def require_admin(cls, user: Any) -> Any:
+        """Raise :class:`AuthError` (403) unless the user is an admin."""
+        if not user or not cls._uget(user, "is_admin", False):
+            raise AuthError("Admin privileges required", status_code=403)
+        return user
+
+    @classmethod
+    def check_partition_access(
+        cls,
+        *,
+        user: Any,
+        partition: str,
+        user_partitions: list[dict[str, Any]],
+        required_role: str,
+        super_admin_mode: bool = False,
+    ) -> bool:
+        """Pure port of ``ensure_partition_role``.
+
+        Unlike the legacy helper this does **not** probe the vector DB for
+        partition existence — the "unknown partition is allowed" branch was
+        an I/O side effect. Callers that still need it must validate
+        existence separately; here, absence of a membership for an
+        otherwise-known partition is a 403.
+        """
+        if super_admin_mode and cls._uget(user, "is_admin", False):
+            return True
+
+        membership = next(
+            (p for p in user_partitions if p.get("partition") == partition),
+            None,
+        )
+        if not membership:
+            raise AuthError(
+                f"Access to partition '{partition}' forbidden",
+                status_code=403,
+            )
+
+        user_role = membership.get("role")
+        if cls.ROLE_HIERARCHY[user_role] < cls.ROLE_HIERARCHY[required_role]:
+            raise AuthError(
+                f"{required_role.capitalize()} role required for partition '{partition}'",
+                status_code=403,
+            )
+        return True
+
+    @classmethod
+    def validate_file_quota(
+        cls,
+        user: Any,
+        *,
+        pending_task_count: int,
+        default_quota: int,
+    ) -> None:
+        """Pure quota check (the pending-task count is supplied by the caller).
+
+        Quota semantics are unchanged from ``check_user_file_quota``:
+        admins bypass; ``default_quota < 0`` disables; ``file_quota`` of
+        ``None`` falls back to the default; ``< 0`` means unlimited.
+        """
+        if cls._uget(user, "is_admin", False):
+            return
+        if default_quota < 0:
+            return
+
+        user_quota = cls._uget(user, "file_quota")
+        if user_quota is None:
+            user_quota = default_quota
+        if user_quota < 0:
+            return
+
+        indexed_count = cls._uget(user, "file_count", 0) or 0
+        total = indexed_count + pending_task_count
+        if total >= user_quota:
+            raise OpenRAGError(
+                f"File quota exceeded. You have {indexed_count} indexed files "
+                f"and {pending_task_count} pending tasks. Limit: {user_quota}",
+                code="FILE_QUOTA_EXCEEDED",
+                status_code=403,
+            )
+
+    def sanitize_next_url(self, next_url: str | None) -> str:
+        """Block open redirects.
+
+        Accept a same-origin relative path (``/...`` but not ``//...``) or
+        an absolute URL whose origin is explicitly whitelisted; fall back
+        to ``/`` otherwise.
+        """
+        if not next_url:
+            return "/"
+        if next_url.startswith("/") and not next_url.startswith("//"):
+            return next_url
+        parsed = urlparse(next_url)
+        if parsed.scheme in ("http", "https") and parsed.netloc:
+            origin = f"{parsed.scheme}://{parsed.netloc}"
+            if origin in self._allowed_next_origins():
+                return next_url
+        return "/"
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _require_client(self) -> OIDCClient:
+        if self._oidc_client is None:
+            raise OIDCFlowError("OIDC is not configured.", status_code=400)
+        return self._oidc_client
+
+    def _state_serializer(self) -> StateCookieSerializer:
+        return StateCookieSerializer(secret_key=self._config.token_encryption_key)
+
+    @staticmethod
+    def _allowed_next_origins() -> set[str]:
+        """Origins accepted as post-login redirect targets.
+
+        Mirrors the CORS allowlist: localhost dev ports plus
+        ``INDEXERUI_URL`` so the separately-served indexer-ui can receive
+        the user back after the flow.
+        """
+        origins = {"http://localhost:3042", "http://localhost:5173"}
+        indexer_ui = os.getenv("INDEXERUI_URL")
+        if indexer_ui:
+            origins.add(indexer_ui.rstrip("/"))
+        return origins
+
+    @staticmethod
+    def _display_name_from_claims(claims: dict[str, Any], sub: str) -> str:
+        """Pick a printable display name from the standard OIDC claims."""
+        for key in ("name", "preferred_username"):
+            value = claims.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        given = claims.get("given_name") or ""
+        family = claims.get("family_name") or ""
+        composed = f"{given} {family}".strip()
+        if composed:
+            return composed
+        return f"oidc-{sub[:8]}"
+
+    @classmethod
+    def _parse_claim_mapping(cls, raw: str) -> dict[str, str]:
+        """Parse ``OIDC_CLAIM_MAPPING`` (CSV of ``db_field:claim`` pairs).
+
+        Non-whitelisted / malformed entries are dropped silently — the
+        hard-failure path is the startup validator; at login time we log
+        and continue rather than break the flow.
+        """
+        raw = (raw or "").strip()
+        if not raw:
+            return {}
+        mapping: dict[str, str] = {}
+        for pair in raw.split(","):
+            pair = pair.strip()
+            if not pair or ":" not in pair:
+                continue
+            db_field, claim = pair.split(":", 1)
+            db_field = db_field.strip()
+            claim = claim.strip()
+            if db_field not in cls._OIDC_CLAIM_MAPPING_ALLOWED_FIELDS or not claim:
+                continue
+            mapping[db_field] = claim
+        return mapping
+
+    async def _resolve_user(self, sub: str, claims: dict[str, Any]) -> User:
+        """Look the user up by ``sub``; auto-provision if configured."""
+        user = await self._user_repo.get_user_by_external_id(sub)
+        if user is not None:
+            return user
+
+        if not self._config.auto_provision_login:
+            logger.warning(f"OIDC login rejected — user not registered (sub={sub!r})")
+            raise OIDCFlowError("User not registered", status_code=403)
+
+        display_name = self._display_name_from_claims(claims, sub)
+        email = claims.get("email")
+        try:
+            user = await self._user_repo.create_user(
+                User(
+                    display_name=display_name,
+                    external_user_id=sub,
+                    email=email if isinstance(email, str) and email.strip() else None,
+                    is_admin=False,
+                )
+            )
+        except Exception as e:
+            # Concurrent first-login race or DB failure — re-read; if still
+            # missing, surface a 500 so the operator notices.
+            logger.exception(f"OIDC auto-provisioning failed for sub={sub!r}: {e}")
+            user = await self._user_repo.get_user_by_external_id(sub)
+            if user is None:
+                raise OIDCFlowError("Failed to provision user", status_code=500) from e
+        else:
+            logger.info(f"OIDC user auto-provisioned (id={user.id}, sub={sub!r}, display_name={display_name!r})")
+        return user
+
+    async def _sync_auto_provisioned(
+        self,
+        user: User,
+        sub: str,
+        claims: dict[str, Any],
+    ) -> User:
+        """Keep display_name/email in sync with the IdP on every login.
+
+        Only active when ``auto_provision_login`` is on — then the IdP is
+        the source of truth for these two fields so a rename upstream does
+        not drift. No-op when the row already matches.
+        """
+        if not self._config.auto_provision_login:
+            return user
+
+        derived_display = self._display_name_from_claims(claims, sub)
+        raw_email = claims.get("email")
+        derived_email = raw_email.strip() if isinstance(raw_email, str) and raw_email.strip() else None
+
+        updates: dict[str, Any] = {}
+        if derived_display and user.display_name != derived_display:
+            updates["display_name"] = derived_display
+        if derived_email is not None and user.email != derived_email:
+            updates["email"] = derived_email
+        if not updates:
+            return user
+
+        try:
+            refreshed = await self._user_repo.update_user(user.id, **updates)
+        except Exception as e:
+            logger.warning(f"OIDC auto-provision sync failed for user_id={user.id}: {e}")
+            return user
+        return refreshed or user
+
+    async def _apply_claim_mapping(self, user: User, bundle: Any) -> User:
+        """Apply the optional ``OIDC_CLAIM_MAPPING`` (display_name/email only)."""
+        mapping = self._parse_claim_mapping(self._config.claim_mapping)
+        if not mapping:
+            return user
+
+        if self._config.claim_source == "userinfo":
+            try:
+                claims_for_mapping = await self._require_client().fetch_userinfo(bundle.access_token)
+            except Exception as e:
+                logger.warning(f"OIDC userinfo fetch failed: {e}")
+                raise OIDCFlowError("Failed to fetch userinfo from IdP.") from e
+        else:
+            claims_for_mapping = bundle.claims
+
+        updates: dict[str, Any] = {}
+        for db_field, claim in mapping.items():
+            value = claims_for_mapping.get(claim)
+            if value is None:
+                continue
+            if getattr(user, db_field, None) == value:
+                continue
+            updates[db_field] = value
+        if not updates:
+            return user
+
+        try:
+            refreshed = await self._user_repo.update_user(user.id, **updates)
+        except Exception as e:
+            logger.warning(f"update_user failed for user_id={user.id}: {e}")
+            return user
+        return refreshed or user
+
+
+__all__ = [
+    "AuthService",
+    "OIDCFlowError",
+    "LoginRedirect",
+    "CallbackResult",
+    "SESSION_COOKIE_NAME",
+]

--- a/openrag/services/orchestrators/conversion_service.py
+++ b/openrag/services/orchestrators/conversion_service.py
@@ -1,0 +1,94 @@
+"""ConversionService — document extraction + chunk lookup (Phase 8E).
+
+Business logic extracted from ``routers/tools.py`` (the ``extractText``
+tool) and ``routers/extract.py`` (chunk-by-id lookup). Both were thin
+wrappers; this service keeps them Ray-free:
+
+- serialization runs in the ``DocSerializer`` Ray actor, reached through
+  the :class:`~core.indexing.serializer.FileSerializer` port (the
+  container injects the ``SerializerRayShim`` during the shim period);
+- chunk lookup goes through the clean :class:`VectorStore` port
+  (``query_chunks_by_filter`` on the Milvus ``_id``), mirroring how
+  PartitionService reads chunks — no LangChain ``Document`` leaks out.
+
+The thin routers keep HTTP transport only: file save + cleanup IO, tool
+dispatch, the request-scoped partition authorization, and the guards
+whose exact ``{"detail": ...}`` body the legacy endpoints returned via
+``HTTPException`` (404 not-found, 403 forbidden, the 4xx/5xx tool-error
+mapping).
+
+Constructor note: the plan's ``ConversionService(config=config)`` is
+underspecified — it takes the two ports it actually needs plus the
+established ``collection`` extra (the vector-store collection name the
+legacy shim read from ``config.vectordb.collection_name``), supplied by
+the container from settings so the service stays Ray/config-free (8H).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.utils.text import sanitize_extracted_text
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.indexing.serializer import FileSerializer
+    from core.vector_stores import VectorStore
+
+logger = get_logger()
+
+
+class ConversionService:
+    """File-to-text extraction and single-chunk retrieval."""
+
+    def __init__(
+        self,
+        *,
+        serializer: FileSerializer,
+        vector_store: VectorStore,
+        collection: str,
+    ) -> None:
+        self._serializer = serializer
+        self._vector_store = vector_store
+        self._collection = collection
+
+    async def serialize_file(
+        self,
+        *,
+        file_path: str,
+        filename: str | None,
+        metadata: dict,
+    ) -> str:
+        """Serialize ``file_path`` to sanitized raw text (``extractText``)."""
+        metadata = dict(metadata or {})
+        metadata.update({"source": str(file_path), "filename": filename})
+        content = await self._serializer.serialize(file_path, metadata)
+        return sanitize_extracted_text(content)
+
+    async def get_chunk(self, chunk_id: str) -> dict | None:
+        """Return ``{"page_content", "metadata"}`` for a chunk, or ``None``.
+
+        Milvus ``_id`` is Int64; a non-integer id is treated as not
+        found (the router maps ``None`` to a 404), matching the legacy
+        ``get_chunk_by_id``.
+        """
+        try:
+            chunk_id_int = int(chunk_id)
+        except (ValueError, TypeError):
+            logger.warning("Invalid chunk_id format - must be an integer", chunk_id=chunk_id)
+            return None
+
+        rows = await self._vector_store.query_chunks_by_filter(
+            self._collection,
+            {"_id": chunk_id_int},
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            "page_content": row["text"],
+            "metadata": {k: v for k, v in row.items() if k not in ("text", "vector")},
+        }
+
+
+__all__ = ["ConversionService"]

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -1,0 +1,196 @@
+"""IndexingService — file ingest orchestration (Phase 8D.1).
+
+Business logic extracted from ``routers/indexer.py``: metadata
+assembly, existence/workspace checks and task dispatch. The heavy work
+(serialize → chunk → embed → insert) still runs in the ``Indexer`` Ray
+actor and task bookkeeping in ``TaskStateManager``; both sit behind the
+:class:`~core.indexing.dispatcher.IndexingDispatcher` port so this
+service stays Ray-free (8H). Phase 9 swaps the shim for a direct
+pipeline call.
+
+The thin router keeps HTTP transport only: file save to disk (IO),
+``request.url_for`` link building, the shared ``Depends`` auth wrappers,
+and the guards whose exact non-bracketed ``{"detail": ...}`` body the
+legacy endpoints returned via ``HTTPException`` (409 already-exists,
+404 not-found, 400 bad workspace_ids, 404 unknown workspace, 404 no
+object ref for cancel).
+
+Constructor note: deviates from the plan's
+``(document_repo, workspace_repo, vector_store, config)``. ``vector_store``
+and ``config`` are dropped — the file delete is routed through the
+Indexer worker (which owns the Milvus delete) and the only config the
+legacy router needed (data dir, vectordb timeout) is a transport / shim
+concern. ``dispatcher`` is added: the Ray-free seam the container fills
+with the ``IndexerRayShim`` during the shim period.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from components.indexer.utils.files import extract_temporal_fields
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.indexing.dispatcher import IndexingDispatcher
+    from core.ports.document_repo import DocumentRepository
+    from core.ports.workspace_repo import WorkspaceRepository
+
+logger = get_logger()
+
+# Client-supplied datetime fields lifted into queryable metadata.
+TEMPORAL_FIELDS = ["created_at"]
+
+
+def _human_readable_size(size_bytes: int) -> str:
+    """Bytes → human-readable string (e.g. ``'2.40 MB'``).
+
+    Kept private here rather than imported from ``routers/utils.py`` —
+    services must not depend on the HTTP layer.
+    """
+    size = float(size_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024:
+            return f"{size:.2f} {unit}"
+        size /= 1024
+    return f"{size:.2f} PB"
+
+
+class IndexingService:
+    """File upload/delete/copy/metadata orchestration over the worker layer."""
+
+    def __init__(
+        self,
+        *,
+        document_repo: DocumentRepository,
+        workspace_repo: WorkspaceRepository,
+        dispatcher: IndexingDispatcher,
+    ) -> None:
+        self._document_repo = document_repo
+        self._workspace_repo = workspace_repo
+        self._dispatcher = dispatcher
+
+    # ------------------------------------------------------------------
+    # Lookups (used by the thin router for its byte-identical guards)
+    # ------------------------------------------------------------------
+
+    async def file_exists(self, file_id: str, partition: str) -> bool:
+        try:
+            return await self._document_repo.file_exists_in_partition(
+                file_id=file_id,
+                partition=partition,
+            )
+        except Exception as e:  # pragma: no cover - defensive, matches legacy
+            logger.exception("File existence check failed.", file_id=file_id, partition=partition, error=str(e))
+            return False
+
+    async def get_workspace(self, workspace_id: str) -> dict | None:
+        return await self._workspace_repo.get_workspace_dict(workspace_id)
+
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    def _build_metadata(
+        self,
+        *,
+        metadata: dict,
+        file_path: str,
+        file_id: str,
+        sanitized_filename: str,
+        original_filename: str | None,
+    ) -> dict:
+        """Assemble the indexing metadata exactly as the legacy router did."""
+        metadata = dict(metadata or {})
+        metadata.update(
+            {
+                "source": str(file_path),
+                "filename": sanitized_filename,
+                "original_filename": original_filename,
+            }
+        )
+        file_stat = Path(file_path).stat()
+        metadata["file_size"] = _human_readable_size(file_stat.st_size)
+        metadata["file_id"] = file_id
+        metadata.update(extract_temporal_fields(metadata, temporal_fields=TEMPORAL_FIELDS))
+        return metadata
+
+    async def add_file(
+        self,
+        *,
+        file_path: str,
+        file_id: str,
+        partition: str,
+        metadata: dict,
+        sanitized_filename: str,
+        original_filename: str | None,
+        user: dict | None,
+        workspace_ids: list[str] | None = None,
+        replace: bool = False,
+    ) -> str:
+        """Assemble metadata and queue an (re)indexing job; return its task id.
+
+        Workspace association happens inside the worker's ``add_file``
+        after a successful index — the router only pre-validates the ids.
+        """
+        full_metadata = self._build_metadata(
+            metadata=metadata,
+            file_path=file_path,
+            file_id=file_id,
+            sanitized_filename=sanitized_filename,
+            original_filename=original_filename,
+        )
+        return await self._dispatcher.dispatch_indexing(
+            path=file_path,
+            metadata=full_metadata,
+            partition=partition,
+            user=user,
+            workspace_ids=workspace_ids,
+            replace=replace,
+        )
+
+    async def delete_file(self, file_id: str, partition: str) -> None:
+        await self._dispatcher.delete_file(file_id, partition)
+
+    async def update_metadata(
+        self,
+        file_id: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+    ) -> None:
+        metadata = dict(metadata or {})
+        metadata["file_id"] = file_id
+        await self._dispatcher.update_file_metadata(file_id, metadata, partition, user)
+
+    async def copy_file(
+        self,
+        *,
+        source_file_id: str,
+        source_partition: str,
+        target_file_id: str,
+        target_partition: str,
+        metadata: dict,
+        user: dict | None,
+    ) -> None:
+        metadata = dict(metadata or {})
+        metadata["file_id"] = target_file_id
+        metadata["partition"] = target_partition
+        await self._dispatcher.copy_file(source_file_id, metadata, source_partition, user)
+
+    # ------------------------------------------------------------------
+    # Task state
+    # ------------------------------------------------------------------
+
+    async def get_task_state(self, task_id: str) -> str | None:
+        return await self._dispatcher.get_task_state(task_id)
+
+    async def get_task_error(self, task_id: str) -> str | None:
+        return await self._dispatcher.get_task_error(task_id)
+
+    async def cancel_task(self, task_id: str) -> bool:
+        return await self._dispatcher.cancel_task(task_id)
+
+
+__all__ = ["IndexingService"]

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -82,5 +82,13 @@ class JobService:
 
         return [{"task_id": tid, "state": i["state"], "details": i["details"]} for tid, i in filtered]
 
+    async def get_user_pending_task_count(self, user_id: int | None) -> int:
+        """Pending (not-yet-completed) indexing tasks for one user.
+
+        Used by UserService for the quota-usage block of ``/users/info``
+        (the legacy router called the actor directly from the handler).
+        """
+        return await self._tsm.get_user_pending_task_count.remote(user_id)
+
 
 __all__ = ["JobService"]

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -23,8 +23,25 @@ _ACTIVE_STATES = ("QUEUED", "SERIALIZING", "CHUNKING", "INSERTING")
 class JobService:
     """Queue/worker introspection over the TaskStateManager actor."""
 
-    def __init__(self, task_state_manager: Any) -> None:
+    def __init__(self, task_state_manager: Any, timeout: float = 60.0) -> None:
         self._tsm = task_state_manager
+        self._timeout = timeout
+
+    async def _call(self, future: Any, task_description: str) -> Any:
+        """Route TaskStateManager calls through the centralized Ray helper.
+
+        Direct ``.remote()`` awaits would bypass timeout/cancellation
+        handling and can stall the queue APIs under Ray degradation. The
+        canonical helper lives in ``services.workers.ray_utils``
+        (``components.ray_utils`` is a backward-compat re-export).
+        """
+        from services.workers.ray_utils import call_ray_actor_with_timeout
+
+        return await call_ray_actor_with_timeout(
+            future=future,
+            timeout=self._timeout,
+            task_description=task_description,
+        )
 
     @staticmethod
     def _format_pool_info(worker_info: dict[str, int]) -> dict[str, int]:
@@ -36,7 +53,7 @@ class JobService:
         }
 
     async def get_queue_info(self) -> dict:
-        all_states: dict = await self._tsm.get_all_states.remote()
+        all_states: dict = await self._call(self._tsm.get_all_states.remote(), "get_all_states")
         status_counts = Counter(all_states.values())
 
         active = {s: status_counts.get(s, 0) for s in _ACTIVE_STATES}
@@ -48,7 +65,7 @@ class JobService:
             "total_failed": status_counts.get("FAILED", 0),
         }
 
-        worker_info = await self._tsm.get_pool_info.remote()
+        worker_info = await self._call(self._tsm.get_pool_info.remote(), "get_pool_info")
         return {"workers": self._format_pool_info(worker_info), "tasks": task_summary}
 
     async def list_tasks(
@@ -68,9 +85,9 @@ class JobService:
         The router decorates each row with the status / error URLs.
         """
         if is_admin:
-            all_info: dict[str, dict] = await self._tsm.get_all_info.remote()
+            all_info: dict[str, dict] = await self._call(self._tsm.get_all_info.remote(), "get_all_info")
         else:
-            all_info = await self._tsm.get_all_user_info.remote(user_id)
+            all_info = await self._call(self._tsm.get_all_user_info.remote(user_id), f"get_all_user_info({user_id})")
 
         if task_status is None:
             filtered = list(all_info.items())
@@ -88,7 +105,10 @@ class JobService:
         Used by UserService for the quota-usage block of ``/users/info``
         (the legacy router called the actor directly from the handler).
         """
-        return await self._tsm.get_user_pending_task_count.remote(user_id)
+        return await self._call(
+            self._tsm.get_user_pending_task_count.remote(user_id),
+            f"get_user_pending_task_count({user_id})",
+        )
 
 
 __all__ = ["JobService"]

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -1,0 +1,86 @@
+"""JobService — task-queue queries (Phase 8D.2).
+
+Thin wrapper around the ``TaskStateManager`` Ray actor, extracted from
+``routers/queue.py``. Aggregation/filtering (the active-status rollup,
+the per-status counts, the ``?task_status=`` filter) is business logic
+and lives here; ``request.url_for`` link building stays in the thin
+router (HTTP transport).
+
+This is the one orchestrator that legitimately keeps Ray remote calls
+during the shim — 8H verification explicitly excepts JobService
+wrapping ``TaskStateManager``. Phase 9 swaps the actor for a DB-backed
+job repository (this service is the hook point for that P0 feature).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+_ACTIVE_STATES = ("QUEUED", "SERIALIZING", "CHUNKING", "INSERTING")
+
+
+class JobService:
+    """Queue/worker introspection over the TaskStateManager actor."""
+
+    def __init__(self, task_state_manager: Any) -> None:
+        self._tsm = task_state_manager
+
+    @staticmethod
+    def _format_pool_info(worker_info: dict[str, int]) -> dict[str, int]:
+        """Condense ``SerializerQueue.pool_info()`` into the API shape."""
+        return {
+            "total_slots": worker_info["total_capacity"],
+            "pool_size": worker_info["pool_size"],
+            "max_per_actor": worker_info["max_tasks_per_worker"],
+        }
+
+    async def get_queue_info(self) -> dict:
+        all_states: dict = await self._tsm.get_all_states.remote()
+        status_counts = Counter(all_states.values())
+
+        active = {s: status_counts.get(s, 0) for s in _ACTIVE_STATES}
+        task_summary = {
+            "active": sum(active.values()),
+            "active_statuses": active,
+            "total_cancelled": status_counts.get("CANCELLED", 0),
+            "total_completed": status_counts.get("COMPLETED", 0),
+            "total_failed": status_counts.get("FAILED", 0),
+        }
+
+        worker_info = await self._tsm.get_pool_info.remote()
+        return {"workers": self._format_pool_info(worker_info), "tasks": task_summary}
+
+    async def list_tasks(
+        self,
+        *,
+        is_admin: bool,
+        user_id: int | None,
+        task_status: str | None = None,
+    ) -> list[dict]:
+        """Return ``{task_id, state, details}`` rows, filtered.
+
+        - admins see every task; regular users only their own
+        - ``task_status='active'`` → QUEUED|SERIALIZING|CHUNKING|INSERTING
+        - any other value → exact match (case-insensitive)
+        - ``None`` → all tasks
+
+        The router decorates each row with the status / error URLs.
+        """
+        if is_admin:
+            all_info: dict[str, dict] = await self._tsm.get_all_info.remote()
+        else:
+            all_info = await self._tsm.get_all_user_info.remote(user_id)
+
+        if task_status is None:
+            filtered = list(all_info.items())
+        elif task_status.lower() == "active":
+            active_states = set(_ACTIVE_STATES)
+            filtered = [(tid, i) for tid, i in all_info.items() if i["state"] in active_states]
+        else:
+            filtered = [(tid, i) for tid, i in all_info.items() if i["state"].lower() == task_status.lower()]
+
+        return [{"task_id": tid, "state": i["state"], "details": i["details"]} for tid, i in filtered]
+
+
+__all__ = ["JobService"]

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -1,0 +1,250 @@
+"""PartitionService — partition CRUD, membership, file/chunk reads (Phase 8B.1).
+
+Business logic extracted from ``routers/partition.py`` and the partition
+slice of the legacy Ray ``vectordb`` shim. The service talks to the
+Phase 7 repositories and the :class:`VectorStore` port directly; it does
+not depend on Ray or pymilvus.
+
+``delete_partition`` is the one cross-cutting method — it must drop the
+partition's vectors from the store *and* the relational rows. It is
+performed through the clean :class:`VectorStore` port
+(``query_ids_by_filter`` + ``delete``) rather than a Milvus-specific
+filter delete, so PartitionService stays backend-agnostic.
+
+Chunk reads return plain dicts (never LangChain ``Document`` objects —
+8H forbids LangChain in orchestrators); the thin router builds the
+``request.url_for`` links and final response shape.
+
+Constructor notes (two args beyond the plan's four, both to preserve
+legacy behaviour without widening into Ray/config): ``collection`` (the
+vector-store collection name the legacy shim read from
+``config.vectordb.collection_name``) and ``user_repo`` (needed to
+reproduce the ``VDBUserNotFound`` 404 the legacy ``add_partition_member``
+raised). The container supplies both from settings/the catalog store.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from core.utils.exceptions import (
+    NotFoundError,
+    PartitionNotFoundError,
+    UserNotFoundError,
+    ValidationError,
+)
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.ports.document_repo import DocumentRepository
+    from core.ports.partition_membership_repo import PartitionMembershipRepository
+    from core.ports.partition_repo import PartitionRepository
+    from core.ports.user_repo import UserRepository
+    from core.vector_stores import VectorStore
+
+logger = get_logger()
+
+
+class PartitionService:
+    """Partition lifecycle, membership and read-through orchestration."""
+
+    def __init__(
+        self,
+        *,
+        partition_repo: PartitionRepository,
+        membership_repo: PartitionMembershipRepository,
+        document_repo: DocumentRepository,
+        vector_store: VectorStore,
+        user_repo: UserRepository,
+        collection: str,
+    ) -> None:
+        self._partition_repo = partition_repo
+        self._membership_repo = membership_repo
+        self._document_repo = document_repo
+        self._vector_store = vector_store
+        self._user_repo = user_repo
+        self._collection = collection
+
+    # ------------------------------------------------------------------
+    # Existence guards (mirror the legacy _check_* helpers, core exceptions)
+    # ------------------------------------------------------------------
+
+    async def _ensure_partition(self, partition: str) -> None:
+        if not await self._partition_repo.partition_exists(name=partition):
+            logger.warning(f"Partition '{partition}' does not exist.")
+            raise PartitionNotFoundError(f"Partition '{partition}' does not exist.")
+
+    async def _ensure_user_exists(self, user_id: int) -> None:
+        if not await self._user_repo.user_exists(user_id):
+            logger.warning(f"User with ID {user_id} does not exist.")
+            raise UserNotFoundError(f"User with ID {user_id} does not exist.")
+
+    async def _ensure_membership(self, partition: str, user_id: int) -> None:
+        await self._ensure_partition(partition)
+        await self._ensure_user_exists(user_id)
+        if not await self._membership_repo.user_is_partition_member(user_id, partition):
+            raise NotFoundError(
+                f"User with ID {user_id} is not a member of partition '{partition}'.",
+                code="MEMBERSHIP_NOT_FOUND",
+            )
+
+    async def file_exists(self, file_id: str, partition: str) -> bool:
+        try:
+            return await self._document_repo.file_exists_in_partition(
+                file_id=file_id,
+                partition=partition,
+            )
+        except Exception as e:  # pragma: no cover - defensive, matches legacy
+            logger.exception("File existence check failed.", file_id=file_id, partition=partition, error=str(e))
+            return False
+
+    # ------------------------------------------------------------------
+    # Partition CRUD
+    # ------------------------------------------------------------------
+
+    async def partition_exists(self, partition: str) -> bool:
+        try:
+            return await self._partition_repo.partition_exists(name=partition)
+        except Exception as e:  # pragma: no cover - defensive, matches legacy
+            logger.exception("Partition existence check failed.", partition=partition, error=str(e))
+            return False
+
+    async def list_partitions(self) -> list[dict]:
+        return await self._partition_repo.list_partitions()
+
+    async def create_partition(self, partition: str, user_id: int) -> None:
+        """Create a partition owned by ``user_id``.
+
+        The 409-on-exists check lives in the thin router (it returns a
+        non-bracketed ``{"detail": ...}`` body that must stay identical);
+        this raises only if the race is lost between that check and here.
+        """
+        if await self._partition_repo.partition_exists(name=partition):
+            raise ValidationError(
+                f"Partition '{partition}' already exists.",
+                status_code=409,
+                code="PARTITION_EXISTS",
+            )
+        await self._partition_repo.create_partition(name=partition, user_id=user_id)
+        logger.info(f"Partition '{partition}' created by user_id {user_id}.")
+
+    async def delete_partition(self, partition: str) -> None:
+        """Drop a partition's vectors *and* relational rows (cross-cutting)."""
+        await self._ensure_partition(partition)
+        ids = await self._vector_store.query_ids_by_filter(
+            self._collection,
+            {"partition": partition},
+        )
+        if ids:
+            deleted = await self._vector_store.delete(ids, self._collection)
+            logger.info("Deleted points from partition", partition=partition, count=deleted)
+        await self._partition_repo.delete_partition(name=partition)
+        logger.info("Partition successfully deleted.", partition=partition)
+
+    # ------------------------------------------------------------------
+    # File / chunk reads
+    # ------------------------------------------------------------------
+
+    async def list_files(self, partition: str, limit: int | None = None) -> list[dict]:
+        await self._ensure_partition(partition)
+        result = await self._document_repo.list_partition_files(partition=partition, limit=limit)
+        return result.get("files", [])
+
+    async def get_file_chunks(self, partition: str, file_id: str, limit: int = 2000) -> list[dict]:
+        """Return chunk rows (``_id`` kept, ``text`` dropped) for one file.
+
+        The router builds the extract links and strips ``_id`` from the
+        surfaced metadata, exactly as before.
+        """
+        if not await self.file_exists(file_id, partition):
+            raise NotFoundError(
+                f"'{file_id}' not found in partition '{partition}'",
+                code="FILE_NOT_FOUND",
+            )
+        rows = await self._vector_store.query_chunks_by_filter(
+            self._collection,
+            {"partition": partition, "file_id": file_id},
+            output_fields=["*"],
+        )
+        if len(rows) > limit:
+            rows = rows[:limit]
+        return [{k: v for k, v in row.items() if k != "text"} for row in rows]
+
+    async def list_all_chunks(self, partition: str, include_embedding: bool = True) -> list[dict]:
+        """Return ``{"content", "metadata"}`` dicts for every chunk."""
+        await self._ensure_partition(partition)
+        excluded = {"text"} if include_embedding else {"text", "vector"}
+        output_fields = ["*", "vector"] if include_embedding else ["*"]
+        rows = await self._vector_store.query_chunks_by_filter(
+            self._collection,
+            {"partition": partition},
+            output_fields=output_fields,
+        )
+
+        def _meta(row: dict[str, Any]) -> dict[str, Any]:
+            meta: dict[str, Any] = {}
+            for k, v in row.items():
+                if k in excluded:
+                    continue
+                if k == "vector":
+                    # Legacy surfaced the embedding as a flat string.
+                    v = str(np.array(v).flatten().tolist())
+                meta[k] = v
+            return meta
+
+        return [{"content": row.get("text"), "metadata": _meta(row)} for row in rows]
+
+    # ------------------------------------------------------------------
+    # Membership
+    # ------------------------------------------------------------------
+
+    async def list_members(self, partition: str) -> list[dict]:
+        await self._ensure_partition(partition)
+        return await self._membership_repo.list_partition_members(partition)
+
+    async def add_member(self, partition: str, user_id: int, role: str) -> None:
+        await self._ensure_partition(partition)
+        await self._ensure_user_exists(user_id)
+        await self._membership_repo.add_partition_member(partition, user_id, role)
+        logger.info(f"User_id {user_id} added to partition '{partition}'.")
+
+    async def remove_member(self, partition: str, user_id: int) -> None:
+        await self._ensure_membership(partition, user_id)
+        await self._membership_repo.remove_partition_member(partition, user_id)
+        logger.info(f"User_id {user_id} removed from partition '{partition}'.")
+
+    async def update_role(self, partition: str, user_id: int, new_role: str) -> None:
+        await self._ensure_membership(partition, user_id)
+        await self._membership_repo.update_partition_member_role(partition, user_id, new_role)
+        logger.info(f"User_id {user_id} role updated to '{new_role}' in partition '{partition}'.")
+
+    # ------------------------------------------------------------------
+    # Document relationships
+    # ------------------------------------------------------------------
+
+    async def get_related_files(self, partition: str, relationship_id: str) -> list[dict]:
+        return await self._document_repo.get_files_by_relationship(
+            partition=partition,
+            relationship_id=relationship_id,
+        )
+
+    async def get_file_ancestors(
+        self,
+        partition: str,
+        file_id: str,
+        max_ancestor_depth: int | None = None,
+    ) -> list[dict]:
+        if not await self.file_exists(file_id, partition):
+            raise NotFoundError(
+                f"'{file_id}' not found in partition '{partition}'",
+                code="FILE_NOT_FOUND",
+            )
+        return await self._document_repo.get_file_ancestors(
+            partition=partition,
+            file_id=file_id,
+            max_ancestor_depth=max_ancestor_depth,
+        )
+
+
+__all__ = ["PartitionService"]

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -1,0 +1,419 @@
+"""QueryService — RAG orchestration (Phase 8C.2).
+
+Rebuilt from ``components/pipeline.py:RagPipeline`` + ``map_reduce.py``.
+The hardest single extraction in Phase 8: query generation, retrieval,
+web search, map-reduce, context formatting, system-prompt assembly, and
+streaming all lived tangled in ``RagPipeline``.
+
+Two logged decisions (REFACTORING_DECISION_LOG Phase 8):
+
+* **Structured output** — the legacy used a LangChain structured-output
+  chain for ``SearchQueries`` (query generation) and ``SummarizedChunk``
+  (map-reduce). 8H bans LangChain in orchestrators, so QueryService uses
+  the injected core ``LLM`` with a
+  JSON-instructed prompt + ``response_format=json_object`` and
+  ``json.loads`` into the Pydantic model, keeping the legacy fallbacks
+  (retry → raw user query; relevancy=False on parse failure).
+* **Streaming + citations live here; the router is pure transport.**
+  ``chat_stream`` drives the proven
+  ``components.utils.stream_with_source_filtering`` (100-char buffer that
+  strips the ``[Sources: N]`` tag before it reaches the client);
+  ``chat`` / ``complete`` return the finalized OpenAI dict with the
+  citation-filtered ``extra`` sources. The router only maps the
+  partition, builds request-bound source links (``prepare_sources``
+  callable — keeps ``request.url_for`` in transport), and wraps
+  ``StreamingResponse`` / ``JSONResponse``.
+
+Imports from ``components.*`` (pure helpers / prompts / websearch) are
+allowed during the Phase-8 shim (legacy layer, unchecked by the guard;
+no LangChain symbol is imported into this file → 8H clean). ``Chunk`` is
+converted to LangChain ``Document`` via ``Chunk.to_langchain()`` at the
+boundary so the existing ``format_context`` / source helpers are reused
+verbatim (no langchain import in this module).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from components.prompts import (
+    QUERY_CONTEXTUALIZER_PROMPT,
+    SPOKEN_STYLE_ANSWER_PROMPT,
+    SYS_PROMPT_TMPLT,
+)
+from components.utils import (
+    SOURCE_SEPARATOR,
+    detect_language,
+    extract_and_strip_sources_block,
+    filter_sources_by_citations,
+    format_context,
+    format_web_context,
+    get_llm_semaphore,
+    stream_with_source_filtering,
+)
+from core.models.query import Query, SearchQueries
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.config.root import Settings
+    from core.llm.llm import LLM
+    from services.orchestrators.retrieval_service import RetrievalService
+    from services.orchestrators.workspace_service import WorkspaceService
+
+logger = get_logger()
+
+PrepareSources = Callable[[list, list], list]
+
+_MAP_SYSTEM_PROMPT = """You are an AI assistant specialized in extracting and synthesizing relevant information from text.
+
+Your task:
+1. Analyze the provided text in relation to the user's question
+2. Extract only the essential information that directly addresses the query
+3. Preserve necessary context (key words, project names, dates) so the summary is self-understandable
+
+Respond with a JSON object exactly matching this schema:
+{"relevancy": <true|false>, "summary": "<summary text, empty string if not relevant>"}
+Set relevancy=false (and summary="") if the text has no relevant content for the query."""
+
+_MAP_USER_PROMPT = """Here is a text:
+{content}
+
+From this document, identify and comprehensively summarize the information useful for answering the following question:
+{query}"""
+
+_QUERY_JSON_HINT = (
+    "\n\nRespond ONLY with a JSON object of the form "
+    '{"query_list": [{"query": "<search query>", "temporal_filters": null}]}.'
+)
+
+
+class RAGMODE(Enum):
+    SIMPLERAG = "SimpleRag"
+    CHATBOTRAG = "ChatBotRag"
+
+
+class QueryService:
+    """End-to-end RAG: query-gen → retrieve (+web) → map-reduce → answer."""
+
+    def __init__(
+        self,
+        *,
+        retrieval_service: RetrievalService,
+        llm: LLM,
+        config: Settings,
+        web_search_service: Any | None,
+        workspace_service: WorkspaceService,
+    ) -> None:
+        self._retrieval = retrieval_service
+        self._llm = llm
+        self._web = web_search_service
+        self._workspace = workspace_service
+
+        self._rag_mode = config.rag.mode
+        self._chat_history_depth = config.rag.chat_history_depth
+        self._max_contextualized_query_len = config.rag.max_contextualized_query_len
+        self._max_context_tokens = config.reranker.top_k * config.chunker.chunk_size
+
+        mr = config.map_reduce
+        self._mr_initial = mr.initial_batch_size
+        self._mr_expansion = mr.expansion_batch_size
+        self._mr_max = mr.max_total_documents
+
+    # ------------------------------------------------------------------
+    # Query generation (was RagPipeline.generate_query — no LangChain)
+    # ------------------------------------------------------------------
+
+    async def generate_query(self, messages: list[dict]) -> SearchQueries:
+        last_user = messages[-1]["content"]
+        if RAGMODE(self._rag_mode) is RAGMODE.SIMPLERAG:
+            return SearchQueries(query_list=[Query(query=last_user)])
+
+        chat_history = "".join(f"{m['role']}: {m['content']}\n" for m in messages)
+        prompt = QUERY_CONTEXTUALIZER_PROMPT.format(
+            query_language=detect_language(last_user),
+            current_date=datetime.now().strftime("%A, %B %d, %Y, %H:%M:%S"),
+        )
+        llm_messages = [
+            {"role": "system", "content": prompt + _QUERY_JSON_HINT},
+            {"role": "user", "content": f"Here is the chat history: \n{chat_history}\n"},
+        ]
+        params = {
+            "max_completion_tokens": self._max_contextualized_query_len,
+            "response_format": {"type": "json_object"},
+        }
+        for attempt in (1, 2):
+            try:
+                resp = await self._llm.chat(llm_messages, **params)
+                content = resp["choices"][0]["message"]["content"]
+                return SearchQueries.model_validate_json(_json_slice(content))
+            except Exception as exc:
+                if attempt == 1:
+                    logger.warning("Query generation parse error — retrying", error=str(exc))
+                else:
+                    logger.warning(
+                        "Query generation failed twice — falling back to raw user query",
+                        error=str(exc),
+                    )
+        return SearchQueries(query_list=[Query(query=last_user)])
+
+    # ------------------------------------------------------------------
+    # Map-reduce (was map_reduce.RAGMapReduce — no LangChain)
+    # ------------------------------------------------------------------
+
+    async def _infer_relevancy(self, query: str, doc) -> tuple[bool, str]:
+        async with get_llm_semaphore():
+            try:
+                resp = await self._llm.chat(
+                    [
+                        {"role": "system", "content": _MAP_SYSTEM_PROMPT},
+                        {"role": "user", "content": _MAP_USER_PROMPT.format(query=query, content=doc.page_content)},
+                    ],
+                    max_tokens=512,
+                    temperature=0.3,
+                    response_format={"type": "json_object"},
+                )
+                data = json.loads(_json_slice(resp["choices"][0]["message"]["content"]))
+                return bool(data.get("relevancy", False)), str(data.get("summary", "") or "")
+            except Exception as e:
+                logger.error("Error during chunk relevancy inference", error=str(e))
+                return False, ""
+
+    async def _map_reduce(self, query: str, docs: list) -> list:
+        """LLM relevancy filter + summarisation, batched with early stop."""
+
+        async def _batch(chunks: list, summaries: list) -> bool:
+            outputs = await asyncio.gather(*[self._infer_relevancy(query, c) for c in chunks])
+            terminate = all(not rel for rel, _ in outputs[-self._mr_expansion :])
+            for (rel, summary), chunk in zip(outputs, chunks, strict=True):
+                if rel:
+                    summaries.append(_summary_doc(chunk, summary))
+            return terminate
+
+        summaries: list = []
+        initial, remaining = docs[: self._mr_initial], docs[self._mr_initial :]
+        terminate = await _batch(initial, summaries)
+        if terminate or not remaining or len(summaries) >= self._mr_max:
+            return summaries
+
+        for i in range(0, len(remaining), self._mr_expansion):
+            n = min(self._mr_expansion, self._mr_max - len(summaries))
+            if n <= 0:
+                break
+            terminate = await _batch(remaining[i : i + n], summaries)
+            if terminate or len(summaries) >= self._mr_max:
+                break
+        logger.debug("Map reduce completed", relevant_chunks_count=len(summaries))
+        return summaries
+
+    # ------------------------------------------------------------------
+    # Preparation (was RagPipeline._prepare_for_chat_completion)
+    # ------------------------------------------------------------------
+
+    async def _prepare_chat(self, partition: list[str] | None, payload: dict):
+        messages = payload["messages"][-self._chat_history_depth :]
+        queries = await self.generate_query(messages)
+
+        metadata = payload.get("metadata") or {}
+        use_map_reduce = metadata.get("use_map_reduce", False)
+        spoken_style = metadata.get("spoken_style_answer", False)
+        use_websearch = metadata.get("websearch", False)
+        workspace = metadata.get("workspace")
+
+        top_k = self._mr_max if use_map_reduce else None
+
+        if workspace:
+            ws = await self._workspace.get_workspace(workspace)
+            if not ws or ("all" not in partition and ws["partition_name"] not in partition):
+                logger.warning("Workspace not found in partition(s) — ignoring", workspace=workspace)
+                workspace = None
+        filter_params = {"workspace_id": workspace} if workspace else None
+
+        web_results: list = []
+        if partition is not None and use_websearch:
+            doc_lists, web_lists = await self._gather_rag_and_web(queries.query_list, partition, top_k, filter_params)
+            chunks = self._retrieval.fuse(doc_lists, top_k=top_k)
+            web_results = _dedupe_web(web_lists)
+        elif partition is not None:
+            chunks = await self._retrieval.retrieve_multi(
+                partitions=partition, search_queries=queries, top_k=top_k, filter_params=filter_params
+            )
+        else:
+            web_results = _dedupe_web(await asyncio.gather(*[self._web.search(q.query) for q in queries.query_list]))
+            chunks = []
+
+        if not chunks and not web_results and partition is None:
+            return payload, [], []
+
+        docs = [c.to_langchain() for c in chunks]
+        if use_map_reduce and docs:
+            docs = await self._map_reduce(" ".join(q.query for q in queries.query_list), docs)
+
+        web_formatted, web_tokens = "", 0
+        if web_results:
+            web_formatted, _, web_tokens = format_web_context(
+                web_results, start_index=1, max_tokens=self._web.max_tokens
+            )
+        context, included = format_context(docs, max_context_tokens=self._max_context_tokens - web_tokens)
+        docs = [docs[i] for i in included]
+
+        if web_results:
+            if docs:
+                web_formatted, _, _ = format_web_context(
+                    web_results, start_index=len(docs) + 1, max_tokens=self._web.max_tokens
+                )
+            else:
+                context = ""
+            context = f"{context}{SOURCE_SEPARATOR}{web_formatted}" if context else web_formatted
+
+        new_messages = copy.deepcopy(messages)
+        tmpl = SPOKEN_STYLE_ANSWER_PROMPT if spoken_style else SYS_PROMPT_TMPLT
+        new_messages.insert(
+            0,
+            {
+                "role": "system",
+                "content": tmpl.format(
+                    context=context, current_date=datetime.now().strftime("%A, %B %d, %Y, %H:%M:%S")
+                ),
+            },
+        )
+        payload["messages"] = new_messages
+        return payload, docs, web_results
+
+    async def _gather_rag_and_web(self, query_list, partition, top_k, filter_params):
+        rag = self._retrieval.retrieve_per_query(
+            partitions=partition, queries=query_list, top_k=top_k, filter_params=filter_params
+        )
+        web = asyncio.gather(*[self._web.search(q.query) for q in query_list])
+        doc_lists, web_lists = await asyncio.gather(rag, web)
+        return doc_lists, web_lists
+
+    async def _prepare_completions(self, partition: list[str], payload: dict):
+        prompt = payload["prompt"]
+        queries = await self.generate_query([{"role": "user", "content": prompt}])
+        chunks = await self._retrieval.retrieve_multi(partitions=partition, search_queries=queries)
+        docs = [c.to_langchain() for c in chunks]
+        context, included = format_context(docs, max_context_tokens=self._max_context_tokens)
+        docs = [docs[i] for i in included]
+        if docs:
+            payload["prompt"] = (
+                f"Given the content\n{context}\nComplete the following prompt: {prompt}\n"
+                "At the very end of your response, on a new line, list which source numbers "
+                "you used: [Sources: 1, 3]"
+            )
+        return payload, docs
+
+    # ------------------------------------------------------------------
+    # Public API (router = transport)
+    # ------------------------------------------------------------------
+
+    async def chat(
+        self,
+        *,
+        partitions: list[str] | None,
+        payload: dict,
+        prepare_sources: PrepareSources,
+        model_name: str,
+    ) -> dict:
+        """Non-streaming chat completion → finalized OpenAI dict."""
+        metadata = payload.get("metadata") or {}
+        if partitions is None and not metadata.get("websearch", False):
+            docs, web_results = [], []
+        else:
+            payload, docs, web_results = await self._prepare_chat(partitions, payload)
+        sources = prepare_sources(docs, web_results)
+
+        chunk = await self._llm.chat(payload["messages"], **_sampling(payload))
+        chunk["model"] = model_name
+        content = chunk.get("choices", [{}])[0].get("message", {}).get("content", "") or ""
+        clean, citations = extract_and_strip_sources_block(content)
+        chunk["choices"][0]["message"]["content"] = clean
+        chunk["extra"] = json.dumps({"sources": filter_sources_by_citations(sources, citations)})
+        return chunk
+
+    async def chat_stream(
+        self,
+        *,
+        partitions: list[str] | None,
+        payload: dict,
+        prepare_sources: PrepareSources,
+        model_name: str,
+    ) -> AsyncIterator[str]:
+        """Streaming chat completion → SSE strings with filtered sources."""
+        metadata = payload.get("metadata") or {}
+        if partitions is None and not metadata.get("websearch", False):
+            docs, web_results = [], []
+        else:
+            payload, docs, web_results = await self._prepare_chat(partitions, payload)
+        sources = prepare_sources(docs, web_results)
+
+        llm_stream = self._llm.stream_chat(payload["messages"], **_sampling(payload))
+        async for sse_line in stream_with_source_filtering(llm_stream, sources, model_name):
+            yield sse_line
+
+    async def complete(
+        self,
+        *,
+        partitions: list[str] | None,
+        payload: dict,
+        prepare_sources: PrepareSources,
+    ) -> dict:
+        """Non-streaming text completion → finalized OpenAI dict."""
+        if partitions is None:
+            docs = []
+        else:
+            payload, docs = await self._prepare_completions(partitions, payload)
+        sources = prepare_sources(docs, [])
+
+        resp = await self._llm.generate(payload["prompt"], **_sampling(payload, key="prompt"))
+        text = resp.get("choices", [{}])[0].get("text", "") or ""
+        clean, citations = extract_and_strip_sources_block(text)
+        resp["choices"][0]["text"] = clean
+        resp["extra"] = json.dumps({"sources": filter_sources_by_citations(sources, citations)})
+        return resp
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _json_slice(text: str) -> str:
+    """Best-effort extract the first JSON object from an LLM response."""
+    start = text.find("{")
+    end = text.rfind("}")
+    return text[start : end + 1] if start != -1 and end > start else text
+
+
+def _summary_doc(chunk, summary: str):
+    """A summarised copy of a LangChain Document (page_content replaced)."""
+    return chunk.__class__(page_content=summary, metadata=chunk.metadata)
+
+
+def _dedupe_web(web_lists: list[list]) -> list:
+    seen: set[str] = set()
+    out: list = []
+    for r in (r for lst in web_lists for r in lst):
+        if r.url not in seen:
+            seen.add(r.url)
+            out.append(r)
+    return out
+
+
+def _sampling(payload: dict, key: str = "messages") -> dict:
+    """Sampling kwargs handed to the core LLM (everything but the body).
+
+    Mirrors the legacy ``_LLMShim``: strip the transport keys; the core
+    ``VLLMClient`` consumes ``metadata`` (llm_override) and the rest as
+    OpenAI sampling params.
+    """
+    drop = {key, "stream", "model"}
+    return {k: v for k, v in payload.items() if k not in drop}
+
+
+__all__ = ["QueryService", "RAGMODE"]

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -1,0 +1,226 @@
+"""RetrievalService — retrieval orchestration (Phase 8C.1).
+
+Wraps the clean ``core.retrieval`` pipeline (strategy + optional reranker
++ related/ancestor expansion + RRF fusion). The legacy
+``components/retriever.py`` and ``RetrieverPipeline`` were Phase-5 shims
+over this same core; this service is the real composition seam.
+
+Searcher backing (logged decision, Phase 8C): the core retriever talks
+to a ``RetrievalSearcher`` port. The only implementation today is
+``MilvusRayShim`` (Ray ``Vectordb`` actor — embeds + hybrid-searches
+internally). Per the dev-workflow doc, Ray cleanup is Phase 9, and
+orchestrators may call Ray actors *behind a port* during the Phase-8
+shim. So the searcher is injected (Ray stays behind the port); this
+file has no Ray remote-call and no Ray import (8H stays satisfied). A
+clean ``VectorStore``-backed searcher replaces it in Phase 9.
+
+Constructor deviates from the plan's prescribed
+``(vector_store, embedder_factory, reranker_factory, llm_factory,
+document_repo, config)`` for the same reason: with the Ray-shim searcher,
+the vector store / embedder / document repo are unused (the shim does
+embedding + related/ancestor itself). The container injects the already
+built ``searcher`` / ``reranker`` / ``llm`` plus ``config``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from core.retrieval.pipeline import RetrieverPipeline
+from core.retrieval.retriever import (
+    HyDeRetriever,
+    MultiQueryRetriever,
+    SingleRetriever,
+    _expand_with_related_chunks,
+)
+from core.retrieval.rrf import rrf_reranking
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.config.root import Settings
+    from core.llm.llm import LLM
+    from core.models.chunk import Chunk
+    from core.models.query import Query, SearchQueries
+    from core.rerankers.reranker import Reranker
+    from core.retrieval.searcher import RetrievalSearcher
+
+logger = get_logger()
+
+
+def _chunk_key(c: Chunk):
+    return c.id or id(c)
+
+
+class RetrievalService:
+    """Retrieval pipeline orchestration (search, single/multi retrieve)."""
+
+    def __init__(
+        self,
+        *,
+        searcher: RetrievalSearcher,
+        reranker: Reranker | None,
+        llm: LLM | None,
+        config: Settings,
+    ) -> None:
+        self._searcher = searcher
+        rcfg = config.retriever
+        common = {
+            "searcher": searcher,
+            "top_k": rcfg.top_k,
+            "similarity_threshold": rcfg.similarity_threshold,
+            "with_surrounding_chunks": rcfg.with_surrounding_chunks,
+            "include_related": rcfg.include_related,
+            "include_ancestors": rcfg.include_ancestors,
+            "related_limit": rcfg.related_limit,
+            "max_ancestor_depth": rcfg.max_ancestor_depth,
+        }
+        rtype = rcfg.type
+        if rtype == "multiQuery":
+            from components.prompts import MULTI_QUERY_PROMPT
+
+            retriever = MultiQueryRetriever(
+                llm=llm,
+                multi_query_template=MULTI_QUERY_PROMPT,
+                k_queries=rcfg.k_queries,
+                **common,
+            )
+        elif rtype == "hyde":
+            from components.prompts import HYDE_PROMPT
+
+            retriever = HyDeRetriever(
+                llm=llm,
+                hyde_template=HYDE_PROMPT,
+                combine=rcfg.combine,
+                **common,
+            )
+        else:
+            retriever = SingleRetriever(**common)
+
+        self._pipeline = RetrieverPipeline(
+            retriever=retriever,
+            reranker=reranker if config.reranker.enabled else None,
+            reranker_top_k=config.reranker.top_k,
+            allow_filterless_fallback=rcfg.allow_filterless_fallback,
+        )
+        logger.debug(
+            "RetrievalService ready",
+            retriever=rtype,
+            reranker_enabled=config.reranker.enabled and reranker is not None,
+        )
+
+    # ------------------------------------------------------------------
+    # Raw semantic search (powers routers/search.py — was indexer.asearch)
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        *,
+        text: str,
+        partitions: str | list[str],
+        top_k: int,
+        similarity_threshold: float,
+        filter: str | None = None,
+        filter_params: dict | None = None,
+        include_related: bool = False,
+        include_ancestors: bool = False,
+        related_limit: int = 20,
+        max_ancestor_depth: int | None = None,
+    ) -> list[Chunk]:
+        """One similarity search, then optional related/ancestor expansion.
+
+        Faithful port of ``indexer.asearch`` + the legacy
+        ``_expand_with_related_chunks``: a single ``searcher.search`` (no
+        query generation / reranking / RRF — those belong to QueryService).
+        """
+        parts = [partitions] if isinstance(partitions, str) else list(partitions)
+        chunks = await self._searcher.search(
+            query=text,
+            partition=parts,
+            top_k=top_k,
+            filter=filter,
+            filter_params=filter_params,
+            similarity_threshold=similarity_threshold,
+            with_surrounding_chunks=True,
+        )
+        if include_related or include_ancestors:
+            chunks = await _expand_with_related_chunks(
+                searcher=self._searcher,
+                results=chunks,
+                include_related=include_related,
+                include_ancestors=include_ancestors,
+                related_limit=related_limit,
+                max_ancestor_depth=max_ancestor_depth,
+            )
+        return chunks
+
+    # ------------------------------------------------------------------
+    # Pipeline retrieval (powers QueryService — 8C.2)
+    # ------------------------------------------------------------------
+
+    async def retrieve(
+        self,
+        *,
+        partitions: list[str],
+        query: Query,
+        top_k: int | None = None,
+        filter_params: dict | None = None,
+    ) -> list[Chunk]:
+        """Single ``Query`` through retrieve → expand → rerank."""
+        return await self._pipeline.retrieve_docs(
+            partition=partitions,
+            query=query,
+            top_k=top_k,
+            filter_params=filter_params,
+        )
+
+    async def retrieve_multi(
+        self,
+        *,
+        partitions: list[str],
+        search_queries: SearchQueries,
+        top_k: int | None = None,
+        filter_params: dict | None = None,
+    ) -> list[Chunk]:
+        """Every sub-query in parallel, fused with RRF."""
+        return await self._pipeline.get_relevant_docs(
+            partition=partitions,
+            search_queries=search_queries,
+            top_k=top_k,
+            filter_params=filter_params,
+        )
+
+    async def retrieve_per_query(
+        self,
+        *,
+        partitions: list[str],
+        queries: list[Query],
+        top_k: int | None = None,
+        filter_params: dict | None = None,
+    ) -> list[list[Chunk]]:
+        """Per-sub-query ranked lists (NOT fused).
+
+        QueryService's combined web-search path interleaves these with web
+        searches concurrently, then fuses; exposing the un-fused lists
+        lets it run one ``asyncio.gather`` over both.
+        """
+        return await asyncio.gather(
+            *[
+                self._pipeline.retrieve_docs(
+                    partition=partitions,
+                    query=q,
+                    top_k=top_k,
+                    filter_params=filter_params,
+                )
+                for q in queries
+            ]
+        )
+
+    @staticmethod
+    def fuse(doc_lists: list[list[Chunk]], top_k: int | None = None) -> list[Chunk]:
+        """RRF-fuse per-query ranked lists (same fusion the pipeline uses)."""
+        fused = rrf_reranking(doc_lists, key_fn=_chunk_key)
+        return fused[:top_k] if top_k is not None else fused
+
+
+__all__ = ["RetrievalService"]

--- a/openrag/services/orchestrators/test_auth_service.py
+++ b/openrag/services/orchestrators/test_auth_service.py
@@ -1,0 +1,385 @@
+"""Unit tests for :class:`AuthService` (Phase 8A.1).
+
+The OIDC primitives (PKCE/state generation, state-cookie signing, Fernet
+token encryption, opaque session-token issuance) are exercised for real;
+only the IdP-facing :class:`OIDCClient` and the persistence repos are
+faked. Each test asserts behaviour the legacy router used to own.
+"""
+
+from __future__ import annotations
+
+import pytest
+from components.auth import StateCookieSerializer, hash_session_token
+from components.auth.oidc_client import LogoutTokenClaims, TokenBundle
+from core.config.auth import OIDCConfig
+from core.models.user import User
+from cryptography.fernet import Fernet
+from services.orchestrators.auth_service import AuthService, OIDCFlowError
+
+KEY = Fernet.generate_key().decode()
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class FakeUserRepo:
+    def __init__(self, users: dict[str, User] | None = None):
+        self._by_ext = users or {}
+        self.created: list[User] = []
+        self.updated: list[tuple[int, dict]] = []
+        self._next_id = 100
+
+    async def get_user_by_external_id(self, external_id: str) -> User | None:
+        return self._by_ext.get(external_id)
+
+    async def create_user(self, user: User) -> User:
+        self._next_id += 1
+        user.id = self._next_id
+        self.created.append(user)
+        if user.external_user_id:
+            self._by_ext[user.external_user_id] = user
+        return user
+
+    async def update_user(self, user_id: int, **fields):
+        self.updated.append((user_id, fields))
+        for u in self._by_ext.values():
+            if u.id == user_id:
+                for k, v in fields.items():
+                    setattr(u, k, v)
+                return u
+        return None
+
+
+class FakeSessionRepo:
+    def __init__(self):
+        self.created = []
+        self.revoked_ids: list[int] = []
+        self.revoked_sids: list[str] = []
+        self._by_hash = {}
+
+    async def create_session(self, session):
+        self.created.append(session)
+        self._by_hash[session.session_token_hash] = session
+        return session
+
+    async def get_by_token_hash(self, token_hash: str):
+        return self._by_hash.get(token_hash)
+
+    async def revoke_session(self, session_id: int) -> bool:
+        self.revoked_ids.append(session_id)
+        return True
+
+    async def revoke_by_sid(self, sid: str) -> int:
+        self.revoked_sids.append(sid)
+        return 3
+
+
+class FakeOIDCClient:
+    def __init__(self, *, bundle=None, logout_claims=None, meta=None, userinfo=None):
+        self._bundle = bundle
+        self._logout_claims = logout_claims
+        self._meta = meta or {}
+        self._userinfo = userinfo or {}
+        self.exchange_calls: list[dict] = []
+
+    async def build_authorization_url(self, *, state, nonce, code_challenge):
+        return f"https://idp.example/auth?state={state}&cc={code_challenge}"
+
+    async def exchange_code(self, *, code, code_verifier, expected_nonce):
+        self.exchange_calls.append({"code": code, "cv": code_verifier, "nonce": expected_nonce})
+        if isinstance(self._bundle, Exception):
+            raise self._bundle
+        return self._bundle
+
+    async def verify_logout_token(self, token):
+        if isinstance(self._logout_claims, Exception):
+            raise self._logout_claims
+        return self._logout_claims
+
+    async def discover(self):
+        return self._meta
+
+    async def fetch_userinfo(self, access_token):
+        return self._userinfo
+
+
+def _cfg(**over) -> OIDCConfig:
+    base = {
+        "enabled": True,
+        "client_id": "openrag",
+        "token_encryption_key": KEY,
+        "claim_source": "id_token",
+        "claim_mapping": "",
+        "post_logout_redirect_uri": "",
+        "auto_provision_login": False,
+    }
+    base.update(over)
+    return OIDCConfig(**base)
+
+
+def _service(*, user_repo=None, session_repo=None, client=None, cfg=None) -> AuthService:
+    return AuthService(
+        user_repo=user_repo or FakeUserRepo(),
+        oidc_session_repo=session_repo or FakeSessionRepo(),
+        membership_repo=object(),
+        oidc_client=client,
+        config=cfg or _cfg(),
+    )
+
+
+def _bundle(**over) -> TokenBundle:
+    base = {
+        "id_token": "idtok",
+        "access_token": "acctok",
+        "refresh_token": "reftok",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "claims": {"sub": "kc-alice", "sid": "sess-1"},
+    }
+    base.update(over)
+    return TokenBundle(**base)
+
+
+# --------------------------------------------------------------------------- #
+# start_oidc_login
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_login_builds_url_and_roundtrips_state_cookie():
+    svc = _service(client=FakeOIDCClient())
+    result = await svc.start_oidc_login("/dashboard")
+
+    assert result.authorization_url.startswith("https://idp.example/auth?state=")
+    payload = StateCookieSerializer(secret_key=KEY).loads(result.state_cookie_value)
+    assert payload.next_url == "/dashboard"
+    # The state in the signed cookie must match the one in the auth URL.
+    assert f"state={payload.state}" in result.authorization_url
+
+
+@pytest.mark.asyncio
+async def test_login_sanitizes_open_redirect():
+    svc = _service(client=FakeOIDCClient())
+    result = await svc.start_oidc_login("//evil.com/phish")
+    payload = StateCookieSerializer(secret_key=KEY).loads(result.state_cookie_value)
+    assert payload.next_url == "/"
+
+
+@pytest.mark.asyncio
+async def test_login_without_client_raises():
+    svc = _service(client=None)
+    with pytest.raises(OIDCFlowError) as ei:
+        await svc.start_oidc_login("/")
+    assert ei.value.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# handle_oidc_callback
+# --------------------------------------------------------------------------- #
+
+
+async def _login_and_get_state(svc) -> tuple[str, str]:
+    """Run login, return (state, signed_cookie_value)."""
+    result = await svc.start_oidc_login("/home")
+    payload = StateCookieSerializer(secret_key=KEY).loads(result.state_cookie_value)
+    return payload.state, result.state_cookie_value
+
+
+@pytest.mark.asyncio
+async def test_callback_happy_path_creates_session():
+    user = User(id=7, display_name="Alice", external_user_id="kc-alice")
+    urepo = FakeUserRepo({"kc-alice": user})
+    srepo = FakeSessionRepo()
+    client = FakeOIDCClient(bundle=_bundle())
+    svc = _service(user_repo=urepo, session_repo=srepo, client=client)
+
+    state, cookie = await _login_and_get_state(svc)
+    result = await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+
+    assert result.next_url == "/home"
+    assert len(srepo.created) == 1
+    sess = srepo.created[0]
+    assert sess.user_id == 7
+    assert sess.sub == "kc-alice"
+    assert sess.sid == "sess-1"
+    # Only the hash is persisted; the plaintext cookie must hash to it.
+    assert sess.session_token_hash == hash_session_token(result.session_cookie_value)
+    # IdP tokens are stored encrypted, not in the clear.
+    assert sess.access_token_encrypted not in (None, b"acctok")
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_code_or_state():
+    svc = _service(client=FakeOIDCClient(bundle=_bundle()))
+    with pytest.raises(OIDCFlowError, match="Missing 'code' or 'state'"):
+        await svc.handle_oidc_callback(code=None, state="x", state_cookie_raw="y")
+
+
+@pytest.mark.asyncio
+async def test_callback_state_mismatch():
+    svc = _service(client=FakeOIDCClient(bundle=_bundle()))
+    _, cookie = await _login_and_get_state(svc)
+    with pytest.raises(OIDCFlowError, match="state mismatch"):
+        await svc.handle_oidc_callback(code="abc", state="not-the-state", state_cookie_raw=cookie)
+
+
+@pytest.mark.asyncio
+async def test_callback_unregistered_user_rejected():
+    svc = _service(user_repo=FakeUserRepo({}), client=FakeOIDCClient(bundle=_bundle()))
+    state, cookie = await _login_and_get_state(svc)
+    with pytest.raises(OIDCFlowError) as ei:
+        await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+    assert ei.value.status_code == 403
+    assert ei.value.message == "User not registered"
+
+
+@pytest.mark.asyncio
+async def test_callback_auto_provisions_when_enabled():
+    urepo = FakeUserRepo({})
+    svc = _service(
+        user_repo=urepo,
+        client=FakeOIDCClient(bundle=_bundle(claims={"sub": "kc-bob", "name": "Bob", "email": "bob@x.io"})),
+        cfg=_cfg(auto_provision_login=True),
+    )
+    state, cookie = await _login_and_get_state(svc)
+    result = await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+
+    assert len(urepo.created) == 1
+    created = urepo.created[0]
+    assert created.external_user_id == "kc-bob"
+    assert created.display_name == "Bob"
+    assert created.is_admin is False
+    assert result.next_url == "/home"
+
+
+@pytest.mark.asyncio
+async def test_callback_code_exchange_failure_is_masked():
+    svc = _service(client=FakeOIDCClient(bundle=RuntimeError("idp 500")))
+    state, cookie = await _login_and_get_state(svc)
+    with pytest.raises(OIDCFlowError, match="OIDC code exchange failed"):
+        await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+
+
+@pytest.mark.asyncio
+async def test_claim_mapping_from_userinfo_updates_user():
+    user = User(id=9, display_name="Old", external_user_id="kc-c", email="old@x.io")
+    urepo = FakeUserRepo({"kc-c": user})
+    client = FakeOIDCClient(
+        bundle=_bundle(claims={"sub": "kc-c", "sid": "s"}),
+        userinfo={"mail": "new@x.io"},
+    )
+    svc = _service(
+        user_repo=urepo,
+        client=client,
+        cfg=_cfg(claim_source="userinfo", claim_mapping="email:mail"),
+    )
+    state, cookie = await _login_and_get_state(svc)
+    await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+
+    assert urepo.updated and urepo.updated[0][1] == {"email": "new@x.io"}
+
+
+# --------------------------------------------------------------------------- #
+# backchannel logout / logout
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_backchannel_logout_revokes_by_sid():
+    srepo = FakeSessionRepo()
+    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid="sess-9", iat=0, jti=None)
+    svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
+    count = await svc.handle_backchannel_logout("tok")
+    assert count == 3
+    assert srepo.revoked_sids == ["sess-9"]
+
+
+@pytest.mark.asyncio
+async def test_backchannel_logout_invalid_token_carries_description():
+    svc = _service(client=FakeOIDCClient(logout_claims=ValueError("bad aud")))
+    with pytest.raises(OIDCFlowError) as ei:
+        await svc.handle_backchannel_logout("tok")
+    assert ei.value.error_description == "bad aud"
+
+
+@pytest.mark.asyncio
+async def test_backchannel_logout_sidless_is_noop_200():
+    srepo = FakeSessionRepo()
+    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid=None, iat=0, jti=None)
+    svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
+    assert await svc.handle_backchannel_logout("tok") == 0
+    assert srepo.revoked_sids == []
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_and_builds_end_session_url():
+    # Seed a real session via the callback path so the stored id_token is
+    # encrypted with the configured key.
+    user = User(id=5, external_user_id="kc-d")
+    urepo = FakeUserRepo({"kc-d": user})
+    srepo = FakeSessionRepo()
+    client = FakeOIDCClient(
+        bundle=_bundle(claims={"sub": "kc-d", "sid": "z"}),
+        meta={"end_session_endpoint": "https://idp.example/logout"},
+    )
+    svc = _service(user_repo=urepo, session_repo=srepo, client=client)
+    state, cookie = await _login_and_get_state(svc)
+    cb = await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+
+    target = await svc.logout(cb.session_cookie_value)
+    assert target.startswith("https://idp.example/logout?")
+    assert "client_id=openrag" in target
+    assert "id_token_hint=idtok" in target
+    assert srepo.revoked_ids == [srepo.created[0].id]
+
+
+@pytest.mark.asyncio
+async def test_logout_no_end_session_returns_none():
+    svc = _service(client=FakeOIDCClient(meta={}))
+    assert await svc.logout(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# pure auth-policy helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_require_admin():
+    assert AuthService.require_admin({"is_admin": True}) == {"is_admin": True}
+    with pytest.raises(OIDCFlowError.__bases__[0]):  # OpenRAGError subclass (AuthError)
+        AuthService.require_admin({"is_admin": False})
+
+
+def test_check_partition_access_role_hierarchy():
+    parts = [{"partition": "p1", "role": "viewer"}]
+    assert AuthService.check_partition_access(
+        user={"is_admin": False}, partition="p1", user_partitions=parts, required_role="viewer"
+    )
+    with pytest.raises(Exception):
+        AuthService.check_partition_access(
+            user={"is_admin": False}, partition="p1", user_partitions=parts, required_role="owner"
+        )
+
+
+def test_check_partition_access_super_admin_bypass():
+    assert AuthService.check_partition_access(
+        user={"is_admin": True},
+        partition="anything",
+        user_partitions=[],
+        required_role="owner",
+        super_admin_mode=True,
+    )
+
+
+def test_validate_file_quota():
+    # Admin bypass.
+    AuthService.validate_file_quota({"is_admin": True}, pending_task_count=99, default_quota=1)
+    # Disabled globally.
+    AuthService.validate_file_quota({"file_count": 50}, pending_task_count=50, default_quota=-1)
+    # Specific limit exceeded (3 indexed + 2 pending >= 5).
+    with pytest.raises(Exception):
+        AuthService.validate_file_quota({"file_count": 3, "file_quota": 5}, pending_task_count=2, default_quota=10)
+    # Under the limit is fine.
+    AuthService.validate_file_quota({"file_count": 1, "file_quota": 5}, pending_task_count=1, default_quota=10)

--- a/openrag/services/orchestrators/test_conversion_service.py
+++ b/openrag/services/orchestrators/test_conversion_service.py
@@ -1,0 +1,83 @@
+"""Unit tests for :class:`ConversionService` (Phase 8E)."""
+
+from __future__ import annotations
+
+import pytest
+from services.orchestrators.conversion_service import ConversionService
+
+
+class FakeSerializer:
+    def __init__(self, *, content="  raw\x00 text  "):
+        self._content = content
+        self.calls: list[tuple[str, dict]] = []
+
+    async def serialize(self, path: str, metadata: dict) -> str:
+        self.calls.append((path, metadata))
+        return self._content
+
+
+class FakeVectorStore:
+    def __init__(self, *, rows=None):
+        self._rows = rows if rows is not None else []
+        self.queries: list[tuple[str, dict]] = []
+
+    async def query_chunks_by_filter(self, collection, filters, output_fields=None):
+        self.queries.append((collection, filters))
+        return list(self._rows)
+
+
+def _service(*, serializer=None, store=None):
+    return ConversionService(
+        serializer=serializer or FakeSerializer(),
+        vector_store=store or FakeVectorStore(),
+        collection="chunks",
+    )
+
+
+@pytest.mark.asyncio
+async def test_serialize_file_merges_metadata_and_sanitizes():
+    ser = FakeSerializer(content="hello\x00world")
+    svc = _service(serializer=ser)
+
+    out = await svc.serialize_file(
+        file_path="/tmp/x.pdf",
+        filename="x.pdf",
+        metadata={"author": "a"},
+    )
+
+    # null byte stripped by sanitize_extracted_text
+    assert "\x00" not in out
+    assert "hello" in out and "world" in out
+    path, md = ser.calls[0]
+    assert path == "/tmp/x.pdf"
+    assert md == {"author": "a", "source": "/tmp/x.pdf", "filename": "x.pdf"}
+
+
+@pytest.mark.asyncio
+async def test_get_chunk_returns_page_content_and_metadata():
+    store = FakeVectorStore(rows=[{"text": "chunk body", "vector": [0.1], "partition": "p1", "file_id": "f1"}])
+    svc = _service(store=store)
+
+    chunk = await svc.get_chunk("42")
+
+    assert chunk == {
+        "page_content": "chunk body",
+        "metadata": {"partition": "p1", "file_id": "f1"},
+    }
+    # queried Milvus _id as int
+    assert store.queries == [("chunks", {"_id": 42})]
+
+
+@pytest.mark.asyncio
+async def test_get_chunk_invalid_id_returns_none_without_query():
+    store = FakeVectorStore(rows=[{"text": "x"}])
+    svc = _service(store=store)
+
+    assert await svc.get_chunk("not-an-int") is None
+    assert store.queries == []
+
+
+@pytest.mark.asyncio
+async def test_get_chunk_missing_returns_none():
+    svc = _service(store=FakeVectorStore(rows=[]))
+    assert await svc.get_chunk("7") is None

--- a/openrag/services/orchestrators/test_indexing_service.py
+++ b/openrag/services/orchestrators/test_indexing_service.py
@@ -1,0 +1,202 @@
+"""Unit tests for :class:`IndexingService` (Phase 8D.1)."""
+
+from __future__ import annotations
+
+import pytest
+from services.orchestrators.indexing_service import IndexingService
+
+
+class FakeDocumentRepo:
+    def __init__(self, *, exists: bool = False, raise_on_check: bool = False):
+        self._exists = exists
+        self._raise = raise_on_check
+
+    async def file_exists_in_partition(self, file_id: str, partition: str) -> bool:
+        if self._raise:
+            raise RuntimeError("boom")
+        return self._exists
+
+
+class FakeWorkspaceRepo:
+    def __init__(self, *, workspace=None):
+        self._workspace = workspace
+
+    async def get_workspace_dict(self, workspace_id: str):
+        return self._workspace
+
+
+class FakeDispatcher:
+    def __init__(self):
+        self.dispatched: list[dict] = []
+        self.deleted: list[tuple[str, str]] = []
+        self.updated: list[tuple] = []
+        self.copied: list[tuple] = []
+        self.cancelled: list[str] = []
+        self.cancel_result = True
+
+    async def dispatch_indexing(self, *, path, metadata, partition, user, workspace_ids, replace):
+        self.dispatched.append(
+            {
+                "path": path,
+                "metadata": metadata,
+                "partition": partition,
+                "user": user,
+                "workspace_ids": workspace_ids,
+                "replace": replace,
+            }
+        )
+        return "task-abc"
+
+    async def delete_file(self, file_id, partition):
+        self.deleted.append((file_id, partition))
+
+    async def update_file_metadata(self, file_id, metadata, partition, user):
+        self.updated.append((file_id, metadata, partition, user))
+
+    async def copy_file(self, file_id, metadata, partition, user):
+        self.copied.append((file_id, metadata, partition, user))
+
+    async def get_task_state(self, task_id):
+        return "QUEUED"
+
+    async def get_task_error(self, task_id):
+        return "trace"
+
+    async def cancel_task(self, task_id):
+        self.cancelled.append(task_id)
+        return self.cancel_result
+
+
+def _service(*, doc=None, ws=None, disp=None):
+    return IndexingService(
+        document_repo=doc or FakeDocumentRepo(),
+        workspace_repo=ws or FakeWorkspaceRepo(),
+        dispatcher=disp or FakeDispatcher(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_exists_passthrough():
+    svc = _service(doc=FakeDocumentRepo(exists=True))
+    assert await svc.file_exists("f1", "p1") is True
+
+
+@pytest.mark.asyncio
+async def test_file_exists_swallows_errors():
+    svc = _service(doc=FakeDocumentRepo(raise_on_check=True))
+    assert await svc.file_exists("f1", "p1") is False
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_passthrough():
+    ws = {"workspace_id": "w1", "partition_name": "p1"}
+    svc = _service(ws=FakeWorkspaceRepo(workspace=ws))
+    assert await svc.get_workspace("w1") == ws
+
+
+@pytest.mark.asyncio
+async def test_add_file_builds_metadata_and_dispatches(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("hello world")
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+
+    task_id = await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="p1",
+        metadata={"author": "alice"},
+        sanitized_filename="doc.txt",
+        original_filename="Doc Original.txt",
+        user={"id": 7},
+        workspace_ids=["w1"],
+    )
+
+    assert task_id == "task-abc"
+    assert len(disp.dispatched) == 1
+    sent = disp.dispatched[0]
+    assert sent["path"] == str(f)
+    assert sent["partition"] == "p1"
+    assert sent["workspace_ids"] == ["w1"]
+    assert sent["replace"] is False
+    md = sent["metadata"]
+    assert md["author"] == "alice"
+    assert md["source"] == str(f)
+    assert md["filename"] == "doc.txt"
+    assert md["original_filename"] == "Doc Original.txt"
+    assert md["file_id"] == "f1"
+    assert md["file_size"] == "11.00 B"
+
+
+@pytest.mark.asyncio
+async def test_replace_sets_replace_flag(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="p1",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user=None,
+        replace=True,
+    )
+    assert disp.dispatched[0]["replace"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_file_delegates():
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.delete_file("f1", "p1")
+    assert disp.deleted == [("f1", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_update_metadata_injects_file_id():
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.update_metadata("f1", {"author": "bob"}, "p1", {"id": 1})
+    file_id, md, partition, user = disp.updated[0]
+    assert file_id == "f1"
+    assert md == {"author": "bob", "file_id": "f1"}
+    assert partition == "p1"
+    assert user == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_copy_file_sets_target_fields():
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.copy_file(
+        source_file_id="src",
+        source_partition="p-src",
+        target_file_id="dst",
+        target_partition="p-dst",
+        metadata={"k": "v"},
+        user={"id": 2},
+    )
+    file_id, md, partition, user = disp.copied[0]
+    assert file_id == "src"
+    assert partition == "p-src"
+    assert md == {"k": "v", "file_id": "dst", "partition": "p-dst"}
+    assert user == {"id": 2}
+
+
+@pytest.mark.asyncio
+async def test_task_state_and_error_passthrough():
+    svc = _service()
+    assert await svc.get_task_state("t1") == "QUEUED"
+    assert await svc.get_task_error("t1") == "trace"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_passthrough():
+    disp = FakeDispatcher()
+    disp.cancel_result = False
+    svc = _service(disp=disp)
+    assert await svc.cancel_task("t1") is False
+    assert disp.cancelled == ["t1"]

--- a/openrag/services/orchestrators/test_job_service.py
+++ b/openrag/services/orchestrators/test_job_service.py
@@ -1,0 +1,94 @@
+"""Unit tests for :class:`JobService` (Phase 8D.2)."""
+
+from __future__ import annotations
+
+import pytest
+from services.orchestrators.job_service import JobService
+
+
+class _Remote:
+    """Mimics a Ray actor method: ``actor.method.remote(...)`` awaitable."""
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def remote(self, *args, **kwargs):
+        async def _coro():
+            return self._fn(*args, **kwargs)
+
+        return _coro()
+
+
+class FakeTSM:
+    def __init__(self, *, states=None, info=None, pool=None):
+        self._states = states or {}
+        self._info = info or {}
+        self._pool = pool or {"total_capacity": 8, "pool_size": 2, "max_tasks_per_worker": 4}
+        self.get_all_states = _Remote(lambda: dict(self._states))
+        self.get_pool_info = _Remote(lambda: dict(self._pool))
+        self.get_all_info = _Remote(lambda: dict(self._info))
+        self.get_all_user_info = _Remote(lambda uid: {k: v for k, v in self._info.items() if v.get("user") == uid})
+
+
+@pytest.mark.asyncio
+async def test_get_queue_info_rolls_up_states():
+    tsm = FakeTSM(
+        states={
+            "a": "QUEUED",
+            "b": "CHUNKING",
+            "c": "COMPLETED",
+            "d": "FAILED",
+            "e": "CANCELLED",
+        }
+    )
+    out = await JobService(tsm).get_queue_info()
+
+    assert out["workers"] == {"total_slots": 8, "pool_size": 2, "max_per_actor": 4}
+    tasks = out["tasks"]
+    assert tasks["active"] == 2
+    assert tasks["active_statuses"] == {"QUEUED": 1, "SERIALIZING": 0, "CHUNKING": 1, "INSERTING": 0}
+    assert tasks["total_completed"] == 1
+    assert tasks["total_failed"] == 1
+    assert tasks["total_cancelled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_admin_sees_all():
+    info = {
+        "t1": {"state": "QUEUED", "details": {"f": 1}, "user": 1},
+        "t2": {"state": "COMPLETED", "details": {"f": 2}, "user": 2},
+    }
+    rows = await JobService(FakeTSM(info=info)).list_tasks(is_admin=True, user_id=1)
+    assert {r["task_id"] for r in rows} == {"t1", "t2"}
+    assert rows[0]["details"] == {"f": 1}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_user_scoped():
+    info = {
+        "t1": {"state": "QUEUED", "details": {}, "user": 1},
+        "t2": {"state": "QUEUED", "details": {}, "user": 2},
+    }
+    rows = await JobService(FakeTSM(info=info)).list_tasks(is_admin=False, user_id=1)
+    assert [r["task_id"] for r in rows] == ["t1"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_active_filter():
+    info = {
+        "t1": {"state": "QUEUED", "details": {}, "user": 1},
+        "t2": {"state": "COMPLETED", "details": {}, "user": 1},
+        "t3": {"state": "INSERTING", "details": {}, "user": 1},
+    }
+    rows = await JobService(FakeTSM(info=info)).list_tasks(is_admin=True, user_id=1, task_status="active")
+    assert sorted(r["task_id"] for r in rows) == ["t1", "t3"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_exact_status_case_insensitive():
+    info = {
+        "t1": {"state": "FAILED", "details": {}, "user": 1},
+        "t2": {"state": "COMPLETED", "details": {}, "user": 1},
+    }
+    rows = await JobService(FakeTSM(info=info)).list_tasks(is_admin=True, user_id=1, task_status="failed")
+    assert [r["task_id"] for r in rows] == ["t1"]

--- a/openrag/services/orchestrators/test_partition_service.py
+++ b/openrag/services/orchestrators/test_partition_service.py
@@ -1,0 +1,293 @@
+"""Unit tests for :class:`PartitionService` (Phase 8B.1)."""
+
+from __future__ import annotations
+
+import pytest
+from core.utils.exceptions import NotFoundError, PartitionNotFoundError, UserNotFoundError, ValidationError
+from services.orchestrators.partition_service import PartitionService
+
+
+class FakePartitionRepo:
+    def __init__(self, existing: set[str] | None = None):
+        self._existing = existing if existing is not None else set()
+        self.created: list[tuple[str, int]] = []
+        self.deleted: list[str] = []
+
+    async def partition_exists(self, name: str) -> bool:
+        return name in self._existing
+
+    async def list_partitions(self) -> list[dict]:
+        return [{"partition": p} for p in sorted(self._existing)]
+
+    async def create_partition(self, name: str, user_id: int | None = None) -> dict:
+        self._existing.add(name)
+        self.created.append((name, user_id))
+        return {"partition": name}
+
+    async def delete_partition(self, name: str) -> bool:
+        self.deleted.append(name)
+        self._existing.discard(name)
+        return True
+
+
+class FakeMembershipRepo:
+    def __init__(self, members: set[tuple[int, str]] | None = None):
+        self._members = members or set()
+        self.added: list[tuple[str, int, str]] = []
+        self.removed: list[tuple[str, int]] = []
+        self.role_updates: list[tuple[str, int, str]] = []
+
+    async def user_is_partition_member(self, user_id: int, partition: str) -> bool:
+        return (user_id, partition) in self._members
+
+    async def list_partition_members(self, partition: str) -> list[dict]:
+        return [{"user_id": u, "role": "viewer"} for (u, p) in self._members if p == partition]
+
+    async def add_partition_member(self, partition: str, user_id: int, role: str) -> bool:
+        self.added.append((partition, user_id, role))
+        return True
+
+    async def remove_partition_member(self, partition: str, user_id: int) -> bool:
+        self.removed.append((partition, user_id))
+        return True
+
+    async def update_partition_member_role(self, partition: str, user_id: int, new_role: str) -> bool:
+        self.role_updates.append((partition, user_id, new_role))
+        return True
+
+
+class FakeDocumentRepo:
+    def __init__(self, files: set[tuple[str, str]] | None = None, listing: dict | None = None):
+        self._files = files or set()
+        self._listing = listing if listing is not None else {}
+
+    async def file_exists_in_partition(self, file_id: str, partition: str) -> bool:
+        return (file_id, partition) in self._files
+
+    async def list_partition_files(self, partition: str, limit=None) -> dict:
+        return self._listing
+
+    async def get_files_by_relationship(self, partition: str, relationship_id: str) -> list[dict]:
+        return [{"file_id": "a", "relationship_id": relationship_id}]
+
+    async def get_file_ancestors(self, partition: str, file_id: str, max_ancestor_depth=None) -> list[dict]:
+        return [{"file_id": "root"}, {"file_id": file_id}]
+
+
+class FakeVectorStore:
+    def __init__(self, ids=None, rows=None):
+        self._ids = ids or []
+        self._rows = rows or []
+        self.deleted_ids: list[str] = []
+
+    async def query_ids_by_filter(self, collection, filters):
+        return list(self._ids)
+
+    async def delete(self, ids, collection="default") -> int:
+        self.deleted_ids.extend(ids)
+        return len(ids)
+
+    async def query_chunks_by_filter(self, collection, filters, output_fields=None):
+        return list(self._rows)
+
+
+class FakeUserRepo:
+    def __init__(self, existing: set[int] | None = None):
+        self._existing = existing if existing is not None else set()
+
+    async def user_exists(self, user_id: int) -> bool:
+        return user_id in self._existing
+
+
+def _svc(
+    *,
+    prepo=None,
+    mrepo=None,
+    drepo=None,
+    vstore=None,
+    urepo=None,
+    collection="vdb",
+) -> PartitionService:
+    return PartitionService(
+        partition_repo=prepo or FakePartitionRepo(),
+        membership_repo=mrepo or FakeMembershipRepo(),
+        document_repo=drepo or FakeDocumentRepo(),
+        vector_store=vstore or FakeVectorStore(),
+        user_repo=urepo or FakeUserRepo(),
+        collection=collection,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_partition_conflict_raises_409():
+    prepo = FakePartitionRepo(existing={"p1"})
+    with pytest.raises(ValidationError) as ei:
+        await _svc(prepo=prepo).create_partition("p1", 1)
+    assert ei.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_partition_success():
+    prepo = FakePartitionRepo()
+    await _svc(prepo=prepo).create_partition("new", 7)
+    assert prepo.created == [("new", 7)]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_missing_raises_404():
+    with pytest.raises(PartitionNotFoundError):
+        await _svc(prepo=FakePartitionRepo(existing=set())).delete_partition("ghost")
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_drops_vectors_then_rows():
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore(ids=["c1", "c2"])
+    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    assert vstore.deleted_ids == ["c1", "c2"]
+    assert prepo.deleted == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_no_vectors_still_deletes_rows():
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore(ids=[])
+    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    assert vstore.deleted_ids == []
+    assert prepo.deleted == ["p1"]
+
+
+# --------------------------------------------------------------------------- #
+# file / chunk reads
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_files_missing_partition_404():
+    with pytest.raises(PartitionNotFoundError):
+        await _svc(prepo=FakePartitionRepo(set())).list_files("nope")
+
+
+@pytest.mark.asyncio
+async def test_list_files_empty_listing_returns_empty_list():
+    svc = _svc(prepo=FakePartitionRepo({"p"}), drepo=FakeDocumentRepo(listing={}))
+    assert await svc.list_files("p") == []
+
+
+@pytest.mark.asyncio
+async def test_get_file_chunks_missing_file_404():
+    svc = _svc(drepo=FakeDocumentRepo(files=set()))
+    with pytest.raises(NotFoundError) as ei:
+        await svc.get_file_chunks("p", "f")
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_file_chunks_strips_text_keeps_id_and_caps_limit():
+    rows = [{"_id": str(i), "text": "body", "page": i} for i in range(5)]
+    svc = _svc(
+        drepo=FakeDocumentRepo(files={("f", "p")}),
+        vstore=FakeVectorStore(rows=rows),
+    )
+    out = await svc.get_file_chunks("p", "f", limit=3)
+    assert len(out) == 3
+    assert all("text" not in r for r in out)
+    assert all("_id" in r for r in out)
+
+
+@pytest.mark.asyncio
+async def test_list_all_chunks_excludes_vector_when_no_embedding():
+    rows = [{"text": "t", "_id": "1", "vector": [0.1, 0.2]}]
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
+    out = await svc.list_all_chunks("p", include_embedding=False)
+    assert out[0]["content"] == "t"
+    assert "vector" not in out[0]["metadata"]
+    assert "text" not in out[0]["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_list_all_chunks_stringifies_vector_when_included():
+    rows = [{"text": "t", "_id": "1", "vector": [0.1, 0.2]}]
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
+    out = await svc.list_all_chunks("p", include_embedding=True)
+    assert isinstance(out[0]["metadata"]["vector"], str)
+
+
+# --------------------------------------------------------------------------- #
+# membership
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_members_missing_partition_404():
+    with pytest.raises(PartitionNotFoundError):
+        await _svc(prepo=FakePartitionRepo(set())).list_members("x")
+
+
+@pytest.mark.asyncio
+async def test_add_member_checks_partition_and_user():
+    mrepo = FakeMembershipRepo()
+    svc = _svc(
+        prepo=FakePartitionRepo({"p"}),
+        mrepo=mrepo,
+        urepo=FakeUserRepo({9}),
+    )
+    await svc.add_member("p", 9, "editor")
+    assert mrepo.added == [("p", 9, "editor")]
+
+
+@pytest.mark.asyncio
+async def test_add_member_unknown_user_404():
+    svc = _svc(prepo=FakePartitionRepo({"p"}), urepo=FakeUserRepo(set()))
+    with pytest.raises(UserNotFoundError):
+        await svc.add_member("p", 123, "viewer")
+
+
+@pytest.mark.asyncio
+async def test_remove_member_requires_existing_membership():
+    svc = _svc(
+        prepo=FakePartitionRepo({"p"}),
+        mrepo=FakeMembershipRepo(members=set()),
+        urepo=FakeUserRepo({9}),
+    )
+    with pytest.raises(NotFoundError) as ei:
+        await svc.remove_member("p", 9)
+    assert ei.value.code == "MEMBERSHIP_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_update_role_success():
+    mrepo = FakeMembershipRepo(members={(9, "p")})
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=FakeUserRepo({9}))
+    await svc.update_role("p", 9, "owner")
+    assert mrepo.role_updates == [("p", 9, "owner")]
+
+
+# --------------------------------------------------------------------------- #
+# relationships
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_get_related_files_delegates():
+    out = await _svc().get_related_files("p", "rel-1")
+    assert out == [{"file_id": "a", "relationship_id": "rel-1"}]
+
+
+@pytest.mark.asyncio
+async def test_get_file_ancestors_missing_file_404():
+    svc = _svc(drepo=FakeDocumentRepo(files=set()))
+    with pytest.raises(NotFoundError):
+        await svc.get_file_ancestors("p", "f")
+
+
+@pytest.mark.asyncio
+async def test_get_file_ancestors_success():
+    svc = _svc(drepo=FakeDocumentRepo(files={("f", "p")}))
+    out = await svc.get_file_ancestors("p", "f")
+    assert out[-1]["file_id"] == "f"

--- a/openrag/services/orchestrators/test_query_service.py
+++ b/openrag/services/orchestrators/test_query_service.py
@@ -1,0 +1,235 @@
+"""Unit tests for :class:`QueryService` (Phase 8C.2).
+
+The Ray-backed LLM semaphore and the model-file-backed language detector
+are monkeypatched (both are infra concerns exercised in integration, not
+here). Retrieval is faked; the real ``format_context`` /
+``stream_with_source_filtering`` helpers run against real ``Chunk`` →
+``Document`` conversions.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+import services.orchestrators.query_service as qs
+from core.models.chunk import Chunk
+from services.orchestrators.query_service import QueryService
+
+
+@pytest.fixture(autouse=True)
+def _patch_infra(monkeypatch):
+    @asynccontextmanager
+    async def _noop_sem():
+        yield
+
+    monkeypatch.setattr(qs, "get_llm_semaphore", _noop_sem)
+    monkeypatch.setattr(qs, "detect_language", lambda _t: "en")
+
+
+class FakeLLM:
+    def __init__(self, *, chat_responses=None, gen_text="answer", stream_lines=None):
+        self._chat_responses = list(chat_responses or [])
+        self._gen_text = gen_text
+        self._stream_lines = stream_lines or ['data: {"choices":[{"delta":{"content":"hi"}}]}\n\n', "data: [DONE]\n\n"]
+        self.chat_calls: list = []
+
+    async def chat(self, messages, **kwargs):
+        self.chat_calls.append((messages, kwargs))
+        if self._chat_responses:
+            content = self._chat_responses.pop(0)
+        else:
+            content = "final answer"
+        return {"choices": [{"message": {"content": content}}]}
+
+    async def generate(self, prompt, **kwargs):
+        return {"choices": [{"text": self._gen_text}]}
+
+    async def stream_chat(self, messages, **kwargs):
+        for line in self._stream_lines:
+            yield line
+
+
+class FakeRetrieval:
+    def __init__(self, chunks=None):
+        self._chunks = chunks if chunks is not None else [Chunk(id="c1", text="ctx", metadata={"_id": "c1"})]
+
+    async def retrieve_multi(self, **kwargs):
+        return list(self._chunks)
+
+    async def retrieve_per_query(self, *, queries, **kwargs):
+        return [list(self._chunks) for _ in queries]
+
+    @staticmethod
+    def fuse(doc_lists, top_k=None):
+        return doc_lists[0] if doc_lists else []
+
+
+class FakeWeb:
+    max_tokens = 2000
+
+    def __init__(self, results=None):
+        self._results = results or []
+
+    async def search(self, query):
+        return list(self._results)
+
+
+class FakeWorkspace:
+    async def get_workspace(self, wid):
+        return None
+
+
+def _config(mode="SimpleRag"):
+    return SimpleNamespace(
+        rag=SimpleNamespace(mode=mode, chat_history_depth=4, max_contextualized_query_len=512),
+        reranker=SimpleNamespace(top_k=5),
+        chunker=SimpleNamespace(chunk_size=512),
+        map_reduce=SimpleNamespace(initial_batch_size=2, expansion_batch_size=2, max_total_documents=4),
+    )
+
+
+def _svc(*, llm=None, retrieval=None, web=None, mode="SimpleRag") -> QueryService:
+    return QueryService(
+        retrieval_service=retrieval or FakeRetrieval(),
+        llm=llm or FakeLLM(),
+        config=_config(mode),
+        web_search_service=web or FakeWeb(),
+        workspace_service=FakeWorkspace(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# generate_query
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_generate_query_simplerag_uses_last_message():
+    sq = await _svc(mode="SimpleRag").generate_query([{"role": "user", "content": "what is X?"}])
+    assert [q.query for q in sq.query_list] == ["what is X?"]
+
+
+@pytest.mark.asyncio
+async def test_generate_query_chatbotrag_parses_json():
+    payload = json.dumps({"query_list": [{"query": "rewritten", "temporal_filters": None}]})
+    svc = _svc(llm=FakeLLM(chat_responses=[payload]), mode="ChatBotRag")
+    sq = await svc.generate_query([{"role": "user", "content": "hi"}])
+    assert sq.query_list[0].query == "rewritten"
+
+
+@pytest.mark.asyncio
+async def test_generate_query_chatbotrag_falls_back_on_garbage():
+    svc = _svc(llm=FakeLLM(chat_responses=["not json", "still not json"]), mode="ChatBotRag")
+    sq = await svc.generate_query([{"role": "user", "content": "raw question"}])
+    assert sq.query_list[0].query == "raw question"  # fallback to raw user query
+
+
+# --------------------------------------------------------------------------- #
+# chat / complete
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_chat_direct_mode_skips_retrieval():
+    retrieval = FakeRetrieval()
+    called = {"n": 0}
+
+    async def _spy(**kwargs):
+        called["n"] += 1
+        return []
+
+    retrieval.retrieve_multi = _spy
+    svc = _svc(retrieval=retrieval, llm=FakeLLM(chat_responses=["hello [Sources: none]"]))
+    out = await svc.chat(
+        partitions=None,
+        payload={"messages": [{"role": "user", "content": "hi"}], "metadata": {}},
+        prepare_sources=lambda d, w: [{"source_type": "document"}],
+        model_name="m1",
+    )
+    assert called["n"] == 0  # no retrieval in direct mode
+    assert out["model"] == "m1"
+    assert out["choices"][0]["message"]["content"] == "hello"  # sources tag stripped
+    assert json.loads(out["extra"])["sources"] == []  # [Sources: none] → no sources
+
+
+@pytest.mark.asyncio
+async def test_chat_with_partition_retrieves_and_filters_sources():
+    svc = _svc(llm=FakeLLM(chat_responses=["answer [Sources: 1]"]))
+    sources = [{"source_type": "document", "n": 1}, {"source_type": "document", "n": 2}]
+    out = await svc.chat(
+        partitions=["p"],
+        payload={"messages": [{"role": "user", "content": "q"}], "metadata": {}},
+        prepare_sources=lambda d, w: sources,
+        model_name="m",
+    )
+    filtered = json.loads(out["extra"])["sources"]
+    assert filtered == [{"source_type": "document", "n": 1}]  # only cited source 1
+
+
+@pytest.mark.asyncio
+async def test_complete_strips_and_filters():
+    svc = _svc(llm=FakeLLM(gen_text="text body [Sources: none]"))
+    out = await svc.complete(
+        partitions=None,
+        payload={"prompt": "do x"},
+        prepare_sources=lambda d, w: [{"x": 1}],
+    )
+    assert out["choices"][0]["text"] == "text body"
+    assert json.loads(out["extra"])["sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_yields_sse_and_done():
+    svc = _svc(llm=FakeLLM())
+    lines = []
+    async for line in svc.chat_stream(
+        partitions=None,
+        payload={"messages": [{"role": "user", "content": "hi"}], "metadata": {}},
+        prepare_sources=lambda d, w: [],
+        model_name="m",
+    ):
+        lines.append(line)
+    assert any("[DONE]" in ln for ln in lines)
+
+
+# --------------------------------------------------------------------------- #
+# map-reduce
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_map_reduce_keeps_relevant_drops_irrelevant():
+    rel = json.dumps({"relevancy": True, "summary": "kept"})
+    irr = json.dumps({"relevancy": False, "summary": ""})
+    svc = _svc(llm=FakeLLM(chat_responses=[rel, irr]))
+    docs = [
+        Chunk(id="a", text="A", metadata={"_id": "a"}).to_langchain(),
+        Chunk(id="b", text="B", metadata={"_id": "b"}).to_langchain(),
+    ]
+    out = await svc._map_reduce("q", docs)
+    assert len(out) == 1
+    assert out[0].page_content == "kept"
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_json_slice_extracts_object():
+    assert qs._json_slice('noise {"a": 1} trailing') == '{"a": 1}'
+
+
+def test_dedupe_web_preserves_first_seen():
+    a = SimpleNamespace(url="u1")
+    b = SimpleNamespace(url="u1")
+    c = SimpleNamespace(url="u2")
+    assert qs._dedupe_web([[a, b], [c]]) == [a, c]
+
+
+def test_sampling_strips_transport_keys():
+    out = qs._sampling({"messages": [], "stream": True, "model": "m", "temperature": 0.5})
+    assert out == {"temperature": 0.5}

--- a/openrag/services/orchestrators/test_retrieval_service.py
+++ b/openrag/services/orchestrators/test_retrieval_service.py
@@ -1,0 +1,171 @@
+"""Unit tests for :class:`RetrievalService` (Phase 8C.1).
+
+The Ray-backed searcher is faked (the service is constructed with a
+``RetrievalSearcher`` stub, exactly as the container will inject
+``MilvusRayShim``). Default config uses the ``single`` retriever with
+the reranker disabled, so the core pipeline path is exercised end-to-end
+without inference services.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from core.models.chunk import Chunk
+from core.models.query import Query, SearchQueries
+from services.orchestrators.retrieval_service import RetrievalService
+
+
+def _chunk(cid: str, text: str = "t") -> Chunk:
+    return Chunk(id=cid, text=text, metadata={"_id": cid})
+
+
+class FakeSearcher:
+    def __init__(self):
+        self.search_calls: list[dict] = []
+        self.search_result: list[Chunk] = []
+        self.related_result: list[Chunk] = []
+        self.ancestor_result: list[Chunk] = []
+
+    async def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return list(self.search_result)
+
+    async def multi_query_search(self, **kwargs):
+        return list(self.search_result)
+
+    async def get_related_chunks(self, **kwargs):
+        return list(self.related_result)
+
+    async def get_ancestor_chunks(self, **kwargs):
+        return list(self.ancestor_result)
+
+
+def _config(rtype: str = "single", reranker_enabled: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        retriever=SimpleNamespace(
+            type=rtype,
+            top_k=6,
+            similarity_threshold=0.5,
+            with_surrounding_chunks=False,
+            include_related=False,
+            include_ancestors=False,
+            related_limit=10,
+            max_ancestor_depth=None,
+            allow_filterless_fallback=True,
+            k_queries=3,
+            combine=False,
+        ),
+        reranker=SimpleNamespace(enabled=reranker_enabled, top_k=5),
+    )
+
+
+def _svc(searcher, *, rtype="single", reranker_enabled=False) -> RetrievalService:
+    return RetrievalService(
+        searcher=searcher,
+        reranker=None,
+        llm=None,
+        config=_config(rtype, reranker_enabled),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# search() — powers routers/search.py
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_search_normalizes_str_partition_and_passes_params():
+    s = FakeSearcher()
+    s.search_result = [_chunk("1"), _chunk("2")]
+    out = await _svc(s).search(
+        text="hello",
+        partitions="p1",
+        top_k=7,
+        similarity_threshold=0.8,
+        filter="file_id == 'x'",
+        filter_params={"a": 1},
+    )
+    assert [c.id for c in out] == ["1", "2"]
+    call = s.search_calls[0]
+    assert call["partition"] == ["p1"]  # str normalized to list
+    assert call["query"] == "hello"
+    assert call["top_k"] == 7
+    assert call["similarity_threshold"] == 0.8
+    assert call["filter"] == "file_id == 'x'"
+    assert call["filter_params"] == {"a": 1}
+    assert call["with_surrounding_chunks"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_no_expansion_when_flags_off():
+    s = FakeSearcher()
+    s.search_result = [_chunk("1")]
+    s.related_result = [_chunk("rel")]
+    out = await _svc(s).search(text="q", partitions=["p"], top_k=5, similarity_threshold=0.5)
+    assert [c.id for c in out] == ["1"]  # related NOT included
+
+
+@pytest.mark.asyncio
+async def test_search_expands_related_when_requested():
+    s = FakeSearcher()
+    # The core expand helper only fetches related chunks for source
+    # chunks that carry both a partition and a relationship_id.
+    src = Chunk(id="1", text="t", partition="p", metadata={"_id": "1", "relationship_id": "r1"})
+    s.search_result = [src]
+    s.related_result = [_chunk("rel")]
+    out = await _svc(s).search(
+        text="q",
+        partitions=["p"],
+        top_k=5,
+        similarity_threshold=0.5,
+        include_related=True,
+        related_limit=3,
+    )
+    ids = {c.id for c in out}
+    assert "1" in ids and "rel" in ids
+
+
+# --------------------------------------------------------------------------- #
+# retrieve / retrieve_multi / fuse — powers QueryService (8C.2)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_retrieve_single_query_via_pipeline():
+    s = FakeSearcher()
+    s.search_result = [_chunk("a"), _chunk("b")]
+    out = await _svc(s).retrieve(partitions=["p"], query=Query(query="hi"))
+    assert [c.id for c in out] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_multi_fuses_subqueries():
+    s = FakeSearcher()
+    s.search_result = [_chunk("a"), _chunk("b")]
+    sq = SearchQueries(query_list=[Query(query="q1"), Query(query="q2")])
+    out = await _svc(s).retrieve_multi(partitions=["p"], search_queries=sq)
+    assert {c.id for c in out} == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_per_query_returns_unfused_lists():
+    s = FakeSearcher()
+    s.search_result = [_chunk("a")]
+    out = await _svc(s).retrieve_per_query(partitions=["p"], queries=[Query(query="q1"), Query(query="q2")])
+    assert len(out) == 2
+    assert all(lst[0].id == "a" for lst in out)
+
+
+def test_fuse_rrf_merges_and_dedupes():
+    a, b, c = _chunk("a"), _chunk("b"), _chunk("c")
+    fused = RetrievalService.fuse([[a, b], [b, c]])
+    ids = [x.id for x in fused]
+    assert set(ids) == {"a", "b", "c"}
+    assert ids[0] == "b"  # appears in both lists -> highest RRF score
+
+
+def test_fuse_respects_top_k():
+    a, b, c = _chunk("a"), _chunk("b"), _chunk("c")
+    assert len(RetrievalService.fuse([[a, b], [b, c]], top_k=2)) == 2

--- a/openrag/services/orchestrators/test_user_service.py
+++ b/openrag/services/orchestrators/test_user_service.py
@@ -1,0 +1,199 @@
+"""Unit tests for :class:`UserService` (Phase 8A.2)."""
+
+from __future__ import annotations
+
+import pytest
+from core.models.user import User
+from core.utils.exceptions import UserNotFoundError, ValidationError
+from models.user import UserCreate, UserUpdate
+from services.orchestrators.user_service import UserService
+
+
+class FakeUserRepo:
+    def __init__(self, existing: set[int] | None = None):
+        self._existing = existing if existing is not None else set()
+        self.created: list[dict] = []
+        self.deleted: list[int] = []
+        self.regenerated: list[int] = []
+        self.regen_results: dict[int, dict] = {}
+        self.updated: list[tuple[int, dict]] = []
+        self._users: dict[int, User] = {}
+
+    async def user_exists(self, user_id: int) -> bool:
+        return user_id in self._existing
+
+    async def create_legacy_user(self, *, display_name, external_user_id, email, is_admin, file_quota):
+        rec = {
+            "id": 42,
+            "display_name": display_name,
+            "external_user_id": external_user_id,
+            "email": email,
+            "token": "or-deadbeef",
+            "is_admin": is_admin,
+            "file_quota": file_quota,
+            "file_count": 0,
+        }
+        self.created.append(rec)
+        return rec
+
+    async def list_users_dict(self):
+        return [{"id": 1, "display_name": "Admin"}]
+
+    async def get_user_dict_by_id(self, user_id: int):
+        return {"id": user_id, "display_name": "U"}
+
+    async def delete_user(self, user_id: int) -> bool:
+        self.deleted.append(user_id)
+        return True
+
+    async def regenerate_user_token(self, user_id: int):
+        self.regenerated.append(user_id)
+        return self.regen_results.get(user_id)
+
+    async def update_user(self, user_id: int, **fields):
+        self.updated.append((user_id, fields))
+        return self._users.get(user_id)
+
+
+def _svc(repo: FakeUserRepo, *, default_quota: int = 10) -> UserService:
+    return UserService(user_repo=repo, auth_service=object(), default_file_quota=default_quota)
+
+
+# --------------------------------------------------------------------------- #
+# create_user
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_user_passes_through_explicit_quota():
+    repo = FakeUserRepo()
+    svc = _svc(repo, default_quota=10)
+    out = await svc.create_user(UserCreate(display_name="Bob", file_quota=3))
+    assert out["token"] == "or-deadbeef"
+    assert repo.created[0]["file_quota"] == 3
+
+
+@pytest.mark.asyncio
+async def test_create_user_applies_default_quota_when_none_and_default_positive():
+    repo = FakeUserRepo()
+    svc = _svc(repo, default_quota=7)
+    await svc.create_user(UserCreate(display_name="Bob", file_quota=None))
+    assert repo.created[0]["file_quota"] == 7
+
+
+@pytest.mark.asyncio
+async def test_create_user_no_default_when_default_not_positive():
+    repo = FakeUserRepo()
+    svc = _svc(repo, default_quota=-1)
+    await svc.create_user(UserCreate(display_name="Bob", file_quota=None))
+    assert repo.created[0]["file_quota"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_bad_email():
+    svc = _svc(FakeUserRepo())
+    with pytest.raises(ValidationError) as ei:
+        await svc.create_user(UserCreate(display_name="Bob", email="not-an-email"))
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_overlong_display_name():
+    svc = _svc(FakeUserRepo())
+    with pytest.raises(ValidationError):
+        await svc.create_user(UserCreate(display_name="x" * 256))
+
+
+# --------------------------------------------------------------------------- #
+# read / delete / regenerate / update
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_users_delegates():
+    assert await _svc(FakeUserRepo()).list_users() == [{"id": 1, "display_name": "Admin"}]
+
+
+@pytest.mark.asyncio
+async def test_get_user_missing_raises_404():
+    svc = _svc(FakeUserRepo(existing=set()))
+    with pytest.raises(UserNotFoundError) as ei:
+        await svc.get_user(9)
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_user_existing_returns_dict():
+    svc = _svc(FakeUserRepo(existing={9}))
+    assert await svc.get_user(9) == {"id": 9, "display_name": "U"}
+
+
+@pytest.mark.asyncio
+async def test_delete_user_missing_raises_and_no_repo_call():
+    repo = FakeUserRepo(existing=set())
+    with pytest.raises(UserNotFoundError):
+        await _svc(repo).delete_user(5)
+    assert repo.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_delete_user_existing_deletes_without_cascade():
+    repo = FakeUserRepo(existing={5})
+    await _svc(repo).delete_user(5)
+    assert repo.deleted == [5]  # no partition cascade in 8A.2 (deferred to 8B)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_token_missing_user_404():
+    repo = FakeUserRepo(existing=set())
+    with pytest.raises(UserNotFoundError):
+        await _svc(repo).regenerate_token(3)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_token_repo_returns_none_404():
+    repo = FakeUserRepo(existing={3})  # exists but repo regen returns None
+    with pytest.raises(UserNotFoundError):
+        await _svc(repo).regenerate_token(3)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_token_success():
+    repo = FakeUserRepo(existing={3})
+    repo.regen_results[3] = {"id": 3, "token": "or-new"}
+    out = await _svc(repo).regenerate_token(3)
+    assert out == {"id": 3, "token": "or-new"}
+    assert repo.regenerated == [3]
+
+
+@pytest.mark.asyncio
+async def test_update_user_missing_404():
+    repo = FakeUserRepo(existing=set())
+    with pytest.raises(UserNotFoundError):
+        await _svc(repo).update_user(2, UserUpdate(display_name="X"))
+
+
+@pytest.mark.asyncio
+async def test_update_user_returns_legacy_dict_shape():
+    repo = FakeUserRepo(existing={2})
+    repo._users[2] = User(id=2, display_name="New", email="a@b.io", is_admin=True, file_quota=5, file_count=4)
+    out = await _svc(repo).update_user(2, UserUpdate(display_name="New"))
+    assert set(out) == {
+        "id",
+        "display_name",
+        "external_user_id",
+        "email",
+        "is_admin",
+        "created_at",
+        "file_quota",
+        "file_count",
+    }
+    assert out["id"] == 2 and out["display_name"] == "New" and out["file_count"] == 4
+    assert isinstance(out["created_at"], str)  # iso-formatted
+
+
+@pytest.mark.asyncio
+async def test_update_user_validates_email():
+    repo = FakeUserRepo(existing={2})
+    with pytest.raises(ValidationError):
+        await _svc(repo).update_user(2, UserUpdate(email="bogus"))

--- a/openrag/services/orchestrators/test_user_service.py
+++ b/openrag/services/orchestrators/test_user_service.py
@@ -71,12 +71,23 @@ class FakeMembershipRepo:
         return self._owned.get(user_id, [])
 
 
+class FakeJobService:
+    def __init__(self, pending: int = 0):
+        self._pending = pending
+        self.calls: list[int | None] = []
+
+    async def get_user_pending_task_count(self, user_id: int | None) -> int:
+        self.calls.append(user_id)
+        return self._pending
+
+
 def _svc(
     repo: FakeUserRepo,
     *,
     default_quota: int = 10,
     partition_service: FakePartitionService | None = None,
     membership_repo: FakeMembershipRepo | None = None,
+    job_service: FakeJobService | None = None,
 ) -> UserService:
     return UserService(
         user_repo=repo,
@@ -84,6 +95,7 @@ def _svc(
         default_file_quota=default_quota,
         partition_service=partition_service or FakePartitionService(),
         membership_repo=membership_repo or FakeMembershipRepo(),
+        job_service=job_service or FakeJobService(),
     )
 
 
@@ -244,3 +256,45 @@ async def test_update_user_validates_email():
     repo = FakeUserRepo(existing={2})
     with pytest.raises(ValidationError):
         await _svc(repo).update_user(2, UserUpdate(email="bogus"))
+
+
+# --------------------------------------------------------------------------- #
+# get_current_user_info — quota-usage block (8F: moved out of the router)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_current_user_info_specific_quota_and_pending():
+    job = FakeJobService(pending=3)
+    svc = _svc(FakeUserRepo(), default_quota=10, job_service=job)
+
+    out = await svc.get_current_user_info({"id": 7, "is_admin": False, "file_quota": 5, "file_count": 4})
+
+    assert out["file_count"] == 4
+    assert out["pending_files"] == 3
+    assert out["total_files"] == 7
+    assert out["file_quota"] == 5
+    assert out["id"] == 7  # original fields preserved
+    assert job.calls == [7]
+
+
+@pytest.mark.asyncio
+async def test_current_user_info_admin_is_unlimited():
+    svc = _svc(FakeUserRepo(), default_quota=10, job_service=FakeJobService(pending=1))
+    out = await svc.get_current_user_info({"id": 1, "is_admin": True, "file_count": 2})
+    assert out["file_quota"] == -1
+    assert out["total_files"] == 3
+
+
+@pytest.mark.asyncio
+async def test_current_user_info_none_quota_falls_back_to_default():
+    svc = _svc(FakeUserRepo(), default_quota=8, job_service=FakeJobService())
+    out = await svc.get_current_user_info({"id": 2, "is_admin": False, "file_count": 0})
+    assert out["file_quota"] == 8
+
+
+@pytest.mark.asyncio
+async def test_current_user_info_negative_default_is_unlimited():
+    svc = _svc(FakeUserRepo(), default_quota=-1, job_service=FakeJobService())
+    out = await svc.get_current_user_info({"id": 2, "is_admin": False, "file_quota": 3, "file_count": 0})
+    assert out["file_quota"] == -1

--- a/openrag/services/orchestrators/test_user_service.py
+++ b/openrag/services/orchestrators/test_user_service.py
@@ -55,8 +55,36 @@ class FakeUserRepo:
         return self._users.get(user_id)
 
 
-def _svc(repo: FakeUserRepo, *, default_quota: int = 10) -> UserService:
-    return UserService(user_repo=repo, auth_service=object(), default_file_quota=default_quota)
+class FakePartitionService:
+    def __init__(self):
+        self.deleted: list[str] = []
+
+    async def delete_partition(self, partition: str) -> None:
+        self.deleted.append(partition)
+
+
+class FakeMembershipRepo:
+    def __init__(self, owned: dict[int, list[dict]] | None = None):
+        self._owned = owned or {}
+
+    async def list_user_partitions_dict(self, user_id: int) -> list[dict]:
+        return self._owned.get(user_id, [])
+
+
+def _svc(
+    repo: FakeUserRepo,
+    *,
+    default_quota: int = 10,
+    partition_service: FakePartitionService | None = None,
+    membership_repo: FakeMembershipRepo | None = None,
+) -> UserService:
+    return UserService(
+        user_repo=repo,
+        auth_service=object(),
+        default_file_quota=default_quota,
+        partition_service=partition_service or FakePartitionService(),
+        membership_repo=membership_repo or FakeMembershipRepo(),
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -137,10 +165,29 @@ async def test_delete_user_missing_raises_and_no_repo_call():
 
 
 @pytest.mark.asyncio
-async def test_delete_user_existing_deletes_without_cascade():
+async def test_delete_user_existing_no_owned_partitions():
     repo = FakeUserRepo(existing={5})
-    await _svc(repo).delete_user(5)
-    assert repo.deleted == [5]  # no partition cascade in 8A.2 (deferred to 8B)
+    ps = FakePartitionService()
+    await _svc(repo, partition_service=ps).delete_user(5)
+    assert repo.deleted == [5]
+    assert ps.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_delete_user_cascades_owned_partitions_first():
+    repo = FakeUserRepo(existing={5})
+    ps = FakePartitionService()
+    mem = FakeMembershipRepo(
+        {
+            5: [
+                {"partition": "p_owned", "role": "owner"},
+                {"partition": "p_viewer", "role": "viewer"},  # not cascaded
+            ]
+        }
+    )
+    await _svc(repo, partition_service=ps, membership_repo=mem).delete_user(5)
+    assert ps.deleted == ["p_owned"]  # only owner-role partitions
+    assert repo.deleted == [5]
 
 
 @pytest.mark.asyncio

--- a/openrag/services/orchestrators/test_workspace_service.py
+++ b/openrag/services/orchestrators/test_workspace_service.py
@@ -1,0 +1,153 @@
+"""Unit tests for :class:`WorkspaceService` (Phase 8B.2)."""
+
+from __future__ import annotations
+
+import pytest
+from services.orchestrators.workspace_service import WorkspaceService
+
+
+class FakeWorkspaceRepo:
+    def __init__(self, *, workspace=None, orphaned=None):
+        self._workspace = workspace
+        self._orphaned = orphaned if orphaned is not None else []
+        self.created: list[tuple] = []
+        self.added: list[tuple[str, list[str]]] = []
+        self.removed: list[tuple[str, str]] = []
+        self.removed_from_all: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
+
+    async def get_workspace_dict(self, workspace_id: str):
+        return self._workspace
+
+    async def list_workspaces_dict(self, partition: str) -> list[dict]:
+        return [{"workspace_id": "w1", "partition_name": partition}]
+
+    async def create_workspace_legacy(self, workspace_id, partition, user_id, display_name):
+        self.created.append((workspace_id, partition, user_id, display_name))
+
+    async def get_existing_file_ids(self, partition: str, file_ids):
+        return [f for f in file_ids if f != "ghost"]
+
+    async def add_files_to_workspace(self, workspace_id: str, file_ids):
+        self.added.append((workspace_id, file_ids))
+        return []
+
+    async def remove_file_from_workspace(self, workspace_id: str, file_id: str) -> bool:
+        self.removed.append((workspace_id, file_id))
+        return True
+
+    async def list_workspace_files(self, workspace_id: str) -> list[str]:
+        return ["f1", "f2"]
+
+    async def get_file_workspaces(self, file_id: str, partition: str) -> list[str]:
+        return ["w1", "w2"]
+
+    async def delete_workspace(self, workspace_id: str) -> list[str]:
+        self.deleted.append(workspace_id)
+        return list(self._orphaned)
+
+    async def remove_file_from_all_workspaces(self, file_id: str, partition: str) -> None:
+        self.removed_from_all.append((file_id, partition))
+
+
+class FakeDocumentRepo:
+    def __init__(self, *, fail_on: set[str] | None = None):
+        self._fail_on = fail_on or set()
+        self.removed: list[tuple[str, str]] = []
+
+    async def remove_file_from_partition(self, file_id: str, partition: str) -> bool:
+        if file_id in self._fail_on:
+            raise RuntimeError(f"boom:{file_id}")
+        self.removed.append((file_id, partition))
+        return True
+
+
+class FakeVectorStore:
+    def __init__(self, ids_by_file=None):
+        self._ids_by_file = ids_by_file or {}
+        self.deleted: list[list[str]] = []
+
+    async def query_ids_by_filter(self, collection, filters):
+        return list(self._ids_by_file.get(filters.get("file_id"), []))
+
+    async def delete(self, ids, collection="default") -> int:
+        self.deleted.append(list(ids))
+        return len(ids)
+
+
+def _svc(*, wrepo=None, drepo=None, vstore=None, collection="vdb") -> WorkspaceService:
+    return WorkspaceService(
+        workspace_repo=wrepo or FakeWorkspaceRepo(),
+        document_repo=drepo or FakeDocumentRepo(),
+        vector_store=vstore or FakeVectorStore(),
+        collection=collection,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# delegations
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_delegates():
+    wrepo = FakeWorkspaceRepo()
+    await _svc(wrepo=wrepo).create_workspace("w1", "p", 5, "Disp")
+    assert wrepo.created == [("w1", "p", 5, "Disp")]
+
+
+@pytest.mark.asyncio
+async def test_get_existing_file_ids_filters():
+    out = await _svc().get_existing_file_ids("p", ["a", "ghost", "b"])
+    assert set(out) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_remove_file_and_list_and_workspaces():
+    wrepo = FakeWorkspaceRepo()
+    svc = _svc(wrepo=wrepo)
+    assert await svc.remove_file("w1", "f1") is True
+    assert await svc.list_files("w1") == ["f1", "f2"]
+    assert await svc.get_file_workspaces("f1", "p") == ["w1", "w2"]
+
+
+# --------------------------------------------------------------------------- #
+# cross-cutting delete_workspace
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_no_orphans():
+    wrepo = FakeWorkspaceRepo(orphaned=[])
+    drepo = FakeDocumentRepo()
+    vstore = FakeVectorStore()
+    out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1")
+    assert out == {"orphaned_files_deleted": 0, "orphaned_files_failed": []}
+    assert wrepo.deleted == ["w1"]
+    assert vstore.deleted == []
+    assert drepo.removed == []
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_cleans_orphans_vectors_and_rows():
+    wrepo = FakeWorkspaceRepo(orphaned=["fA", "fB"])
+    drepo = FakeDocumentRepo()
+    vstore = FakeVectorStore(ids_by_file={"fA": ["c1", "c2"], "fB": []})
+    out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1")
+
+    assert out == {"orphaned_files_deleted": 2, "orphaned_files_failed": []}
+    # fA had chunks -> a delete call; fB had none -> no delete call.
+    assert vstore.deleted == [["c1", "c2"]]
+    assert set(drepo.removed) == {("fA", "p"), ("fB", "p")}
+    assert set(wrepo.removed_from_all) == {("fA", "p"), ("fB", "p")}
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_collects_per_file_failures():
+    wrepo = FakeWorkspaceRepo(orphaned=["good", "bad"])
+    drepo = FakeDocumentRepo(fail_on={"bad"})
+    vstore = FakeVectorStore(ids_by_file={"good": ["c1"], "bad": ["c2"]})
+    out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1")
+
+    assert out["orphaned_files_deleted"] == 1
+    assert out["orphaned_files_failed"] == ["bad"]

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -1,0 +1,156 @@
+"""UserService — user CRUD orchestration (Phase 8A.2).
+
+Business logic extracted from ``routers/users.py``. The legacy router was
+already mostly delegation (each endpoint issued one Ray ``vectordb``
+user call); this service owns the parts that were *not* pure
+delegation: input validation, the default-quota rule, and the
+existence / not-found semantics. It talks to the Phase 7
+:class:`UserRepository` directly instead of the Ray ``vectordb`` actor.
+
+Response shape is kept identical to the legacy endpoints — the repo's
+``*_dict`` helpers reproduce the exact ``PartitionFileManager`` dict
+contract the Ray actor used to expose, so existing clients are
+unaffected.
+
+Known temporary gap (deferred to Phase 8B / PartitionService): the
+legacy Ray ``delete_user`` cascade-deleted every partition the user
+owned (Milvus + Postgres) before removing the row. PartitionService owns
+that cross-cutting delete, so :meth:`delete_user` here is a plain repo
+delete; owner-partition cleanup is reintroduced in 8B.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from core.utils.exceptions import UserNotFoundError, ValidationError
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.ports.user_repo import UserRepository
+    from models.user import UserCreate, UserUpdate
+    from services.orchestrators.auth_service import AuthService
+
+logger = get_logger()
+
+# Pragmatic, permissive address shape — the IdP / caller is the real
+# source of truth; this only rejects obviously malformed input.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_MAX_DISPLAY_NAME = 255
+
+
+class UserService:
+    """User account CRUD — validation + repo delegation."""
+
+    def __init__(
+        self,
+        *,
+        user_repo: UserRepository,
+        auth_service: AuthService,
+        default_file_quota: int,
+    ) -> None:
+        self._user_repo = user_repo
+        # Injected per the Phase 8 prescribed signature: the place future
+        # phases consolidate authz (e.g. require_admin) once the shared
+        # FastAPI Depends wrappers in routers/utils.py are retired.
+        self._auth_service = auth_service
+        # Legacy ``file_quota_per_user`` (config.rdb.default_file_quota).
+        # Only applied as a creation default when > 0, matching the old
+        # ``vectordb.create_user`` behaviour.
+        self._default_file_quota = default_file_quota
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_profile(display_name: Any, email: Any) -> None:
+        if isinstance(display_name, str) and len(display_name) > _MAX_DISPLAY_NAME:
+            raise ValidationError(
+                f"display_name exceeds {_MAX_DISPLAY_NAME} characters.",
+                status_code=400,
+            )
+        if isinstance(email, str) and email.strip() and not _EMAIL_RE.match(email.strip()):
+            raise ValidationError(f"Invalid email address: {email!r}", status_code=400)
+
+    async def _ensure_exists(self, user_id: int) -> None:
+        if not await self._user_repo.user_exists(user_id):
+            logger.warning(f"User with ID {user_id} does not exist.")
+            raise UserNotFoundError(f"User with ID {user_id} does not exist.")
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def create_user(self, body: UserCreate) -> dict:
+        """Create a user, returning the legacy dict (token shown once)."""
+        fields = body.model_dump()
+        self._validate_profile(fields.get("display_name"), fields.get("email"))
+
+        file_quota = fields.get("file_quota")
+        if self._default_file_quota > 0 and file_quota is None:
+            file_quota = self._default_file_quota
+
+        user = await self._user_repo.create_legacy_user(
+            display_name=fields.get("display_name"),
+            external_user_id=fields.get("external_user_id"),
+            email=fields.get("email"),
+            is_admin=fields.get("is_admin", False),
+            file_quota=file_quota,
+        )
+        logger.info("Created new user", user_id=user["id"])
+        return user
+
+    async def list_users(self) -> list[dict]:
+        users = await self._user_repo.list_users_dict()
+        logger.debug("Returned list of users.", user_count=len(users))
+        return users
+
+    async def get_user(self, user_id: int) -> dict:
+        await self._ensure_exists(user_id)
+        user = await self._user_repo.get_user_dict_by_id(user_id)
+        if user is None:
+            raise UserNotFoundError(f"User '{user_id}' not found")
+        return user
+
+    async def delete_user(self, user_id: int) -> None:
+        """Delete a user row.
+
+        Owner-partition cascade is intentionally NOT performed here — see
+        the module docstring (deferred to PartitionService, 8B).
+        """
+        await self._ensure_exists(user_id)
+        await self._user_repo.delete_user(user_id)
+        logger.info("Deleted user", user_id=user_id)
+
+    async def regenerate_token(self, user_id: int) -> dict:
+        await self._ensure_exists(user_id)
+        user = await self._user_repo.regenerate_user_token(user_id)
+        if user is None:
+            raise UserNotFoundError(f"User '{user_id}' not found")
+        logger.info("Regenerated user token", user_id=user_id)
+        return user
+
+    async def update_user(self, user_id: int, body: UserUpdate) -> dict:
+        await self._ensure_exists(user_id)
+        updates = body.model_dump(exclude_unset=True)
+        self._validate_profile(updates.get("display_name"), updates.get("email"))
+
+        user = await self._user_repo.update_user(user_id, **updates)
+        if user is None:
+            raise UserNotFoundError(f"User '{user_id}' not found")
+        logger.info("Updated user info", user_id=user_id)
+        return {
+            "id": user.id,
+            "display_name": user.display_name,
+            "external_user_id": user.external_user_id,
+            "email": user.email,
+            "is_admin": user.is_admin,
+            "created_at": user.created_at.isoformat() if user.created_at else None,
+            "file_quota": user.file_quota,
+            "file_count": user.file_count,
+        }
+
+
+__all__ = ["UserService"]

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -12,11 +12,11 @@ Response shape is kept identical to the legacy endpoints — the repo's
 contract the Ray actor used to expose, so existing clients are
 unaffected.
 
-Known temporary gap (deferred to Phase 8B / PartitionService): the
-legacy Ray ``delete_user`` cascade-deleted every partition the user
-owned (Milvus + Postgres) before removing the row. PartitionService owns
-that cross-cutting delete, so :meth:`delete_user` here is a plain repo
-delete; owner-partition cleanup is reintroduced in 8B.
+Owner-partition cascade (restored in Phase 8B): the legacy Ray
+``delete_user`` deleted every partition the user owned (Milvus +
+Postgres) before removing the row. That cross-cutting delete is owned by
+PartitionService; :meth:`delete_user` composes it so the behaviour
+matches the legacy endpoint again.
 """
 
 from __future__ import annotations
@@ -28,9 +28,11 @@ from core.utils.exceptions import UserNotFoundError, ValidationError
 from utils.logger import get_logger
 
 if TYPE_CHECKING:
+    from core.ports.partition_membership_repo import PartitionMembershipRepository
     from core.ports.user_repo import UserRepository
     from models.user import UserCreate, UserUpdate
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.partition_service import PartitionService
 
 logger = get_logger()
 
@@ -49,6 +51,8 @@ class UserService:
         user_repo: UserRepository,
         auth_service: AuthService,
         default_file_quota: int,
+        partition_service: PartitionService,
+        membership_repo: PartitionMembershipRepository,
     ) -> None:
         self._user_repo = user_repo
         # Injected per the Phase 8 prescribed signature: the place future
@@ -59,6 +63,12 @@ class UserService:
         # Only applied as a creation default when > 0, matching the old
         # ``vectordb.create_user`` behaviour.
         self._default_file_quota = default_file_quota
+        # 8B: reinstating the owner-partition cascade dropped in 8A.2.
+        # delete_user must also delete every partition the user owns
+        # (Milvus + Postgres) — that cross-cutting delete is owned by
+        # PartitionService, so UserService composes it.
+        self._partition_service = partition_service
+        self._membership_repo = membership_repo
 
     # ------------------------------------------------------------------
     # Validation
@@ -115,14 +125,22 @@ class UserService:
         return user
 
     async def delete_user(self, user_id: int) -> None:
-        """Delete a user row.
+        """Delete a user, cascading partitions the user owns first.
 
-        Owner-partition cascade is intentionally NOT performed here — see
-        the module docstring (deferred to PartitionService, 8B).
+        Mirrors the legacy Ray ``delete_user``: every partition where the
+        user holds the ``owner`` role is deleted (vectors + relational
+        rows, via PartitionService) before the user row is removed.
         """
         await self._ensure_exists(user_id)
+        owned = [
+            p["partition"]
+            for p in await self._membership_repo.list_user_partitions_dict(user_id)
+            if p.get("role") == "owner"
+        ]
+        for partition in owned:
+            await self._partition_service.delete_partition(partition)
         await self._user_repo.delete_user(user_id)
-        logger.info("Deleted user", user_id=user_id)
+        logger.info("Deleted user", user_id=user_id, cascaded_partitions=len(owned))
 
     async def regenerate_token(self, user_id: int) -> dict:
         await self._ensure_exists(user_id)

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from core.ports.user_repo import UserRepository
     from models.user import UserCreate, UserUpdate
     from services.orchestrators.auth_service import AuthService
+    from services.orchestrators.job_service import JobService
     from services.orchestrators.partition_service import PartitionService
 
 logger = get_logger()
@@ -53,6 +54,7 @@ class UserService:
         default_file_quota: int,
         partition_service: PartitionService,
         membership_repo: PartitionMembershipRepository,
+        job_service: JobService,
     ) -> None:
         self._user_repo = user_repo
         # Injected per the Phase 8 prescribed signature: the place future
@@ -69,6 +71,12 @@ class UserService:
         # PartitionService, so UserService composes it.
         self._partition_service = partition_service
         self._membership_repo = membership_repo
+        # /users/info reports quota usage = indexed files + pending
+        # indexing tasks. The pending count comes from the TaskStateManager
+        # actor, which JobService wraps (8H excepts JobService, not
+        # UserService) — so UserService composes JobService rather than
+        # holding a Ray handle itself.
+        self._job_service = job_service
 
     # ------------------------------------------------------------------
     # Validation
@@ -111,6 +119,38 @@ class UserService:
         )
         logger.info("Created new user", user_id=user["id"])
         return user
+
+    async def get_current_user_info(self, user: dict) -> dict:
+        """Augment the authenticated user with the quota-usage block.
+
+        ``user`` is the request-state dict the auth middleware set (no DB
+        fetch — identical to the legacy ``/users/info`` handler). Quota
+        rule, byte-for-byte: admins and a negative global default mean
+        unlimited; a ``None`` per-user quota falls back to the global
+        default; a negative per-user quota means unlimited. ``file_quota``
+        is surfaced as ``-1`` when unlimited.
+        """
+        is_admin = user.get("is_admin", False)
+        if is_admin or self._default_file_quota < 0:
+            user_quota: float | int = float("inf")
+        else:
+            user_quota = user.get("file_quota", None)
+            if user_quota is None:
+                user_quota = self._default_file_quota
+            elif user_quota < 0:
+                user_quota = float("inf")
+
+        file_count = user.get("file_count", 0)
+        pending_count = await self._job_service.get_user_pending_task_count(user.get("id"))
+        total = file_count + pending_count
+
+        return {
+            **user,
+            "file_count": file_count,
+            "pending_files": pending_count,
+            "total_files": total,
+            "file_quota": -1 if user_quota == float("inf") else user_quota,
+        }
 
     async def list_users(self) -> list[dict]:
         users = await self._user_repo.list_users_dict()

--- a/openrag/services/orchestrators/workspace_service.py
+++ b/openrag/services/orchestrators/workspace_service.py
@@ -1,0 +1,154 @@
+"""WorkspaceService — workspace CRUD + file association (Phase 8B.2).
+
+Business logic extracted from ``routers/workspaces.py`` and the
+workspace slice of the legacy Ray ``vectordb`` shim. The simple
+endpoints were already 1:1 repo delegations; the substantive extraction
+is :meth:`delete_workspace`, the cross-cutting op that drops the
+workspace, then deletes every file orphaned by that removal from *both*
+the vector store and the relational catalog (the legacy router looped the Ray vectordb
+delete-file call itself).
+
+The thin router keeps the HTTP guards whose exact non-bracketed
+``{"detail": ...}`` body must stay identical (409 on duplicate, the
+``require_workspace_in_partition`` 404, the unknown/missing-file 404s).
+
+Constructor note: ``collection`` (vector-store collection name) is one
+arg beyond the plan's three — the legacy ``delete_file`` read it from
+``config.vectordb.collection_name``; the container supplies it from
+settings so the service stays Ray/config-free (8H).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from core.ports.document_repo import DocumentRepository
+    from core.ports.workspace_repo import WorkspaceRepository
+    from core.vector_stores import VectorStore
+
+logger = get_logger()
+
+
+class WorkspaceService:
+    """Workspace lifecycle, file association and orphan cleanup."""
+
+    def __init__(
+        self,
+        *,
+        workspace_repo: WorkspaceRepository,
+        document_repo: DocumentRepository,
+        vector_store: VectorStore,
+        collection: str,
+    ) -> None:
+        self._workspace_repo = workspace_repo
+        self._document_repo = document_repo
+        self._vector_store = vector_store
+        self._collection = collection
+
+    # ------------------------------------------------------------------
+    # CRUD / lookups (thin repo delegations)
+    # ------------------------------------------------------------------
+
+    async def get_workspace(self, workspace_id: str) -> dict | None:
+        return await self._workspace_repo.get_workspace_dict(workspace_id)
+
+    async def list_workspaces(self, partition: str) -> list[dict]:
+        return await self._workspace_repo.list_workspaces_dict(partition)
+
+    async def create_workspace(
+        self,
+        workspace_id: str,
+        partition: str,
+        user_id: int | None = None,
+        display_name: str | None = None,
+    ) -> None:
+        """Create a workspace.
+
+        The 409-on-exists guard lives in the thin router (byte-identical
+        non-bracketed body); this is the plain repo create.
+        """
+        await self._workspace_repo.create_workspace_legacy(
+            workspace_id,
+            partition,
+            user_id,
+            display_name,
+        )
+
+    async def get_existing_file_ids(self, partition: str, file_ids: list[str]) -> list[str]:
+        return list(await self._workspace_repo.get_existing_file_ids(partition, file_ids))
+
+    async def add_files(self, workspace_id: str, file_ids: list[str]) -> list[str]:
+        """Associate files; returns any file_ids that were not found."""
+        return await self._workspace_repo.add_files_to_workspace(workspace_id, file_ids)
+
+    async def remove_file(self, workspace_id: str, file_id: str) -> bool:
+        return await self._workspace_repo.remove_file_from_workspace(workspace_id, file_id)
+
+    async def list_files(self, workspace_id: str) -> list[str]:
+        return await self._workspace_repo.list_workspace_files(workspace_id)
+
+    async def get_file_workspaces(self, file_id: str, partition: str) -> list[str]:
+        return await self._workspace_repo.get_file_workspaces(file_id, partition)
+
+    # ------------------------------------------------------------------
+    # Cross-cutting: delete workspace + clean up orphaned files
+    # ------------------------------------------------------------------
+
+    async def delete_workspace(self, partition: str, workspace_id: str) -> dict:
+        """Delete the workspace, then fully delete any files it orphaned.
+
+        ``workspace_repo.delete_workspace`` removes the workspace and its
+        associations and returns the file_ids that are no longer
+        referenced by *any* workspace. Each of those is deleted from the
+        vector store and the relational catalog — concurrently, with
+        per-file failures collected rather than raised, matching the
+        legacy router's ``asyncio.gather(..., return_exceptions=True)``.
+        """
+        orphaned = await self._workspace_repo.delete_workspace(workspace_id)
+
+        deleted_count = 0
+        failed_file_ids: list[str] = []
+        if orphaned:
+            results = await asyncio.gather(
+                *[self._delete_file(file_id, partition) for file_id in orphaned],
+                return_exceptions=True,
+            )
+            for file_id, result in zip(orphaned, results, strict=True):
+                if isinstance(result, Exception):
+                    logger.warning(
+                        "Failed to delete orphaned file from vector store",
+                        file_id=file_id,
+                        error=str(result),
+                    )
+                    failed_file_ids.append(file_id)
+                else:
+                    deleted_count += 1
+
+        return {
+            "orphaned_files_deleted": deleted_count,
+            "orphaned_files_failed": failed_file_ids,
+        }
+
+    async def _delete_file(self, file_id: str, partition: str) -> None:
+        """Port of the legacy ``vectordb.delete_file``.
+
+        Drops the file's chunks from the vector store (via the clean
+        port: query ids by filter + delete), then detaches it from every
+        workspace and removes the relational file row.
+        """
+        ids = await self._vector_store.query_ids_by_filter(
+            self._collection,
+            {"partition": partition, "file_id": file_id},
+        )
+        if ids:
+            await self._vector_store.delete(ids, self._collection)
+        await self._workspace_repo.remove_file_from_all_workspaces(file_id, partition)
+        await self._document_repo.remove_file_from_partition(file_id=file_id, partition=partition)
+        logger.info("Deleted orphaned file", file_id=file_id, partition=partition)
+
+
+__all__ = ["WorkspaceService"]

--- a/openrag/services/storage/indexer_ray_shim.py
+++ b/openrag/services/storage/indexer_ray_shim.py
@@ -1,0 +1,167 @@
+"""Transitional ``IndexingDispatcher`` adapter over the Ray worker actors.
+
+``IndexingService`` (Phase 8D.1) talks to the clean
+``core.indexing.dispatcher.IndexingDispatcher`` ABC; this shim plugs the
+still-existing ``Indexer`` + ``TaskStateManager`` Ray actors into that
+ABC for the duration of the Phase-8 shim period. Phase 9 replaces it
+with a direct pipeline call and deletes this file.
+
+Bookkeeping calls (state / object-ref / cancel) are routed through
+``call_ray_actor_with_timeout`` so timeout & cancellation behaviour
+matches the rest of the legacy app. The indexing job itself is *not*
+awaited — ``add_file`` is fire-and-forget on the actor; we only capture
+its task id and register the object ref so it can be cancelled later
+(legacy ``routers/indexer.py`` behaviour, preserved exactly).
+
+The Ray imports are deferred to method bodies / the factory so this
+module stays importable without Ray (unit tests inject a fake actor).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.indexing.dispatcher import IndexingDispatcher
+
+# Mirrors the legacy default in routers/indexer.py
+# (config.ray.indexer.vectordb_timeout). Override via the factory.
+DEFAULT_TIMEOUT = 60.0
+
+
+class IndexerRayShim(IndexingDispatcher):
+    """Adapter exposing the Indexer + TaskStateManager actors as a dispatcher.
+
+    Args:
+        indexer: Ray actor handle for ``Indexer`` (or any object whose
+            remote methods match it — handy for tests).
+        task_state_manager: Ray actor handle for ``TaskStateManager``.
+        timeout: Per-call timeout for the bookkeeping calls.
+    """
+
+    def __init__(self, indexer: Any, task_state_manager: Any, timeout: float = DEFAULT_TIMEOUT) -> None:
+        self._indexer = indexer
+        self._tsm = task_state_manager
+        self._timeout = timeout
+
+    async def _call(self, future: Any, task_description: str) -> Any:
+        from services.workers.ray_utils import call_ray_actor_with_timeout
+
+        return await call_ray_actor_with_timeout(
+            future=future,
+            timeout=self._timeout,
+            task_description=task_description,
+        )
+
+    async def dispatch_indexing(
+        self,
+        *,
+        path: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+        workspace_ids: list[str] | None,
+        replace: bool,
+    ) -> str:
+        # Fire-and-forget on the actor: we keep the ObjectRef so the task
+        # can be cancelled, but never await it here (the work runs async).
+        task = self._indexer.add_file.remote(
+            path=path,
+            metadata=metadata,
+            partition=partition,
+            user=user,
+            workspace_ids=workspace_ids,
+            replace=replace,
+        )
+        task_id = task.task_id().hex()
+        await self._call(
+            self._tsm.set_state.remote(task_id, "QUEUED"),
+            task_description=f"set_state({task_id})",
+        )
+        await self._call(
+            self._tsm.set_object_ref.remote(task_id, {"ref": task}),
+            task_description=f"set_object_ref({task_id})",
+        )
+        return task_id
+
+    async def delete_file(self, file_id: str, partition: str) -> None:
+        await self._call(
+            self._indexer.delete_file.remote(file_id, partition),
+            task_description=f"delete_file({file_id})",
+        )
+
+    async def update_file_metadata(
+        self,
+        file_id: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+    ) -> None:
+        await self._call(
+            self._indexer.update_file_metadata.remote(file_id, metadata, partition, user=user),
+            task_description=f"update_file_metadata({file_id})",
+        )
+
+    async def copy_file(
+        self,
+        file_id: str,
+        metadata: dict,
+        partition: str,
+        user: dict | None,
+    ) -> None:
+        await self._call(
+            self._indexer.copy_file.remote(file_id=file_id, metadata=metadata, partition=partition, user=user),
+            task_description=f"copy_file({file_id})",
+        )
+
+    async def get_task_state(self, task_id: str) -> str | None:
+        return await self._call(
+            self._tsm.get_state.remote(task_id),
+            task_description=f"get_state({task_id})",
+        )
+
+    async def get_task_error(self, task_id: str) -> str | None:
+        return await self._call(
+            self._tsm.get_error.remote(task_id),
+            task_description=f"get_error({task_id})",
+        )
+
+    async def cancel_task(self, task_id: str) -> bool:
+        import ray
+
+        obj_ref = await self._call(
+            self._tsm.get_object_ref.remote(task_id),
+            task_description=f"get_object_ref({task_id})",
+        )
+        if obj_ref is None:
+            return False
+
+        ray.cancel(obj_ref["ref"], recursive=True)
+        current_state = await self._call(
+            self._tsm.get_state.remote(task_id),
+            task_description=f"get_state({task_id})",
+        )
+        if current_state not in {"COMPLETED", "FAILED"}:
+            await self._call(
+                self._tsm.set_state.remote(task_id, "CANCELLED"),
+                task_description=f"set_state({task_id})",
+            )
+        return True
+
+
+def from_ray_namespace(
+    namespace: str = "openrag",
+    timeout: float = DEFAULT_TIMEOUT,
+) -> IndexerRayShim:
+    """Look up the Indexer + TaskStateManager actors and wrap them.
+
+    Convenience for the composition root. The Ray import is deferred so
+    importing this module without Ray (unit tests with a fake actor)
+    does not fail.
+    """
+    import ray
+
+    return IndexerRayShim(
+        ray.get_actor("Indexer", namespace=namespace),
+        ray.get_actor("TaskStateManager", namespace=namespace),
+        timeout=timeout,
+    )

--- a/openrag/services/storage/serializer_ray_shim.py
+++ b/openrag/services/storage/serializer_ray_shim.py
@@ -1,0 +1,45 @@
+"""Transitional ``FileSerializer`` adapter over the Ray DocSerializer actor.
+
+``ConversionService`` (Phase 8E) talks to the clean
+``core.indexing.serializer.FileSerializer`` ABC; this shim plugs the
+still-existing ``DocSerializer`` Ray actor into that ABC for the
+duration of the Phase-8 shim period. Phase 9 replaces it with a direct
+serializer call and deletes this file.
+
+It reuses the legacy ``components.indexer.utils.files.serialize_file``
+helper (which already routes through ``call_ray_actor_with_timeout``,
+preserving the timeout behaviour the tools router relied on). The Ray
+imports are deferred so this module stays importable without Ray (unit
+tests inject a fake serializer instead).
+"""
+
+from __future__ import annotations
+
+from core.indexing.serializer import FileSerializer
+
+# Task-id label passed to the serializer when not running inside a Ray
+# task (the FastAPI process is the Ray driver). Mirrors the role of the
+# legacy router's ``ray.get_runtime_context().get_task_id()`` value —
+# the serializer only uses it for logging / state keys.
+_FALLBACK_TASK_ID = "tools-extract"
+
+
+class SerializerRayShim(FileSerializer):
+    """Adapter exposing the DocSerializer actor as a ``FileSerializer``."""
+
+    async def serialize(self, path: str, metadata: dict) -> str:
+        import ray
+        from components.indexer.utils.files import serialize_file
+
+        task_id = ray.get_runtime_context().get_task_id() or _FALLBACK_TASK_ID
+        doc = await serialize_file(task_id, path=path, metadata=metadata)
+        return doc.page_content
+
+
+def from_ray_namespace() -> SerializerRayShim:
+    """Build the shim. Convenience for the composition root.
+
+    The DocSerializer actor is resolved lazily inside ``serialize_file``
+    (per call), so nothing Ray-related runs at construction time.
+    """
+    return SerializerRayShim()

--- a/tests/api_tests/test_oidc_lifecycle.py
+++ b/tests/api_tests/test_oidc_lifecycle.py
@@ -206,13 +206,15 @@ class _StubVectorDB:
         return row
 
     def _impl_get_oidc_session_by_token(self, session_token_plain: str):
-        sid_key = self._sessions_by_token.get(session_token_plain)
-        if sid_key is None:
-            return None
-        row = self._sessions[sid_key]
-        if row.get("revoked_at"):
-            return None
-        return row
+        # Faithful to production: PartitionFileManager.get_oidc_session_by_token
+        # hashes the plaintext and matches on session_token_hash. Post-Phase-8
+        # the row is written by AuthService via the repo adapter (hash only),
+        # so the legacy plaintext index no longer applies.
+        token_hash = hash_session_token(session_token_plain)
+        for row in self._sessions.values():
+            if row.get("session_token_hash") == token_hash and not row.get("revoked_at"):
+                return row
+        return None
 
     def _impl_get_user(self, user_id: int):
         return self._users_by_id.get(user_id)
@@ -250,13 +252,121 @@ def _install_stubs():
 
 _install_stubs()
 
-# Reload auth deps + routers after stub installation
-from components.auth import deps as _auth_deps  # noqa: E402
+# Reload routers after stub installation. Post-Phase-8 the auth/users routers
+# resolve AuthService/UserService from the DI providers, so we import the
+# provider symbols here (di.providers is not popped, so these are the same
+# function objects the routers close over) to key dependency_overrides.
+from components.auth import OIDCClient  # noqa: E402
+from components.auth.session_tokens import hash_session_token  # noqa: E402
+from core.config.auth import OIDCConfig  # noqa: E402
+from core.models.user import OIDCSession, User  # noqa: E402
+from di.providers import get_auth_service, get_user_service  # noqa: E402
+from services.orchestrators.auth_service import AuthService  # noqa: E402
+from services.orchestrators.user_service import UserService  # noqa: E402
 
 sys.modules.pop("routers.auth", None)
 sys.modules.pop("routers.users", None)
 _auth_router_mod = importlib.import_module("routers.auth")
 _users_router_mod = importlib.import_module("routers.users")
+
+
+# ---------------------------------------------------------------------------
+# Phase-8 repository-port adapters over the shared _StubVectorDB state.
+# AuthService/UserService take repo ports, not the Ray vdb actor; these
+# wrap the same dicts the auth middleware reads through _StubVectorDB so a
+# session created by AuthService is visible to the middleware and vice-versa.
+# ---------------------------------------------------------------------------
+
+
+class _StubUserRepo:
+    def __init__(self, vdb: _StubVectorDB):
+        self._vdb = vdb
+
+    @staticmethod
+    def _to_user(d: dict | None) -> User | None:
+        if d is None:
+            return None
+        return User(
+            id=d["id"],
+            display_name=d.get("display_name"),
+            external_user_id=d.get("external_user_id"),
+            email=d.get("email"),
+            is_admin=d.get("is_admin", False),
+        )
+
+    async def get_user_by_external_id(self, external_id: str) -> User | None:
+        return self._to_user(self._vdb._users_by_sub.get(external_id))
+
+    async def get_user(self, user_id: int) -> User | None:
+        return self._to_user(self._vdb._users_by_id.get(user_id))
+
+    async def create_user(self, user: User) -> User:
+        new_id = max(self._vdb._users_by_id, default=0) + 1
+        user.id = new_id
+        rec = {
+            "id": new_id,
+            "email": user.email,
+            "external_user_id": user.external_user_id,
+            "is_admin": user.is_admin,
+            "display_name": user.display_name,
+        }
+        self._vdb._users_by_id[new_id] = rec
+        if user.external_user_id:
+            self._vdb._users_by_sub[user.external_user_id] = rec
+        return user
+
+    async def update_user(self, user_id: int, **fields) -> User | None:
+        rec = self._vdb._users_by_id.get(user_id)
+        if rec is None:
+            return None
+        for k, v in fields.items():
+            rec[k] = v
+        return self._to_user(rec)
+
+
+class _StubOIDCSessionRepo:
+    def __init__(self, vdb: _StubVectorDB):
+        self._vdb = vdb
+
+    async def create_session(self, session: OIDCSession) -> OIDCSession:
+        sid_key = self._vdb._next_session_id
+        self._vdb._next_session_id += 1
+        session.id = sid_key
+        self._vdb._sessions[sid_key] = {
+            "id": sid_key,
+            "user_id": session.user_id,
+            "sub": session.sub,
+            "sid": session.sid,
+            "session_token_hash": session.session_token_hash,
+            "id_token_encrypted": session.id_token_encrypted,
+            "access_token_encrypted": session.access_token_encrypted,
+            "refresh_token_encrypted": session.refresh_token_encrypted,
+            "access_token_expires_at": session.access_token_expires_at,
+            "session_expires_at": session.session_expires_at,
+            "created_at": session.created_at,
+            "last_refresh_at": None,
+            "revoked_at": None,
+        }
+        return session
+
+    async def get_by_token_hash(self, token_hash: str) -> OIDCSession | None:
+        for row in self._vdb._sessions.values():
+            if row.get("session_token_hash") == token_hash and not row.get("revoked_at"):
+                return OIDCSession(**{k: row.get(k) for k in OIDCSession.model_fields})
+        return None
+
+    async def revoke_session(self, session_id: int) -> bool:
+        self._vdb._impl_revoke_oidc_session_by_id(session_id)
+        return True
+
+    async def revoke_by_sid(self, sid: str) -> int:
+        return self._vdb._impl_revoke_oidc_sessions_by_sid(sid)
+
+
+class _StubJobService:
+    async def get_user_pending_task_count(self, user_id) -> int:
+        return 0
+
 
 # ---------------------------------------------------------------------------
 # Build the composite app (auth + users)
@@ -264,9 +374,13 @@ _users_router_mod = importlib.import_module("routers.users")
 
 
 def _make_app(router) -> tuple[FastAPI, TestClient]:
-    """Build a minimal FastAPI app combining auth + users routers, with a
-    respx MockRouter injected into the OIDCClient singleton. respx >= 0.22
-    exposes MockRouter + httpx.MockTransport(router.handler)."""
+    """Build a minimal FastAPI app combining the auth + users routers.
+
+    Post-Phase-8 the routers pull AuthService/UserService from the DI
+    providers, so rather than patching a client singleton we build the real
+    services over the shared _StubVectorDB state, inject a respx-mocked
+    OIDCClient, and override get_auth_service / get_user_service. respx >=
+    0.22 exposes MockRouter + httpx.MockTransport(router.handler)."""
     app = FastAPI()
 
     # Install the AuthMiddleware (from components.auth.middleware)
@@ -277,9 +391,7 @@ def _make_app(router) -> tuple[FastAPI, TestClient]:
     app.include_router(_auth_router_mod.router)
     app.include_router(_users_router_mod.router, prefix="/users")
 
-    # Override OIDCClient singleton with our mocked http transport.
-    _auth_deps.reset_oidc_client()
-    _auth_deps._client = _auth_router_mod.OIDCClient(
+    oidc_client = OIDCClient(
         issuer=ISSUER,
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -287,6 +399,37 @@ def _make_app(router) -> tuple[FastAPI, TestClient]:
         scopes=SCOPES,
         http_client=httpx.AsyncClient(transport=httpx.MockTransport(router.handler)),
     )
+    cfg = OIDCConfig(
+        enabled=True,
+        issuer_url=ISSUER,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        redirect_uri=REDIRECT_URI,
+        scopes=SCOPES,
+        token_encryption_key=_FERNET_KEY,
+        claim_source="id_token",
+        claim_mapping="",
+        post_logout_redirect_uri="/",
+        auto_provision_login=False,
+    )
+    user_repo = _StubUserRepo(_stub_vdb)
+    auth_service = AuthService(
+        user_repo=user_repo,
+        oidc_session_repo=_StubOIDCSessionRepo(_stub_vdb),
+        membership_repo=object(),
+        oidc_client=oidc_client,
+        config=cfg,
+    )
+    user_service = UserService(
+        user_repo=user_repo,
+        auth_service=auth_service,
+        default_file_quota=10,
+        partition_service=object(),
+        membership_repo=object(),
+        job_service=_StubJobService(),
+    )
+    app.dependency_overrides[get_auth_service] = lambda: auth_service
+    app.dependency_overrides[get_user_service] = lambda: user_service
 
     client = TestClient(app, raise_server_exceptions=True)
     return app, client
@@ -317,7 +460,6 @@ def test_full_oidc_lifecycle(monkeypatch):
     monkeypatch.setenv("OIDC_POST_LOGOUT_REDIRECT_URI", "/")
     monkeypatch.delenv("OIDC_CLAIM_MAPPING", raising=False)
     monkeypatch.delenv("AUTH_TOKEN", raising=False)
-    _auth_deps.reset_oidc_client()
 
     # ── Pre-seed alice with the exact sub that the IdP mock will return ────────
     ALICE_SUB = "alice-sub"


### PR DESCRIPTION
## Scope

Extracts a service layer between the routers and the components, thinning each router down to request/response handling and pushing orchestration into dedicated services.

Commits (10):

- 8A.1 add AuthService, thin routers/auth.py
- 8A.2 add UserService, thin routers/users.py
- 8B.1 add PartitionService, thin routers/partition.py, restore delete-user cascade
- 8B.2 add WorkspaceService, thin routers/workspaces.py
- 8C.1 add RetrievalService, thin routers/search.py
- 8C.2 add QueryService, thin routers/openai.py
- 8D add IndexingService + JobService, thin routers/indexer.py + queue.py
- 8D.1 flag the components extract_temporal_fields shim debt for phase 9
- 8E add ConversionService, thin routers/tools.py + extract.py
- 8F verify orchestrator DI wiring, pull last Ray call out of routers/users.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OIDC auto-provisioning to create user accounts from IdP claims.

* **Refactor**
  * HTTP routers now act as thin transport layers; business logic moved to orchestration services for more reliable, consistent behavior.

* **Bug Fixes**
  * Restored search response metadata (includes file_id) and improved auth/session/logout handling.
  * Safer token counting fallback to avoid failures when external LLM client is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->