### PR TITLE
refactor(12C): load retrieval/query prompts via core loader, drop components.prompts

### DIFF
--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -42,16 +42,12 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from components.prompts import (
-    QUERY_CONTEXTUALIZER_PROMPT,
-    SPOKEN_STYLE_ANSWER_PROMPT,
-    SYS_PROMPT_TMPLT,
-)
 from core.models.query import Query, SearchQueries
 from core.prompts import (
     SOURCE_SEPARATOR,
     format_context,
     format_web_context,
+    load_template_by_key,
 )
 from core.utils.logging import get_logger
 from core.utils.source_filtering import (
@@ -127,6 +123,11 @@ class QueryService:
         self._mr_expansion = mr.expansion_batch_size
         self._mr_max = mr.max_total_documents
 
+        prompts_dir, mapping = config.paths.prompts_dir, config.prompts
+        self._query_contextualizer_prompt = load_template_by_key(prompts_dir, mapping, "query_contextualizer")
+        self._spoken_style_answer_prompt = load_template_by_key(prompts_dir, mapping, "spoken_style_answer")
+        self._sys_prompt_tmplt = load_template_by_key(prompts_dir, mapping, "sys_prompt")
+
     # ------------------------------------------------------------------
     # Query generation (was RagPipeline.generate_query — no LangChain)
     # ------------------------------------------------------------------
@@ -137,7 +138,7 @@ class QueryService:
             return SearchQueries(query_list=[Query(query=last_user)])
 
         chat_history = "".join(f"{m['role']}: {m['content']}\n" for m in messages)
-        prompt = QUERY_CONTEXTUALIZER_PROMPT.format(
+        prompt = self._query_contextualizer_prompt.format(
             query_language=detect_language(last_user),
             current_date=datetime.now().strftime("%A, %B %d, %Y, %H:%M:%S"),
         )
@@ -284,7 +285,7 @@ class QueryService:
             context = f"{context}{SOURCE_SEPARATOR}{web_formatted}" if context else web_formatted
 
         new_messages = copy.deepcopy(messages)
-        tmpl = SPOKEN_STYLE_ANSWER_PROMPT if spoken_style else SYS_PROMPT_TMPLT
+        tmpl = self._spoken_style_answer_prompt if spoken_style else self._sys_prompt_tmplt
         new_messages.insert(
             0,
             {

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from core.prompts import load_template_by_key
 from core.retrieval.pipeline import RetrieverPipeline
 from core.retrieval.retriever import (
     HyDeRetriever,
@@ -77,20 +78,16 @@ class RetrievalService:
         }
         rtype = rcfg.type
         if rtype == "multiQuery":
-            from components.prompts import MULTI_QUERY_PROMPT
-
             retriever = MultiQueryRetriever(
                 llm=llm,
-                multi_query_template=MULTI_QUERY_PROMPT,
+                multi_query_template=load_template_by_key(config.paths.prompts_dir, config.prompts, "multi_query"),
                 k_queries=rcfg.k_queries,
                 **common,
             )
         elif rtype == "hyde":
-            from components.prompts import HYDE_PROMPT
-
             retriever = HyDeRetriever(
                 llm=llm,
-                hyde_template=HYDE_PROMPT,
+                hyde_template=load_template_by_key(config.paths.prompts_dir, config.prompts, "hyde"),
                 combine=rcfg.combine,
                 **common,
             )

--- a/openrag/services/orchestrators/test_query_service.py
+++ b/openrag/services/orchestrators/test_query_service.py
@@ -15,8 +15,13 @@ from types import SimpleNamespace
 
 import pytest
 import services.orchestrators.query_service as qs
+from core.config import load_config
 from core.models.chunk import Chunk
 from services.orchestrators.query_service import QueryService
+
+# Real prompt-template config (dir + key->filename mapping) so QueryService
+# can load its system / contextualizer / spoken-style templates from disk.
+_PROMPT_CFG = load_config()
 
 
 @pytest.fixture(autouse=True)
@@ -88,6 +93,8 @@ def _config(mode="SimpleRag"):
         reranker=SimpleNamespace(top_k=5),
         chunker=SimpleNamespace(chunk_size=512),
         map_reduce=SimpleNamespace(initial_batch_size=2, expansion_batch_size=2, max_total_documents=4),
+        paths=_PROMPT_CFG.paths,
+        prompts=_PROMPT_CFG.prompts,
     )
 
 


### PR DESCRIPTION
## Phase 12C — Migrate prompt constants off `components.prompts`

Removes the last `from components.prompts import …` consumers so the shim can be deleted in 12H.

> **Based on the Phase-12 integration tip** (`refactor/phase-12a-logger` @ `c7be6380`, which already bundles 12A/12D/12E/12G), so the diff is just 12C's 3 files. Independent of 12B (#436).

### Design note — deviation from the guide's letter, faithful to its intent
The 12C plan assumed these were Python string constants to inline into `core/prompts/` builders. They are **not** — `components/prompts/prompts.py` is a shim whose "constants" (`HYDE_PROMPT`, `MULTI_QUERY_PROMPT`, `SYS_PROMPT_TMPLT`, `QUERY_CONTEXTUALIZER_PROMPT`, `SPOKEN_STYLE_ANSWER_PROMPT`) are **disk templates eager-loaded via `load_config()`** at import.

Distributing them as eager module-level constants into the builders would add **import-time disk I/O + a config dependency to the entire `core.prompts` package** (its `__init__` imports every builder) — an architectural regression that also breaks `core`'s import-time purity.

Instead, each orchestrator loads its templates from the **injected `Settings`** using the existing pure `core.prompts.load_template_by_key(prompts_dir, mapping, key)` — precisely the call shape `template_loader`'s docstring prescribes for callers. This removes the shim dependency, keeps `core` pure, and binds prompts to the instance's config (more correct than the old process-global eager load). The real per-template-file migration remains Phase 13D.

### Changes
- **`retrieval_service.py`** — `multiQuery` / `hyde` branches load `"multi_query"` / `"hyde"` from `config` (already a constructor arg) instead of the inline shim import.
- **`query_service.py`** — load `"query_contextualizer"` / `"spoken_style_answer"` / `"sys_prompt"` once in `__init__` from the injected config, stored on the instance; use sites updated.
- **`test_query_service.py`** — extend the fake `SimpleNamespace` config with the real `paths`/`prompts` so `QueryService` can resolve templates.

### Verification
- `grep "components.prompts"` outside `components/` → zero results
- `ruff check` on all changed files → clean
- `test_query_service.py` + `test_retrieval_service.py` + `core/prompts/` → 55 passed
- Smoke-checked all 5 template keys resolve against the real config
- Full collection: 1211 tests, no import errors

> Note: the `multiQuery`/`hyde` retrieval branches have no existing unit test (true before this change too — the old inline imports were equally uncovered). Verified manually that both keys resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized prompt template management by loading templates from a unified configuration source instead of using dispersed constants. This improves maintainability and consistency across the query and retrieval orchestration services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/openrag/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->