### PR TITLE
fix(milvus): raise gRPC channel-ready timeout to 60 s

### DIFF
--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -144,10 +144,10 @@ class MilvusVectorStore(VectorStore):
         self._collection_name = config.collection_name
         self._hybrid = config.hybrid_search
         self._uri = f"http://{config.host}:{config.port}"
-
+        self._timeout = 60
         try:
-            self._client = MilvusClient(uri=self._uri)
-            self._async_client = AsyncMilvusClient(uri=self._uri)
+            self._client = MilvusClient(uri=self._uri, timeout=self._timeout)
+            self._async_client = AsyncMilvusClient(uri=self._uri, timeout=self._timeout)
         except MilvusException as e:
             raise VDBConnectionError(
                 f"Failed to connect to Milvus: {e!s}",


### PR DESCRIPTION
## Problem

On low-resource machines the Milvus 2.6 gRPC channel handshake takes longer than pymilvus's default 10-second \`channel_ready_future\` timeout, producing:

\`\`\`
VDBInsertError: Milvus insert failed: <MilvusException: (code=2, message=Fail connecting to
server on milvus:19530, illegal connection params or server unavailable)>
\`\`\`

The error is misleading — DNS resolves correctly, TCP port 19530 is open, and the HTTP health endpoint (port 9091) responds OK. The gRPC handshake simply needs more time under resource pressure. Root-cause confirmed: fails with default 10 s timeout, connects cleanly with \`timeout=60\` against the same \`milvus:2.6.11\` container.

## Fix

- Pass \`timeout=60\` to both \`MilvusClient\` and \`AsyncMilvusClient\` in \`MilvusVectorStore.__init__\`
- Store the value in \`self._timeout\` as a single source of truth

## Test plan

- [ ] Index a document on a low-resource machine — no \`VDBInsertError\` on startup or during insert
- [ ] \`MilvusVectorStore\` constructs successfully with \`timeout=60\` against a freshly started Milvus 2.6 container

🤖 Generated with [Claude Code](https://claude.com/claude-code)