### PR TITLE
chore: replace default postgres 'root' user with dedicated 'openrag' user

### DIFF
--- a/charts/openrag-stack/values.yaml
+++ b/charts/openrag-stack/values.yaml
@@ -26,9 +26,19 @@ ray:
 postgresql:
   enabled: true
   auth:
-    username: &pgUser root
-    password: &pgPass root_password
+    # Dedicated application user (non-superuser). OpenRAG creates its
+    # database (partitions_for_collection_<collection>) at runtime, hence
+    # the CREATEDB grant in primary.initdb.scripts below.
+    username: &pgUser openrag
+    password: &pgPass openrag_password
+    database: openrag
   primary:
+    initdb:
+      scripts:
+        # Runs once, on first initialization of an empty data volume.
+        # The role name must match auth.username above.
+        10-grant-createdb.sql: |
+          ALTER ROLE openrag CREATEDB;
     persistence:
       enabled: true
       size: 10Gi

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -63,8 +63,8 @@ vectordb:
 rdb:
   host: rdb
   port: 5432
-  user: root
-  password: "root_password"
+  user: openrag
+  password: "openrag_password"
   default_file_quota: -1
 
 # --- Reranker ---

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -132,8 +132,8 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
-      - POSTGRES_USER=${POSTGRES_USER:-root}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-openrag_password}
+      - POSTGRES_USER=${POSTGRES_USER:-openrag}
     volumes:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
     expose:

--- a/docs/assets/compose_linux_gpu.yaml
+++ b/docs/assets/compose_linux_gpu.yaml
@@ -87,8 +87,8 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
-      - POSTGRES_USER=${POSTGRES_USER:-root}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-openrag_password}
+      - POSTGRES_USER=${POSTGRES_USER:-openrag}
     volumes:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
 

--- a/docs/assets/compose_ollama_cpu.yaml
+++ b/docs/assets/compose_ollama_cpu.yaml
@@ -38,8 +38,8 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=root
-      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=openrag_password
+      - POSTGRES_USER=openrag
     volumes:
       - ./db:/var/lib/postgresql/data
 

--- a/docs/content/docs/documentation/chainlit_data_persistency.md
+++ b/docs/content/docs/documentation/chainlit_data_persistency.md
@@ -33,7 +33,7 @@ Knowing that OpenRAG already has a running postgres service (**`rdb`**) (refer t
 
 ```bash
 // .env
-DATABASE_URL=postgresql://root:root_password@rdb:5432/chainlit
+DATABASE_URL=postgresql://openrag:openrag_password@rdb:5432/chainlit
 ```
 * Variables for chainlit to use the **`S3 Bucket`**
 Add the following variables to your `.env` so that chainlit can use them to connect to the locally deployed S3 bucket

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -192,8 +192,8 @@ The PostgreSQL database is configured using the following environment variables:
 |----------|------|---------|-------------|
 | `POSTGRES_HOST` | str | rdb | Hostname of the PostgreSQL database service |
 | `POSTGRES_PORT` | int | 5432 | Port on which the PostgreSQL database listens |
-| `POSTGRES_USER` | str | root | Username for database authentication |
-| `POSTGRES_PASSWORD` | str | root_password | Password for database authentication |
+| `POSTGRES_USER` | str | openrag | Username for database authentication |
+| `POSTGRES_PASSWORD` | str | openrag_password | Password for database authentication |
 
 ## Chat Pipeline
 ### LLM & VLM Configuration

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -119,7 +119,7 @@ class VectorDBConfig(ConfigMixin):
 class RDBConfig(ConfigMixin):
     host: str = "rdb"
     port: int = 5432
-    user: str = "root"
+    user: str = "openrag"
     password: str = Field(default="", repr=False)
     default_file_quota: int = -1
 

--- a/openrag/scripts/check_file_counts.py
+++ b/openrag/scripts/check_file_counts.py
@@ -16,8 +16,8 @@ from components.indexer.vectordb.utils import File, User
 def build_database_url(args):
     host = args.host or os.environ.get("POSTGRES_HOST", "localhost")
     port = args.port or os.environ.get("POSTGRES_PORT", "5432")
-    user = args.user or os.environ.get("POSTGRES_USER", "root")
-    password = args.password or os.environ.get("POSTGRES_PASSWORD", "root_password")
+    user = args.user or os.environ.get("POSTGRES_USER", "openrag")
+    password = args.password or os.environ.get("POSTGRES_PASSWORD", "openrag_password")
     collection = args.collection or os.environ.get("VDB_COLLECTION_NAME", "vdb_test")
     db_name = f"partitions_for_collection_{collection}"
     return f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
@@ -87,7 +87,7 @@ def main():
     parser = argparse.ArgumentParser(description="Verify user file_count against actual files in the database.")
     parser.add_argument("--host", help="PostgreSQL host (default: $POSTGRES_HOST or localhost)")
     parser.add_argument("--port", help="PostgreSQL port (default: $POSTGRES_PORT or 5432)")
-    parser.add_argument("--user", help="PostgreSQL user (default: $POSTGRES_USER or root)")
+    parser.add_argument("--user", help="PostgreSQL user (default: $POSTGRES_USER or openrag)")
     parser.add_argument("--password", help="PostgreSQL password (default: $POSTGRES_PASSWORD)")
     parser.add_argument("--collection", help="VDB collection name (default: $VDB_COLLECTION_NAME or vdb_test)")
     parser.add_argument("--fix", action="store_true", help="Fix mismatched counts in the database")

--- a/quick_start/docker-compose.yaml
+++ b/quick_start/docker-compose.yaml
@@ -105,8 +105,8 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
-      - POSTGRES_USER=${POSTGRES_USER:-root}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-openrag_password}
+      - POSTGRES_USER=${POSTGRES_USER:-openrag}
     volumes:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
 

--- a/tests/api_tests/api_run/docker-compose.yaml
+++ b/tests/api_tests/api_run/docker-compose.yaml
@@ -19,10 +19,10 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=root_password
-      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=openrag_password
+      - POSTGRES_USER=openrag
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U root"]
+      test: ["CMD-SHELL", "pg_isready -U openrag"]
       interval: 2s
       timeout: 5s
       retries: 10
@@ -82,8 +82,8 @@ services:
       - EMBEDDER_BASE_URL=http://vllm:8000/v1/
       - EMBEDDER_API_KEY=EMPTY
       - POSTGRES_HOST=rdb
-      - POSTGRES_USER=root
-      - POSTGRES_PASSWORD=root_password
+      - POSTGRES_USER=openrag
+      - POSTGRES_PASSWORD=openrag_password
       - VDB_HOST=milvus
       - BASE_URL=http://vllm:8000/v1/
       - API_KEY=EMPTY


### PR DESCRIPTION
## What

The default PostgreSQL credentials were `root` / `root_password` everywhere. With the official `postgres` image (compose) this creates a genuine **superuser** named `root`; in the bitnami sub-chart it is a confusingly named application user. This PR replaces it with a dedicated `openrag` user across the board.

## Changes

- **docker-compose** (root, `quick_start/`, `docs/assets/`, CI compose in `tests/api_tests/api_run/`): default `POSTGRES_USER=openrag`, `POSTGRES_PASSWORD=openrag_password` (still overridable via env)
- **Helm chart**: `auth.username=openrag`, `auth.database=openrag`, plus a `primary.initdb` script granting `CREATEDB` — required because the app creates its database (`partitions_for_collection_<collection>`) at runtime via `_ensure_database_exists()`. With bitnami this user is a plain non-superuser, unlike before where the name suggested otherwise.
- **App defaults**: `conf/config.yaml`, `RDBConfig` (both copies), `check_file_counts.py` fallbacks
- **Test fixtures**: integration admin DSN, connection stub; **docs**: env var table, chainlit persistence example

## Upgrade notes

- Already-initialized data volumes/PVCs keep their original `root` user — existing deployments keep working as long as `POSTGRES_USER`/`POSTGRES_PASSWORD` are set explicitly (or keep setting them to the old values). Only fresh-install defaults change.
- The chart's `initdb` grant only runs on first initialization of an empty volume.
- `extern/chainlit-datalayer` (submodule) still defaults to `root` internally; its compose reads `POSTGRES_USER`/`POSTGRES_PASSWORD` from the environment so it follows along when those are set.

## Verification

- `helm lint` + `helm template` render the new user into `POSTGRES_USER`/`POSTGRES_PASSWORD` correctly
- `pytest` on persistence/config tests: pass (the `loaders/audio/test_openai.py` collection error also exists on clean `main`, unrelated)
- All compose files re-parsed as valid YAML; repo-wide grep shows no remaining `root` postgres references outside the submodule

Part of the deployment hardening series (next up: CloudNativePG migration, Milvus operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized database user credentials across all deployment and configuration files, replacing the root user with a dedicated OpenRAG application role with appropriate database permissions
  * Updated all documentation examples and configuration references to reflect the new credential defaults
  * Updated Docker Compose and Helm configurations for consistency across development and deployment environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->