### PR TITLE
fix(loaders): accumulate all pages in CustomDocLoader (#376)

### DIFF
--- a/openrag/components/indexer/loaders/CustomDocLoader.py
+++ b/openrag/components/indexer/loaders/CustomDocLoader.py
@@ -34,6 +34,6 @@ class CustomDocLoader(BaseLoader):
 
         s = ""
         for page_num, p in enumerate(pages, start=1):
-            s = p.page_content.strip() + f"\n[PAGE_{page_num}]\n"
+            s += p.page_content.strip() + f"\n[PAGE_{page_num}]\n"
 
         return Document(page_content=s, metadata=metadata)

--- a/openrag/components/indexer/loaders/test_customdocloader.py
+++ b/openrag/components/indexer/loaders/test_customdocloader.py
@@ -13,7 +13,7 @@ from langchain_core.documents.base import Document as LCDocument
 
 @pytest.mark.asyncio
 async def test_customdocloader_accumulates_all_pages(tmp_path):
-    from openrag.components.indexer.loaders.CustomDocLoader import CustomDocLoader
+    from components.indexer.loaders.CustomDocLoader import CustomDocLoader
 
     fake_pages = [
         LCDocument(page_content="page-one"),

--- a/openrag/components/indexer/loaders/test_customdocloader.py
+++ b/openrag/components/indexer/loaders/test_customdocloader.py
@@ -36,4 +36,5 @@ async def test_customdocloader_accumulates_all_pages(tmp_path):
     assert "page-two" in result.page_content
     assert "page-three" in result.page_content
     assert "[PAGE_1]" in result.page_content
+    assert "[PAGE_2]" in result.page_content
     assert "[PAGE_3]" in result.page_content

--- a/openrag/components/indexer/loaders/test_customdocloader.py
+++ b/openrag/components/indexer/loaders/test_customdocloader.py
@@ -1,0 +1,39 @@
+"""Regression test for CustomDocLoader page accumulation (#376).
+
+The previous loop body used ``s = ...`` instead of ``s += ...``, so only
+the final page survived. This test confirms every page's content is now
+in the returned ``Document``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.documents.base import Document as LCDocument
+
+
+@pytest.mark.asyncio
+async def test_customdocloader_accumulates_all_pages(tmp_path):
+    from openrag.components.indexer.loaders.CustomDocLoader import CustomDocLoader
+
+    fake_pages = [
+        LCDocument(page_content="page-one"),
+        LCDocument(page_content="page-two"),
+        LCDocument(page_content="page-three"),
+    ]
+    fake_loader_instance = MagicMock()
+    fake_loader_instance.aload = AsyncMock(return_value=fake_pages)
+    fake_loader_cls = MagicMock(return_value=fake_loader_instance)
+
+    file_path = tmp_path / "stub.docx"
+    file_path.write_text("ignored")
+
+    with patch.dict(CustomDocLoader.doc_loaders, {".docx": fake_loader_cls}, clear=True):
+        # BaseLoader.__init__ pulls a config; we bypass it with object.__new__
+        loader = object.__new__(CustomDocLoader)
+        result = await loader.aload_document(str(file_path), metadata={"src": "x"})
+
+    assert "page-one" in result.page_content
+    assert "page-two" in result.page_content
+    assert "page-three" in result.page_content
+    assert "[PAGE_1]" in result.page_content
+    assert "[PAGE_3]" in result.page_content


### PR DESCRIPTION
## Summary

`openrag/components/indexer/loaders/CustomDocLoader.py:37` used `s = p.page_content.strip() + ...` inside the page loop, overwriting `s` on every iteration. Result: every multi-page legacy `.doc`/`.docx`/`.odt` document indexed via this loader silently dropped every page except the last, with no error visible in logs.

This PR changes the assignment to `s +=` so all pages are accumulated.

## Test plan

- [ ] Load a `.doc` file with three or more pages and confirm all pages are present in the returned content
- [ ] Existing unit tests for loaders still pass

Fixes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document loader so multi-page documents now preserve and concatenate every page’s content with page separators, preventing data loss across pages.

* **Tests**
  * Added a regression test that verifies multi-page documents are fully accumulated and include the expected page markers to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->