### PR TITLE
fix(auth): don't rotate the admin token on every startup (#361)

### DIFF
--- a/openrag/components/indexer/vectordb/test_ensure_admin_user.py
+++ b/openrag/components/indexer/vectordb/test_ensure_admin_user.py
@@ -1,0 +1,67 @@
+"""Regression test for #361 — _ensure_admin_user must not rotate the admin
+token on every startup when AUTH_TOKEN is unset.
+
+Previously the bootstrap generated a fresh ``or-`` token whenever
+``AUTH_TOKEN`` was unset and unconditionally overwrote the existing row.
+That invalidated any token issued via ``POST /users/1/regenerate_token``
+on every container restart, with no audit trail.
+"""
+
+import pytest
+from components.indexer.vectordb.models import Base, User
+from components.indexer.vectordb.utils import PartitionFileManager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from utils.logger import get_logger
+
+
+@pytest.fixture()
+def pfm():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    mgr = PartitionFileManager.__new__(PartitionFileManager)
+    mgr.engine = engine
+    mgr.Session = Session
+    mgr.logger = get_logger()
+    mgr.file_quota_per_user = -1
+    yield mgr
+    engine.dispose()
+
+
+def test_first_call_creates_admin_with_provided_token(pfm):
+    pfm._ensure_admin_user("or-static-token")
+    with pfm.Session() as s:
+        admin = s.query(User).filter_by(id=1).first()
+        assert admin is not None
+        assert admin.is_admin is True
+        assert admin.token == pfm.hash_token("or-static-token")
+
+
+def test_restart_with_no_auth_token_preserves_existing_token(pfm):
+    # Bootstrap with a fresh row + explicit token
+    pfm._ensure_admin_user("or-original")
+    with pfm.Session() as s:
+        orig_hash = s.query(User).filter_by(id=1).first().token
+
+    # Simulate a /users/1/regenerate_token rotation
+    new_hash = pfm.hash_token("or-rotated")
+    with pfm.Session() as s:
+        admin = s.query(User).filter_by(id=1).first()
+        admin.token = new_hash
+        s.commit()
+
+    # "Restart" with AUTH_TOKEN unset — must NOT overwrite the rotated token
+    pfm._ensure_admin_user("")
+    with pfm.Session() as s:
+        kept = s.query(User).filter_by(id=1).first().token
+    assert kept == new_hash, "rotated admin token was clobbered on restart"
+    assert kept != orig_hash
+
+
+def test_restart_with_auth_token_syncs_db_to_env(pfm):
+    pfm._ensure_admin_user("or-old")
+    pfm._ensure_admin_user("or-new")
+    with pfm.Session() as s:
+        admin = s.query(User).filter_by(id=1).first()
+    assert admin.token == pfm.hash_token("or-new")

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -54,25 +54,36 @@ class PartitionFileManager:
             )
 
     def _ensure_admin_user(self, admin_token: str):
-        if not admin_token:
-            admin_token = f"or-{secrets.token_hex(16)}"
-        hashed_token = self.hash_token(admin_token)
         with self.Session() as s:
             admin = s.query(User).filter_by(id=1).first()
             if not admin:
+                # Brand-new bootstrap: use AUTH_TOKEN if provided, else
+                # generate a one-shot token. Either way, persist it.
+                token = admin_token or f"or-{secrets.token_hex(16)}"
                 admin = User(
                     display_name="Admin",
-                    token=hashed_token,
+                    token=self.hash_token(token),
                     is_admin=True,
                 )
                 s.add(admin)
                 s.commit()
                 self.logger.info("Created admin user")
-            else:
+            elif admin_token:
+                # Operator-provided AUTH_TOKEN is authoritative: keep DB in sync.
                 admin.is_admin = True
-                admin.token = hashed_token
+                admin.token = self.hash_token(admin_token)
                 s.commit()
-                self.logger.info("Upgraded existing user to admin")
+                self.logger.info("Synced admin user with AUTH_TOKEN")
+            else:
+                # No AUTH_TOKEN: leave the persisted token untouched so admin
+                # clients and regenerated tokens survive container restarts.
+                if not admin.is_admin:
+                    admin.is_admin = True
+                    s.commit()
+                self.logger.warning(
+                    "AUTH_TOKEN unset; keeping previously stored admin token. "
+                    "Set AUTH_TOKEN to pin a static admin token across restarts."
+                )
 
     def list_partition_files(self, partition: str, limit: int | None = None):
         """List files in a partition with optional limit - Optimized by querying File table directly"""

--- a/openrag/services/persistence/user_repo.py
+++ b/openrag/services/persistence/user_repo.py
@@ -380,30 +380,36 @@ class PgUserRepository(UserRepository):
         token hash matching ``admin_token``. Generates a token if none
         is supplied. Returns whichever plaintext token is now valid.
         """
-        plaintext = admin_token or f"or-{secrets.token_hex(16)}"
-        token_hash = _hash_token(plaintext)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
-                existing = await conn.fetchrow("SELECT id FROM users WHERE id = 1")
+                existing = await conn.fetchrow("SELECT id, token FROM users WHERE id = 1")
                 if existing is None:
+                    plaintext = admin_token or f"or-{secrets.token_hex(16)}"
                     await conn.execute(
                         """
                         INSERT INTO users (id, display_name, token, is_admin, file_count, created_at)
                         VALUES (1, 'Admin', $1, TRUE, 0, NOW())
                         """,
-                        token_hash,
+                        _hash_token(plaintext),
                     )
                     # Keep the sequence ahead of the explicit id=1 insert so
                     # subsequent `INSERT INTO users` calls don't collide.
                     await conn.execute(
                         "SELECT setval(pg_get_serial_sequence('users','id'), GREATEST(1, (SELECT MAX(id) FROM users)))"
                     )
-                else:
+                    return plaintext
+                if admin_token:
+                    # Operator-provided AUTH_TOKEN is authoritative: keep DB in sync.
                     await conn.execute(
                         "UPDATE users SET is_admin = TRUE, token = $1 WHERE id = 1",
-                        token_hash,
+                        _hash_token(admin_token),
                     )
-        return plaintext
+                    return admin_token
+                # AUTH_TOKEN unset: preserve the previously stored token (and
+                # any /users/{id}/regenerate_token rotation) instead of
+                # silently invalidating every admin client on each restart.
+                await conn.execute("UPDATE users SET is_admin = TRUE WHERE id = 1")
+                return ""
 
     # ── Helpers ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`_ensure_admin_user` (legacy `PartitionFileManager` path) and `UserRepository.ensure_admin_user` (Phase 7 catalog path) generated a fresh `or-` token whenever `AUTH_TOKEN` was unset and unconditionally wrote it to the existing admin row. Every container restart therefore overwrote the value previously stored, including any token issued via `POST /users/{id}/regenerate_token` for user id 1, silently invalidating all admin clients and CI integrations with no audit trail.

After this PR:

- A brand-new admin row still gets a freshly generated token if no `AUTH_TOKEN` is provided
- If `AUTH_TOKEN` is set, it's written to the existing row to keep DB state in sync
- If `AUTH_TOKEN` is unset and the admin row already exists, the stored token is left untouched; the legacy path emits a single warning explaining how to pin a static token

## Test plan

- [ ] Fresh database + no `AUTH_TOKEN` → admin row created with a generated token, logged once
- [ ] Restart with no `AUTH_TOKEN` → admin token is preserved (regression test against the original bug)
- [ ] `AUTH_TOKEN` set → admin row's stored hash matches the env var on each restart
- [ ] `POST /users/1/regenerate_token` then restart with no `AUTH_TOKEN` → the regenerated token still works

Fixes #361