### PR TITLE
fix(streaming): don't attach finish_reason to content-bearing chunk

### DIFF
--- a/openrag/components/utils.py
+++ b/openrag/components/utils.py
@@ -267,6 +267,10 @@ async def stream_with_source_filtering(
             if chunk_template and len(final_clean) > emitted_len:
                 tail_chunk = copy.deepcopy(chunk_template)
                 tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
+                # Content chunk must not carry finish_reason (template may be the
+                # finish chunk); clients treat such a chunk as terminal and drop its
+                # delta. The separate finish chunk below emits it with an empty delta.
+                tail_chunk["choices"][0]["finish_reason"] = None
                 tail_chunk["extra"] = filtered_json
                 yield f"data: {json.dumps(tail_chunk)}\n\n"
 


### PR DESCRIPTION
## Problem

`stream_with_source_filtering` (`openrag/components/utils.py`) emits the final
content of a streamed chat completion in a chunk that **also carries
`finish_reason: "stop"`**.

At end-of-stream the function builds the tail chunk via
`copy.deepcopy(chunk_template)`, and `chunk_template` at that point is the
upstream **finish** chunk (the one whose `choices[0].finish_reason` is set).
The resulting tail chunk therefore contains both the remaining `delta.content`
**and** `finish_reason: "stop"`:

```
[0] finish_reason='stop'  content="Bonjour ! Comment puis-je vous aider ..."   <-- both
[1] finish_reason='stop'  content=None
[2] [DONE]
```

Spec-compliant OpenAI streaming clients treat a chunk with a non-null
`finish_reason` as terminal and ignore its `delta`. Such clients (e.g. the
Twake Workplace RAG integration) therefore drop the tail content:

- **short answers render blank** (the whole answer fits in the held-back
  look-ahead window and is flushed only in the finish-tagged tail chunk);
- **long answers lose their final ~look-ahead window of text** (silent
  truncation).

The HTTP response is still `200`, so the regression is invisible server-side.
Behaviour was correct in 1.1.7, which emitted content chunks with
`finish_reason: null` and a separate empty finish chunk.

## Fix

Clear `finish_reason` on the content-bearing tail chunk. The separate finish
chunk that immediately follows still emits `finish_reason` with an empty
`delta`, matching the OpenAI streaming contract.

```
[0] finish_reason=None    content="Bonjour ! Comment puis-je vous aider ..."
[1] finish_reason='stop'  content=None
[2] [DONE]
```

## Verification

- Short answer: full content delivered in a non-terminal chunk.
- Long answer (202 chunks): 0 content-chunks-carrying-finish_reason, single
  finish chunk, complete text (no truncation), sources still delivered in
  `extra`.
- Non-streaming path unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streamed response termination so trailing content is no longer mistaken for the final signal. Streams now emit the content tail separately from the final termination notification, ensuring clients do not prematurely close and the final finish message carries the correct filtered metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->