### PR TITLE
fix(websearch): enable TLS verification by default (#382)

### DIFF
--- a/openrag/components/websearch/test_content_fetcher.py
+++ b/openrag/components/websearch/test_content_fetcher.py
@@ -173,9 +173,8 @@ class TestEnrichResults:
 def test_fetch_verify_ssl_default_is_true():
     """TLS verification must be enabled by default for any web-search fetch.
 
-    The previous default was ``False`` which made every server-side fetch
-    of a web-search result skip TLS verification, exposing citation
-    contents to silent MITM tampering. The default must be ``True``.
+    ``fetch_verify_ssl`` defaults to ``True`` so server-side fetches of
+    web-search results verify TLS unless an operator opts out.
     """
     from config.models import StaanWebSearchConfig
 

--- a/openrag/components/websearch/test_content_fetcher.py
+++ b/openrag/components/websearch/test_content_fetcher.py
@@ -163,3 +163,21 @@ class TestEnrichResults:
             enriched = await fetcher.enrich(results)
 
         assert enriched[0].content is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_verify_ssl default — regression for #382
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_verify_ssl_default_is_true():
+    """TLS verification must be enabled by default for any web-search fetch.
+
+    The previous default was ``False`` which made every server-side fetch
+    of a web-search result skip TLS verification, exposing citation
+    contents to silent MITM tampering. The default must be ``True``.
+    """
+    from config.models import StaanWebSearchConfig
+
+    cfg = StaanWebSearchConfig()
+    assert cfg.fetch_verify_ssl is True

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -484,7 +484,7 @@ class _BaseWebSearchConfig(ConfigMixin):
     fetch_max_results: int = 3
     fetch_timeout: float = 1.0
     fetch_max_tokens: int = 500
-    fetch_verify_ssl: bool = False
+    fetch_verify_ssl: bool = True
 
 
 class StaanWebSearchConfig(_BaseWebSearchConfig):


### PR DESCRIPTION
## Summary

`_BaseWebSearchConfig.fetch_verify_ssl` defaulted to `False`, and `ContentFetcher` passed that value straight into `httpx.AsyncClient(verify=...)`. Every server-side fetch of a web search result skipped TLS verification by default, leaving citation contents open to silent man-in-the-middle tampering even when `WEBSEARCH_API_TOKEN` was configured against an HTTPS provider.

This PR flips the default to `True`. Operators who legitimately need self-signed hosts can still opt out via the existing config knob.

## Test plan

- [ ] Confirm web search continues to work against the default Staan provider (which uses a valid cert)
- [ ] Confirm that an operator setting `websearch.fetch_verify_ssl: false` in their config still gets the previous behavior

Fixes #382