### PR TITLE
fix(indexing): honor disabled image captioning in legacy parser

### DIFF
--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from core.models.document import Document
+from services.workers.parsers.doc_serializer_bridge import INDEXATION_CONFIG_METADATA_KEY
 from services.workers.pipeline_builder import IndexingPipeline
 
 
@@ -57,7 +58,7 @@ class IndexerWorker:
         """
         await self._tsm.set_state.remote(task_id, "SERIALIZING")
         try:
-            document = _load_document(path, metadata, partition)
+            document = _load_document(path, metadata, partition, indexation_config=indexation_config)
             row: dict[str, Any] = {
                 "document": document,
                 "partition": partition,
@@ -121,14 +122,23 @@ async def _write_catalog_record(
     )
 
 
-def _load_document(path: str, metadata: dict[str, Any], partition: str) -> Document:
+def _load_document(
+    path: str,
+    metadata: dict[str, Any],
+    partition: str,
+    *,
+    indexation_config: dict[str, Any] | None = None,
+) -> Document:
     p = Path(path)
+    document_metadata = dict(metadata)
+    if indexation_config is not None:
+        document_metadata[INDEXATION_CONFIG_METADATA_KEY] = dict(indexation_config)
     return Document(
         filename=metadata.get("file_id") or p.name,
         raw_bytes=p.read_bytes(),
         content_type=Document.detect_content_type(p.name),
         partition=partition,
-        metadata=metadata,
+        metadata=document_metadata,
     )
 
 

--- a/openrag/services/workers/parsers/doc_serializer_bridge.py
+++ b/openrag/services/workers/parsers/doc_serializer_bridge.py
@@ -7,6 +7,8 @@ from typing import Any
 from core.indexing.parsers.document_parser import DocumentParser
 from core.models.document import Document, DocumentType, ProcessedDocument, TextBlock
 
+INDEXATION_CONFIG_METADATA_KEY = "_openrag_indexation_config"
+
 
 class DocSerializerBridgeParser(DocumentParser):
     """Transitional parser backed by the legacy loader registry."""
@@ -33,11 +35,12 @@ class DocSerializerBridgeParser(DocumentParser):
 
     async def _load_via_legacy(self, path: str, document: Document) -> ProcessedDocument:
         metadata = dict(document.metadata or {})
+        indexation_config = metadata.pop(INDEXATION_CONFIG_METADATA_KEY, None)
         loader_cls = self._loader_for(path, metadata)
         if loader_cls is None:
             raise ValueError(f"No loader registered for file extension {Path(path).suffix.lower()!r}")
 
-        loader = loader_cls(config=self._config)
+        loader = loader_cls(config=_legacy_loader_config(self._config, indexation_config))
         lang_doc = await loader.aload_document(
             file_path=path,
             metadata=metadata,
@@ -76,6 +79,22 @@ def _suffix_from_document(document: Document) -> str:
         if suffix:
             return suffix
     return f".{document.content_type.value}" if document.content_type else ""
+
+
+def _legacy_loader_config(config: Any, indexation_config: Any) -> Any:
+    """Apply per-file indexation overrides to legacy loader config."""
+    if not isinstance(indexation_config, dict):
+        return config
+    if indexation_config.get("enable_image_captioning", True):
+        return config
+
+    loader = config.loader.model_copy(
+        update={
+            "image_captioning": False,
+            "image_captioning_url": False,
+        }
+    )
+    return config.model_copy(update={"loader": loader})
 
 
 __all__ = ["DocSerializerBridgeParser"]

--- a/tests/unit/services/workers/parsers/test_doc_serializer_bridge.py
+++ b/tests/unit/services/workers/parsers/test_doc_serializer_bridge.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from core.config.root import Settings
+from core.models.document import Document, DocumentType
+from langchain_core.documents.base import Document as LangChainDocument
+from services.workers.parsers.doc_serializer_bridge import (
+    INDEXATION_CONFIG_METADATA_KEY,
+    DocSerializerBridgeParser,
+)
+
+
+class _FakeLoader:
+    seen_config: Any = None
+    seen_metadata: dict[str, Any] | None = None
+
+    def __init__(self, *, config: Any) -> None:
+        type(self).seen_config = config
+
+    async def aload_document(self, *, file_path: str, metadata: dict | None = None, save_markdown: bool = False):
+        type(self).seen_metadata = dict(metadata or {})
+        return LangChainDocument(page_content="hello", metadata=metadata or {})
+
+
+@pytest.mark.asyncio
+async def test_bridge_disables_legacy_captioning_from_indexation_config(monkeypatch):
+    """Per-file Phase 14 config disables legacy loader image captioning."""
+
+    def fake_loader_classes(config):
+        return {".txt": _FakeLoader}
+
+    monkeypatch.setattr("services.workers.parsers.legacy_loaders.get_loader_classes", fake_loader_classes)
+
+    parser = DocSerializerBridgeParser(
+        Settings(
+            loader={
+                "image_captioning": True,
+                "image_captioning_url": True,
+            }
+        )
+    )
+    document = Document(
+        filename="note.txt",
+        content_type=DocumentType.TEXT,
+        raw_bytes=b"hello",
+        metadata={
+            "source": "note.txt",
+            INDEXATION_CONFIG_METADATA_KEY: {"enable_image_captioning": False},
+        },
+    )
+
+    await parser.parse(document)
+
+    assert _FakeLoader.seen_config.loader.image_captioning is False
+    assert _FakeLoader.seen_config.loader.image_captioning_url is False
+    assert _FakeLoader.seen_metadata == {"source": "note.txt"}

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -8,6 +8,7 @@ import pytest
 from core.models.chunk import Chunk
 from core.models.document import Document, DocumentType, ProcessedDocument, TextBlock
 from services.workers.indexer_actor import IndexerWorker, _load_document
+from services.workers.parsers.doc_serializer_bridge import INDEXATION_CONFIG_METADATA_KEY
 from services.workers.pipeline_builder import build_indexing_pipeline
 
 # ---------------------------------------------------------------------------
@@ -113,6 +114,16 @@ def test_load_document_falls_back_to_filename_when_no_file_id(tmp_path: Path) ->
     doc = _load_document(str(p), {}, "p")
 
     assert doc.filename == "note.txt"
+
+
+def test_load_document_attaches_internal_indexation_config(tmp_path: Path) -> None:
+    p = tmp_path / "note.txt"
+    p.write_bytes(b"hi")
+    config = {"enable_image_captioning": False}
+
+    doc = _load_document(str(p), {"source": "note.txt"}, "p", indexation_config=config)
+
+    assert doc.metadata[INDEXATION_CONFIG_METADATA_KEY] == config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #453.

## Context

PDF indexing performance depends heavily on whether image captioning runs. When captioning is disabled for an indexing request, the backend should skip that VLM work consistently across parser paths.

## Problem

One indexing path can still run image captioning from the legacy parser bridge even after captioning was disabled for the current request. That makes ingestion unexpectedly slow and makes benchmark results difficult to trust.

## Expected behavior

Disabling image captioning for an indexing request should apply consistently to every parser path, without exposing internal indexing configuration in stored metadata.

## Validation

- `uv run ruff format --check openrag/ tests/`
- `uv run ruff check openrag/ tests/`
- focused worker/parser regression tests
- `uv run pytest tests/unit -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Document indexation configuration is now properly applied during document processing, fixing an issue where configuration parameters were previously ignored
  * Per-document configuration overrides are now fully supported and respected throughout the indexing pipeline, allowing fine-grained control over processing behavior on a file-by-file basis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->