### PR TITLE
refactor(12B): switch auth imports from components.auth to services.auth

### DIFF
--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -34,11 +34,11 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote
 
-from components.auth.refresh import refresh_session_if_needed
 from core.config.auth import AuthBypassConfig
 from core.utils.logging import get_logger
 from fastapi import Request
 from fastapi.responses import JSONResponse, RedirectResponse
+from services.auth.refresh import refresh_session_if_needed
 from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger()

--- a/openrag/api/routers/auth/oidc.py
+++ b/openrag/api/routers/auth/oidc.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 import os
 
-from components.auth import StateCookieSerializer
 from core.utils.exceptions import OpenRAGError
 from core.utils.logging import get_logger
 from di.providers import get_auth_service
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
+from services.auth.state_cookie import StateCookieSerializer
 
 logger = get_logger()
 router = APIRouter()

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -276,7 +276,7 @@ class ServiceContainer:
             cfg = self._oidc_config
             client = None
             if cfg.enabled:
-                from components.auth import get_oidc_client
+                from services.auth import get_oidc_client
 
                 client = get_oidc_client()
             self._auth_service = AuthService(

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -12,9 +12,7 @@ the Ray ``vectordb`` actor, so it deals in :class:`User` /
 
 The cryptographic / cookie primitives (``OIDCClient``, the state-cookie
 serializer, Fernet token (de)encryption, opaque session-token issuance)
-still come from ``components.auth`` during the Phase-8 shim period —
-those are infrastructure adapters scheduled to move under
-``services/auth`` in Phase 9.
+come from ``services.auth`` — the infrastructure adapters for OIDC.
 """
 
 from __future__ import annotations
@@ -25,7 +23,10 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode, urlparse
 
-from components.auth import (
+from core.models.user import OIDCSession, User
+from core.utils.exceptions import AuthError, OpenRAGError
+from core.utils.logging import get_logger, mask_email
+from services.auth import (
     OIDCClient,
     StateCookiePayload,
     StateCookieSerializer,
@@ -34,9 +35,6 @@ from components.auth import (
     hash_session_token,
     issue_session_token,
 )
-from core.models.user import OIDCSession, User
-from core.utils.exceptions import AuthError, OpenRAGError
-from core.utils.logging import get_logger, mask_email
 
 if TYPE_CHECKING:
     from core.config.auth import OIDCConfig

--- a/openrag/services/orchestrators/test_auth_service.py
+++ b/openrag/services/orchestrators/test_auth_service.py
@@ -9,11 +9,11 @@ faked. Each test asserts behaviour the legacy router used to own.
 from __future__ import annotations
 
 import pytest
-from components.auth import StateCookieSerializer, hash_session_token
-from components.auth.oidc_client import LogoutTokenClaims, TokenBundle
 from core.config.auth import OIDCConfig
 from core.models.user import User
 from cryptography.fernet import Fernet
+from services.auth import StateCookieSerializer, hash_session_token
+from services.auth.oidc_client import LogoutTokenClaims, TokenBundle
 from services.orchestrators.auth_service import AuthService, OIDCFlowError
 
 KEY = Fernet.generate_key().decode()

--- a/openrag/services/persistence/oidc_session_repo.py
+++ b/openrag/services/persistence/oidc_session_repo.py
@@ -10,7 +10,7 @@ seven OIDC methods (``create_oidc_session``, ``get_oidc_session_by_token``,
 
 Tokens (``id_token``, ``access_token``, ``refresh_token``) are stored
 **Fernet-encrypted** as ``BYTEA``. Encryption and decryption are the
-caller's responsibility (see ``components.auth.crypto``) — the repo
+caller's responsibility (see ``services.auth.session_tokens``) — the repo
 treats the bytes as opaque. The plain session cookie value is hashed
 (SHA-256) at the caller before being passed in.
 
@@ -302,7 +302,7 @@ class PgOIDCSessionRepository(OIDCSessionRepository):
 
         ``SELECT ... FOR UPDATE`` serialises concurrent refresh callers on
         the same session row — Postgres only. The wider stampede guard in
-        :mod:`components.auth.refresh` short-circuits before this is even
+        :mod:`services.auth.refresh` short-circuits before this is even
         called in the common case.
         """
         async with self.pool.acquire() as conn:


### PR DESCRIPTION
## Phase 12B — Switch auth imports to `services/auth/`

Re-points the remaining consumers of the legacy `components.auth` shims onto the canonical `services/auth/` implementations. No code moves — `services/auth/` already holds the real OIDC client, session-token, state-cookie, and deps modules (created in Phase 8); `components/auth/*` are now thin re-export shims.

> **Stacked on #434 (Phase 12A).** Based on `refactor/phase-12a-logger` so the diff is just 12B's 6 files. Retarget to `refactor/hexagonal` once #434 merges. Independent of Person B's 12D/12E/12G work.

### Import re-points
| File | Old | New |
| --- | --- | --- |
| `api/middleware/auth.py` | `components.auth.refresh` | `services.auth.refresh` |
| `api/routers/auth/oidc.py` | `components.auth` | `services.auth.state_cookie` |
| `di/container.py` | `components.auth` | `services.auth` |
| `services/orchestrators/auth_service.py` | `components.auth` (7 symbols) | `services.auth` |
| `services/orchestrators/test_auth_service.py` | `components.auth` (2 lines) | `services.auth` |

### Also
- Refreshed stale module references in docstrings that still named the old `components.auth.*` paths (the `auth_service` header note about the "Phase-8 shim period", and two `oidc_session_repo` cross-references).
- Re-sorted import blocks (`components.*` sorted before `core.*`, `services.*` sorts after) so `ruff check` stays clean.

### Canonical-equivalence check
Confirmed `components/auth/{oidc_client,session_tokens,deps,__init__}.py` are re-export shims delegating to `services.auth.*` (the real implementations), so re-pointing is behaviour-preserving and the shims are safe for 12H to delete.

### Verification
- `grep "from components.auth"` / `components.auth` outside `components/` → zero results
- `ruff check` on all changed files → clean
- Auth suites: `test_auth_service.py`, `test_auth_router.py`, `services/auth/` → 41 passed
- Full test collection: 1212 tests, no import errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal reorganization of authentication service imports for improved code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->