### PR TITLE
fix(loaders): cap nested .eml recursion depth in EmlLoader (#364)

### DIFF
--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -20,16 +20,16 @@ def json_serial(obj):
 
 
 class EmlLoader(BaseLoader):
-    # Cap how deeply nested .eml attachments may be processed; bounds the
-    # recursion when .eml files are nested inside one another.
-    MAX_EML_RECURSION_DEPTH = 5
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Store all kwargs for passing to sub-loaders
         self.kwargs = kwargs
         # Get available loaders for processing attachments
         self.loader_classes = get_loader_classes(config=self.config)
+        # Cap how deeply nested .eml attachments may be processed; operator-
+        # tunable via loader config. Bounds recursion when .eml files are
+        # nested inside one another.
+        self.max_eml_recursion_depth = self.config.loader.eml_max_recursion_depth
 
     async def aload_document(
         self,
@@ -137,12 +137,12 @@ class EmlLoader(BaseLoader):
                             loader_cls = self.loader_classes.get(file_ext)
 
                             # Stop the recursion before we descend into another
-                            # .eml — past MAX_EML_RECURSION_DEPTH we annotate
+                            # .eml — past max_eml_recursion_depth we annotate
                             # the chain and skip the load.
-                            if loader_cls is EmlLoader and _eml_recursion_depth + 1 >= self.MAX_EML_RECURSION_DEPTH:
+                            if loader_cls is EmlLoader and _eml_recursion_depth + 1 >= self.max_eml_recursion_depth:
                                 attachments_text += (
                                     f"Skipped nested .eml attachment '{filename}': "
-                                    f"recursion depth limit ({self.MAX_EML_RECURSION_DEPTH}) reached.\n"
+                                    f"recursion depth limit ({self.max_eml_recursion_depth}) reached.\n"
                                 )
                                 attachments_text += "---\n"
                                 continue

--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -20,10 +20,8 @@ def json_serial(obj):
 
 
 class EmlLoader(BaseLoader):
-    # Cap how deeply nested .eml attachments may be processed. A maliciously
-    # or accidentally nested chain of .eml-in-.eml otherwise causes stack
-    # overflow and file-descriptor exhaustion long after the indexer has
-    # consumed significant resources.
+    # Cap how deeply nested .eml attachments may be processed; bounds the
+    # recursion when .eml files are nested inside one another.
     MAX_EML_RECURSION_DEPTH = 5
 
     def __init__(self, **kwargs):

--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -20,6 +20,12 @@ def json_serial(obj):
 
 
 class EmlLoader(BaseLoader):
+    # Cap how deeply nested .eml attachments may be processed. A maliciously
+    # or accidentally nested chain of .eml-in-.eml otherwise causes stack
+    # overflow and file-descriptor exhaustion long after the indexer has
+    # consumed significant resources.
+    MAX_EML_RECURSION_DEPTH = 5
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Store all kwargs for passing to sub-loaders
@@ -27,7 +33,13 @@ class EmlLoader(BaseLoader):
         # Get available loaders for processing attachments
         self.loader_classes = get_loader_classes(config=self.config)
 
-    async def aload_document(self, file_path, metadata: dict | None = None, save_markdown: bool = False):
+    async def aload_document(
+        self,
+        file_path,
+        metadata: dict | None = None,
+        save_markdown: bool = False,
+        _eml_recursion_depth: int = 0,
+    ):
         try:
             with open(file_path, "rb") as fhdl:
                 raw_email = fhdl.read()
@@ -126,6 +138,20 @@ class EmlLoader(BaseLoader):
                             # Check if we have a loader for this file type
                             loader_cls = self.loader_classes.get(file_ext)
 
+                            # Stop the recursion before we descend into another
+                            # .eml — past MAX_EML_RECURSION_DEPTH we annotate
+                            # the chain and skip the load.
+                            if (
+                                loader_cls is EmlLoader
+                                and _eml_recursion_depth + 1 >= self.MAX_EML_RECURSION_DEPTH
+                            ):
+                                attachments_text += (
+                                    f"Skipped nested .eml attachment '{filename}': "
+                                    f"recursion depth limit ({self.MAX_EML_RECURSION_DEPTH}) reached.\n"
+                                )
+                                attachments_text += "---\n"
+                                continue
+
                             if loader_cls:
                                 # Save attachment to temporary file
                                 with tempfile.NamedTemporaryFile(suffix=file_ext, delete=False) as temp_file:
@@ -135,9 +161,13 @@ class EmlLoader(BaseLoader):
                                 try:
                                     # Use appropriate loader to process attachment
                                     loader = loader_cls(**self.kwargs)
+                                    sub_kwargs: dict = {}
+                                    if loader_cls is EmlLoader:
+                                        sub_kwargs["_eml_recursion_depth"] = _eml_recursion_depth + 1
                                     attachment_doc = await loader.aload_document(
                                         temp_file_path,
                                         metadata={"source": f"attachment:{filename}"},
+                                        **sub_kwargs,
                                     )
                                     attachments_text += f"Content:\n{attachment_doc.page_content}\n"
                                 except Exception as e:

--- a/openrag/components/indexer/loaders/eml_loader.py
+++ b/openrag/components/indexer/loaders/eml_loader.py
@@ -141,10 +141,7 @@ class EmlLoader(BaseLoader):
                             # Stop the recursion before we descend into another
                             # .eml — past MAX_EML_RECURSION_DEPTH we annotate
                             # the chain and skip the load.
-                            if (
-                                loader_cls is EmlLoader
-                                and _eml_recursion_depth + 1 >= self.MAX_EML_RECURSION_DEPTH
-                            ):
+                            if loader_cls is EmlLoader and _eml_recursion_depth + 1 >= self.MAX_EML_RECURSION_DEPTH:
                                 attachments_text += (
                                     f"Skipped nested .eml attachment '{filename}': "
                                     f"recursion depth limit ({self.MAX_EML_RECURSION_DEPTH}) reached.\n"

--- a/openrag/components/indexer/loaders/test_eml_recursion.py
+++ b/openrag/components/indexer/loaders/test_eml_recursion.py
@@ -1,11 +1,9 @@
 """Regression test for #364 — EmlLoader nested .eml recursion is capped.
 
-The loader's attachment processing path resolved each attachment's
-extension via ``self.loader_classes`` and recursed via ``aload_document``
-with no depth counter. A maliciously or accidentally nested chain of
-.eml-in-.eml caused stack overflow / FD exhaustion. The fix threads a
-``_eml_recursion_depth`` keyword and stops descending once
-``MAX_EML_RECURSION_DEPTH`` is reached.
+The loader recursed into .eml attachments via ``aload_document`` with no
+depth counter, so .eml files nested inside one another recursed without
+bound. The fix threads a ``_eml_recursion_depth`` keyword and stops
+descending once ``MAX_EML_RECURSION_DEPTH`` is reached.
 """
 
 import base64

--- a/openrag/components/indexer/loaders/test_eml_recursion.py
+++ b/openrag/components/indexer/loaders/test_eml_recursion.py
@@ -46,7 +46,7 @@ def _make_leaf_eml() -> bytes:
 
 @pytest.mark.asyncio
 async def test_eml_recursion_caps_at_max_depth(tmp_path):
-    from openrag.components.indexer.loaders.eml_loader import EmlLoader
+    from components.indexer.loaders.eml_loader import EmlLoader
 
     # A single outer .eml whose attachment is another .eml. We seed the
     # call at depth = MAX_EML_RECURSION_DEPTH - 1, so processing the
@@ -70,7 +70,7 @@ async def test_eml_recursion_caps_at_max_depth(tmp_path):
 @pytest.mark.asyncio
 async def test_eml_below_cap_does_not_skip(tmp_path):
     """At depth 0 the guard does not fire — attachments are still attempted."""
-    from openrag.components.indexer.loaders.eml_loader import EmlLoader
+    from components.indexer.loaders.eml_loader import EmlLoader
 
     eml_path = tmp_path / "nested.eml"
     eml_path.write_bytes(_make_eml_with_attached_eml(_make_leaf_eml()))

--- a/openrag/components/indexer/loaders/test_eml_recursion.py
+++ b/openrag/components/indexer/loaders/test_eml_recursion.py
@@ -41,13 +41,7 @@ def _make_eml_with_attached_eml(inner_bytes: bytes, subject: str = "outer") -> b
 
 
 def _make_leaf_eml() -> bytes:
-    return (
-        b"Subject: leaf\r\n"
-        b"From: a@example.com\r\n"
-        b"To: b@example.com\r\n"
-        b"\r\n"
-        b"leaf body\r\n"
-    )
+    return b"Subject: leaf\r\nFrom: a@example.com\r\nTo: b@example.com\r\n\r\nleaf body\r\n"
 
 
 @pytest.mark.asyncio

--- a/openrag/components/indexer/loaders/test_eml_recursion.py
+++ b/openrag/components/indexer/loaders/test_eml_recursion.py
@@ -3,7 +3,8 @@
 The loader recursed into .eml attachments via ``aload_document`` with no
 depth counter, so .eml files nested inside one another recursed without
 bound. The fix threads a ``_eml_recursion_depth`` keyword and stops
-descending once ``MAX_EML_RECURSION_DEPTH`` is reached.
+descending once the operator-tunable ``loader.eml_max_recursion_depth``
+is reached.
 """
 
 import base64
@@ -47,18 +48,18 @@ async def test_eml_recursion_caps_at_max_depth(tmp_path):
     from components.indexer.loaders.eml_loader import EmlLoader
 
     # A single outer .eml whose attachment is another .eml. We seed the
-    # call at depth = MAX_EML_RECURSION_DEPTH - 1, so processing the
-    # outer's attachment (which would push us past the cap) trips the
-    # guard. This proves the depth cap stops the descent before the
-    # nested .eml is loaded again.
+    # call at depth = cap - 1, so processing the outer's attachment (which
+    # would push us past the cap) trips the guard. This proves the depth
+    # cap stops the descent before the nested .eml is loaded again.
     eml_path = tmp_path / "nested.eml"
     eml_path.write_bytes(_make_eml_with_attached_eml(_make_leaf_eml()))
 
     loader = object.__new__(EmlLoader)
     loader.loader_classes = {".eml": EmlLoader}
     loader.kwargs = {}
+    loader.max_eml_recursion_depth = 5
 
-    seeded_depth = EmlLoader.MAX_EML_RECURSION_DEPTH - 1
+    seeded_depth = loader.max_eml_recursion_depth - 1
     doc = await loader.aload_document(str(eml_path), _eml_recursion_depth=seeded_depth)
     assert "recursion depth limit" in doc.page_content
     # The body of the outer .eml must still be retained
@@ -76,7 +77,18 @@ async def test_eml_below_cap_does_not_skip(tmp_path):
     loader = object.__new__(EmlLoader)
     loader.loader_classes = {".eml": EmlLoader}
     loader.kwargs = {}
+    loader.max_eml_recursion_depth = 5
 
     doc = await loader.aload_document(str(eml_path), _eml_recursion_depth=0)
     # The guard message should NOT appear at low depth
     assert "recursion depth limit" not in doc.page_content
+
+
+def test_recursion_cap_lives_in_loader_config():
+    """The cap must come from the loader config (operator-tunable), not be
+    hardcoded in the loader. Assert the contract: a positive integer."""
+    from config import load_config
+
+    cap = load_config().loader.eml_max_recursion_depth
+    assert isinstance(cap, int)
+    assert cap > 0

--- a/openrag/components/indexer/loaders/test_eml_recursion.py
+++ b/openrag/components/indexer/loaders/test_eml_recursion.py
@@ -1,0 +1,90 @@
+"""Regression test for #364 — EmlLoader nested .eml recursion is capped.
+
+The loader's attachment processing path resolved each attachment's
+extension via ``self.loader_classes`` and recursed via ``aload_document``
+with no depth counter. A maliciously or accidentally nested chain of
+.eml-in-.eml caused stack overflow / FD exhaustion. The fix threads a
+``_eml_recursion_depth`` keyword and stops descending once
+``MAX_EML_RECURSION_DEPTH`` is reached.
+"""
+
+import base64
+
+import pytest
+
+
+def _make_eml_with_attached_eml(inner_bytes: bytes, subject: str = "outer") -> bytes:
+    """Build a multipart/mixed .eml whose attachment (Content-Disposition:
+    attachment; filename=nested.eml) is the given inner .eml bytes.
+    """
+    encoded = base64.b64encode(inner_bytes).decode("ascii")
+    boundary = "============TEST_BOUNDARY============"
+    return (
+        f"Subject: {subject}\r\n"
+        "From: a@example.com\r\n"
+        "To: b@example.com\r\n"
+        "MIME-Version: 1.0\r\n"
+        f'Content-Type: multipart/mixed; boundary="{boundary}"\r\n'
+        "\r\n"
+        f"--{boundary}\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "outer body\r\n"
+        f"--{boundary}\r\n"
+        'Content-Type: application/octet-stream; name="nested.eml"\r\n'
+        'Content-Disposition: attachment; filename="nested.eml"\r\n'
+        "Content-Transfer-Encoding: base64\r\n"
+        "\r\n"
+        f"{encoded}\r\n"
+        f"--{boundary}--\r\n"
+    ).encode("ascii")
+
+
+def _make_leaf_eml() -> bytes:
+    return (
+        b"Subject: leaf\r\n"
+        b"From: a@example.com\r\n"
+        b"To: b@example.com\r\n"
+        b"\r\n"
+        b"leaf body\r\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_eml_recursion_caps_at_max_depth(tmp_path):
+    from openrag.components.indexer.loaders.eml_loader import EmlLoader
+
+    # A single outer .eml whose attachment is another .eml. We seed the
+    # call at depth = MAX_EML_RECURSION_DEPTH - 1, so processing the
+    # outer's attachment (which would push us past the cap) trips the
+    # guard. This proves the depth cap stops the descent before the
+    # nested .eml is loaded again.
+    eml_path = tmp_path / "nested.eml"
+    eml_path.write_bytes(_make_eml_with_attached_eml(_make_leaf_eml()))
+
+    loader = object.__new__(EmlLoader)
+    loader.loader_classes = {".eml": EmlLoader}
+    loader.kwargs = {}
+
+    seeded_depth = EmlLoader.MAX_EML_RECURSION_DEPTH - 1
+    doc = await loader.aload_document(str(eml_path), _eml_recursion_depth=seeded_depth)
+    assert "recursion depth limit" in doc.page_content
+    # The body of the outer .eml must still be retained
+    assert "outer body" in doc.page_content
+
+
+@pytest.mark.asyncio
+async def test_eml_below_cap_does_not_skip(tmp_path):
+    """At depth 0 the guard does not fire — attachments are still attempted."""
+    from openrag.components.indexer.loaders.eml_loader import EmlLoader
+
+    eml_path = tmp_path / "nested.eml"
+    eml_path.write_bytes(_make_eml_with_attached_eml(_make_leaf_eml()))
+
+    loader = object.__new__(EmlLoader)
+    loader.loader_classes = {".eml": EmlLoader}
+    loader.kwargs = {}
+
+    doc = await loader.aload_document(str(eml_path), _eml_recursion_depth=0)
+    # The guard message should NOT appear at low depth
+    assert "recursion depth limit" not in doc.page_content

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -371,6 +371,9 @@ class LoaderConfig(ConfigMixin):
     docling_retry_base_delay: float = 2.0
     transcriber: TranscriberConfig = Field(default_factory=TranscriberConfig)
     openai: OpenAILoaderConfig = Field(default_factory=OpenAILoaderConfig)
+    # Max depth of nested .eml-in-.eml attachments the EmlLoader will descend
+    # into. Bounds recursion when .eml files are nested inside one another.
+    eml_max_recursion_depth: int = 5
 
 
 # ---------------------------------------------------------------------------

--- a/openrag/core/config/indexation.py
+++ b/openrag/core/config/indexation.py
@@ -179,3 +179,6 @@ class LoaderConfig(ConfigMixin):
     docling_retry_base_delay: float = 2.0
     transcriber: TranscriberConfig = Field(default_factory=TranscriberConfig)
     openai: OpenAILoaderConfig = Field(default_factory=OpenAILoaderConfig)
+    # Max depth of nested .eml-in-.eml attachments the EmlLoader will descend
+    # into. Bounds recursion when .eml files are nested inside one another.
+    eml_max_recursion_depth: int = 5


### PR DESCRIPTION
## Summary

`EmlLoader.aload_document` resolved each attachment's extension via `self.loader_classes.get(...)`, instantiated the resulting class, and called `aload_document` with no depth counter and no visited guard. A nested chain of `.eml`-in-`.eml` attachments therefore caused stack overflow, file-descriptor exhaustion, and finally a confusing crash long after the indexer had consumed significant resources.

This PR threads a `_eml_recursion_depth` keyword through `aload_document`, stops descending before reaching `MAX_EML_RECURSION_DEPTH` (5), and annotates the partial output so operators see exactly where the chain was cut.

## Test plan

- [ ] A 1-level .eml with a non-eml attachment loads as before
- [ ] A 6-level nested .eml chain stops at depth 5 with a clear annotation in the markdown
- [ ] No other loader path is affected (non-.eml attachments still get their normal kwargs)

Fixes #364