### PR TITLE
chore: run the OpenRAG container and service stack as non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,17 +56,23 @@ ENV APP_iPORT=${APP_iPORT:-8080}
 
 # --- Run as an unprivileged user -------------------------------------------
 # openrag only ever writes under /app (data, logs, db, the HF model cache and
-# the uv-created venv) and binds non-privileged ports, so it has no need for
-# root. Create a dedicated user that owns those paths. UID/GID are build args
-# so a deployment can match the host user owning the bind-mounted volumes
+# the uv-created venv) plus uv's cache, and binds non-privileged ports, so it
+# has no need for root. Create a dedicated user and give it ownership of *only*
+# those runtime-write paths, plus the /app dir node itself so the runtime
+# `uv run` can create the venv and the editable install's openrag.egg-info at
+# the project root. The application code, config files and uv's managed Python
+# install stay root-owned/read-only (least privilege). UID/GID are build
+# args so a deployment can match the host user owning the bind-mounted volumes
 # (./data, ./logs, ~/.cache/huggingface); the 1000 default fits a typical
 # single-user host.
 ARG APP_UID=1000
 ARG APP_GID=1000
 RUN groupadd --gid ${APP_GID} openrag \
     && useradd --uid ${APP_UID} --gid ${APP_GID} --no-log-init --create-home --shell /bin/bash openrag \
-    && mkdir -p /app/data /app/logs /app/db /app/model_weights/hub /opt/uv \
-    && chown -R openrag:openrag /app /opt/uv
+    && mkdir -p /app/data /app/logs /app/db /app/model_weights/hub /app/.venv /opt/uv/cache \
+    && chown openrag:openrag /app \
+    && chown -R openrag:openrag \
+       /app/data /app/logs /app/db /app/model_weights /app/.venv /opt/uv/cache
 USER openrag
 
 ENTRYPOINT ../entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ ENV HF_HUB_CACHE=${HF_HUB_CACHE:-/app/model_weights/hub}
 # Set workdir for uv
 WORKDIR /app
 
+# Keep uv's managed Python, cache and project venv outside $HOME so the
+# artifacts produced during the (root) build stay reachable for the
+# unprivileged user that runs the container.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_CACHE_DIR=/opt/uv/cache \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
 # Install uv & setup venv
 COPY pyproject.toml uv.lock ./
 RUN pip3 install uv && \
@@ -46,4 +53,20 @@ COPY prompts/ /app/prompts/
 COPY conf/ /app/conf/
 ENV PYTHONPATH=/app/openrag/
 ENV APP_iPORT=${APP_iPORT:-8080}
+
+# --- Run as an unprivileged user -------------------------------------------
+# openrag only ever writes under /app (data, logs, db, the HF model cache and
+# the uv-created venv) and binds non-privileged ports, so it has no need for
+# root. Create a dedicated user that owns those paths. UID/GID are build args
+# so a deployment can match the host user owning the bind-mounted volumes
+# (./data, ./logs, ~/.cache/huggingface); the 1000 default fits a typical
+# single-user host.
+ARG APP_UID=1000
+ARG APP_GID=1000
+RUN groupadd --gid ${APP_GID} openrag \
+    && useradd --uid ${APP_UID} --gid ${APP_GID} --no-log-init --create-home --shell /bin/bash openrag \
+    && mkdir -p /app/data /app/logs /app/db /app/model_weights/hub /opt/uv \
+    && chown -R openrag:openrag /app /opt/uv
+USER openrag
+
 ENTRYPOINT ../entrypoint.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,11 @@ x-openrag: &openrag_template
   build:
     context: .
     dockerfile: Dockerfile
+    args:
+      # Keep the image's baked-in user in sync with the uid/gid that owns the
+      # bind-mounted volumes (see init-perms below).
+      APP_UID: ${PUID:-1000}
+      APP_GID: ${PGID:-1000}
   extra_hosts:
     # Let containers reach services running on the Docker host via
     # ``host.docker.internal`` (Linux Docker >= 20.10). Useful when an OIDC
@@ -40,8 +45,18 @@ x-openrag: &openrag_template
 x-vllm-env: &vllm_env
   HUGGING_FACE_HUB_TOKEN:
   VLLM_SLEEP_WHEN_IDLE: 1  # Avoid 100% CPU usage when idle
+  # Run unprivileged: point HOME and the HF cache at the writable mounted
+  # volume so vllm never needs to write under root-owned /root.
+  HOME: /cache
+  HF_HOME: /cache/huggingface
+  # vllm calls getpass.getuser() (torch.compile temp dir). With an arbitrary
+  # uid that has no /etc/passwd entry it would fall back to pwd.getpwuid() and
+  # crash; setting USER/LOGNAME makes getuser() resolve without a passwd entry.
+  USER: openrag
+  LOGNAME: openrag
 
 x-vllm: &vllm_template
+  user: "${PUID:-1000}:${PGID:-1000}"
   networks:
     default:
       aliases:
@@ -51,7 +66,7 @@ x-vllm: &vllm_template
     <<: *vllm_env
   ipc: "host"
   volumes:
-    - ${VLLM_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface # put ./vllm_cache if you want to have the weights on the vllm_cache folder in your project
+    - ${VLLM_CACHE:-./.cache/huggingface}:/cache # HF + framework caches (HOME=/cache)
   command: >
     --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
     --trust-remote-code
@@ -60,6 +75,9 @@ x-vllm: &vllm_template
     --max-model-len ${MAX_MODEL_LEN:-8192}
   # --max-num-seqs 1
   # gpu_memory_utilization, max-num-seqs et max-model-len can be tuned depending on your GPU memory
+  depends_on:
+    init-perms:
+      condition: service_completed_successfully
 
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
@@ -70,7 +88,41 @@ x-vllm: &vllm_template
   # ports:
   #   - ${VLLM_PORT:-8000}:8000
 services:
+  # ---------------------------------------------------------------------------
+  # One-shot ownership bootstrap. This is the ONLY container that runs as root,
+  # and it runs no application code: it just creates the host bind-mount
+  # directories and chowns them to the unprivileged uid/gid the real services
+  # run as. Docker creates missing bind-mount sources as root, so without this
+  # the non-root services below could not write to their volumes. It exits
+  # immediately and every other service waits for it via depends_on.
+  # ---------------------------------------------------------------------------
+  init-perms:
+    image: busybox:1.37
+    user: "0:0"
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /mnt/data /mnt/logs /mnt/db /mnt/hfcache \
+                 /mnt/volumes/etcd /mnt/volumes/minio /mnt/volumes/milvus
+        chown -R ${PUID:-1000}:${PGID:-1000} /mnt/data /mnt/logs /mnt/hfcache /mnt/volumes
+        chown -R 999:999 /mnt/db
+    volumes:
+      - ${DATA_VOLUME:-./data}:/mnt/data
+      - ./logs:/mnt/logs
+      - ${DB_VOLUME:-./db}:/mnt/db
+      - ${VLLM_CACHE:-./.cache/huggingface}:/mnt/hfcache
+      # NB: vdb/milvus.yaml is `include`d, so its default ./volumes resolves
+      # relative to vdb/ — i.e. ./vdb/volumes from here. Keep these in sync.
+      - ${MILVUS_VOLUME_DIRECTORY:-./vdb/volumes}:/mnt/volumes
+    restart: "no"
+
   # OpenRAG Indexer UI
+  # NOTE: still runs as root. Its entrypoint writes /app/config.json into the
+  # image's root-owned /app at startup, so it can't drop privileges without an
+  # image-level fix in the openrag-admin-ui repo (add a USER + a writable
+  # config path). Tracked as the remaining non-root gap.
   indexer-ui:
     image: linagoraai/indexer-ui:latest
     build:
@@ -108,6 +160,8 @@ services:
     profiles:
       - ""
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       rdb:
         condition: service_started
       milvus:
@@ -122,6 +176,8 @@ services:
     profiles:
       - "cpu"
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       rdb:
         condition: service_started
       milvus:
@@ -131,6 +187,9 @@ services:
 
   rdb:
     image: postgres:15
+    # Run as the image's built-in `postgres` user (uid 999) instead of root;
+    # init-perms hands /var/lib/postgresql/data to 999.
+    user: "999:999"
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
       - POSTGRES_USER=${POSTGRES_USER:-root}
@@ -138,6 +197,9 @@ services:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
     expose:
       - 5432
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   vllm-gpu:
     <<: *vllm_template
@@ -181,4 +243,3 @@ services:
     # For details see https://github.com/vllm-project/vllm/issues/21179
     profiles:
       - "cpu"
-

--- a/extern/reranker/infinity.yaml
+++ b/extern/reranker/infinity.yaml
@@ -1,10 +1,22 @@
 x-reranker: &reranker_template
+  user: "${PUID:-1000}:${PGID:-1000}"
   networks:
     default:
       aliases:
         - reranker
+  environment:
+    # Run unprivileged: keep HOME and the HF cache on the writable mounted
+    # volume so infinity never needs to write under root-owned /root.
+    HOME: /cache
+    HF_HOME: /cache/huggingface
   volumes:
-    - ${VLLM_CACHE:-/root/.cache/huggingface}:/app/.cache/huggingface # Model weights for RAG
+    # This file is `include`d, so a relative default resolves relative to
+    # extern/reranker/. ../../ points back at the project root so the cache
+    # matches vllm's and the dir init-perms chowns.
+    - ${VLLM_CACHE:-../../.cache/huggingface}:/cache # Model weights for RAG (HOME=/cache)
+  depends_on:
+    init-perms:
+      condition: service_completed_successfully
   # ports:
   #   - ${RERANKER_PORT:-7997}:7997
 

--- a/vdb/milvus.yaml
+++ b/vdb/milvus.yaml
@@ -1,6 +1,7 @@
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.5.25
+    user: "${PUID:-1000}:${PGID:-1000}"
     environment:
       - ETCD_AUTO_COMPACTION_MODE=revision
       - ETCD_AUTO_COMPACTION_RETENTION=1000
@@ -14,9 +15,13 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z
+    user: "${PUID:-1000}:${PGID:-1000}"
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
@@ -28,9 +33,15 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   milvus:
     image: milvusdb/milvus:v2.6.11
+    # gid 0 (not PGID): the milvus binary/libs are root:root mode 0775, so an
+    # arbitrary uid needs group root to exec them. Data dir is owned by PUID.
+    user: "${PUID:-1000}:0"
     command: ["milvus", "run", "standalone"]
     security_opt:
     - seccomp:unconfined
@@ -48,5 +59,9 @@ services:
     # ports:
     #   - "${VDB_PORT:-19530}:${VDB_iPORT:-19530}"
     depends_on:
-      - "etcd"
-      - "minio"
+      init-perms:
+        condition: service_completed_successfully
+      etcd:
+        condition: service_started
+      minio:
+        condition: service_started


### PR DESCRIPTION
## What

Make the OpenRAG Docker stack run **unprivileged** instead of as root. Two commits:

### 1. App image (`Dockerfile`)
The `openrag` image had no `USER`, so the container ran as root. It only writes under `/app` and binds non-privileged ports, so:
- Add a dedicated `openrag` user (uid/gid `1000`, overridable via `APP_UID`/`APP_GID`) that owns `/app`, with `USER` before the entrypoint.
- Relocate uv's managed Python/cache out of root's `$HOME` so the root-built artifacts stay reachable for the runtime user.

### 2. Compose stack (`docker-compose.yaml`, `vdb/milvus.yaml`, `extern/reranker/infinity.yaml`)
Every other service ran as root too. Now:
- A single one-shot **`init-perms`** (busybox) — the only container that uses root, running no app code — creates the host bind-mount dirs and chowns them to the unprivileged uid/gid. Docker creates bind mounts as root, so this is what lets the non-root services write their volumes. Services wait on it via `depends_on: service_completed_successfully`.
- **postgres** → `999:999` (built-in user); **etcd/minio** → `1000:1000`; **milvus** → `1000:0` (its binary is `root:root 0775`, so it needs group root to exec); **vllm/reranker** → `1000:1000` with `HOME`/`HF_HOME` on a writable mounted cache, plus `USER`/`LOGNAME` so vllm's `getpass.getuser()` doesn't crash on a uid with no `/etc/passwd` entry.

## Verification (all from scratch, non-root)

- **App image:** builds; runs as `uid=1000(openrag)`; uv resolves pinned Python; writes `/app/data`,`/app/logs`,venv. ✅
- **Data layer:** `init-perms → rdb, etcd, minio, milvus` all reach **healthy** (postgres `999`, etcd/minio/milvus `1000`); **every host file is owned by the unprivileged uid — no root-owned data**. ✅
- **Model servers (`--profile cpu`):** **reranker-cpu** and **vllm-cpu** both run as `uid=1000` and serve `/health` **200** — vllm returned a real **1024-dim embedding**; model caches on the host owned by the unprivileged uid. ✅

## Known remaining gap

- **indexer-ui still runs as root** — its entrypoint writes `/app/config.json` into the image's root-owned `/app`, so it can't drop privileges without an image-level fix in the `openrag-admin-ui` repo. Documented inline.

## Notes

- `Dockerfile.ray` (separate Ray-cluster image) is intentionally left as-is.
- uid/gid default to `1000`; deployments whose host user differs override `PUID`/`PGID` (and `APP_UID`/`APP_GID` for the build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Services now run unprivileged where possible to improve container security.
  * Added a startup permission-init step so bind mounts, caches and writable dirs get correct ownership before services start.
  * Cache and data mount locations updated so services use writable cache paths at runtime.
  * Service startup ordering adjusted so dependent services wait for permission initialization to complete.
  * Indexer UI still runs as root due to startup constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
