### PR TITLE
fix: add content when the RAG response is empty

### DIFF
--- a/openrag/components/prompts/prompts.py
+++ b/openrag/components/prompts/prompts.py
@@ -39,4 +39,3 @@ MULTI_QUERY_PROMPT = load_prompt("multi_query")
 
 # Short answer prompt
 SPOKEN_STYLE_ANSWER_PROMPT = load_prompt("spoken_style_answer")
-

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -264,21 +264,28 @@ async def stream_with_source_filtering(
             filtered = filter_sources_by_citations(sources, citations)
             filtered_json = json.dumps({"sources": filtered})
 
-            if chunk_template and len(final_clean) > emitted_len:
-                tail_chunk = copy.deepcopy(chunk_template)
-                tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
-                tail_chunk["extra"] = filtered_json
-                yield f"data: {json.dumps(tail_chunk)}\n\n"
+            def _sse(delta: dict, finish_reason: str | None = None) -> str:
+                """Build an SSE chunk from the template, overriding delta/extra."""
+                chunk = copy.deepcopy(chunk_template)
+                chunk["choices"][0]["delta"] = delta
+                if finish_reason is not None:
+                    chunk["choices"][0]["finish_reason"] = finish_reason
+                chunk["extra"] = filtered_json
+                return f"data: {json.dumps(chunk)}\n\n"
+
+            if chunk_template and not final_clean.strip():
+                # Response was only a [Sources: ...] tag (or empty) — send a default
+                # message so the client never receives an empty completion.
+                logger.warning("LLM and RAG response empty after source stripping, returning fallback message")
+                yield _sse({"content": "I do not have the necessary documentation in order to answer your message"})
+            elif chunk_template and len(final_clean) > emitted_len:
+                yield _sse({"content": final_clean[emitted_len:]})
 
             if chunk_template:
                 # FIXME: race condition where clients miss sources because finish_reason
                 # arrives before the sources metadata
                 await asyncio.sleep(0.05)
-                finish_chunk = copy.deepcopy(chunk_template)
-                finish_chunk["choices"][0]["delta"] = {}
-                finish_chunk["choices"][0]["finish_reason"] = last_finish_reason or "stop"
-                finish_chunk["extra"] = filtered_json
-                yield f"data: {json.dumps(finish_chunk)}\n\n"
+                yield _sse({}, finish_reason=last_finish_reason or "stop")
 
             yield "data: [DONE]\n\n"
             continue

--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -16,8 +16,6 @@ from utils.logger import get_logger
 
 SOURCE_SEPARATOR = "-" * 10 + "\n\n"
 
-# Sent to the client when the LLM produces no usable content (e.g. the whole
-# response was a [Sources: ...] tag), so it never receives an empty completion.
 # Global variables
 config = load_config()
 logger = get_logger()

--- a/openrag/config/fallbackanswer.py
+++ b/openrag/config/fallbackanswer.py
@@ -1,1 +1,3 @@
+# Sent to the client when the LLM produces no usable content (e.g. the whole
+# response was a [Sources: ...] tag), so it never receives an empty completion.
 EMPTY_RESPONSE_FALLBACK_MESSAGE = "I could not generate an answer based on the retrieved documents"

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -365,6 +365,11 @@ async def openai_chat_completion(
         filtered = filter_sources_by_citations(sources, citations)
         chunk["extra"] = json.dumps({"sources": filtered})
         log.debug("Returning non-streaming completion chunk.")
+        if not clean_content.strip():
+            log.warning("LLM and RAG response empty after source stripping, returning fallback message")
+            chunk["choices"][0]["message"]["content"] = (
+                "I do not have the necessary documentation in order to answer your message"
+            )
         return JSONResponse(content=chunk)
 
 
@@ -440,4 +445,9 @@ async def openai_completion(
     filtered = filter_sources_by_citations(sources, citations)
     complete_response["extra"] = json.dumps({"sources": filtered})
     log.debug("Returning completion response.")
+    if not clean_text.strip():
+        log.warning("LLM and RAG response empty after source stripping, returning fallback message")
+        complete_response["choices"][0]["text"] = (
+            "I do not have the necessary documentation in order to answer your message"
+        )
     return JSONResponse(content=complete_response)


### PR DESCRIPTION
Adding tests in open_ai_chat_completion() and streaming_with_source filtering that verify if the message sent by the llm has any text in it and if not, it had a generic text (I wrote something  but it is just an exemple...) : I do not have the necessary documentation in order to answer your message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear client-facing fallback message when a reply becomes empty after removing source attributions, covering both streaming and non-streaming chat/completions.
  * Improved streaming end-of-response chunking so the final message reliably includes either the remaining content or the fallback, avoiding empty completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->