### PR TITLE
fix(stream): size source-filter buffer to fit max possible [Sources: …] tag (#390)

### DIFF
--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -241,3 +241,51 @@ class TestStreamWithSourceFiltering:
         result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
         assert _collect_content(result) == "Answer without any sources tag."
         assert _parse_finish_sources(result) == self.SOURCES
+
+
+# ---------------------------------------------------------------------------
+# Regression for #390 — buffer size scales with number of sources so the
+# [Sources: 1, 2, …, N] tag isn't evicted from the buffer before it can match.
+# ---------------------------------------------------------------------------
+
+
+def test_min_sources_tag_buffer_size_fits_many_sources():
+    from components.utils import _min_sources_tag_buffer_size
+
+    # The helper bound must cover the full max-length tag at this N.
+    for n in (1, 10, 60, 100):
+        tag = "\n[Sources: " + ", ".join(str(i) for i in range(1, n + 1)) + "]"
+        assert _min_sources_tag_buffer_size(n) >= len(tag), n
+    # The caller in stream_with_source_filtering tops this off with
+    # max(100, _min_sources_tag_buffer_size(...)) so the small-list case is
+    # not the helper's responsibility.
+    assert _min_sources_tag_buffer_size(0) >= 1
+
+
+class TestStreamWithManySources:
+    """Repro the #390 scenario: 60 sources cited at the end of the stream."""
+
+    @pytest.mark.asyncio
+    async def test_60_source_citation_survives_buffer_eviction(self):
+        sources = [{"file": f"src-{i}.pdf"} for i in range(60)]
+        # Build a long answer body, then a [Sources: 1, …, 60] tag whose total
+        # length exceeds the old hardcoded 100-char buffer.
+        body = "This is the answer body. " * 30
+        cited = ", ".join(str(i) for i in range(1, 61))
+        tag = f"\n[Sources: {cited}]"
+        # Stream the body in many small chunks plus the tag at the end.
+        lines = [_make_chunk(p) for p in [body[i : i + 5] for i in range(0, len(body), 5)]]
+        lines.append(_make_chunk(tag))
+        lines.append(_make_finish())
+        lines.append(DONE_LINE)
+
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), sources, "test-model"))
+
+        # The raw tag must not leak into the user-visible content
+        content = _collect_content(result)
+        assert "[Sources:" not in content
+        assert content.startswith("This is the answer body.")
+        assert content.endswith("This is the answer body.")
+        # All 60 sources should be reflected in the finish chunk
+        finished = _parse_finish_sources(result)
+        assert finished == sources

--- a/openrag/components/test_source_filtering.py
+++ b/openrag/components/test_source_filtering.py
@@ -268,8 +268,8 @@ class TestStreamWithManySources:
     @pytest.mark.asyncio
     async def test_60_source_citation_survives_buffer_eviction(self):
         sources = [{"file": f"src-{i}.pdf"} for i in range(60)]
-        # Build a long answer body, then a [Sources: 1, …, 60] tag whose total
-        # length exceeds the old hardcoded 100-char buffer.
+        # Build a long answer body, then a [Sources: 1, …, 60] tag long enough
+        # that the source-filter buffer must size to the full tag to catch it.
         body = "This is the answer body. " * 30
         cited = ", ".join(str(i) for i in range(1, 61))
         tag = f"\n[Sources: {cited}]"

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -158,20 +158,39 @@ def filter_sources_by_citations(sources: list, citations: set[int] | None) -> li
     return filtered if filtered else sources
 
 
+def _min_sources_tag_buffer_size(n_sources: int) -> int:
+    """Pessimistic upper bound on the length of a ``[Sources: 1, 2, …, N]`` tag.
+
+    Worst case: every source cited, plus the wrapping characters and a small
+    margin for whitespace / leading newline variations the prompt allows.
+    """
+    if n_sources <= 0:
+        return 100
+    digits_total = sum(len(str(i)) for i in range(1, n_sources + 1))
+    separators = max(0, n_sources - 1) * 2  # ", "
+    wrapping = len("\n[Sources: ") + len("]") + 8  # margin for whitespace / trailing chars
+    return digits_total + separators + wrapping
+
+
 async def stream_with_source_filtering(
     llm_stream,
     sources: list,
     model_name: str,
-    buffer_size: int = 100,
+    buffer_size: int | None = None,
 ):
     """Process an LLM SSE stream, stripping the [Sources: ...] tag from content.
 
-    Buffers the last `buffer_size` chars of content to intercept the sources tag
+    Buffers the last ``buffer_size`` chars of content to intercept the sources tag
     before it reaches the client. On stream end, strips the tag and emits a finish
     chunk with filtered source metadata.
 
+    ``buffer_size`` defaults to the minimum size that can hold a tag citing
+    *every* available source. Callers can override it explicitly (e.g. tests).
+
     Yields SSE "data: ..." lines ready to forward to the client.
     """
+    if buffer_size is None:
+        buffer_size = max(100, _min_sources_tag_buffer_size(len(sources)))
     chunk_buffer: deque[dict] = deque()
     buffered_content_len = 0
     last_chunk_template = None


### PR DESCRIPTION
## Summary

`stream_with_source_filtering` defaulted `buffer_size` to 100 chars and evicted oldest chunks once `buffered_content_len > buffer_size`. The LLM's `[Sources: 1, 2, …, N]` tag at the end of a streamed response easily exceeds 100 chars when many sources are cited, in which case its leading characters are flushed to the client before the trailing-anchored regex `_SOURCES_NUMS_RE` can match. The user then sees raw `[Sources: ...]` text in the response and citation filtering falls back to all sources rather than the cited subset.

This PR derives the buffer size from the maximum possible tag length (every source cited, with wrapping characters and a small whitespace margin) and applies it dynamically per request. Callers can still override via the `buffer_size` kwarg (e.g. tests). The new default is always `>= 100`, so existing behavior on small source lists is unchanged.

## Test plan

- [ ] Existing `test_source_filtering.py` cases pass unchanged
- [ ] Streamed response with 50+ sources locks behavior: the full `[Sources: …]` tag is detected and stripped before any leading character reaches the client

Fixes #390