### PR TITLE
fix(oidc): block backslash-host and CRLF injection in next_url (#360)

### DIFF
--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -414,15 +414,31 @@ class AuthService:
             )
 
     def sanitize_next_url(self, next_url: str | None) -> str:
-        """Block open redirects.
+        """Block open redirects, header injection, and protocol-relative paths.
 
-        Accept a same-origin relative path (``/...`` but not ``//...``) or
-        an absolute URL whose origin is explicitly whitelisted; fall back
-        to ``/`` otherwise.
+        Accept a same-origin relative path (``/...`` but not ``//...`` and
+        not ``/\\...``) or an absolute URL whose origin is explicitly
+        whitelisted; fall back to ``/`` otherwise.
+
+        Defenses applied beyond the basic prefix check:
+          * any CR / LF / NUL byte triggers fallback (HTTP response splitting
+            and header injection via ``Location: ...``).
+          * a path-relative value whose second character is ``/`` or ``\\``
+            is rejected because Chrome / Edge parse ``/\\evil.com`` as a
+            host-relative URL whose host is ``evil.com``.
+          * any apparent path is re-parsed and only accepted when
+            ``urlsplit`` confirms an empty ``scheme`` and ``netloc``.
         """
         if not next_url:
             return "/"
-        if next_url.startswith("/") and not next_url.startswith("//"):
+        if any(ch in next_url for ch in ("\r", "\n", "\x00")):
+            return "/"
+        if next_url.startswith("/"):
+            if len(next_url) > 1 and next_url[1] in ("/", "\\"):
+                return "/"
+            parsed = urlparse(next_url)
+            if parsed.scheme or parsed.netloc:
+                return "/"
             return next_url
         parsed = urlparse(next_url)
         if parsed.scheme in ("http", "https") and parsed.netloc:

--- a/openrag/services/orchestrators/test_auth_service.py
+++ b/openrag/services/orchestrators/test_auth_service.py
@@ -167,6 +167,35 @@ async def test_login_sanitizes_open_redirect():
     assert payload.next_url == "/"
 
 
+# Regression for #360 — backslash-host and CRLF/NUL injection in next_url.
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "/\\evil.com/phish",      # Chrome/Edge treat /\evil as netloc=evil.com
+        "/\\\\evil.com",
+        "/path\r\nLocation: http://evil",  # CRLF response splitting
+        "/path\n\nSet-Cookie: stolen=1",
+        "/path\x00admin",
+        "//evil.com",
+        "http://evil.com",
+    ],
+)
+@pytest.mark.asyncio
+async def test_login_blocks_backslash_and_crlf_in_next_url(evil):
+    svc = _service(client=FakeOIDCClient())
+    result = await svc.start_oidc_login(evil)
+    payload = StateCookieSerializer(secret_key=KEY).loads(result.state_cookie_value)
+    assert payload.next_url == "/", f"unsafe next_url leaked through: {payload.next_url!r}"
+
+
+@pytest.mark.asyncio
+async def test_login_preserves_safe_relative_path():
+    svc = _service(client=FakeOIDCClient())
+    result = await svc.start_oidc_login("/dashboard?foo=bar")
+    payload = StateCookieSerializer(secret_key=KEY).loads(result.state_cookie_value)
+    assert payload.next_url == "/dashboard?foo=bar"
+
+
 @pytest.mark.asyncio
 async def test_login_without_client_raises():
     svc = _service(client=None)

--- a/openrag/services/orchestrators/test_auth_service.py
+++ b/openrag/services/orchestrators/test_auth_service.py
@@ -171,7 +171,7 @@ async def test_login_sanitizes_open_redirect():
 @pytest.mark.parametrize(
     "evil",
     [
-        "/\\evil.com/phish",      # Chrome/Edge treat /\evil as netloc=evil.com
+        "/\\evil.com/phish",  # Chrome/Edge treat /\evil as netloc=evil.com
         "/\\\\evil.com",
         "/path\r\nLocation: http://evil",  # CRLF response splitting
         "/path\n\nSet-Cookie: stolen=1",


### PR DESCRIPTION
## Summary

`AuthService.sanitize_next_url` returned `next_url` unchanged whenever it began with `/` and did not begin with `//`. A value like `/\evil.com/path` (which Chrome and Edge parse as a host-relative URL whose host is `evil.com`) and any value containing `%0d%0a` therefore passed the check, then flowed into the `Location` header on the OIDC redirect — open-redirect phishing and HTTP response-splitting against authenticated sessions.

This PR tightens the sanitizer:

- Any `\r`, `\n`, or `\x00` byte forces fallback to `/`
- A second character of `/` or `\` is rejected (covers both `//evil.com` and `/\evil.com`)
- Any apparent path is re-parsed with `urlparse` and only accepted when `scheme` and `netloc` are both empty

The allowlist for absolute URLs is unchanged.

## Test plan

- [ ] `/foo/bar` still passes through
- [ ] `//evil.com`, `/\evil.com`, `/path\\nLocation: http://evil` all return `/`
- [ ] Same-origin and whitelisted absolute URLs still pass through

Fixes #360