### PR TITLE
fix: allow usage of existingSecret in helm chart

### DIFF
--- a/charts/openrag-stack/templates/_helpers.tpl
+++ b/charts/openrag-stack/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Name of the secret holding sensitive env vars.
+Uses an existing secret when env.existingSecret is set, otherwise the chart-managed one.
+*/}}
+{{- define "openrag-stack.secretName" -}}
+{{- .Values.env.existingSecret | default "rag-env-secrets" }}
+{{- end }}

--- a/charts/openrag-stack/templates/openrag.yaml
+++ b/charts/openrag-stack/templates/openrag.yaml
@@ -43,7 +43,7 @@ spec:
             - configMapRef:
                 name: rag-env
             - secretRef:
-                name: rag-env-secrets
+                name: {{ include "openrag-stack.secretName" . }}
           volumeMounts:
             - name: model-weights
               mountPath: /app/model_weights

--- a/charts/openrag-stack/templates/raycluster.yaml
+++ b/charts/openrag-stack/templates/raycluster.yaml
@@ -69,7 +69,7 @@ spec:
               - configMapRef:
                   name: rag-env
               - secretRef:
-                  name: rag-env-secrets
+                  name: {{ include "openrag-stack.secretName" . }}
             resources:
               limits:
                 nvidia.com/gpu: 1
@@ -129,7 +129,7 @@ spec:
                 - configMapRef:
                     name: rag-env
                 - secretRef:
-                    name: rag-env-secrets
+                    name: {{ include "openrag-stack.secretName" $ }}
               resources:
                 limits:
                   nvidia.com/gpu: 1

--- a/charts/openrag-stack/templates/secrets-env.yaml
+++ b/charts/openrag-stack/templates/secrets-env.yaml
@@ -1,9 +1,11 @@
+{{- if not .Values.env.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rag-env-secrets
+  name: {{ include "openrag-stack.secretName" . }}
 type: Opaque
 stringData:
 {{- range $key, $value := .Values.env.secrets }}
   {{ $key }}: "{{ $value }}"
+{{- end }}
 {{- end }}

--- a/charts/openrag-stack/values.yaml
+++ b/charts/openrag-stack/values.yaml
@@ -287,7 +287,6 @@ env:
     POSTGRES_HOST: "{{ .Release.Name }}-postgresql"
     POSTGRES_PORT: *pgPort
     POSTGRES_USER: *pgUser
-    POSTGRES_PASSWORD: *pgPass
 
     # Embedder
     EMBEDDER_MODEL_NAME: *embedderModel
@@ -324,6 +323,18 @@ env:
     UV_LINK_MODE: "copy"
     UV_CACHE_DIR: "/tmp/uv-cache"
 
+  # Name of a pre-existing Kubernetes Secret whose keys will be injected as env vars
+  # into the openrag and ray pods (via envFrom.secretRef).
+  # When set:
+  #   - The chart does NOT create the rag-env-secrets Secret.
+  #   - env.secrets values below are ignored.
+  #   - The referenced secret must contain ALL keys listed under env.secrets,
+  #     including POSTGRES_PASSWORD.
+  #   - vLLM pods reference HF_TOKEN via vllm.servingEngineSpec.modelSpec[*].hf_token;
+  #     update those secretName fields to match your existing secret name as well.
+  existingSecret: ""
+
+  # Used only when existingSecret is empty (chart creates the rag-env-secrets Secret).
   secrets:
     API_KEY: "sk-xxxx" # LLM API KEY
     VLM_API_KEY: "sk-xxxx" # VLM API KEY
@@ -331,3 +342,4 @@ env:
     TRANSCRIBER_API_KEY: "EMPTY"
     AUTH_TOKEN: "sk-xxxx" # API KEY for OpenRAG
     HF_TOKEN: "hf_xxxx" # HuggingFace token
+    POSTGRES_PASSWORD: *pgPass # PostgreSQL password


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for referencing existing Kubernetes secrets for sensitive environment variables, eliminating automatic secret creation when using external secret management.
  * Enhanced configuration flexibility for production deployments where secrets are managed externally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->