### PR TITLE
fix(openai): guard Path(None) when chunk metadata lacks source key (#370)

### DIFF
--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -104,7 +104,8 @@ def __prepare_sources(request: Request, docs: list, web_results: list | None = N
     links = []
     for doc in docs:
         doc_metadata = dict(doc.metadata)
-        filename = Path(doc_metadata.get("source")).name
+        source = doc_metadata.get("source") or ""
+        filename = Path(source).name
         file_url = str(request.url_for("static", path=filename))
         encoded_url = quote(file_url, safe=":/")
         links.append(

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -13,8 +13,7 @@ handed to the service as a callable), and ``StreamingResponse`` /
 
 import asyncio
 import json
-from pathlib import Path
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import consts
 from components.indexer.utils.text_sanitizer import sanitize_text
@@ -29,6 +28,7 @@ from services.orchestrators.query_service import QueryService
 from utils.exceptions.base import OpenRAGError
 from utils.logger import get_logger
 
+from .source_links import build_document_source_link
 from .utils import (
     check_llm_model_availability,
     current_user,
@@ -101,23 +101,16 @@ async def list_models(
 
 
 def __prepare_sources(request: Request, docs: list, web_results: list | None = None):
+    def static_url(filename: str) -> str:
+        return str(request.url_for("static", path=filename))
+
+    def chunk_url(extract_id) -> str:
+        return str(request.url_for("get_extract", extract_id=extract_id))
+
     links = []
     for doc in docs:
         doc_metadata = dict(doc.metadata)
-        source = doc_metadata.get("source") or ""
-        filename = Path(source).name
-        encoded_url = None
-        if filename:
-            file_url = str(request.url_for("static", path=filename))
-            encoded_url = quote(file_url, safe=":/")
-        links.append(
-            {
-                "source_type": "document",
-                **({"file_url": encoded_url} if encoded_url else {}),
-                "chunk_url": str(request.url_for("get_extract", extract_id=doc_metadata["_id"])),
-                **doc_metadata,
-            }
-        )
+        links.append(build_document_source_link(doc_metadata, static_url, chunk_url))
     for result in web_results or []:
         url = sanitize_text(result.url or "")
         if not url or urlparse(url).scheme not in ("http", "https"):

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -106,12 +106,14 @@ def __prepare_sources(request: Request, docs: list, web_results: list | None = N
         doc_metadata = dict(doc.metadata)
         source = doc_metadata.get("source") or ""
         filename = Path(source).name
-        file_url = str(request.url_for("static", path=filename))
-        encoded_url = quote(file_url, safe=":/")
+        encoded_url = None
+        if filename:
+            file_url = str(request.url_for("static", path=filename))
+            encoded_url = quote(file_url, safe=":/")
         links.append(
             {
                 "source_type": "document",
-                "file_url": encoded_url,
+                **({"file_url": encoded_url} if encoded_url else {}),
                 "chunk_url": str(request.url_for("get_extract", extract_id=doc_metadata["_id"])),
                 **doc_metadata,
             }

--- a/openrag/routers/source_links.py
+++ b/openrag/routers/source_links.py
@@ -1,0 +1,39 @@
+"""Pure helpers for assembling source-link dicts in API responses.
+
+Kept import-light (stdlib only) so the logic can be unit-tested without
+importing ``routers/openai.py``, which pulls in Ray, the audio loaders, and
+the OpenAI SDK.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from urllib.parse import quote
+
+
+def build_document_source_link(
+    doc_metadata: dict,
+    static_url_builder: Callable[[str], str],
+    chunk_url_builder: Callable[[str], str],
+) -> dict:
+    """Build the response dict for one document source.
+
+    ``file_url`` is emitted only when the metadata yields a non-empty
+    filename, so a missing/empty ``source`` never produces a static URL with
+    an empty path. The static URL is percent-encoded.
+
+    Args:
+        doc_metadata: The chunk metadata (must contain ``_id``).
+        static_url_builder: Maps a filename to its static file URL.
+        chunk_url_builder: Maps an extract id to its chunk URL.
+    """
+    source = doc_metadata.get("source") or ""
+    filename = Path(source).name
+    encoded_url = None
+    if filename:
+        encoded_url = quote(static_url_builder(filename), safe=":/")
+    return {
+        "source_type": "document",
+        **({"file_url": encoded_url} if encoded_url else {}),
+        "chunk_url": chunk_url_builder(doc_metadata["_id"]),
+        **doc_metadata,
+    }

--- a/openrag/routers/test_openai_prepare_sources.py
+++ b/openrag/routers/test_openai_prepare_sources.py
@@ -1,0 +1,47 @@
+"""Regression test for #370 — Path(None) guard in chunk-source rendering.
+
+We mirror the relevant logic from ``routers/openai.py::__prepare_sources``
+rather than importing the router (which pulls in Ray, langchain_openai,
+and the real ``openai`` package — and the file being named ``openai.py``
+creates a circular-import hazard when imported from a test).
+
+The bug: ``Path(doc_metadata.get(\"source\")).name`` raises TypeError when
+the ``source`` key is missing. The fix coerces a missing value to ``\"\"``
+before constructing the Path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _prepare_sources_filename(doc_metadata: dict) -> str:
+    """Mirror of the fixed logic in routers/openai.py::__prepare_sources."""
+    source = doc_metadata.get("source") or ""
+    return Path(source).name
+
+
+def test_filename_handles_missing_source_key():
+    assert _prepare_sources_filename({}) == ""
+    assert _prepare_sources_filename({"_id": "x"}) == ""
+
+
+def test_filename_handles_none_source_value():
+    assert _prepare_sources_filename({"source": None}) == ""
+
+
+def test_filename_handles_empty_source_value():
+    assert _prepare_sources_filename({"source": ""}) == ""
+
+
+def test_filename_extracts_basename_when_present():
+    assert _prepare_sources_filename({"source": "/srv/data/doc.pdf"}) == "doc.pdf"
+    assert _prepare_sources_filename({"source": "doc.pdf"}) == "doc.pdf"
+
+
+def test_buggy_form_used_to_raise():
+    """Sanity check that the *old* code path would indeed crash —
+    this documents what the fix protected against.
+    """
+    with pytest.raises(TypeError):
+        Path(None).name  # noqa: B018  — invocation has the side effect we test

--- a/openrag/routers/test_openai_prepare_sources.py
+++ b/openrag/routers/test_openai_prepare_sources.py
@@ -21,6 +21,16 @@ def _prepare_sources_filename(doc_metadata: dict) -> str:
     return Path(source).name
 
 
+def _emits_file_url(doc_metadata: dict) -> bool:
+    """Mirror of the file_url inclusion decision in __prepare_sources.
+
+    ``file_url`` is only emitted when there is an actual filename, so an
+    empty/missing source never produces a static URL with an empty path.
+    """
+    source = doc_metadata.get("source") or ""
+    return bool(Path(source).name)
+
+
 def test_filename_handles_missing_source_key():
     assert _prepare_sources_filename({}) == ""
     assert _prepare_sources_filename({"_id": "x"}) == ""
@@ -37,6 +47,16 @@ def test_filename_handles_empty_source_value():
 def test_filename_extracts_basename_when_present():
     assert _prepare_sources_filename({"source": "/srv/data/doc.pdf"}) == "doc.pdf"
     assert _prepare_sources_filename({"source": "doc.pdf"}) == "doc.pdf"
+
+
+def test_file_url_omitted_when_source_missing_or_empty():
+    assert _emits_file_url({}) is False
+    assert _emits_file_url({"source": None}) is False
+    assert _emits_file_url({"source": ""}) is False
+
+
+def test_file_url_emitted_when_source_present():
+    assert _emits_file_url({"source": "/srv/data/doc.pdf"}) is True
 
 
 def test_buggy_form_used_to_raise():

--- a/openrag/routers/test_openai_prepare_sources.py
+++ b/openrag/routers/test_openai_prepare_sources.py
@@ -1,67 +1,61 @@
-"""Regression test for #370 — Path(None) guard in chunk-source rendering.
+"""Regression test for #370 — document source-link building.
 
-We mirror the relevant logic from ``routers/openai.py::__prepare_sources``
-rather than importing the router (which pulls in Ray, langchain_openai,
-and the real ``openai`` package — and the file being named ``openai.py``
-creates a circular-import hazard when imported from a test).
+These tests exercise the real ``build_document_source_link`` helper used by
+``routers/openai.py::__prepare_sources``. The helper lives in the
+import-light ``routers/source_links`` module so it can be tested without
+importing ``routers/openai.py`` (which pulls in Ray, the audio loaders, and
+the OpenAI SDK).
 
-The bug: ``Path(doc_metadata.get(\"source\")).name`` raises TypeError when
-the ``source`` key is missing. The fix coerces a missing value to ``\"\"``
-before constructing the Path.
+Covered:
+- ``Path(source)`` must not crash when ``source`` is missing/None (the #370 bug).
+- ``file_url`` must be omitted when there is no filename, and present and
+  URL-encoded when there is.
 """
 
-from pathlib import Path
-
-import pytest
+from routers.source_links import build_document_source_link
 
 
-def _prepare_sources_filename(doc_metadata: dict) -> str:
-    """Mirror of the fixed logic in routers/openai.py::__prepare_sources."""
-    source = doc_metadata.get("source") or ""
-    return Path(source).name
+def _static(filename: str) -> str:
+    return f"https://host/static/{filename}"
 
 
-def _emits_file_url(doc_metadata: dict) -> bool:
-    """Mirror of the file_url inclusion decision in __prepare_sources.
-
-    ``file_url`` is only emitted when there is an actual filename, so an
-    empty/missing source never produces a static URL with an empty path.
-    """
-    source = doc_metadata.get("source") or ""
-    return bool(Path(source).name)
+def _chunk(extract_id) -> str:
+    return f"https://host/extract/{extract_id}"
 
 
-def test_filename_handles_missing_source_key():
-    assert _prepare_sources_filename({}) == ""
-    assert _prepare_sources_filename({"_id": "x"}) == ""
+def _build(doc_metadata: dict) -> dict:
+    return build_document_source_link(doc_metadata, _static, _chunk)
 
 
-def test_filename_handles_none_source_value():
-    assert _prepare_sources_filename({"source": None}) == ""
+def test_missing_source_key_does_not_crash_and_omits_file_url():
+    link = _build({"_id": "x"})
+    assert link["source_type"] == "document"
+    assert "file_url" not in link
+    assert link["chunk_url"] == "https://host/extract/x"
 
 
-def test_filename_handles_empty_source_value():
-    assert _prepare_sources_filename({"source": ""}) == ""
+def test_none_source_value_omits_file_url():
+    link = _build({"_id": "x", "source": None})
+    assert "file_url" not in link
 
 
-def test_filename_extracts_basename_when_present():
-    assert _prepare_sources_filename({"source": "/srv/data/doc.pdf"}) == "doc.pdf"
-    assert _prepare_sources_filename({"source": "doc.pdf"}) == "doc.pdf"
+def test_empty_source_value_omits_file_url():
+    link = _build({"_id": "x", "source": ""})
+    assert "file_url" not in link
 
 
-def test_file_url_omitted_when_source_missing_or_empty():
-    assert _emits_file_url({}) is False
-    assert _emits_file_url({"source": None}) is False
-    assert _emits_file_url({"source": ""}) is False
+def test_file_url_emitted_and_encoded_when_source_present():
+    link = _build({"_id": "x", "source": "/srv/data/my doc.pdf"})
+    # basename only, with spaces percent-encoded by quote()
+    assert link["file_url"] == "https://host/static/my%20doc.pdf"
 
 
-def test_file_url_emitted_when_source_present():
-    assert _emits_file_url({"source": "/srv/data/doc.pdf"}) is True
+def test_basename_extracted_from_path():
+    link = _build({"_id": "x", "source": "/srv/data/doc.pdf"})
+    assert link["file_url"] == "https://host/static/doc.pdf"
 
 
-def test_buggy_form_used_to_raise():
-    """Sanity check that the *old* code path would indeed crash —
-    this documents what the fix protected against.
-    """
-    with pytest.raises(TypeError):
-        Path(None).name  # noqa: B018  — invocation has the side effect we test
+def test_metadata_is_passed_through():
+    link = _build({"_id": "x", "source": "doc.pdf", "author": "alice"})
+    assert link["author"] == "alice"
+    assert link["chunk_url"] == "https://host/extract/x"


### PR DESCRIPTION
## Summary

`routers/openai.py:107` (`__prepare_sources`) builds the displayed filename via `Path(doc_metadata.get(\"source\")).name`. When the metadata key is absent, `dict.get` returns `None` and `Path(None)` raises `TypeError`, crashing the response handler with a 500 instead of either omitting the link or showing a placeholder.

This affects retrieval results that lack `source` (older partitions, web-search results inserted by `_prepare_for_web_only`, or chunks from loaders that forget to set the field).

This PR defaults the missing key to an empty string before constructing the `Path`.

## Test plan

- [ ] Issue a chat completion with a chunk whose metadata has no `source` key and confirm the response is rendered (with empty filename) rather than 500
- [ ] Verify existing chat completions still produce correct filenames

Fixes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or empty source metadata so filename extraction no longer fails; file links are now included only when a valid source exists, while chunk links remain stable.
* **Tests**
  * Added regression tests covering missing, empty, and present source metadata, URL encoding of filenames, and metadata passthrough.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->