### PR TITLE
fix(oidc): verify userinfo.sub matches id_token.sub before claim mapping (#386)

### DIFF
--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -573,6 +573,14 @@ class AuthService:
             except Exception as e:
                 logger.warning(f"OIDC userinfo fetch failed: {e}")
                 raise OIDCFlowError("Failed to fetch userinfo from IdP.") from e
+            # OIDC Core 1.0 §5.3.2: verify userinfo.sub matches id_token.sub
+            # before trusting any userinfo claim, to defend against userinfo
+            # response substitution.
+            id_token_sub = bundle.claims.get("sub") if isinstance(bundle.claims, dict) else None
+            userinfo_sub = claims_for_mapping.get("sub") if isinstance(claims_for_mapping, dict) else None
+            if not userinfo_sub or userinfo_sub != id_token_sub:
+                logger.warning("OIDC userinfo sub mismatch — refusing claim mapping")
+                raise OIDCFlowError("Userinfo sub does not match ID token sub.")
         else:
             claims_for_mapping = bundle.claims
 

--- a/openrag/services/orchestrators/test_auth_service.py
+++ b/openrag/services/orchestrators/test_auth_service.py
@@ -268,7 +268,9 @@ async def test_claim_mapping_from_userinfo_updates_user():
     urepo = FakeUserRepo({"kc-c": user})
     client = FakeOIDCClient(
         bundle=_bundle(claims={"sub": "kc-c", "sid": "s"}),
-        userinfo={"mail": "new@x.io"},
+        # OIDC Core 1.0 §5.3.2: userinfo must echo the same sub as the
+        # id_token before claim mapping is allowed.
+        userinfo={"sub": "kc-c", "mail": "new@x.io"},
     )
     svc = _service(
         user_repo=urepo,
@@ -279,6 +281,26 @@ async def test_claim_mapping_from_userinfo_updates_user():
     await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
 
     assert urepo.updated and urepo.updated[0][1] == {"email": "new@x.io"}
+
+
+@pytest.mark.asyncio
+async def test_claim_mapping_rejects_userinfo_sub_mismatch():
+    user = User(id=9, display_name="Old", external_user_id="kc-c", email="old@x.io")
+    urepo = FakeUserRepo({"kc-c": user})
+    client = FakeOIDCClient(
+        bundle=_bundle(claims={"sub": "kc-c", "sid": "s"}),
+        # userinfo sub differs from id_token sub — token-substitution scenario.
+        userinfo={"sub": "kc-attacker", "mail": "evil@x.io"},
+    )
+    svc = _service(
+        user_repo=urepo,
+        client=client,
+        cfg=_cfg(claim_source="userinfo", claim_mapping="email:mail"),
+    )
+    state, cookie = await _login_and_get_state(svc)
+    with pytest.raises(OIDCFlowError, match="Userinfo sub does not match"):
+        await svc.handle_oidc_callback(code="abc", state=state, state_cookie_raw=cookie)
+    assert not urepo.updated
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

When `OIDC_CLAIM_SOURCE=userinfo`, `_apply_claim_mapping` in `services/orchestrators/auth_service.py` fetched `claims_for_mapping` from the `/userinfo` endpoint and fed them straight into the claim-mapping write path. OIDC Core 1.0 §5.3.2 requires the RP to verify that `userinfo.sub == id_token.sub` before trusting any userinfo claim. Without that check, a malformed userinfo response or a token-substitution attack at the userinfo endpoint could rewrite the matched user's `display_name` and `email` on every login.

This PR adds the `sub` binding check and aborts the callback with `OIDCFlowError` on mismatch.

## Test plan

- [ ] Login with `OIDC_CLAIM_SOURCE=userinfo` and matching subs continues to succeed and update claims
- [ ] Mocked userinfo response with a different `sub` raises `OIDCFlowError`
- [ ] `OIDC_CLAIM_SOURCE=id_token` (the default) is unaffected

Fixes #386