### PR TITLE
fix(indexing): return 422 when uploaded file part has no filename (#368)

### DIFF
--- a/openrag/core/indexing/test_validators.py
+++ b/openrag/core/indexing/test_validators.py
@@ -67,3 +67,15 @@ class TestValidateFileFormat:
         with pytest.raises(ValidationError) as exc:
             validate_file_format("img.exe", self.formats, self.mimetypes, mimetype="application/x-msdownload")
         assert exc.value.status_code == 415
+
+    # Regression for #368 — UploadFile.filename is str | None; a None or empty
+    # value must surface as a clean 422 instead of TypeError → 500.
+    def test_none_filename_raises_422(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_file_format(None, self.formats, self.mimetypes, mimetype="application/pdf")
+        assert exc.value.status_code == 422
+
+    def test_empty_filename_raises_422(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_file_format("", self.formats, self.mimetypes, mimetype="application/pdf")
+        assert exc.value.status_code == 422

--- a/openrag/core/indexing/validators.py
+++ b/openrag/core/indexing/validators.py
@@ -55,7 +55,7 @@ def validate_file_id(
 
 
 def validate_file_format(
-    filename: str,
+    filename: str | None,
     accepted_formats: Iterable[str],
     accepted_mimetypes: Iterable[str],
     mimetype: str | None = None,
@@ -63,8 +63,15 @@ def validate_file_format(
     """Validate the file by extension or mimetype.
 
     Returns the lowercased file extension (without the leading dot, possibly
-    empty). Raises ``ValidationError`` (HTTP 415) on rejection.
+    empty). Raises ``ValidationError`` (HTTP 415) on rejection, or
+    ``ValidationError`` (HTTP 422) when the filename is missing from the
+    multipart upload.
     """
+    if not filename:
+        raise ValidationError(
+            "Uploaded file part has no filename.",
+            status_code=422,
+        )
     file_extension = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
     formats = set(accepted_formats)
     mimetypes = set(accepted_mimetypes)


### PR DESCRIPTION
## Summary

`core/indexing/validators.py::validate_file_format` evaluated `\".\" in filename` to detect the extension, but FastAPI's `UploadFile.filename` is typed `str | None` and is `None` for any multipart part that omits the filename header. Such uploads produced `TypeError: argument of type 'NoneType' is not iterable`, which surfaced as a generic 500 and masked what was otherwise a simple client-side mistake.

This PR rejects a missing or empty filename with a clean `ValidationError(status_code=422, \"Uploaded file part has no filename.\")` before the substring check.

## Test plan

- [ ] Multipart upload with no filename header returns 422 with the new detail message
- [ ] Multipart upload with a regular filename continues to validate as before
- [ ] Existing `test_validators.py::TestValidateFileFormat` cases still pass

Fixes #368