### PR TITLE
fix(serve): trust proxy headers from configurable CIDR via UVICORN_FORWARDED_ALLOW_IPS (#384)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,14 @@ VLM_MODEL=
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234
 # Optional: semicolon-separated extra allowed origins
-# CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'  
+# CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'
+
+# Reverse-proxy trust list for uvicorn. Required when OpenRAG runs behind
+# a TLS-terminating proxy that lives outside loopback (typical
+# docker-compose / k8s); otherwise X-Forwarded-Proto is dropped and OIDC
+# cookies ship with Secure=False even on HTTPS. Accepts a comma-separated
+# list of CIDRs / IPs or "*" to trust all peers. Default: 127.0.0.1.
+# UVICORN_FORWARDED_ALLOW_IPS=*
 
 # SAVE_UPLOADED_FILES=true # usefull for chainlit (chat interface) source viewing
 

--- a/openrag/main.py
+++ b/openrag/main.py
@@ -401,4 +401,21 @@ if __name__ == "__main__":
             serve.run(OpenRagAPI.bind(), route_prefix="/", blocking=True)
 
     else:
-        uvicorn.run("main:app", host="0.0.0.0", port=8080, reload=True, proxy_headers=True)
+        # When fronted by a reverse proxy, proxy_headers alone is not enough:
+        # uvicorn only honors X-Forwarded-Proto / -For from peers listed in
+        # forwarded_allow_ips (default: 127.0.0.1). Without this set, a proxy
+        # outside loopback (the usual docker-compose / k8s case) is ignored,
+        # request.url.scheme stays 'http', _is_request_secure returns False,
+        # and the OIDC openrag_session and state cookies ship with
+        # Secure=False even on HTTPS deployments. UVICORN_FORWARDED_ALLOW_IPS
+        # accepts a comma-separated list of CIDRs / IPs or '*' to trust all.
+        forwarded_allow_ips = os.environ.get("UVICORN_FORWARDED_ALLOW_IPS", "127.0.0.1")
+        logger.info("Trusting proxy headers from forwarded_allow_ips=%s", forwarded_allow_ips)
+        uvicorn.run(
+            "main:app",
+            host="0.0.0.0",
+            port=8080,
+            reload=True,
+            proxy_headers=True,
+            forwarded_allow_ips=forwarded_allow_ips,
+        )

--- a/openrag/test_main_proxy_headers.py
+++ b/openrag/test_main_proxy_headers.py
@@ -1,0 +1,55 @@
+"""Regression test for #384 — uvicorn.run must be called with
+``forwarded_allow_ips`` so that ``X-Forwarded-Proto`` from a non-loopback
+reverse proxy is honored, instead of being silently dropped (which made
+OIDC cookies ship with ``Secure=False`` even on HTTPS).
+"""
+
+import ast
+import os
+
+_MAIN_PATH = os.path.dirname(__file__) + "/main.py"
+
+
+def test_uvicorn_run_passes_forwarded_allow_ips():
+    """Scan main.py's AST for the uvicorn.run call that serves the app and
+    assert ``forwarded_allow_ips`` is passed as a kwarg."""
+    with open(_MAIN_PATH) as f:
+        tree = ast.parse(f.read())
+
+    found_with_kwarg = False
+    found_any_run = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match uvicorn.run(...) — direct attribute access only
+        if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "uvicorn"):
+            continue
+        found_any_run = True
+        # Look for "main:app" as first positional to identify the API serve
+        # call (the other uvicorn.run is for the Chainlit standalone app).
+        if not node.args:
+            continue
+        first = node.args[0]
+        if not (isinstance(first, ast.Constant) and first.value == "main:app"):
+            continue
+        kw_names = {kw.arg for kw in node.keywords}
+        if "forwarded_allow_ips" in kw_names:
+            found_with_kwarg = True
+
+    assert found_any_run, "No uvicorn.run(...) call found in main.py"
+    assert found_with_kwarg, (
+        "uvicorn.run(\"main:app\", ...) must pass forwarded_allow_ips so that "
+        "X-Forwarded-Proto from a reverse proxy is honored."
+    )
+
+
+def test_default_forwarded_allow_ips_env_var_used():
+    """The implementation should read the trusted-proxy CIDR list from
+    ``UVICORN_FORWARDED_ALLOW_IPS`` to allow operators to override.
+    """
+    with open(_MAIN_PATH) as f:
+        src = f.read()
+    assert "UVICORN_FORWARDED_ALLOW_IPS" in src

--- a/openrag/test_main_proxy_headers.py
+++ b/openrag/test_main_proxy_headers.py
@@ -41,7 +41,7 @@ def test_uvicorn_run_passes_forwarded_allow_ips():
 
     assert found_any_run, "No uvicorn.run(...) call found in main.py"
     assert found_with_kwarg, (
-        "uvicorn.run(\"main:app\", ...) must pass forwarded_allow_ips so that "
+        'uvicorn.run("main:app", ...) must pass forwarded_allow_ips so that '
         "X-Forwarded-Proto from a reverse proxy is honored."
     )
 


### PR DESCRIPTION
## Summary

`uvicorn.run(..., proxy_headers=True)` was set, but `forwarded_allow_ips` was not, so Uvicorn fell back to its default of `127.0.0.1` and discarded `X-Forwarded-Proto` from any reverse proxy that did not share the loopback. The OIDC code at `routers/auth.py` then saw `request.url.scheme == \"http\"`, `_is_request_secure` returned False, and the `openrag_session` and state cookies were written with `Secure=False` even on real HTTPS deployments — exposing them to plaintext exfiltration.

This PR reads the trusted-proxy CIDR list from `UVICORN_FORWARDED_ALLOW_IPS`, defaulting to `127.0.0.1` to preserve the current docker-compose behavior, and logs the resolved value at startup so operators notice when it's wrong.

## Test plan

- [ ] Default deploy (`UVICORN_FORWARDED_ALLOW_IPS` unset) keeps the previous loopback-only behavior
- [ ] Setting `UVICORN_FORWARDED_ALLOW_IPS=*` (or a real proxy CIDR) makes uvicorn honor `X-Forwarded-Proto` from a non-loopback proxy
- [ ] Behind a TLS-terminating proxy with the env var set, OIDC cookies ship with `Secure=True`

Fixes #384