### PR TITLE
fix(vectordb): use random nonce for chunk section IDs to avoid collisions (#356)

### DIFF
--- a/openrag/components/indexer/vectordb/test_chunk_order_metadata.py
+++ b/openrag/components/indexer/vectordb/test_chunk_order_metadata.py
@@ -1,0 +1,40 @@
+"""Regression test for #356 — concurrent chunk section IDs must not collide.
+
+The previous implementation seeded every call with ``time.time_ns()`` and
+incremented by ``i``. Two ingestions starting within the same nanosecond
+produced overlapping integer ranges, corrupting prev/next_section_id
+navigation across documents. The fix replaces the seed with a
+cryptographically random 60-bit base.
+"""
+
+from components.indexer.vectordb.vectordb import _gen_chunk_order_metadata
+
+
+def test_two_concurrent_calls_have_disjoint_ranges():
+    a = _gen_chunk_order_metadata(n=200)
+    b = _gen_chunk_order_metadata(n=200)
+    ids_a = {row["section_id"] for row in a}
+    ids_b = {row["section_id"] for row in b}
+    assert ids_a.isdisjoint(ids_b)
+
+
+def test_ids_fit_in_int64():
+    rows = _gen_chunk_order_metadata(n=10_000)
+    int64_max = 2**63 - 1
+    for row in rows:
+        assert 0 <= row["section_id"] < int64_max
+
+
+def test_prev_next_chain_is_consistent_within_call():
+    rows = _gen_chunk_order_metadata(n=5)
+    section_ids = [row["section_id"] for row in rows]
+    # prev/next must reference adjacent neighbours from the same call
+    for i, row in enumerate(rows):
+        if i == 0:
+            assert row["prev_section_id"] is None
+        else:
+            assert row["prev_section_id"] == section_ids[i - 1]
+        if i == len(rows) - 1:
+            assert row["next_section_id"] is None
+        else:
+            assert row["next_section_id"] == section_ids[i + 1]

--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -1,5 +1,5 @@
 import asyncio
-import time
+import secrets
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from typing import Any
@@ -1277,9 +1277,17 @@ class MilvusDB(BaseVectorDB):
 
 
 def _gen_chunk_order_metadata(n: int = 20) -> list[dict]:
-    # Use base timestamp + index to ensure uniqueness
-    base_ts = int(time.time_ns())
-    ids: list[int] = [base_ts + i for i in range(n)]
+    # Two concurrent ingestions starting within the same nanosecond would
+    # otherwise produce overlapping integer ranges (base_ts + i collides
+    # across tasks), corrupting prev_section_id / next_section_id
+    # navigation by stitching together chunks from different documents.
+    # A cryptographically random 60-bit base makes the per-call ranges
+    # disjoint with overwhelming probability while staying well under the
+    # int64 ceiling Milvus uses for the section_id field. The
+    # prev/next_section_id navigation only needs ordering *within* a single
+    # call, so the lost wall-clock monotonicity across calls is fine.
+    base = secrets.randbits(60)
+    ids: list[int] = [base + i for i in range(n)]
     L = []
     for i in range(n):
         prev_chunk_id = ids[i - 1] if i > 0 else None


### PR DESCRIPTION
## Summary

`_gen_chunk_order_metadata` derived section IDs as `[time.time_ns() + i for i in range(n)]`. The Indexer Ray actor allows concurrent `add_file` calls under multiple concurrency groups, so two ingestions starting within the same nanosecond window produced overlapping integer ranges. Surrounding-chunk navigation through `prev_section_id` / `next_section_id` then crossed document boundaries, returning chunks from a different file when callers requested context expansion.

This PR uses a cryptographically random 60-bit base so two concurrent ingestions can never produce overlapping ranges. Birthday-collision probability over the 60-bit space at realistic ingestion volumes is effectively zero. The prev/next navigation only requires ordering *within* a single call, so the lost wall-clock-monotonic property across calls is fine.

## Test plan

- [ ] Two concurrent `add_file` calls produce disjoint section_id ranges
- [ ] Surrounding-chunk navigation still works within a single ingested document
- [ ] section_ids fit in the Milvus int64 column (60-bit values, no overflow)

Fixes #356