### PR TITLE
fix(vectordb): refuse to auto-create partition with NULL owner (#371)

### DIFF
--- a/openrag/components/indexer/vectordb/test_add_file_to_partition_user_id.py
+++ b/openrag/components/indexer/vectordb/test_add_file_to_partition_user_id.py
@@ -1,0 +1,49 @@
+"""Regression test for #371 — add_file_to_partition must refuse to auto-create
+a partition when ``user_id`` is None. PartitionMembership.user_id is
+NOT NULL, so a None silently surfaced as IntegrityError at commit time
+and left the partition row half-created.
+"""
+
+import pytest
+from components.indexer.vectordb.models import Base, File, Partition
+from components.indexer.vectordb.utils import PartitionFileManager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from utils.logger import get_logger
+
+
+@pytest.fixture()
+def pfm():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    mgr = PartitionFileManager.__new__(PartitionFileManager)
+    mgr.engine = engine
+    mgr.Session = Session
+    mgr.logger = get_logger()
+    mgr.file_quota_per_user = -1
+    yield mgr
+    engine.dispose()
+
+
+def test_auto_create_refuses_when_user_id_is_none(pfm):
+    with pytest.raises(ValueError, match="without a user_id"):
+        pfm.add_file_to_partition(file_id="f1", partition="new-part", user_id=None)
+    # No partition row should be created
+    with pfm.Session() as s:
+        assert s.query(Partition).filter_by(partition="new-part").first() is None
+        assert s.query(File).filter_by(file_id="f1").first() is None
+
+
+def test_auto_create_succeeds_with_real_user_id(pfm):
+    # Seed a user the bootstrap can be tied to
+    from components.indexer.vectordb.models import User
+
+    with pfm.Session() as s:
+        s.add(User(id=42, display_name="u42", token="t42", is_admin=False))
+        s.commit()
+
+    pfm.add_file_to_partition(file_id="f1", partition="new-part", user_id=42)
+    with pfm.Session() as s:
+        assert s.query(Partition).filter_by(partition="new-part").first() is not None
+        assert s.query(File).filter_by(file_id="f1").first() is not None

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -130,6 +130,14 @@ class PartitionFileManager:
 
                 partition_obj = session.query(Partition).filter(Partition.partition == partition).first()
                 if not partition_obj:
+                    # Refuse to bootstrap a partition without a real owner —
+                    # PartitionMembership.user_id is NOT NULL, so a None here
+                    # only surfaces as an IntegrityError at commit time and
+                    # leaves the partition row half-created.
+                    if user_id is None:
+                        raise ValueError(
+                            f"Cannot create partition '{partition}' without a user_id for the owner row."
+                        )
                     partition_obj = Partition(partition=partition)
                     session.add(partition_obj)
                     log.info("Created new partition")

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -135,9 +135,7 @@ class PartitionFileManager:
                     # only surfaces as an IntegrityError at commit time and
                     # leaves the partition row half-created.
                     if user_id is None:
-                        raise ValueError(
-                            f"Cannot create partition '{partition}' without a user_id for the owner row."
-                        )
+                        raise ValueError(f"Cannot create partition '{partition}' without a user_id for the owner row.")
                     partition_obj = Partition(partition=partition)
                     session.add(partition_obj)
                     log.info("Created new partition")


### PR DESCRIPTION
## Summary

`add_file_to_partition` built `PartitionMembership(partition_name=..., user_id=user_id, role=\"owner\")` inside the partition auto-create branch with no guard that `user_id is not None`. `PartitionMembership.user_id` is `nullable=False`, so calling `add_file_to_partition(..., user_id=None, ...)` (the default in the function signature) raised `IntegrityError` at commit time and left the partition row half-created.

This PR validates `user_id` at the top of the auto-create branch and raises a clean `ValueError` so the caller can translate it to a proper HTTP 400 instead of an opaque IntegrityError.

## Test plan

- [ ] `add_file_to_partition(file_id, \"new-part\", user_id=None)` raises `ValueError` cleanly (no partition row created)
- [ ] `add_file_to_partition(file_id, \"new-part\", user_id=42)` continues to create the partition + owner row + file

Fixes #371