### PR TITLE
fix: don't expose Ray dashboard port by default (CVE-2023-48022)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,8 +27,15 @@ x-openrag: &openrag_template
     - ./logs:/app/logs # For dev mode
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
-    - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
-    - ${CHAINLIT_PORT:-8090}:${CHAINLIT_PORT:-8090}
+    # Ray Dashboard (8265) is commented out by default: Ray's dashboard/job
+    # submission API has NO authentication and is actively exploited for
+    # unauthenticated RCE (CVE-2023-48022 / "ShadowRay"). Only expose it on a
+    # trusted network behind an auth proxy. Uncomment if you need it locally.
+    # - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
+    # Chainlit is served under the API port at /chainlit; this extra direct
+    # port mapping is not needed for the default deployment. Uncomment to
+    # expose Chainlit on its own port.
+    # - ${CHAINLIT_PORT:-8090}:${CHAINLIT_PORT:-8090}
   networks:
     default:
       aliases:

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -349,7 +349,7 @@ Ray is used for distributed task processing and parallel execution in the RAG pi
 |----------|------|---------|-------------|
 | `RAY_POOL_SIZE` | `int` | 1 | Number of serializer actor instances (typically 1 actor per cluster node) |
 | `RAY_MAX_TASKS_PER_WORKER` | `int` | 8 | Maximum number of concurrent tasks (serialization tasks) per serializer actor instance |
-| `RAY_DASHBOARD_PORT` | `int` | 8265 | Ray Dashboard port used for monitoring. In production, [comment out this line](https://github.com/linagora/openrag/blob/ee732ea8e080dcde0107d62d12703a7525f810cd/docker-compose.yaml#L21C1-L22C1) to avoid exposing the port, as it may introduce security vulnerabilities. |
+| `RAY_DASHBOARD_PORT` | `int` | 8265 | Ray Dashboard port used for monitoring. **The mapping is commented out by default in `docker-compose.yaml`** because Ray's dashboard / job-submission API has no authentication and is actively exploited for unauthenticated remote code execution ([CVE-2023-48022](https://www.sentinelone.com/vulnerability-database/cve-2023-48022/) / ["ShadowRay"](https://www.oligo.security/blog/shadowray-attack-ai-workloads-actively-exploited-in-the-wild)). Only uncomment it to expose the dashboard on a trusted network, ideally behind an authentication proxy. |
 
 :::danger[Attention]
 The following environment variables control Ray's logging behavior, task retry settings. These are not set by default and must be supplied [as suggested in the .env](/openrag/getting_started/quickstart#2-create-a-env-file)

--- a/docs/content/docs/getting_started/usage.mdx
+++ b/docs/content/docs/getting_started/usage.mdx
@@ -12,7 +12,10 @@ By default, OpenRAG services are exposed on the following ports:
 |-------------------|----------------|----------------------------------------------------------------|
 | API Documentation | 8080/docs      | Main FastAPI’s for document ingestion and querying. See [this](/openrag/documentation/api)|
 | Chainlit UI       | 8080/chainlit  | User interface for interacting with the RAG system             |
-| Ray Dashboard     | 8265           | Ray dashboard for monitoring and managing tasks                |
 | Indexer UI        | 3042/          | Main user interface for indexing and viewing indexed documents |
 
 More information about the different services can be found in their respective documentation pages.
+
+:::caution[Ray Dashboard is not exposed by default]
+The Ray Dashboard (port `8265`) port mapping is **commented out** in `docker-compose.yaml`. Ray's dashboard / job-submission API has no authentication and is actively exploited for unauthenticated remote code execution ([CVE-2023-48022](https://www.sentinelone.com/vulnerability-database/cve-2023-48022/) / ["ShadowRay"](https://www.oligo.security/blog/shadowray-attack-ai-workloads-actively-exploited-in-the-wild)). Only uncomment it to expose the dashboard on a trusted network, ideally behind an authentication proxy.
+:::


### PR DESCRIPTION
## What

Comment out two host port mappings in `docker-compose.yaml`:

- **Ray Dashboard (`8265`)** — security fix
- **Chainlit (`8090`)** — redundant; Chainlit is already served under the API port at `/chainlit`

## Why

Ray's dashboard / job-submission API has **no authentication by default**. Anyone with network access to port `8265` can submit arbitrary jobs and achieve **unauthenticated remote code execution**. This is actively exploited in the wild:

- [CVE-2023-48022](https://www.sentinelone.com/vulnerability-database/cve-2023-48022/)
- ["ShadowRay" campaign — Oligo Security](https://www.oligo.security/blog/shadowray-attack-ai-workloads-actively-exploited-in-the-wild) (thousands of exposed Ray servers compromised)

Exposing it by default is a footgun. Operators who need the dashboard can uncomment the mapping and restrict access to a trusted network / auth proxy.

## Docs

- `docs/.../documentation/env_vars.md` — updated `RAY_DASHBOARD_PORT` note with the CVE rationale and how to re-enable safely.
- `docs/.../getting_started/usage.mdx` — removed Ray Dashboard from the default ports table and added a caution callout.

The compose file also carries inline comments explaining why each mapping is disabled and how to re-enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced Ray Dashboard security documentation with CVE-2023-48022 vulnerability details
* Clarified that Ray Dashboard is not exposed by default in Docker configuration
* Added guidance for safely exposing Ray Dashboard only on trusted networks behind authentication proxies
* Updated port mapping documentation with improved security warnings and configuration clarifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->