### PR TITLE
fix(vectordb): cap ancestor recursion depth to defend against cycles (#369)

### DIFF
--- a/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
+++ b/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
@@ -25,8 +25,13 @@ def pfm():
     engine.dispose()
 
 
-def test_hard_cap_constant_is_defined_and_positive():
-    assert PartitionFileManager._ANCESTOR_RECURSION_HARD_CAP >= 100
+def test_hard_cap_lives_in_retriever_config():
+    """The cap value must come from the retriever config (operator-tunable),
+    not be hardcoded inside the data-access layer."""
+    from config import load_config
+
+    cap = int(load_config().retriever.max_ancestor_depth_cap)
+    assert cap >= 100
 
 
 def test_none_max_depth_is_clamped(pfm):
@@ -47,7 +52,9 @@ def test_explicit_depth_above_cap_is_clamped(pfm):
     be silently clamped — a misconfigured caller cannot bypass the
     safety net.
     """
-    cap = PartitionFileManager._ANCESTOR_RECURSION_HARD_CAP
+    from config import load_config
+
+    cap = int(load_config().retriever.max_ancestor_depth_cap)
     with pfm.Session() as s:
         s.add(Partition(partition="p"))
         s.commit()

--- a/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
+++ b/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
@@ -4,7 +4,7 @@ parent_id chains that would otherwise loop until the DB aborts.
 """
 
 import pytest
-from components.indexer.vectordb.models import Base, File, Partition
+from components.indexer.vectordb.models import Base, Partition
 from components.indexer.vectordb.utils import PartitionFileManager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
+++ b/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
@@ -1,0 +1,64 @@
+"""Regression test for #369 — get_file_ancestors must apply a hard depth
+cap regardless of the caller-supplied value, to defend against cyclic
+parent_id chains that would otherwise loop until the DB aborts.
+"""
+
+import pytest
+from components.indexer.vectordb.models import Base, File, Partition
+from components.indexer.vectordb.utils import PartitionFileManager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from utils.logger import get_logger
+
+
+@pytest.fixture()
+def pfm():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    mgr = PartitionFileManager.__new__(PartitionFileManager)
+    mgr.engine = engine
+    mgr.Session = Session
+    mgr.logger = get_logger()
+    mgr.file_quota_per_user = -1
+    yield mgr
+    engine.dispose()
+
+
+def test_hard_cap_constant_is_defined_and_positive():
+    assert PartitionFileManager._ANCESTOR_RECURSION_HARD_CAP >= 100
+
+
+def test_none_max_depth_is_clamped(pfm):
+    """When max_ancestor_depth=None, the query must run with the hard cap
+    instead of unlimited recursion. We only verify that the call returns
+    a list (which it would not if the recursion were unbounded against a
+    cyclic chain). For this smoke test the partition is empty so the
+    result is []."""
+    with pfm.Session() as s:
+        s.add(Partition(partition="p"))
+        s.commit()
+    out = pfm.get_file_ancestors(partition="p", file_id="missing", max_ancestor_depth=None)
+    assert out == []
+
+
+def test_explicit_depth_above_cap_is_clamped(pfm):
+    """An explicit ``max_ancestor_depth`` larger than the hard cap must
+    be silently clamped — a misconfigured caller cannot bypass the
+    safety net.
+    """
+    cap = PartitionFileManager._ANCESTOR_RECURSION_HARD_CAP
+    with pfm.Session() as s:
+        s.add(Partition(partition="p"))
+        s.commit()
+    # Smoke test: large value still returns cleanly (it would hang under
+    # the pre-fix code on a cyclic chain).
+    out = pfm.get_file_ancestors(partition="p", file_id="missing", max_ancestor_depth=cap * 10)
+    assert out == []
+
+
+# NB: a full ancestor-walk test would require Postgres because the raw-SQL
+# CTE in get_file_ancestors returns file_metadata as a JSON column —
+# SQLite's plain-TEXT column surfaces it as a str, which the row-flattening
+# code can't unpack. The three tests above are sufficient to verify the
+# depth-cap behavior the fix introduced.

--- a/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
+++ b/openrag/components/indexer/vectordb/test_ancestor_recursion_cap.py
@@ -6,9 +6,35 @@ parent_id chains that would otherwise loop until the DB aborts.
 import pytest
 from components.indexer.vectordb.models import Base, Partition
 from components.indexer.vectordb.utils import PartitionFileManager
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from utils.logger import get_logger
+
+
+def _insert_cyclic_chain(pfm, partition: str):
+    """Insert two files whose parent_id pointers loop back to each other.
+
+    ``a.parent_id == "b"`` and ``b.parent_id == "a"`` — traversing this with
+    no depth guard would recurse forever. We write the rows with raw SQL so
+    ``file_metadata`` stays SQL ``NULL`` (the ORM column defaults to ``{}``,
+    which SQLite would surface to the raw CTE query as the string ``"{}"``
+    and break the row-flattening ``**(row.file_metadata or {})``).
+    """
+    with pfm.Session() as s:
+        s.add(Partition(partition=partition))
+        s.commit()
+        s.execute(
+            text(
+                "INSERT INTO files "
+                "(file_id, partition_name, relationship_id, parent_id, file_metadata) "
+                "VALUES (:fid, :p, :rid, :pid, NULL)"
+            ),
+            [
+                {"fid": "a", "p": partition, "rid": "rel", "pid": "b"},
+                {"fid": "b", "p": partition, "rid": "rel", "pid": "a"},
+            ],
+        )
+        s.commit()
 
 
 @pytest.fixture()
@@ -27,11 +53,16 @@ def pfm():
 
 def test_hard_cap_lives_in_retriever_config():
     """The cap value must come from the retriever config (operator-tunable),
-    not be hardcoded inside the data-access layer."""
+    not be hardcoded inside the data-access layer.
+
+    We assert the contract — the cap is a positive integer — rather than a
+    specific magnitude, so legitimate operator configurations don't fail.
+    """
     from config import load_config
 
-    cap = int(load_config().retriever.max_ancestor_depth_cap)
-    assert cap >= 100
+    cap = load_config().retriever.max_ancestor_depth_cap
+    assert isinstance(cap, int)
+    assert cap > 0
 
 
 def test_none_max_depth_is_clamped(pfm):
@@ -64,8 +95,30 @@ def test_explicit_depth_above_cap_is_clamped(pfm):
     assert out == []
 
 
-# NB: a full ancestor-walk test would require Postgres because the raw-SQL
-# CTE in get_file_ancestors returns file_metadata as a JSON column —
-# SQLite's plain-TEXT column surfaces it as a str, which the row-flattening
-# code can't unpack. The three tests above are sufficient to verify the
-# depth-cap behavior the fix introduced.
+def test_cyclic_chain_is_bounded_by_explicit_depth(pfm):
+    """An actual a→b→a cycle must terminate at the (clamped) depth instead
+    of recursing forever. With an explicit depth below the hard cap, the
+    walk stops at exactly that many levels."""
+    _insert_cyclic_chain(pfm, partition="p")
+    depth = 5
+    out = pfm.get_file_ancestors(partition="p", file_id="a", max_ancestor_depth=depth)
+    # Base row (depth 0) plus one row per recursion step while depth < cap.
+    assert len(out) == depth + 1
+    assert max(row["depth"] for row in out) == depth
+
+
+def test_cyclic_chain_is_bounded_by_hard_cap(pfm):
+    """With ``max_ancestor_depth=None`` a cyclic chain must still terminate,
+    bounded by the configured hard cap rather than looping indefinitely."""
+    from config import load_config
+
+    cap = int(load_config().retriever.max_ancestor_depth_cap)
+    _insert_cyclic_chain(pfm, partition="p")
+    out = pfm.get_file_ancestors(partition="p", file_id="a", max_ancestor_depth=None)
+    assert len(out) == cap + 1
+
+
+# NB: these tests run against SQLite, which supports WITH RECURSIVE. The rows
+# above carry NULL file_metadata on purpose — a non-null JSON value would be
+# surfaced by SQLite to the raw-SQL CTE as a str and break row flattening, so
+# exercising the *metadata* unpacking path still requires Postgres.

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -602,6 +602,12 @@ class PartitionFileManager:
             )
             return [r[0] for r in results]
 
+    # Hard ceiling applied regardless of the caller-supplied depth — a
+    # self-referential or cyclic parent_id chain (A→B→A) would otherwise
+    # loop until Postgres aborts the query, hanging the request and tying
+    # up a backend.
+    _ANCESTOR_RECURSION_HARD_CAP = 1000
+
     def get_file_ancestors(self, partition: str, file_id: str, max_ancestor_depth: int | None = None) -> list[dict]:
         """Get all ancestors of a file using recursive CTE.
 
@@ -610,15 +616,23 @@ class PartitionFileManager:
         Args:
             partition: Partition name
             file_id: The file identifier to find ancestors for
-            max_ancestor_depth: Maximum depth to traverse (None = unlimited)
+            max_ancestor_depth: Maximum depth to traverse. ``None`` falls back
+                to ``_ANCESTOR_RECURSION_HARD_CAP``; explicit values are
+                additionally capped at the same constant so cyclic
+                ``parent_id`` chains can't loop indefinitely.
 
         Returns:
             List of file dictionaries ordered from root to the specified file
         """
 
         with self.Session() as session:
-            # Recursive CTE for ancestor traversal with optional max depth
-            depth_condition = "WHERE a.depth < :max_ancestor_depth" if max_ancestor_depth is not None else ""
+            effective_cap = self._ANCESTOR_RECURSION_HARD_CAP
+            if max_ancestor_depth is not None:
+                effective_cap = min(max_ancestor_depth, self._ANCESTOR_RECURSION_HARD_CAP)
+            # Recursive CTE for ancestor traversal — always capped at
+            # _ANCESTOR_RECURSION_HARD_CAP, even if the caller passed None
+            # or a larger value.
+            depth_condition = "WHERE a.depth < :max_ancestor_depth"
             query = text(f"""
                 WITH RECURSIVE ancestors AS (
                     -- Base case: start with the target file
@@ -642,9 +656,11 @@ class PartitionFileManager:
                 SELECT * FROM ancestors ORDER BY depth DESC
             """)
 
-            params = {"file_id": file_id, "partition": partition}
-            if max_ancestor_depth is not None:
-                params["max_ancestor_depth"] = max_ancestor_depth
+            params = {
+                "file_id": file_id,
+                "partition": partition,
+                "max_ancestor_depth": effective_cap,
+            }
 
             result = session.execute(query, params)
 

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -602,12 +602,6 @@ class PartitionFileManager:
             )
             return [r[0] for r in results]
 
-    # Hard ceiling applied regardless of the caller-supplied depth — a
-    # self-referential or cyclic parent_id chain (A→B→A) would otherwise
-    # loop until Postgres aborts the query, hanging the request and tying
-    # up a backend.
-    _ANCESTOR_RECURSION_HARD_CAP = 1000
-
     def get_file_ancestors(self, partition: str, file_id: str, max_ancestor_depth: int | None = None) -> list[dict]:
         """Get all ancestors of a file using recursive CTE.
 
@@ -617,18 +611,20 @@ class PartitionFileManager:
             partition: Partition name
             file_id: The file identifier to find ancestors for
             max_ancestor_depth: Maximum depth to traverse. ``None`` falls back
-                to ``_ANCESTOR_RECURSION_HARD_CAP``; explicit values are
-                additionally capped at the same constant so cyclic
-                ``parent_id`` chains can't loop indefinitely.
+                to ``retriever.max_ancestor_depth_cap``; explicit values are
+                additionally clamped at the same cap so a self-referential
+                or cyclic ``parent_id`` chain can't loop indefinitely and
+                hang a Postgres backend.
 
         Returns:
             List of file dictionaries ordered from root to the specified file
         """
 
         with self.Session() as session:
-            effective_cap = self._ANCESTOR_RECURSION_HARD_CAP
+            hard_cap = int(config.retriever.max_ancestor_depth_cap)
+            effective_cap = hard_cap
             if max_ancestor_depth is not None:
-                effective_cap = min(max_ancestor_depth, self._ANCESTOR_RECURSION_HARD_CAP)
+                effective_cap = min(max_ancestor_depth, hard_cap)
             # Recursive CTE for ancestor traversal — always capped at
             # _ANCESTOR_RECURSION_HARD_CAP, even if the caller passed None
             # or a larger value.

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -439,6 +439,12 @@ class _BaseRetrieverConfig(ConfigMixin):
     include_ancestors: bool = True
     related_limit: int = 10
     max_ancestor_depth: int = 10
+    # Absolute upper bound on ancestor-CTE recursion regardless of caller-
+    # supplied depth — defends against cyclic parent_id chains that would
+    # otherwise loop until the DB aborts the query. Operators can tune via
+    # the retriever config; the default is well above realistic deep
+    # document hierarchies.
+    max_ancestor_depth_cap: int = 1000
     allow_filterless_fallback: bool = True
 
 

--- a/openrag/core/config/retrieval.py
+++ b/openrag/core/config/retrieval.py
@@ -55,6 +55,12 @@ class _BaseRetrieverConfig(ConfigMixin):
     include_ancestors: bool = True
     related_limit: int = 10
     max_ancestor_depth: int = 10
+    # Absolute upper bound on ancestor-CTE recursion regardless of caller-
+    # supplied depth — defends against cyclic parent_id chains that would
+    # otherwise loop until the DB aborts the query. Operators can tune via
+    # the retriever config; the default is well above realistic deep
+    # document hierarchies.
+    max_ancestor_depth_cap: int = 1000
     allow_filterless_fallback: bool = True
 
 

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -457,12 +457,6 @@ class PgDocumentRepository(DocumentRepository):
         )
         return [r["file_id"] for r in rows]
 
-    # Hard ceiling applied regardless of the caller-supplied depth — a
-    # self-referential or cyclic parent_id chain (A→B→A) would otherwise
-    # loop until Postgres aborts the query, hanging the request and tying
-    # up a backend.
-    _ANCESTOR_RECURSION_HARD_CAP = 1000
-
     async def get_file_ancestors(
         self,
         partition: str,
@@ -473,14 +467,17 @@ class PgDocumentRepository(DocumentRepository):
 
         Returns a list ordered from root → self (depth DESC). When
         ``max_ancestor_depth`` is given, the recursion stops once the
-        accumulated depth meets the cap. A hard ceiling of
-        ``_ANCESTOR_RECURSION_HARD_CAP`` is always applied to defend
-        against accidental cycles, even if the caller passes ``None`` or
-        a larger explicit value.
+        accumulated depth meets the cap. The cap is additionally clamped
+        at ``retriever.max_ancestor_depth_cap`` (operator-tunable, default
+        1000) so a self-referential or cyclic ``parent_id`` chain can't
+        loop indefinitely.
         """
-        effective_cap = self._ANCESTOR_RECURSION_HARD_CAP
+        from config import load_config
+
+        hard_cap = int(load_config().retriever.max_ancestor_depth_cap)
+        effective_cap = hard_cap
         if max_ancestor_depth is not None:
-            effective_cap = min(max_ancestor_depth, self._ANCESTOR_RECURSION_HARD_CAP)
+            effective_cap = min(max_ancestor_depth, hard_cap)
         params: list[Any] = [file_id, partition, effective_cap]
         depth_filter = f"AND a.depth < ${len(params)}"
         rows = await self.pool.fetch(

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -457,6 +457,12 @@ class PgDocumentRepository(DocumentRepository):
         )
         return [r["file_id"] for r in rows]
 
+    # Hard ceiling applied regardless of the caller-supplied depth — a
+    # self-referential or cyclic parent_id chain (A→B→A) would otherwise
+    # loop until Postgres aborts the query, hanging the request and tying
+    # up a backend.
+    _ANCESTOR_RECURSION_HARD_CAP = 1000
+
     async def get_file_ancestors(
         self,
         partition: str,
@@ -467,13 +473,16 @@ class PgDocumentRepository(DocumentRepository):
 
         Returns a list ordered from root → self (depth DESC). When
         ``max_ancestor_depth`` is given, the recursion stops once the
-        accumulated depth meets the cap.
+        accumulated depth meets the cap. A hard ceiling of
+        ``_ANCESTOR_RECURSION_HARD_CAP`` is always applied to defend
+        against accidental cycles, even if the caller passes ``None`` or
+        a larger explicit value.
         """
-        depth_filter = ""
-        params: list[Any] = [file_id, partition]
+        effective_cap = self._ANCESTOR_RECURSION_HARD_CAP
         if max_ancestor_depth is not None:
-            params.append(max_ancestor_depth)
-            depth_filter = f"AND a.depth < ${len(params)}"
+            effective_cap = min(max_ancestor_depth, self._ANCESTOR_RECURSION_HARD_CAP)
+        params: list[Any] = [file_id, partition, effective_cap]
+        depth_filter = f"AND a.depth < ${len(params)}"
         rows = await self.pool.fetch(
             f"""
             WITH RECURSIVE ancestors AS (


### PR DESCRIPTION
## Summary

`get_file_ancestors` builds a recursive CTE walking `parent_id` upward. When `max_ancestor_depth=None` the recursion had no depth limit and no visited set, so a self-referential or cyclic `parent_id` chain (`A→B→A`) looped until the database aborted the query, hanging the request and tying up a Postgres backend.

This PR applies a hard ceiling (1000) regardless of the caller-supplied value:
- `None` falls back to the ceiling
- Explicit values are clamped to the same constant so a misconfigured caller can't bypass it

The cap is deliberately well above realistic deep document hierarchies. Applied to both the legacy sync helper in `vectordb/utils.py` and the new async `PgDocumentRepository`.

## Test plan

- [ ] Legitimate ancestor chains shorter than 1000 still return all rows
- [ ] A cyclic `parent_id` chain `A→B→A` returns after at most 1000 iterations instead of hanging
- [ ] `max_ancestor_depth=5` still limits to depth 5

Fixes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevents unbounded recursion when file relationships contain cycles, protecting system stability and preventing excessive database queries.
  * Added configurable depth limit for file hierarchy traversal (default: 1000 levels) that enforces a hard maximum to prevent infinite recursion.

* **Tests**
  * Added regression tests to validate recursion depth limit enforcement and cyclic relationship handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->