### PR TITLE
refactor: repoint config imports to core.config (12H prep)

### DIFF
--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -51,7 +51,7 @@ from api.routers.user.chat import router as openai_router
 from api.routers.user.extract import router as extract_router
 from api.routers.user.health import router as health_router
 from api.routers.user.search import router as search_router
-from config import load_config
+from core.config import load_config
 from core.utils.logging import get_logger
 from di.container import ServiceContainer
 from di.providers import set_container

--- a/openrag/api/mcp/server.py
+++ b/openrag/api/mcp/server.py
@@ -35,7 +35,7 @@ from api.mcp.auth_context import (
     reset_auth_context,
     set_auth_context,
 )
-from config import load_config
+from core.config import load_config
 from core.utils.log_tail import app_log_file
 from core.utils.logging import get_logger
 from di.container import ServiceContainer

--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -30,7 +30,7 @@ from api.dependencies.llm import (
 )
 from api.routers.user.source_links import build_document_source_link
 from api.schemas.user.chat import OpenAIChatCompletionRequest, OpenAICompletionRequest
-from config import load_config
+from core.config import load_config
 from core.utils.exceptions import OpenRAGError
 from core.utils.logging import get_logger
 from core.utils.text import get_num_tokens, sanitize_text

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 
 def default_max_tokens():
-    from config import load_config
+    from core.config import load_config
 
     return load_config().llm_context.max_output_tokens
 

--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 def _get_auth_service(request):
     container = getattr(request.app.state, "container", None)
     if container is None:
-        from config import load_config
+        from core.config import load_config
         from di.container import ServiceContainer
 
         container = ServiceContainer(load_config())

--- a/openrag/scripts/backup.py
+++ b/openrag/scripts/backup.py
@@ -212,7 +212,7 @@ def main():
         Returns:
             tuple: (RDBConfig, VectorDBConfig) Pydantic config models.
         """
-        from config import load_config
+        from core.config import load_config
 
         try:
             config = load_config()

--- a/openrag/scripts/restore.py
+++ b/openrag/scripts/restore.py
@@ -261,7 +261,7 @@ def main():
         Returns:
             tuple: (RDBConfig, VectorDBConfig) Pydantic config models.
         """
-        from config import load_config
+        from core.config import load_config
 
         try:
             config = load_config()

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -474,7 +474,7 @@ class PgDocumentRepository(DocumentRepository):
         1000) so a self-referential or cyclic ``parent_id`` chain can't
         loop indefinitely.
         """
-        from config import load_config
+        from core.config import load_config
 
         hard_cap = int(load_config().retriever.max_ancestor_depth_cap)
         effective_cap = hard_cap

--- a/openrag/services/persistence/migrations/alembic/env.py
+++ b/openrag/services/persistence/migrations/alembic/env.py
@@ -7,7 +7,7 @@ from logging.config import fileConfig
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from alembic import context
-from config import load_config
+from core.config import load_config
 from services.persistence.schema import metadata as target_metadata
 from sqlalchemy import URL, engine_from_config, pool
 

--- a/openrag/services/persistence/migrations/milvus/1.add_created_at_temporal_fields.py
+++ b/openrag/services/persistence/migrations/milvus/1.add_created_at_temporal_fields.py
@@ -32,7 +32,7 @@ Or run this script directly:
 import argparse
 import sys
 
-from config import load_config
+from core.config import load_config
 from core.utils.logging import get_logger
 from pymilvus import DataType, MilvusClient
 from services.storage.milvus_store import SCHEMA_VERSION_PROPERTY_KEY

--- a/openrag/services/persistence/migrations/milvus/migrate.py
+++ b/openrag/services/persistence/migrations/milvus/migrate.py
@@ -36,7 +36,7 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
-from config import load_config
+from core.config import load_config
 from core.utils.logging import get_logger
 from pymilvus import MilvusClient
 from services.storage.milvus_store import SCHEMA_VERSION_PROPERTY_KEY

--- a/openrag/services/persistence/test_ancestor_recursion_cap.py
+++ b/openrag/services/persistence/test_ancestor_recursion_cap.py
@@ -13,7 +13,7 @@ class _FakePool:
 
 
 def test_hard_cap_lives_in_retriever_config():
-    from config import load_config
+    from core.config import load_config
 
     cap = load_config().retriever.max_ancestor_depth_cap
     assert isinstance(cap, int)
@@ -22,7 +22,7 @@ def test_hard_cap_lives_in_retriever_config():
 
 @pytest.mark.asyncio
 async def test_none_max_depth_is_clamped_to_hard_cap():
-    from config import load_config
+    from core.config import load_config
     from services.persistence.document_repo import PgDocumentRepository
 
     pool = _FakePool()
@@ -34,7 +34,7 @@ async def test_none_max_depth_is_clamped_to_hard_cap():
 
 @pytest.mark.asyncio
 async def test_explicit_depth_above_cap_is_clamped():
-    from config import load_config
+    from core.config import load_config
     from services.persistence.document_repo import PgDocumentRepository
 
     cap = int(load_config().retriever.max_ancestor_depth_cap)

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -13,7 +13,7 @@ class IndexerPool:
 
     def __init__(self) -> None:
         import services.inference.vllm_client  # noqa: F401
-        from config import load_config
+        from core.config import load_config
         from core.embeddings import embedder_registry
         from services.storage.milvus_store import MilvusVectorStore
         from services.storage.postgres_store import PostgresStore

--- a/openrag/services/workers/parsers/doc_serializer.py
+++ b/openrag/services/workers/parsers/doc_serializer.py
@@ -18,7 +18,7 @@ from services.workers.parsers.legacy_loaders import get_loader_classes
 @ray.remote(max_restarts=5)
 class DocSerializer:
     def __init__(self, data_dir=None, **kwargs) -> None:
-        from config import load_config
+        from core.config import load_config
         from core.utils.logging import get_logger
 
         self.logger = get_logger()

--- a/openrag/services/workers/parsers/doc_serializer_adapter.py
+++ b/openrag/services/workers/parsers/doc_serializer_adapter.py
@@ -17,7 +17,7 @@ class DocSerializerAdapter(FileSerializer):
 
     async def serialize(self, path: str, metadata: dict) -> str:
         import ray
-        from config import load_config
+        from core.config import load_config
         from services.workers.ray_utils import call_ray_actor_with_timeout
 
         cfg = load_config()

--- a/openrag/services/workers/parsers/docling_workers.py
+++ b/openrag/services/workers/parsers/docling_workers.py
@@ -14,7 +14,7 @@ import asyncio
 
 import ray
 import torch
-from config import load_config
+from core.config import load_config
 from core.indexing.image_preprocessor import pil_to_png_bytes
 from core.indexing.parsers.document_parser import BasePooledParser
 from core.models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock

--- a/openrag/services/workers/parsers/legacy_loaders/test_doc_loader.py
+++ b/openrag/services/workers/parsers/legacy_loaders/test_doc_loader.py
@@ -12,7 +12,8 @@ without being swallowed.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from config.models import LoaderConfig, VLMConfig
+from core.config.endpoints import VLMConfig
+from core.config.indexation import LoaderConfig
 from core.models.document import ProcessedDocument, TextBlock
 from langchain_core.documents.base import Document as LCDocument
 

--- a/openrag/services/workers/parsers/legacy_loaders/test_eml_recursion.py
+++ b/openrag/services/workers/parsers/legacy_loaders/test_eml_recursion.py
@@ -87,7 +87,7 @@ async def test_eml_below_cap_does_not_skip(tmp_path):
 def test_recursion_cap_lives_in_loader_config():
     """The cap must come from the loader config (operator-tunable), not be
     hardcoded in the loader. Assert the contract: a positive integer."""
-    from config import load_config
+    from core.config import load_config
 
     cap = load_config().loader.eml_max_recursion_depth
     assert isinstance(cap, int)

--- a/openrag/services/workers/parsers/marker_workers.py
+++ b/openrag/services/workers/parsers/marker_workers.py
@@ -6,7 +6,7 @@ import time
 import pypdfium2
 import ray
 import torch
-from config import load_config
+from core.config import load_config
 from core.indexing.image_preprocessor import pil_to_png_bytes
 from core.indexing.parsers.document_parser import BasePooledParser
 from core.models.document import (
@@ -33,7 +33,7 @@ class MarkerWorker:
     def __init__(self):
         import os
 
-        from config import load_config
+        from core.config import load_config
         from core.utils.logging import get_logger
 
         self.logger = get_logger()
@@ -176,7 +176,7 @@ class MarkerWorker:
 @ray.remote(max_restarts=5)
 class MarkerPool:
     def __init__(self):
-        from config import load_config
+        from core.config import load_config
         from core.utils.logging import get_logger
 
         self.logger = get_logger()

--- a/openrag/services/workers/parsers/whisper_workers.py
+++ b/openrag/services/workers/parsers/whisper_workers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import ray
 import torch
-from config import load_config
+from core.config import load_config
 from core.indexing.parsers.document_parser import BasePooledParser
 from core.models.document import (
     Document,
@@ -39,7 +39,7 @@ LANG_DETECT_SAMPLE_MS = 30_000  # 30 s
 class WhisperActor:
     def __init__(self):
         import torch
-        from config import load_config
+        from core.config import load_config
         from core.utils.logging import get_logger
 
         self.logger = get_logger()
@@ -102,7 +102,7 @@ class WhisperPool:
     """
 
     def __init__(self):
-        from config import load_config
+        from core.config import load_config
         from core.utils.logging import get_logger
 
         self.logger = get_logger()

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -7,7 +7,7 @@ from typing import Any
 import ray
 
 try:
-    from config import load_config as _load_config
+    from core.config import load_config as _load_config
 
     _cfg = _load_config()
     _POOL_SIZE: int = _cfg.ray.pool_size


### PR DESCRIPTION
## Phase 12 cleanup prep — drop the `config/` shim dependency

Repoints every **surviving** (non-`components/`) consumer of the legacy `config/` shim to the canonical `core.config`, so `config/` can be deleted in 12H.

> Based on the Phase-12 integration branch (`refactor/phase-12a-logger`).

### Context
12G (chunker) is already done (Person B's c7be6380; `indexer_pool` uses `core.chunking.factory.create_chunker`). With 12A–12G complete, the remaining work before 12H is clearing the imports that still point at the to-be-deleted `components/`, `config/`, `utils/` dirs. This PR handles the `config/` slice.

### Changes (21 files)
- `from config import load_config` → `from core.config import load_config` across `api/`, `services/` (orchestrators, persistence, workers, migrations), `scripts/`, and `chainlit_api.py` — both top-level and lazy/in-function imports.
- `legacy_loaders/test_doc_loader.py`: `from config.models import LoaderConfig, VLMConfig` → `core.config.indexation.LoaderConfig` + `core.config.endpoints.VLMConfig` (verified the core models accept the same kwargs by construction).

`components/` still imports `from config` internally; those files are deleted wholesale in 12H, so they're deliberately left untouched (keeps this PR scoped to surviving code, no churn on the deletion set).

### Verification
- No surviving module imports the `config/` shim (`grep "from config"` outside `config/`+`components/` → clean)
- `ruff check` / import-sort clean on all changed files
- `scripts/check_layer_imports.py` → OK
- Full collection: **1211 tests, no import errors**
- Affected suites (api, persistence, workers, legacy loader test) → 149 + 7 passed

### Remaining 12H blockers (separate work)
- `legacy_loaders/{base,pdf_loaders/docling}.py` → `components.utils` (`SingletonMeta`, `get_vlm_semaphore`, `load_config`) + `components.prompts` (`IMAGE_DESCRIBER`) — the 12F entanglement; needs canonical homes (12E-adjacent).
- `tests/test_relationships_integration.py` → `components.retriever.RelationshipAwareRetriever` (test-only).