### PR TITLE
fix(users): normalize empty external_user_id to NULL on create (#121)

### DIFF
--- a/openrag/services/persistence/test_user_repo_external_id.py
+++ b/openrag/services/persistence/test_user_repo_external_id.py
@@ -10,7 +10,6 @@ binding parameter is ``None`` rather than ``''``.
 
 from __future__ import annotations
 
-import inspect
 from typing import Any
 
 import pytest

--- a/openrag/services/persistence/test_user_repo_external_id.py
+++ b/openrag/services/persistence/test_user_repo_external_id.py
@@ -1,0 +1,144 @@
+"""Regression test for #121 — PgUserRepository.create_user / create_legacy_user
+must normalize empty external_user_id strings to NULL. Otherwise the second
+insert raises UniqueViolation on the unique-but-nullable column.
+
+We exercise the normalization logic directly without requiring a live
+Postgres connection. The actual pool is replaced with a fake that records
+the values passed to ``execute`` / ``fetchrow`` so we can assert the
+binding parameter is ``None`` rather than ``''``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+
+class _FakeRow(dict):
+    """asyncpg returns Record-like objects; tests just need dict access."""
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+
+class _FakePool:
+    def __init__(self):
+        self.last_query: str | None = None
+        self.last_params: tuple = ()
+        self._next_row: _FakeRow | None = None
+
+    def set_next_row(self, **fields):
+        self._next_row = _FakeRow(fields)
+
+    async def fetchrow(self, query: str, *params):
+        self.last_query = query
+        self.last_params = params
+        return self._next_row
+
+    async def execute(self, query: str, *params):
+        self.last_query = query
+        self.last_params = params
+        return "INSERT 0 1"
+
+    # asyncpg.Pool.acquire returns a context manager — not exercised here
+
+    async def fetch(self, query: str, *params):
+        self.last_query = query
+        self.last_params = params
+        return []
+
+
+def _make_user_with_ext(ext: str | None):
+    from core.models.user import User
+
+    return User(
+        display_name="x",
+        external_user_id=ext,
+        email=None,
+        is_admin=False,
+        file_quota=None,
+        file_count=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_user_coerces_empty_external_id_to_none():
+    from services.persistence.user_repo import PgUserRepository
+
+    pool = _FakePool()
+    pool.set_next_row(
+        id=42,
+        display_name="x",
+        external_user_id=None,
+        email=None,
+        token=None,
+        is_admin=False,
+        file_quota=None,
+        file_count=0,
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+    )
+    repo = PgUserRepository(pool_getter=lambda: pool)
+
+    await repo.create_user(_make_user_with_ext(""))
+    # Position 2 is external_user_id in the INSERT (display_name=$1, external=$2)
+    assert pool.last_params[1] is None, f"empty external_user_id was not coerced: {pool.last_params[1]!r}"
+
+    # Same for whitespace-only
+    await repo.create_user(_make_user_with_ext("   "))
+    assert pool.last_params[1] is None
+
+
+@pytest.mark.asyncio
+async def test_create_user_preserves_real_external_id():
+    from services.persistence.user_repo import PgUserRepository
+
+    pool = _FakePool()
+    pool.set_next_row(
+        id=42,
+        display_name="x",
+        external_user_id="kc-alice",
+        email=None,
+        token=None,
+        is_admin=False,
+        file_quota=None,
+        file_count=0,
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+    )
+    repo = PgUserRepository(pool_getter=lambda: pool)
+
+    await repo.create_user(_make_user_with_ext("kc-alice"))
+    assert pool.last_params[1] == "kc-alice"
+
+
+@pytest.mark.asyncio
+async def test_create_legacy_user_coerces_empty_external_id_to_none():
+    from services.persistence.user_repo import PgUserRepository
+
+    pool = _FakePool()
+    pool.set_next_row(
+        id=42,
+        display_name="x",
+        external_user_id=None,
+        email=None,
+        token="hash",
+        is_admin=False,
+        file_quota=None,
+        file_count=0,
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+    )
+    repo = PgUserRepository(pool_getter=lambda: pool)
+
+    await repo.create_legacy_user(
+        display_name="x",
+        external_user_id="",
+        email=None,
+        is_admin=False,
+        file_quota=None,
+    )
+    # Same column position (display_name, external_user_id, ...)
+    assert pool.last_params[1] is None

--- a/openrag/services/persistence/user_repo.py
+++ b/openrag/services/persistence/user_repo.py
@@ -72,6 +72,11 @@ class PgUserRepository(UserRepository):
         exist yet — when password auth lands we'll add the column and
         wire it here. ``token`` / ``token_hash`` should be set out-of-band
         via :meth:`set_user_token`; this method does NOT generate one.
+
+        ``external_user_id`` is normalized: an empty string is coerced to
+        ``NULL`` so the UNIQUE constraint allows multiple users with no
+        external id, instead of raising a UniqueViolation on the second
+        insert.
         """
         row = await self.pool.fetchrow(
             """
@@ -81,7 +86,7 @@ class PgUserRepository(UserRepository):
             RETURNING *
             """,
             user.display_name,
-            user.external_user_id,
+            (user.external_user_id.strip() or None) if user.external_user_id else None,
             (user.email.strip().lower() if user.email else None),
             user.is_admin,
             user.file_quota,
@@ -231,7 +236,7 @@ class PgUserRepository(UserRepository):
             RETURNING *
             """,
             display_name,
-            external_user_id,
+            (external_user_id.strip() or None) if external_user_id else None,
             (email.strip().lower() if email else None),
             token_hash,
             is_admin,


### PR DESCRIPTION
## Summary

`users.external_user_id` is `unique=True, nullable=True`. Postgres treats `NULL` as distinct under `UNIQUE`, so multiple users with no external id are fine — but an empty string `''` is a regular value and the second insert raises `UniqueViolation`. The legacy bug from #121 still exists on the new `PgUserRepository` (both `create_user` and `create_legacy_user`).

This PR coerces `''` (after `strip()`) to `NULL` on the two insert paths so accidental empty strings don't break user creation.

## Test plan

- [ ] Two users created via `POST /users/` without an `external_user_id` both succeed (one becomes NULL, the other becomes NULL)
- [ ] A user explicitly created with `external_user_id=\"alice\"` still validates uniqueness as before

Fixes #121