### PR TITLE
fix(auth): tighten /chainlit bypass to exact path or subtree (#359)

### DIFF
--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -93,7 +93,7 @@ def is_ui_path(path: str) -> bool:
 
 
 def is_bypass_path(path: str) -> bool:
-    return path in _BYPASS_PATHS or path.startswith("/chainlit")
+    return path in _BYPASS_PATHS or path == "/chainlit" or path.startswith("/chainlit/")
 
 
 class AuthMiddleware(BaseHTTPMiddleware):

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -496,3 +496,24 @@ class TestRefreshHelper:
             out = await refresh_session_if_needed(session=stale_session, enc_key="k", vectordb=vdb)
 
         assert out is None
+
+
+# ---------------------------------------------------------------------------
+# is_bypass_path — regression for #359 (chainlit prefix bypass tightening)
+# ---------------------------------------------------------------------------
+
+
+def test_is_bypass_path_chainlit_subtree_only():
+    """Only the actual /chainlit subtree may bypass auth — not /chainlitevil."""
+    from components.auth.middleware import is_bypass_path
+
+    # Legitimate Chainlit paths still bypass
+    assert is_bypass_path("/chainlit") is True
+    assert is_bypass_path("/chainlit/") is True
+    assert is_bypass_path("/chainlit/login") is True
+    assert is_bypass_path("/chainlit/anything/deep") is True
+
+    # The bug from #359: any prefix-shared path used to bypass auth
+    assert is_bypass_path("/chainlitevil") is False
+    assert is_bypass_path("/chainlit-spoof") is False
+    assert is_bypass_path("/chainlitX") is False

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -513,7 +513,7 @@ def test_is_bypass_path_chainlit_subtree_only():
     assert is_bypass_path("/chainlit/login") is True
     assert is_bypass_path("/chainlit/anything/deep") is True
 
-    # The bug from #359: any prefix-shared path used to bypass auth
+    # Paths that merely share the /chainlit prefix must not bypass auth
     assert is_bypass_path("/chainlitevil") is False
     assert is_bypass_path("/chainlit-spoof") is False
     assert is_bypass_path("/chainlitX") is False


### PR DESCRIPTION
## Summary

`openrag/components/auth/middleware.py:96` returned `path in _BYPASS_PATHS or path.startswith(\"/chainlit\")`. The `startswith` check has no boundary character, so requests to `/chainlitevil`, `/chainlit-spoof`, or any future route that happens to share the prefix bypassed authentication entirely.

This PR replaces the prefix check with `path == \"/chainlit\" or path.startswith(\"/chainlit/\")` so only the actual Chainlit subtree skips auth.

## Test plan

- [ ] `/chainlit` and `/chainlit/foo` continue to bypass auth as before
- [ ] `/chainlitevil` returns 401 (token mode) or 302 to `/auth/login` (OIDC mode)

Fixes #359