### PR TITLE
fix(oidc): recover gracefully when auto-provisioning hits the email unique index

### DIFF
--- a/openrag/components/indexer/vectordb/test_oidc_sessions.py
+++ b/openrag/components/indexer/vectordb/test_oidc_sessions.py
@@ -18,7 +18,9 @@ from datetime import datetime, timedelta
 import pytest
 from components.indexer.vectordb.models import Base, User
 from components.indexer.vectordb.utils import PartitionFileManager
+from models.user import UserCreate
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from utils.logger import get_logger
 
@@ -82,6 +84,42 @@ def test_get_user_by_external_id_returns_user(pfm):
 def test_get_user_by_external_id_returns_none_for_unknown(pfm):
     _make_user(pfm, external_user_id="sub-abc-123")
     assert pfm.get_user_by_external_id("sub-other") is None
+
+
+# ---------------------------------------------------------------------------
+# create_user — email uniqueness vs. null emails
+# ---------------------------------------------------------------------------
+
+
+def test_create_user_allows_multiple_null_emails(pfm):
+    """No email provided → the user is still created, and a second null-email
+    user is allowed too. NULLs are distinct under the unique email index, so
+    email-less accounts never collide with each other."""
+    u1 = pfm.create_user(UserCreate(display_name="A", external_user_id="sub-a", email=None))
+    u2 = pfm.create_user(UserCreate(display_name="B", external_user_id="sub-b", email=None))
+    # Empty-string email is treated as "no email" too.
+    u3 = pfm.create_user(UserCreate(display_name="C", external_user_id="sub-c", email=""))
+    assert u1["email"] is None
+    assert u2["email"] is None
+    assert u3["email"] is None
+    assert len({u1["id"], u2["id"], u3["id"]}) == 3
+
+
+def test_create_user_rejects_duplicate_email_case_insensitive(pfm):
+    """A real (non-null) email is unique and matched case-insensitively, since
+    create_user lowercases before storing."""
+    pfm.create_user(UserCreate(display_name="A", external_user_id="sub-a", email="dup@example.com"))
+    with pytest.raises(IntegrityError):
+        pfm.create_user(UserCreate(display_name="B", external_user_id="sub-b", email="DUP@Example.com"))
+
+
+def test_get_user_by_email_is_case_insensitive_and_none_safe(pfm):
+    pfm.create_user(UserCreate(display_name="A", external_user_id="sub-a", email="Found@Example.com"))
+    assert pfm.get_user_by_email("found@example.com") is not None
+    assert pfm.get_user_by_email("FOUND@EXAMPLE.COM") is not None
+    assert pfm.get_user_by_email("missing@example.com") is None
+    assert pfm.get_user_by_email("") is None
+    assert pfm.get_user_by_email(None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -882,6 +882,22 @@ class PartitionFileManager:
                 return None
             return self._user_to_dict(user)
 
+    def get_user_by_email(self, email: str) -> dict | None:
+        """Return the user (as dict) whose ``email`` matches (case-insensitive), or None.
+
+        Email is normalized the same way ``create_user`` stores it (stripped,
+        lowercased). This is used only to explain an auto-provisioning collision
+        on the unique ``email`` index — never as a login-matching path, which
+        stays ``external_user_id``-only.
+        """
+        if not isinstance(email, str) or not email.strip():
+            return None
+        with self.Session() as s:
+            user = s.query(User).filter(User.email == email.strip().lower()).first()
+            if not user:
+                return None
+            return self._user_to_dict(user)
+
     def update_user_fields(self, user_id: int, fields: dict[str, object]) -> None:
         """Update whitelisted scalar fields on the users table.
 

--- a/openrag/models/user.py
+++ b/openrag/models/user.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class UserBase(BaseModel):
     display_name: str | None = None
     external_user_id: str | None = None
-    email: str | None = None
+    email: str | None = Field(default=None, examples=[None])
     is_admin: bool = False
     file_quota: int | None = Field(default=10)
 

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -368,12 +368,29 @@ async def callback(request: Request, code: str | None = None, state: str | None 
                 )
             )
         except Exception as e:
-            # Race condition (concurrent first-login) or DB failure — try to
-            # recover by re-reading; if still missing, surface a 500 so the
-            # operator notices instead of silently masking the problem.
+            # create_user failed. Separate the two causes:
+            #   1. Concurrent first-login on the same sub — another request
+            #      already inserted the row; re-read by external_id and proceed.
+            #   2. The unique email index rejected the insert because a row with
+            #      this email already exists under a different identity. Matching
+            #      is external_id-only, so it wasn't found above, and only an
+            #      admin can reconcile it — surface an actionable 409 rather than
+            #      an opaque 500.
             logger.exception(f"OIDC auto-provisioning failed for sub={sub!r}: {e}")
             user = await vdb.get_user_by_external_id.remote(sub)
             if user is None:
+                if isinstance(email, str) and email.strip() and await vdb.get_user_by_email.remote(email):
+                    logger.error(
+                        f"OIDC auto-provisioning blocked for sub={sub!r}: an account with email "
+                        f"{email!r} already exists under a different identity. Set that user's "
+                        f"external_user_id to this sub to allow login."
+                    )
+                    return _json_error(
+                        status.HTTP_409_CONFLICT,
+                        "An account with this email already exists. Ask your administrator to "
+                        "link it to your identity provider login.",
+                        delete_state_cookie=True,
+                    )
                 return _json_error(
                     status.HTTP_500_INTERNAL_SERVER_ERROR,
                     "Failed to provision user",

--- a/openrag/routers/auth.py
+++ b/openrag/routers/auth.py
@@ -33,7 +33,7 @@ from fastapi import APIRouter, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
 from models.user import UserCreate
 from utils.dependencies import get_vectordb
-from utils.logger import get_logger
+from utils.logger import get_logger, mask_email
 
 # Whitelist mirrors ``api._OIDC_CLAIM_MAPPING_ALLOWED_FIELDS`` — kept in sync
 # at the DB layer too (``PartitionFileManager.update_user_fields``).
@@ -382,8 +382,8 @@ async def callback(request: Request, code: str | None = None, state: str | None 
                 if isinstance(email, str) and email.strip() and await vdb.get_user_by_email.remote(email):
                     logger.error(
                         f"OIDC auto-provisioning blocked for sub={sub!r}: an account with email "
-                        f"{email!r} already exists under a different identity. Set that user's "
-                        f"external_user_id to this sub to allow login."
+                        f"{mask_email(email)} already exists under a different identity. Set that "
+                        f"user's external_user_id to this sub to allow login."
                     )
                     return _json_error(
                         status.HTTP_409_CONFLICT,
@@ -397,7 +397,9 @@ async def callback(request: Request, code: str | None = None, state: str | None 
                     delete_state_cookie=True,
                 )
         else:
-            logger.info(f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r}, display_name={display_name!r})")
+            # display_name (the user's real name) is intentionally not logged — id + sub
+            # identify the row without writing PII to the logs.
+            logger.info(f"OIDC user auto-provisioned (id={user['id']}, sub={sub!r})")
 
     # --- 4b. Auto-provision: keep display_name + email in sync with claims ----
     # When OIDC_AUTO_PROVISION_LOGIN is on, the IdP is treated as the source of

--- a/openrag/routers/test_auth_router.py
+++ b/openrag/routers/test_auth_router.py
@@ -35,6 +35,7 @@ from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
 from cryptography.fernet import Fernet  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.exc import IntegrityError  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants — align with the existing auth unit tests
@@ -139,6 +140,7 @@ class _StubVectorDB:
     def __init__(self):
         self.calls: list[tuple[str, tuple, dict]] = []
         self._users_by_sub: dict[str, dict] = {}
+        self._users_by_email: dict[str, dict] = {}
         self._users_by_id: dict[int, dict] = {}
         self._sessions: dict[int, dict] = {}
         self._sessions_by_token: dict[str, int] = {}
@@ -148,6 +150,7 @@ class _StubVectorDB:
         self.get_user_by_external_id = _RayMethodStub(
             "get_user_by_external_id", self._impl_get_user_by_external_id, self.calls
         )
+        self.get_user_by_email = _RayMethodStub("get_user_by_email", self._impl_get_user_by_email, self.calls)
         self.update_user_fields = _RayMethodStub("update_user_fields", self._impl_update_user_fields, self.calls)
         self.create_user = _RayMethodStub("create_user", self._impl_create_user, self.calls)
         self.create_oidc_session = _RayMethodStub("create_oidc_session", self._impl_create_oidc_session, self.calls)
@@ -181,12 +184,19 @@ class _StubVectorDB:
         self._users_by_id[user_id] = user
         if external_user_id:
             self._users_by_sub[external_user_id] = user
+        if email:
+            self._users_by_email[email.strip().lower()] = user
         return user
 
     # Impls ------------------------------------------------------------------
 
     def _impl_get_user_by_external_id(self, external_user_id: str):
         return self._users_by_sub.get(external_user_id)
+
+    def _impl_get_user_by_email(self, email: str):
+        if not isinstance(email, str) or not email.strip():
+            return None
+        return self._users_by_email.get(email.strip().lower())
 
     def _impl_create_user(self, body):
         # Accept either UserCreate or a plain dict, like the real Ray method
@@ -195,13 +205,18 @@ class _StubVectorDB:
             data = body.model_dump()
         else:
             data = dict(body)
+        normalized_email = data.get("email").strip().lower() if data.get("email") else None
+        # Faithful to the unique ix_users_email index: a second row with the
+        # same email is rejected, just like Postgres would.
+        if normalized_email and normalized_email in self._users_by_email:
+            raise IntegrityError("duplicate key value violates unique constraint", None, Exception())
         user_id = self._next_user_id
         self._next_user_id += 1
         user = {
             "id": user_id,
             "display_name": data.get("display_name"),
             "external_user_id": data.get("external_user_id"),
-            "email": (data.get("email").strip().lower() if data.get("email") else None),
+            "email": normalized_email,
             "is_admin": bool(data.get("is_admin", False)),
             "file_quota": data.get("file_quota"),
             "file_count": 0,
@@ -210,6 +225,8 @@ class _StubVectorDB:
         self._users_by_id[user_id] = user
         if data.get("external_user_id"):
             self._users_by_sub[data["external_user_id"]] = user
+        if normalized_email:
+            self._users_by_email[normalized_email] = user
         return user
 
     def _impl_update_user_fields(self, user_id: int, fields: dict):
@@ -532,6 +549,28 @@ def test_callback_auto_provisions_user_when_enabled(client, fresh_stub_vectordb,
     assert data["display_name"] == "Alice Liddell"
     assert data["email"] == "alice@example.com"
     assert data["is_admin"] is False  # auto-provisioned users are NEVER admin
+
+
+def test_callback_auto_provision_email_collision_returns_409(client, fresh_stub_vectordb, monkeypatch):
+    """First-login auto-provisioning where the email already belongs to a row
+    under a different identity must not 500. Matching is external_id-only, so
+    the existing row isn't found by sub; create_user then hits the unique email
+    index. The callback recovers with an actionable 409 instead of 500."""
+    monkeypatch.setenv("OIDC_AUTO_PROVISION_LOGIN", "true")
+    # Pre-existing user with this email but a *different* external_user_id.
+    fresh_stub_vectordb.add_user(user_id=7, email="alice@example.com", external_user_id="sub-old")
+
+    _setup_jwks(client.oidc_router)
+    state, nonce = _begin_login_and_extract_state(client)
+    id_token = _sign_jwt(_id_token_payload(nonce, sub="sub-new-user", email="alice@example.com", extra={}))
+    _mock_token_endpoint(client.oidc_router, id_token)
+
+    r = client.get(f"/auth/callback?code=c&state={state}", follow_redirects=False)
+
+    assert r.status_code == 409, r.text
+    assert "already exists" in r.text
+    # No session was minted for the failed login.
+    assert not any(c[0] == "create_oidc_session" for c in fresh_stub_vectordb.calls)
 
 
 def test_callback_auto_provision_falls_back_to_sub_when_no_name(client, fresh_stub_vectordb, monkeypatch):

--- a/openrag/utils/logger.py
+++ b/openrag/utils/logger.py
@@ -11,6 +11,22 @@ def escape_markup(s: str) -> str:
     return s.replace("\\", "\\\\").replace("<", "\\<").replace(">", "\\>")
 
 
+def mask_email(email: str | None) -> str:
+    """Mask an email address for logging — keep the first local character and
+    the domain, e.g. ``alice@example.com`` -> ``a***@example.com``.
+
+    The domain is retained so an operator can still tell which tenant/IdP an
+    entry relates to; the local part (the personal identifier) is redacted.
+    Non-string or malformed input returns ``"***"`` so a raw address can never
+    reach the logs by accident.
+    """
+    if not isinstance(email, str) or "@" not in email:
+        return "***"
+    local, _, domain = email.partition("@")
+    masked_local = f"{local[0]}***" if local else "***"
+    return f"{masked_local}@{domain}"
+
+
 def get_logger():
     def formatter(record):
         level = record["level"].name

--- a/openrag/utils/test_logger.py
+++ b/openrag/utils/test_logger.py
@@ -1,4 +1,20 @@
-from utils.logger import escape_markup
+from utils.logger import escape_markup, mask_email
+
+
+def test_mask_email_keeps_first_char_and_domain():
+    assert mask_email("alice@example.com") == "a***@example.com"
+
+
+def test_mask_email_redacts_short_and_uppercase_local_parts():
+    assert mask_email("a@example.com") == "a***@example.com"
+    assert mask_email("Bob.Smith@corp.io") == "B***@corp.io"
+
+
+def test_mask_email_handles_missing_or_malformed_values():
+    assert mask_email(None) == "***"
+    assert mask_email("") == "***"
+    assert mask_email("not-an-email") == "***"
+    assert mask_email(123) == "***"
 
 
 def test_escape_markup_escapes_angle_brackets():


### PR DESCRIPTION
## Problem

OIDC first-connection auto-provisioning (`OIDC_AUTO_PROVISION_LOGIN=true`) matches users **exclusively** by `external_user_id == sub`. When that lookup misses but a `users` row already exists with the same `email` (a unique-indexed column — `models.py` + migration `f5b6c918f741`), `create_user` violates the `ix_users_email` unique constraint.

The previous recovery handler only re-read by `external_user_id`, so it still came up empty and returned an opaque `500 "Failed to provision user"` — the user was permanently locked out. This is the realistic case where an admin pre-creates a user by their email (the natural identifier) but the IdP's opaque `sub` doesn't already match the row.

## Fix

Matching policy is unchanged (still `external_id`-only; email is never a login path). The recovery path is made informative instead:

- On `create_user` failure, first re-read by `external_id` — handles the safe concurrent same-`sub` first-login race (unchanged behavior).
- If still absent and a row with that email already exists under a different identity, return an actionable **409** ("An account with this email already exists. Ask your administrator to link it to your identity provider login.") and log the `sub` + email so an admin can set that row's `external_user_id`.
- Genuine failures still surface a 500.

Auto-linking by email was deliberately **not** chosen: binding an unverified IdP email claim to an existing account is an account-takeover vector.

## Changes

- `vectordb/utils.py` — add read-only `get_user_by_email` (normalized like `create_user`; documented as not a login-matching path).
- `routers/auth.py` — distinguish the email-collision case in the recovery handler and return 409.
- `routers/test_auth_router.py` — stub now raises `IntegrityError` on a duplicate email like Postgres; adds `test_callback_auto_provision_email_collision_returns_409`.

## Testing

New test passes; lint/format clean. The 2 unrelated failures seen when running `test_auth_router.py` in isolation are pre-existing (identical on `main`) and caused by a local `.env` setting `OIDC_AUTO_PROVISION_LOGIN=true`, not by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC auto-provisioning now returns HTTP 409 on email collisions with guidance to link accounts (instead of a generic failure).

* **New Features**
  * Case-insensitive, whitespace-normalized email lookup for user matching.
  * Email redaction for logs to avoid exposing full addresses.

* **Tests**
  * Added tests covering email lookup, uniqueness rules, collision handling, and email masking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->