### PR TITLE
fix(oidc): require azp == client_id on multi-audience ID tokens (#385)

### DIFF
--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -284,9 +284,7 @@ class TestExchangeCode:
         _setup_jwks(client._mock_router)
 
         nonce = "n-azp-ok"
-        id_token = _sign_jwt(
-            _id_token_payload(nonce, extra={"aud": [CLIENT_ID, "other-client"], "azp": CLIENT_ID})
-        )
+        id_token = _sign_jwt(_id_token_payload(nonce, extra={"aud": [CLIENT_ID, "other-client"], "azp": CLIENT_ID}))
         token_response = {
             "id_token": id_token,
             "access_token": "at",

--- a/openrag/components/auth/test_oidc_client.py
+++ b/openrag/components/auth/test_oidc_client.py
@@ -253,6 +253,54 @@ class TestExchangeCode:
         with pytest.raises(ValueError, match="nonce"):
             await client.exchange_code(code="code", code_verifier="v", expected_nonce="wrong-nonce")
 
+    # OIDC Core 1.0 §3.1.3.7: when aud lists multiple audiences, azp MUST
+    # be present and equal to client_id. Regression for #385.
+    @pytest.mark.asyncio
+    async def test_multi_aud_requires_matching_azp(self, client):
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
+
+        nonce = "n-azp"
+        # Multi-aud token with the wrong (or missing) azp must be rejected
+        id_token = _sign_jwt(
+            _id_token_payload(nonce, extra={"aud": [CLIENT_ID, "other-client"], "azp": "other-client"})
+        )
+        token_response = {
+            "id_token": id_token,
+            "access_token": "at",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        with pytest.raises(ValueError, match="multi-aud"):
+            await client.exchange_code(code="code", code_verifier="v", expected_nonce=nonce)
+
+    @pytest.mark.asyncio
+    async def test_multi_aud_with_correct_azp_passes(self, client):
+        _setup_discovery(client._mock_router)
+        _setup_jwks(client._mock_router)
+
+        nonce = "n-azp-ok"
+        id_token = _sign_jwt(
+            _id_token_payload(nonce, extra={"aud": [CLIENT_ID, "other-client"], "azp": CLIENT_ID})
+        )
+        token_response = {
+            "id_token": id_token,
+            "access_token": "at",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+        client._mock_router.post(f"{ISSUER}/protocol/openid-connect/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        bundle = await client.exchange_code(code="code", code_verifier="v", expected_nonce=nonce)
+        assert bundle.claims["aud"] == [CLIENT_ID, "other-client"]
+        assert bundle.claims["azp"] == CLIENT_ID
+
 
 # ---------------------------------------------------------------------------
 # Token refresh

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -291,9 +291,7 @@ class OIDCClient:
             if len(aud) > 1:
                 azp = decoded.get("azp")
                 if azp != self.client_id:
-                    raise ValueError(
-                        f"ID token has multi-aud {aud!r} but azp {azp!r} != client_id {self.client_id!r}"
-                    )
+                    raise ValueError(f"ID token has multi-aud {aud!r} but azp {azp!r} != client_id {self.client_id!r}")
         elif aud != self.client_id:
             raise ValueError(f"ID token aud {aud!r} != client_id {self.client_id!r}")
 

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -286,6 +286,14 @@ class OIDCClient:
         if isinstance(aud, list):
             if self.client_id not in aud:
                 raise ValueError(f"ID token aud {aud!r} does not contain client_id {self.client_id!r}")
+            # OIDC Core 1.0 §3.1.3.7: when aud lists multiple audiences, azp
+            # MUST be present and equal to client_id.
+            if len(aud) > 1:
+                azp = decoded.get("azp")
+                if azp != self.client_id:
+                    raise ValueError(
+                        f"ID token has multi-aud {aud!r} but azp {azp!r} != client_id {self.client_id!r}"
+                    )
         elif aud != self.client_id:
             raise ValueError(f"ID token aud {aud!r} != client_id {self.client_id!r}")
 


### PR DESCRIPTION
## Summary

`services/auth/oidc_client.py` only checked `client_id in aud` when `aud` was a JSON array. Per OIDC Core 1.0 §3.1.3.7, a token whose `aud` lists multiple audiences must also contain an `azp` claim equal to the RP's `client_id`. Without that check, a token issued by the same IdP for a sibling client that happened to include this client in its audience list was accepted, letting one tenant's tokens authenticate against another tenant's sessions.

This PR adds the `azp` validation branch in the ID token verifier. (The logout-token verifier is intentionally left alone for now: back-channel logout already requires a matching session id and is a different threat model — happy to apply the same change there if reviewers prefer.)

## Test plan

- [ ] Single-audience tokens (the common case) continue to validate
- [ ] Multi-audience token with `azp == client_id` validates
- [ ] Multi-audience token with missing or mismatched `azp` is rejected

Fixes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened OpenID Connect multi-audience ID token validation by requiring the authorized party claim to match the client ID when multiple audiences are present.

* **Tests**
  * Added unit tests validating multi-audience ID token rejection and acceptance based on authorized party claim verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->