### PR TITLE
fix(partition): require admin for POST /partition/{name} (#358)

### DIFF
--- a/openrag/routers/partition.py
+++ b/openrag/routers/partition.py
@@ -22,6 +22,7 @@ from utils.logger import get_logger
 from .utils import (
     ROLE_HIERARCHY,
     partitions_with_details,
+    require_admin,
     require_partition_owner,
     require_partition_viewer,
 )
@@ -234,6 +235,7 @@ Returns 409 Conflict if partition already exists.
 async def create_partition(
     request: Request,
     partition: str,
+    _=Depends(require_admin),
     service: PartitionService = Depends(get_partition_service),
 ):
     if await service.partition_exists(partition):

--- a/tests/api_tests/test_indexer.py
+++ b/tests/api_tests/test_indexer.py
@@ -385,24 +385,25 @@ class TestUserQuotaEnforcement:
         return response.json()
 
     def _create_partition(self, api_client, partition_name: str, user_token: str):
-        """Helper to create a partition and grant the test user editor access.
+        """Helper to create a partition and promote the test user to owner.
 
         POST /partition/{name} requires admin since the RBAC tightening; the
         api_client fixture already carries the admin token. After creating the
-        partition we add the per-test user as an editor so subsequent upload
-        / delete calls authorized with their token still hit a partition they
-        can write to.
+        partition we promote the per-test user to owner so subsequent test
+        operations (member management, partition delete) authorized with the
+        user's own token keep the same capabilities they had before the
+        admin-only partition gate.
         """
         # Create as admin (api_client default headers carry AUTH_TOKEN).
         response = api_client.post(f"/partition/{partition_name}")
         assert response.status_code in [200, 201], f"Failed to create partition: {response.text}"
-        # Look up the user behind user_token and grant them editor on the partition.
+        # Look up the user behind user_token and promote them to owner.
         info = api_client.get("/users/info", headers={"Authorization": f"Bearer {user_token}"})
         assert info.status_code == 200, f"Failed to resolve user: {info.text}"
         user_id = info.json()["id"]
         grant = api_client.post(
             f"/partition/{partition_name}/users",
-            data={"user_id": user_id, "role": "editor"},
+            data={"user_id": user_id, "role": "owner"},
         )
         assert grant.status_code in [200, 201, 204], f"Failed to grant access: {grant.text}"
 

--- a/tests/api_tests/test_indexer.py
+++ b/tests/api_tests/test_indexer.py
@@ -385,13 +385,26 @@ class TestUserQuotaEnforcement:
         return response.json()
 
     def _create_partition(self, api_client, partition_name: str, user_token: str):
-        """Helper to create a partition for user user given its token."""
-        # Create partition as the user
-        response = api_client.post(
-            f"/partition/{partition_name}",
-            headers={"Authorization": f"Bearer {user_token}"},
-        )
+        """Helper to create a partition and grant the test user editor access.
+
+        POST /partition/{name} requires admin since the RBAC tightening; the
+        api_client fixture already carries the admin token. After creating the
+        partition we add the per-test user as an editor so subsequent upload
+        / delete calls authorized with their token still hit a partition they
+        can write to.
+        """
+        # Create as admin (api_client default headers carry AUTH_TOKEN).
+        response = api_client.post(f"/partition/{partition_name}")
         assert response.status_code in [200, 201], f"Failed to create partition: {response.text}"
+        # Look up the user behind user_token and grant them editor on the partition.
+        info = api_client.get("/users/info", headers={"Authorization": f"Bearer {user_token}"})
+        assert info.status_code == 200, f"Failed to resolve user: {info.text}"
+        user_id = info.json()["id"]
+        grant = api_client.post(
+            f"/partition/{partition_name}/users",
+            data={"user_id": user_id, "role": "editor"},
+        )
+        assert grant.status_code in [200, 201, 204], f"Failed to grant access: {grant.text}"
 
     def _upload_file(self, api_client, partition: str, file_id: str, user_token: str, content: str = "Test content"):
         """Helper to upload a file as a specific user."""

--- a/tests/api_tests/test_indexer.py
+++ b/tests/api_tests/test_indexer.py
@@ -396,7 +396,7 @@ class TestUserQuotaEnforcement:
         """
         # Create as admin (api_client default headers carry AUTH_TOKEN).
         response = api_client.post(f"/partition/{partition_name}")
-        assert response.status_code in [200, 201], f"Failed to create partition: {response.text}"
+        assert response.status_code == 201, f"Failed to create partition: {response.text}"
         # Look up the user behind user_token and promote them to owner.
         info = api_client.get("/users/info", headers={"Authorization": f"Bearer {user_token}"})
         assert info.status_code == 200, f"Failed to resolve user: {info.text}"
@@ -405,7 +405,7 @@ class TestUserQuotaEnforcement:
             f"/partition/{partition_name}/users",
             data={"user_id": user_id, "role": "owner"},
         )
-        assert grant.status_code in [200, 201, 204], f"Failed to grant access: {grant.text}"
+        assert grant.status_code == 201, f"Failed to grant access: {grant.text}"
 
     def _upload_file(self, api_client, partition: str, file_id: str, user_token: str, content: str = "Test content"):
         """Helper to upload a file as a specific user."""


### PR DESCRIPTION
## Summary

`routers/partition.py` declared `create_partition` with only `request: Request` and a `PartitionService` dependency. No role dependency was attached, so any authenticated non-admin user could `POST /partition/{name}` to create arbitrary partitions and be recorded as the owner, bypassing the RBAC model documented in `CLAUDE.md`.

This PR adds `_=Depends(require_admin)` to the route signature.

## Test plan

- [ ] Admin user can still create partitions
- [ ] Non-admin user gets 403 when calling POST /partition/{name}

Fixes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partition creation is now restricted to administrators only, enforcing stricter authorization controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->