### PR TITLE
fix(chainlit): refuse to start with hardcoded fallback auth secret (#380)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,13 @@ PREFERRED_URL_SCHEME=https
 #   - oidc:           OpenID Connect flow (auth code + PKCE).
 # AUTH_MODE=token
 
+# Chainlit session-cookie signing secret. REQUIRED whenever authentication
+# is enabled (either AUTH_TOKEN or AUTH_MODE=oidc) — Chainlit signs its
+# session JWTs with this value, and a missing / weak secret lets anyone
+# forge a session for any user.
+# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# CHAINLIT_AUTH_SECRET=
+
 # --- OIDC (only required when AUTH_MODE=oidc) ---
 # Issuer URL — MUST match EXACTLY the "issuer" field returned by the IdP's
 # /.well-known/openid-configuration (trailing slash matters, per OIDC spec).

--- a/.env.example
+++ b/.env.example
@@ -93,10 +93,9 @@ PREFERRED_URL_SCHEME=https
 # AUTH_MODE=token
 
 # Chainlit session-cookie signing secret. REQUIRED whenever authentication
-# is enabled (either AUTH_TOKEN or AUTH_MODE=oidc) — Chainlit signs its
-# session JWTs with this value, and a missing / weak secret lets anyone
-# forge a session for any user.
-# Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# is enabled (either AUTH_TOKEN or AUTH_MODE=oidc). Keep it secret and stable
+# across restarts. Generate one with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
 # CHAINLIT_AUTH_SECRET=
 
 # --- OIDC (only required when AUTH_MODE=oidc) ---

--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -104,7 +104,7 @@ if AUTH_TOKEN and AUTH_MODE != "oidc":
     if not CHAINLIT_AUTH_SECRET:
         raise RuntimeError(
             "CHAINLIT_AUTH_SECRET is required when authentication is enabled. "
-            "Generate one with `python -c \"import secrets; print(secrets.token_urlsafe(32))\"` "
+            'Generate one with `python -c "import secrets; print(secrets.token_urlsafe(32))"` '
             "and set it in your environment. The previously shipped default "
             "(`default_secret_for_openrag_ui`) is source-published and lets "
             "anyone forge a valid session for any user."
@@ -142,7 +142,7 @@ elif AUTH_MODE == "oidc":
     if not CHAINLIT_AUTH_SECRET:
         raise RuntimeError(
             "CHAINLIT_AUTH_SECRET is required when AUTH_MODE=oidc. "
-            "Generate one with `python -c \"import secrets; print(secrets.token_urlsafe(32))\"` "
+            'Generate one with `python -c "import secrets; print(secrets.token_urlsafe(32))"` '
             "and set it in your environment. The previously shipped default "
             "(`default_secret_for_openrag_ui`) is source-published and lets "
             "anyone forge a valid session for any user."

--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -105,9 +105,7 @@ if AUTH_TOKEN and AUTH_MODE != "oidc":
         raise RuntimeError(
             "CHAINLIT_AUTH_SECRET is required when authentication is enabled. "
             'Generate one with `python -c "import secrets; print(secrets.token_urlsafe(32))"` '
-            "and set it in your environment. The previously shipped default "
-            "(`default_secret_for_openrag_ui`) is source-published and lets "
-            "anyone forge a valid session for any user."
+            "and set it in your environment."
         )
 
     @cl.password_auth_callback
@@ -143,9 +141,7 @@ elif AUTH_MODE == "oidc":
         raise RuntimeError(
             "CHAINLIT_AUTH_SECRET is required when AUTH_MODE=oidc. "
             'Generate one with `python -c "import secrets; print(secrets.token_urlsafe(32))"` '
-            "and set it in your environment. The previously shipped default "
-            "(`default_secret_for_openrag_ui`) is source-published and lets "
-            "anyone forge a valid session for any user."
+            "and set it in your environment."
         )
 
     @cl.header_auth_callback

--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -102,10 +102,13 @@ if PERSISTENCY:
 
 if AUTH_TOKEN and AUTH_MODE != "oidc":
     if not CHAINLIT_AUTH_SECRET:
-        # logger.warning(
-        #     "`CHAINLIT_AUTH_SECRET` is not set a default value will be used. Not recommended for production."
-        # )
-        os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"  # Set default value
+        raise RuntimeError(
+            "CHAINLIT_AUTH_SECRET is required when authentication is enabled. "
+            "Generate one with `python -c \"import secrets; print(secrets.token_urlsafe(32))\"` "
+            "and set it in your environment. The previously shipped default "
+            "(`default_secret_for_openrag_ui`) is source-published and lets "
+            "anyone forge a valid session for any user."
+        )
 
     @cl.password_auth_callback
     async def auth_callback(username: str, password: str):
@@ -137,7 +140,13 @@ if AUTH_TOKEN and AUTH_MODE != "oidc":
 
 elif AUTH_MODE == "oidc":
     if not CHAINLIT_AUTH_SECRET:
-        os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"
+        raise RuntimeError(
+            "CHAINLIT_AUTH_SECRET is required when AUTH_MODE=oidc. "
+            "Generate one with `python -c \"import secrets; print(secrets.token_urlsafe(32))\"` "
+            "and set it in your environment. The previously shipped default "
+            "(`default_secret_for_openrag_ui`) is source-published and lets "
+            "anyone forge a valid session for any user."
+        )
 
     @cl.header_auth_callback
     async def header_auth_callback(headers: dict) -> cl.User | None:

--- a/openrag/test_app_front_secret.py
+++ b/openrag/test_app_front_secret.py
@@ -6,12 +6,10 @@ session JWTs with the source-published default secret
 
 import os
 import sys
-import textwrap
 
 import pytest
 
-
-_FIX_SOURCE = (os.path.dirname(__file__) + "/app_front.py")
+_FIX_SOURCE = os.path.dirname(__file__) + "/app_front.py"
 
 
 def test_no_hardcoded_default_secret_assignment_in_source():
@@ -24,10 +22,9 @@ def test_no_hardcoded_default_secret_assignment_in_source():
     """
     with open(_FIX_SOURCE) as f:
         content = f.read()
-    assert (
-        'os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"'
-        not in content
-    ), "The hardcoded chainlit-auth secret assignment must not be reintroduced"
+    assert 'os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"' not in content, (
+        "The hardcoded chainlit-auth secret assignment must not be reintroduced"
+    )
 
 
 def test_app_front_raises_when_secret_missing(monkeypatch):

--- a/openrag/test_app_front_secret.py
+++ b/openrag/test_app_front_secret.py
@@ -1,0 +1,48 @@
+"""Regression test for #380 — app_front.py must raise on startup when
+CHAINLIT_AUTH_SECRET is unset, instead of silently signing Chainlit
+session JWTs with the source-published default secret
+``default_secret_for_openrag_ui``.
+"""
+
+import os
+import sys
+import textwrap
+
+import pytest
+
+
+_FIX_SOURCE = (os.path.dirname(__file__) + "/app_front.py")
+
+
+def test_no_hardcoded_default_secret_assignment_in_source():
+    """The fall-through to a literal default secret must be gone.
+
+    The bug was the assignment that quietly substituted a known-bad value
+    when the env var was unset. The string itself may still appear in
+    error messages (telling operators *not* to use it) — so we look for
+    the assignment pattern, not just the literal.
+    """
+    with open(_FIX_SOURCE) as f:
+        content = f.read()
+    assert (
+        'os.environ["CHAINLIT_AUTH_SECRET"] = "default_secret_for_openrag_ui"'
+        not in content
+    ), "The hardcoded chainlit-auth secret assignment must not be reintroduced"
+
+
+def test_app_front_raises_when_secret_missing(monkeypatch):
+    """Importing app_front.py without CHAINLIT_AUTH_SECRET must raise."""
+    monkeypatch.setenv("AUTH_TOKEN", "test-token")
+    monkeypatch.delenv("CHAINLIT_AUTH_SECRET", raising=False)
+    monkeypatch.setenv("AUTH_MODE", "token")
+
+    # Drop the previously-imported app_front module so the import body re-runs.
+    for mod in [m for m in sys.modules if m == "app_front" or m.endswith(".app_front")]:
+        sys.modules.pop(mod, None)
+
+    import importlib
+
+    spec = importlib.util.spec_from_file_location("app_front_test", _FIX_SOURCE)
+    module = importlib.util.module_from_spec(spec)
+    with pytest.raises(RuntimeError, match="CHAINLIT_AUTH_SECRET"):
+        spec.loader.exec_module(module)

--- a/openrag/test_app_front_secret.py
+++ b/openrag/test_app_front_secret.py
@@ -1,7 +1,6 @@
 """Regression test for #380 — app_front.py must raise on startup when
-CHAINLIT_AUTH_SECRET is unset, instead of silently signing Chainlit
-session JWTs with the source-published default secret
-``default_secret_for_openrag_ui``.
+CHAINLIT_AUTH_SECRET is unset, instead of falling back to a hardcoded
+default secret.
 """
 
 import os
@@ -15,10 +14,8 @@ _FIX_SOURCE = os.path.dirname(__file__) + "/app_front.py"
 def test_no_hardcoded_default_secret_assignment_in_source():
     """The fall-through to a literal default secret must be gone.
 
-    The bug was the assignment that quietly substituted a known-bad value
-    when the env var was unset. The string itself may still appear in
-    error messages (telling operators *not* to use it) — so we look for
-    the assignment pattern, not just the literal.
+    The bug was an assignment that substituted a hardcoded value when the
+    env var was unset. We assert that assignment is not present in source.
     """
     with open(_FIX_SOURCE) as f:
         content = f.read()


### PR DESCRIPTION
## Summary

`app_front.py` resolved `CHAINLIT_AUTH_SECRET` via `os.environ.get(..., \"default_secret_for_openrag_ui\")` (with the warning that previously flagged it commented out). Any deployment that forgot to set the variable signed Chainlit session JWTs with a globally known, source-published secret, which let anyone forge a valid session for any user without needing the IdP or a real token.

This PR drops the literal default and raises on startup if the env var is unset, in both the token-mode and OIDC-mode branches. The error message points the operator at the exact command to generate a fresh secret.

## Test plan

- [ ] Booting with `AUTH_TOKEN` set and `CHAINLIT_AUTH_SECRET` unset now exits with a clear error
- [ ] Booting with `AUTH_MODE=oidc` and `CHAINLIT_AUTH_SECRET` unset now exits with a clear error
- [ ] Booting with `CHAINLIT_AUTH_SECRET` set keeps the existing behavior

Fixes #380