### PR TITLE
feat(phase-15): sync Keycloak groups to partition memberships

### DIFF
--- a/REFACTORING_DECISION_LOG.md
+++ b/REFACTORING_DECISION_LOG.md
@@ -1399,6 +1399,73 @@ All five CI jobs (Layer guard, Linting, Unit, Integration, API) are
 green on the branch after these fixes.
 
 ---
+## Phase 15 — OIDC group → partition authorization (2026-06-12)
+
+**1. Variable names uniformized onto the shipped `OIDC_*` surface; the
+strategy doc's draft names are not reintroduced.**
+- Why: `REFACTORING_STRATEGY_v1.md` §Phase 15 (and `REFACTORING_DEV_WORKFLOW.md`)
+  sketch a *stateless raw-JWT-bearer* design with its own env vocabulary
+  (`OIDC_ENABLED`, `OIDC_ISSUER_URL`, `OIDC_AUDIENCE`, `OIDC_JWKS_CACHE_TTL`,
+  `VITE_OIDC_*`). The shipped OIDC is the **session-cookie Authorization
+  Code + PKCE** flow (`docs/oidc.md`), which already reads `AUTH_MODE=oidc`,
+  `OIDC_ENDPOINT`, `OIDC_REDIRECT_URI`, … The two never coexisted in code, so
+  Phase 15 adopts the shipped names as canonical and only adds vars for the
+  one genuinely-missing half (group → partition mapping):
+  `OIDC_CLAIM_GROUPS`, `OIDC_GROUP_PREFIX`, `OIDC_GROUP_PATTERN`,
+  `OIDC_GROUP_SYNC_PRUNE`. Draft names like `OIDC_ISSUER_URL` are *not* read.
+- Alternative considered: a reconciliation note in `docs/oidc.md` pointing
+  operators at the draft↔shipped mapping. Rejected — `docs/oidc.md` is
+  operator-facing; an operator never read the internal drafts, so the note
+  was pure noise. The reconciliation lives here and in `phase15.md` §A
+  (developer-facing), not in the operator guide.
+
+**2. `OIDC_GROUP_SYNC_PRUNE` is an opt-in flag (default off), not the
+strategy doc's unconditional "remove stale".**
+- Why: the doc (provisioner step 4) says *"Keycloak is source of truth — add
+  missing, update changed, remove stale"* — i.e. delete any membership absent
+  from the token on every login. That assumes a greenfield where the IdP is
+  the *only* membership source. We're adding to a shipped system where
+  memberships are also granted manually via the `/partition/{p}/users` admin
+  API; unconditional prune would silently wipe those on the next login. So
+  sync is additive + role-update by default, and prune is behind
+  `OIDC_GROUP_SYNC_PRUNE=true` for operators who want the doc's literal
+  "sole source of truth" behavior. The var name itself is ours (not in any
+  doc); only the behavior traces to the strategy doc.
+- Alternative considered: prune-by-default to match the doc verbatim.
+  Rejected as data-loss-prone for mixed manual+SSO deployments.
+- Follow-up (mass-revocation guard): even with prune *on*, removal runs only
+  when the token actually **asserts** the groups claim. A missing claim
+  (mapper disabled, wrong `OIDC_CLAIM_GROUPS`, scope not granted, transient
+  omission) produces an empty ``desired`` that means "no signal", not "revoke
+  everything" — without the guard a single config typo would wipe every
+  synced user's access on next login (the classic directory-sync footgun). An
+  explicit empty list (``groups: []``) is a real signal and still prunes. The
+  two failure directions are asymmetric: silent mass-revocation is
+  catastrophic, a lingering stale membership is trivially fixable — so we fail
+  safe on the missing-claim case.
+
+**3. role → `is_admin` mapping (`OIDC_CLAIM_ROLES` / `OIDC_ADMIN_ROLE`)
+deferred, not implemented.**
+- Why: the strategy doc puts it in scope, but `docs/oidc.md` documents a
+  *hard* boundary — `is_admin` is never writable via claims (same whitelist
+  that blocks it in `OIDC_CLAIM_MAPPING`). Honoring the doc here would breach
+  a shipped security guarantee. Admin stays an explicit operator action.
+- Alternative considered: ship it behind a loud opt-in. Left as an open
+  decision for the maintainers rather than bundled into this phase.
+
+**4. Group sync hooks into `AuthService.handle_oidc_callback`, not the
+strategy doc's new `jwt_validator`/`oidc_mapper`/`oidc_provisioner` files
+or an `api/dependencies/auth.py` dispatch.**
+- Why: those files target the stateless-bearer path the session-cookie flow
+  obviates. Authentication already runs in `AuthMiddleware` →
+  `AuthService.handle_oidc_callback`, where the verified ID-token claims and
+  the (already-injected) `membership_repo` are in hand. The work is one pure
+  mapper (`services/auth/oidc_groups.py`) plus a `_sync_oidc_memberships`
+  step after the existing claim-mapping call — no new dispatch layer, no
+  extra IdP round-trip. An unknown partition (FK violation) is logged and
+  skipped per-membership so it can never block an otherwise-valid login.
+
+---
 ## Template for future entries
 
 ```

--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -10,12 +10,13 @@ This guide walks you through configuring and using OpenRag's OIDC authentication
 4. [User Pre-provisioning](#user-pre-provisioning)
 5. [Claim Mapping (optional)](#claim-mapping-optional)
 6. [Auto-provisioning (optional)](#auto-provisioning-optional)
-7. [Keycloak Setup](#keycloak-setup)
-8. [LemonLDAP::NG Setup](#lemonldapng-setup)
-9. [Programmatic Access](#programmatic-access)
-10. [Back-Channel Logout](#back-channel-logout)
-11. [Troubleshooting](#troubleshooting)
-12. [Security Considerations](#security-considerations)
+7. [Group → Partition Mapping (optional)](#group--partition-mapping-optional)
+8. [Keycloak Setup](#keycloak-setup)
+9. [LemonLDAP::NG Setup](#lemonldapng-setup)
+10. [Programmatic Access](#programmatic-access)
+11. [Back-Channel Logout](#back-channel-logout)
+12. [Troubleshooting](#troubleshooting)
+13. [Security Considerations](#security-considerations)
 
 ---
 
@@ -341,6 +342,75 @@ The two flags are independent and compose cleanly:
 ### Threat Model
 
 Enabling auto-provisioning shifts the trust boundary: the IdP's user list becomes the source of truth for OpenRag accounts. Strict-whitelist deployments leave the flag unset and keep the historical `403`. There is no path to grant `is_admin=true` via OIDC claims; promotion remains an explicit admin action.
+
+---
+
+## Group → Partition Mapping (optional)
+
+By default, OIDC manages only *who* a user is; their **partition access** is still granted
+manually through the `/partition/{partition}/users` admin API. If your IdP already models access as
+**groups** (Keycloak groups, LLNG/Azure roles, …), OpenRag can read those groups from the login
+token and reconcile the user's partition memberships automatically on every login.
+
+This feature is **off** unless `OIDC_CLAIM_GROUPS` is set — existing deployments are unaffected.
+
+### How It Works
+
+Each group in the configured claim is matched as:
+
+```
+<OIDC_GROUP_PREFIX><partition>/<role>
+        e.g.  /openrag/project-alpha/editor   ->   partition "project-alpha", role "editor"
+```
+
+1. The claim named by `OIDC_CLAIM_GROUPS` is read from the **verified ID token** (no extra HTTP call).
+2. `OIDC_GROUP_PREFIX` is stripped from each group; groups without the prefix are ignored (they
+   belong to other apps).
+3. The remainder is matched against `OIDC_GROUP_PATTERN`, whose two capture groups are
+   `(partition, role)`. Roles are the usual `viewer` / `editor` / `owner`.
+4. When several groups grant the same partition, the **highest** role wins.
+5. The user's memberships are reconciled: missing ones are **added**, changed roles **updated**.
+6. If `OIDC_GROUP_SYNC_PRUNE=true`, memberships **absent** from the token are **removed** (the IdP
+   becomes the sole source of truth). Default (`false`) leaves manually-granted memberships intact.
+   **Mass-revocation guard:** prune runs only when the token actually carries the groups claim. If
+   the claim is *missing* (mapper disabled, wrong `OIDC_CLAIM_GROUPS`, scope not granted), prune is
+   skipped and a warning is logged — a misconfiguration cannot silently wipe everyone's access. An
+   explicit empty list (`groups: []`, the user is genuinely in no groups) **does** prune.
+
+A group that names a partition which does not exist yet is **skipped with a warning** — it never
+blocks the login. Create the partition first (any indexing call auto-creates it), then the next
+login will attach the membership.
+
+> **`is_admin` is never derived from groups.** Admin remains an explicit operator action
+> (`POST /users/` or `PATCH /users/{id}`), the same hard boundary as [Claim Mapping](#claim-mapping-optional).
+> The role vocabulary here is strictly the partition roles `viewer`/`editor`/`owner`.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OIDC_CLAIM_GROUPS` | — (feature off) | Name of the token claim holding the group list (Keycloak: `groups`). |
+| `OIDC_GROUP_PREFIX` | `/openrag/` | Prefix stripped from each group before matching; non-matching groups are ignored. |
+| `OIDC_GROUP_PATTERN` | `(.+)/(owner\|editor\|viewer)$` | Regex with two capture groups: 1 = partition, 2 = role. Validated at startup. |
+| `OIDC_GROUP_SYNC_PRUNE` | `false` | `true` removes memberships not present in the token (IdP = source of truth). |
+
+```bash
+OIDC_CLAIM_GROUPS=groups
+OIDC_GROUP_PREFIX=/openrag/
+OIDC_GROUP_PATTERN=(.+)/(owner|editor|viewer)$
+OIDC_GROUP_SYNC_PRUNE=false
+```
+
+### Keycloak Setup for Groups
+
+1. **Realm** → **Groups**: create a group tree mirroring your partitions, e.g.
+   `/openrag/project-alpha/editor`, `/openrag/project-alpha/viewer`, `/openrag/project-beta/owner`.
+2. Assign users to the appropriate leaf groups (**Users** → user → **Groups** → **Join**).
+3. Add a **Group Membership** mapper so the groups land in the token:
+   **Clients** → `openrag` → **Client scopes** → `openrag-dedicated` → **Add mapper** →
+   **Group Membership**. Set **Token Claim Name** = `groups`, **Full group path** = ON, and ensure
+   **Add to ID token** = ON (OpenRag reads the ID token by default).
+4. Set `OIDC_CLAIM_GROUPS=groups` in OpenRag's `.env` and restart.
 
 ---
 

--- a/docs/content/docs/documentation/sso-quickstart.md
+++ b/docs/content/docs/documentation/sso-quickstart.md
@@ -122,6 +122,14 @@ Each pair is `db_field:oidc_claim`. Only `display_name` and `email` are writable
 
 By default OpenRag reads the claims from the verified ID token (`OIDC_CLAIM_SOURCE=id_token`, no extra HTTP call). Switch to `userinfo` if your IdP only exposes certain claims via the `/userinfo` endpoint.
 
+### Optional: grant partition access from IdP groups
+
+If your IdP models access as groups (e.g. Keycloak groups like `/openrag/project-alpha/editor`),
+OpenRag can map them to partition memberships automatically on every login — set
+`OIDC_CLAIM_GROUPS` and friends. See `docs/oidc.md` →
+[Group → Partition Mapping](./oidc.md#group--partition-mapping-optional). (`is_admin` is never
+derived from groups.)
+
 ---
 
 ## Step 5 — Pre-provision users

--- a/docs/refactoring/phase-15.md
+++ b/docs/refactoring/phase-15.md
@@ -1,0 +1,306 @@
+# Phase 15 — Keycloak Group → Partition Authorization (reconciled & uniformized)
+
+## Context
+
+`docs/refactoring/REFACTORING_STRATEGY_v1.md` §"Phase 15 — OIDC / Keycloak SSO" specs an OIDC
+feature in two halves:
+
+1. **SSO login** — interactive authentication via an external IdP, and
+2. **Claim-driven authorization** — map Keycloak *groups → partition memberships* and a
+   *role → `is_admin`*.
+
+**Half #1 already shipped — but as a different design with different variable names.** Both the
+strategy doc and `docs/refactoring/REFACTORING_DEV_WORKFLOW.md:434` sketch a *stateless
+raw-JWT-bearer* flow (`jwt_validator.py` / `oidc_mapper.py` / `oidc_provisioner.py`,
+`api/dependencies/auth.py` dual-auth dispatch) and invent an env surface for it
+(`OIDC_ENABLED`, `OIDC_ISSUER_URL`, `OIDC_AUDIENCE`, `VITE_OIDC_*`…). What actually exists in the
+tree (and in `docs/oidc.md` + `docs/sso-quickstart.md`) is a **session-cookie Authorization Code +
+PKCE** flow with its own, already-stable variable surface (`AUTH_MODE=oidc`, `OIDC_ENDPOINT`,
+`OIDC_REDIRECT_URI`, `OIDC_TOKEN_ENCRYPTION_KEY`, …). It covers SSO login, back-channel logout,
+lazy refresh, programmatic `users.token` access, and `display_name`/`email` claim sync.
+
+So Phase 15 is **not** a greenfield build. It is:
+
+- **(A) Uniformization** — the strategy doc names several things that *already exist under
+  different names*. We adopt the shipped names as canonical, drop the strategy doc's duplicates,
+  and never introduce a second variable for an existing concept.
+- **(B) The one genuinely-missing half** — claim-driven authorization (groups → partition
+  memberships). Today the callback consumes *no* group/role claims; partition access is managed
+  only via the `/partition/{p}/users` admin API.
+
+This document is the plan for **both**. No code is written yet.
+
+---
+
+## Part A — Variable uniformization
+
+The single source of truth is the **shipped** `OIDCConfig` in
+`openrag/core/config/auth.py` (env reader: `OIDCConfig.from_env`). The strategy doc's Phase 15
+variable list is reconciled against it below. **Rule: never add a new variable for a concept that
+already has a shipped variable.**
+
+### A.1 — Already shipped under a different name → use the shipped name (no new var)
+
+| Strategy-doc var / field        | Shipped canonical (KEEP)        | Notes                                                            |
+| ------------------------------- | ------------------------------- | --------------------------------------------------------------- |
+| `OIDC_ENABLED` / `enabled`      | **`AUTH_MODE=oidc`**            | Boolean enable is derived from `AUTH_MODE`; no `OIDC_ENABLED`.   |
+| `OIDC_ISSUER_URL` / `issuer_url`| **`OIDC_ENDPOINT`**             | Same meaning (issuer base for discovery). Field stays `issuer_url`, env stays `OIDC_ENDPOINT`. |
+| `OIDC_CLIENT_ID` / `client_id`  | **`OIDC_CLIENT_ID`**            | Identical — no change.                                           |
+| `OIDC_CLIENT_SECRET`            | **`OIDC_CLIENT_SECRET`**        | Identical — no change.                                           |
+| `OIDC_AUTO_PROVISION` / `auto_provision` | **`OIDC_AUTO_PROVISION_LOGIN`** | Shipped name is more explicit; keep it.                  |
+| `OIDC_DEFAULT_QUOTA` / `default_quota` | **`DEFAULT_FILE_QUOTA`** (`rdb.default_file_quota`) | Global quota default already exists (`loader.py:55`); auto-provisioned users already inherit it. No OIDC-specific quota var. |
+
+### A.2 — Subsumed by an existing, more general mechanism → do NOT add
+
+| Strategy-doc field | Subsumed by (KEEP)                       | Notes                                                                          |
+| ------------------ | ---------------------------------------- | ------------------------------------------------------------------------------ |
+| `claim_sub`        | hard-coded `sub` matching                | Matching is exclusively `external_user_id == sub` (documented); not configurable by design. |
+| `claim_name`       | `OIDC_CLAIM_MAPPING=display_name:<claim>`| The generic claim-mapping already syncs display name.                          |
+| `claim_email`      | `OIDC_CLAIM_MAPPING=email:<claim>`       | Same — generic mapping already syncs email.                                    |
+| (claim read source)| `OIDC_CLAIM_SOURCE` (`id_token`/`userinfo`)| Already chooses where claims are read.                                        |
+
+### A.3 — Strategy-doc vars that do NOT apply to the shipped design → DROP
+
+| Strategy-doc var | Reason dropped                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| `OIDC_AUDIENCE` / `audience` | The session flow validates the ID token via Authlib against `client_id`/nonce; no separate audience knob is exposed. (Revisit only if a raw-JWT-bearer path is ever added.) |
+| `OIDC_JWKS_CACHE_TTL` / `jwks_cache_ttl` | JWKS fetching/caching is handled inside the OIDC client (Authlib); not an operator knob. |
+| `VITE_OIDC_ENABLED` / `VITE_OIDC_ISSUER_URL` / `VITE_OIDC_CLIENT_ID` | Frontend needs none — login is a backend `302 → /auth/login` redirect; the indexer-ui does not run its own OIDC client. |
+| stateless raw-JWT bearer dual-auth (`_is_jwt`/`eyJ`) | Redundant: session cookie (UI) + `users.token` (machine) already cover both audiences. Out of scope. |
+
+### A.4 — Genuinely NEW variables this phase adds (Part B)
+
+Named to match the **shipped** `OIDC_*` convention, *not* re-inventing. These are the only new
+env vars introduced:
+
+| New env var (field)                         | Default                        | Purpose                                                    |
+| ------------------------------------------- | ------------------------------ | ---------------------------------------------------------- |
+| `OIDC_CLAIM_GROUPS` (`claim_groups`)        | `""` (feature OFF)             | Name of the claim holding the user's group list. Empty disables group sync entirely. |
+| `OIDC_GROUP_PREFIX` (`group_prefix`)        | `/openrag/`                    | Prefix stripped from each group before pattern matching.   |
+| `OIDC_GROUP_PATTERN` (`group_pattern`)      | `(.+)/(owner\|editor\|viewer)$`| Regex → capture group 1 = partition, group 2 = role.       |
+| `OIDC_GROUP_SYNC_PRUNE` (`group_sync_prune`)| `false`                        | When true, remove memberships absent from the token (Keycloak = sole source of truth). |
+
+**Deferred behind an Open Decision (NOT added unless approved):** `OIDC_CLAIM_ROLES` +
+`OIDC_ADMIN_ROLE` (role → `is_admin`). The shipped design documents a *hard* boundary —
+`is_admin` is never writable via claims — so these are out by default. See Open Decisions.
+
+### A.5 — Fidelity review vs. the strategy docs (intentional deviations)
+
+The strategy doc (`REFACTORING_STRATEGY_v1.md` §Phase 15) and the workflow doc
+(`REFACTORING_DEV_WORKFLOW.md:434`) both describe the *unbuilt, greenfield* design
+(stateless JWT bearer: `jwt_validator.py` / `oidc_mapper.py` / `oidc_provisioner.py`,
+`api/dependencies/auth.py` dual-auth dispatch, indexer-ui `oidc-client-ts`). The shipped
+reality is the session-cookie flow, so this plan **deliberately diverges** on the points below.
+Each deviation is intentional and justified — listed here so a future reader doesn't "correct"
+the plan back toward the obsolete spec:
+
+| # | Strategy doc says | This plan does | Why |
+| - | ----------------- | -------------- | --- |
+| 1 | `claim_groups` defaults to `"groups"` → **group sync ON by default** | `OIDC_CLAIM_GROUPS` defaults to `""` → **OFF by default** | Greenfield could default-on; we add to a *shipped* system and must not silently change any existing deployment's authorization. |
+| 2 | `group_pattern = (.+)/(owner\|editor\|viewer)` (no end anchor) | adds a trailing `$` anchor | Avoids a trailing-garbage group accidentally matching; stricter, operator-overridable. |
+| 3 | Surfaces only `OIDC_ADMIN_ROLE` + `OIDC_GROUP_PREFIX` as env; `claim_groups`/`group_pattern` are hard-coded defaults | also surfaces `OIDC_CLAIM_GROUPS` + `OIDC_GROUP_PATTERN` as env | The group claim name varies per IdP (Keycloak `groups` vs LLNG/Azure); it must be operator-settable for the feature to work at all. |
+| 4 | role → `is_admin` is in-scope (`claim_roles`, `admin_role`, `_is_admin()`) | **deferred** behind Open Decision #2 | Honoring it breaches the shipped, documented "`is_admin` never claim-writable" boundary (`docs/oidc.md` §Claim Mapping). Needs an explicit, loud opt-in. |
+| 5 | New files `jwt_validator.py`, `oidc_mapper.py`, `oidc_provisioner.py`; dispatch in `api/dependencies/auth.py` | one pure helper `services/auth/oidc_groups.py` + a method on the existing `AuthService`; no `api/dependencies/auth.py` change | Those files target the stateless-bearer path that the session-cookie flow already obviates. Authn lives in `AuthMiddleware` + `AuthService.handle_oidc_callback`, which is where the group sync belongs. |
+| 6 | Adds `get_user_by_external_id()` to `UserRepository` | already exists (`user_repo.py:130`) | Shipped during the session-OIDC work; nothing to add. |
+| 7 | `default_quota = 10`, `auto_provision = True` defaults | uses shipped `DEFAULT_FILE_QUOTA` (= `-1`) and `OIDC_AUTO_PROVISION_LOGIN` (= `false`) | These are pre-existing shipped defaults; this plan does not re-open them. |
+
+**Consistent with the docs (no deviation):** the four-step Keycloak setup, group-prefix stripping
+to `/openrag/`, `viewer/editor/owner` role vocabulary (== `AUTH_SERVICE.ROLE_HIERARCHY`), and
+"Keycloak is source of truth" framing (offered via `OIDC_GROUP_SYNC_PRUNE`).
+
+---
+
+## Part B — Implementation: group → partition membership sync
+
+### What's already in place (reuse, do not rebuild)
+
+- **Seam** — `AuthService.handle_oidc_callback()`
+  (`openrag/services/orchestrators/auth_service.py:165`). After resolving the user it already runs
+  `_sync_auto_provisioned` (`:207`) then `_apply_claim_mapping` (`:208`). The new membership sync
+  slots in **immediately after `:208`**.
+- **Membership repo already injected** — `self._membership_repo` (`auth_service.py:124`, comment:
+  *"Retained for the role/membership helpers that later phases will [use]"*). Clean port methods
+  (`openrag/services/persistence/partition_membership_repo.py` /
+  `openrag/core/ports/partition_membership_repo.py`):
+  `list_user_partitions(user_id)`, `assign_partition(UserPartition)`,
+  `update_partition_role(user_id, partition, PartitionRole)`, `remove_partition(user_id, partition)`.
+  Use these (not the `*_partition_member` legacy methods marked `TODO(phase-9)`).
+- **Config + startup validation** — `OIDCConfig` / `OIDCConfig.from_env()` in
+  `core/config/auth.py`; validated once at startup by `ServiceContainer` (`di/container.py:98`).
+- **`User` shape & helpers** — callback `user` is a `core.models.user.User` (`.id`, `.email`,
+  `.display_name`, `.external_user_id`); `PartitionRole` enum values are `viewer`/`editor`/`owner`,
+  matching `AuthService.ROLE_HIERARCHY`.
+- **FK reality** — `partition_memberships.partition_name` → `partitions.partition` (CASCADE,
+  `schema.py:202`). Assigning a membership for a non-existent partition raises a FK violation,
+  which the per-membership try/except (below) catches → logged & skipped ("skip + warn" default).
+
+### Step 1 — Extend `OIDCConfig` (`core/config/auth.py`)
+
+Add the four `A.4` fields. In `from_env()`, read the four env vars; validate that
+`OIDC_GROUP_PATTERN` compiles and exposes ≥2 capture groups (parse-and-discard, like the existing
+`_parse_oidc_claim_mapping`, so a bad regex fails at startup regardless of whether the feature is
+on). Group sync is **active only when `OIDC_CLAIM_GROUPS` is non-empty** → zero behavior change for
+every current deployment.
+
+### Step 2 — New pure mapper `openrag/services/auth/oidc_groups.py`
+
+```python
+def extract_partition_roles(claims, cfg) -> list[tuple[str, str]]:
+    # "/openrag/project-alpha/editor" --strip prefix--> "project-alpha/editor"
+    #   --pattern--> ("project-alpha", "editor")
+    # Drop non-matching groups; de-dupe keeping the highest role per partition.
+```
+No I/O, fully unit-testable. Accepts a list/str groups claim; uses a local
+`_ROLE_RANK = {"viewer":1,"editor":2,"owner":3}` (kept local so the pure mapper has no dependency
+on the orchestrator layer). Imported directly from the submodule (not re-exported via
+`services/auth/__init__.py`) to avoid any import cycle.
+
+### Step 3 — `_sync_oidc_memberships` in `AuthService` + call after `:208`
+
+```python
+async def _sync_oidc_memberships(self, user, claims) -> None:
+    if not (self._config.claim_groups or "").strip():
+        return
+    desired = dict(extract_partition_roles(claims, self._config))      # {partition: role}
+    current = {m.partition: m.role.value
+               for m in await self._membership_repo.list_user_partitions(user.id)}
+    # add missing (assign_partition) / update changed (update_partition_role)
+    # if group_sync_prune: remove_partition for partitions in current - desired
+    # each membership op wrapped in try/except → logger.bind(...).warning + continue
+    #   (one bad/unknown-partition group must never block the login)
+```
+Reads groups from `bundle.claims` — the same verified ID-token claims already in hand, **no extra
+IdP round-trip**. Logs every add/update/prune at info with `user_id`/`partition`/`role`.
+
+### Step 4 — Config docs & example
+
+- `infra/compose/.env.example`: add the four new vars under the existing OIDC block, commented/
+  optional, with a one-line "off unless `OIDC_CLAIM_GROUPS` is set" note.
+- `docs/oidc.md`: new **"Group → Partition Mapping (optional)"** section — Keycloak group + group-
+  membership-mapper setup, the prefix/pattern, the prune flag, and an explicit callout that
+  `is_admin` is still **not** claim-writable. Include a short note reconciling the strategy doc's
+  old names (Part A) so future readers don't reintroduce `OIDC_ISSUER_URL`/`OIDC_ENABLED`.
+- `docs/sso-quickstart.md`: one-line pointer to the new section.
+
+### Step 5 — Tests
+
+- **Unit** — `extract_partition_roles`: prefix strip, pattern match, non-match drop, highest-role
+  de-dupe, list-vs-scalar groups claim, empty-claim short-circuit. `OIDCConfig.from_env`: the four
+  new vars parse; bad `OIDC_GROUP_PATTERN` (uncompilable / <2 groups) raises at startup; feature
+  stays off when `OIDC_CLAIM_GROUPS` unset.
+- **Service** — `_sync_oidc_memberships` against a fake membership repo: add, role-change, prune-on
+  vs prune-off, unknown-partition (assign raises) is isolated & logged, per-membership failure
+  isolation.
+- **Regression** — existing `tests/integration/api/test_oidc_lifecycle.py` still passes with groups
+  unset (proves zero behavior change).
+
+---
+
+## Open decisions
+
+1. **Reconciliation strategy** — default **additive + role-update; prune behind
+   `OIDC_GROUP_SYNC_PRUNE=false`**. Alternative: prune-by-default (matches the strategy doc's
+   "Keycloak is source of truth" wording, but wipes manually-granted memberships on next login).
+   *Implemented with a mass-revocation guard:* even with prune on, removal runs only when the token
+   actually asserts the groups claim — a missing/misconfigured claim skips prune (an explicit
+   `groups: []` still prunes). See decision log Phase 15 §2.
+2. **`role → is_admin`** — default **excluded** to preserve the documented hard boundary
+   (`is_admin` never claim-writable). Approving the alternative adds `OIDC_CLAIM_ROLES` +
+   `OIDC_ADMIN_ROLE` (Part A.4 deferred row) behind a loud, explicit opt-in.
+3. **Unknown partition referenced by a group** — default **skip + warn** (FK violation caught per
+   membership). Alternative: auto-create the partition via `PartitionService` (needs that service
+   injected into `AuthService` — a small DI change).
+
+---
+
+## Verification
+
+```bash
+uv run pytest tests/unit/ -k "oidc or group or membership"      # new + existing units
+uv run pytest tests/integration/api/test_oidc_lifecycle.py      # no regression, groups unset
+uv run ruff check openrag/ tests/
+python scripts/check_layer_imports.py                           # core/services layering intact
+```
+End-to-end (manual, against a Keycloak realm): create groups `/openrag/<partition>/<role>`, assign
+a test user, log in via `/auth/login`, confirm `GET /users/info` (or `/auth/me`) reflects the
+synced memberships; toggle `OIDC_GROUP_SYNC_PRUNE` and re-login to confirm prune behavior.
+
+## Non-goals (explicit)
+
+- No rename of any shipped `OIDC_*` / `AUTH_MODE` variable (Part A only *adopts* shipped names as
+  canonical and drops strategy-doc duplicates).
+- No `VITE_OIDC_*` / frontend OIDC client, no raw-JWT-bearer dual-auth, no `OIDC_AUDIENCE` /
+  `OIDC_JWKS_CACHE_TTL`, no DB migration (uses existing `partition_memberships`).
+
+---
+
+## Key considerations
+
+Two questions a reader coming from the strategy doc will ask — answered here so the divergence from
+§15C/§15D/§15E reads as intentional, not as an oversight.
+
+### Why no `OIDCUserMapper` / `OIDCUserProvisioner` classes
+
+The strategy doc's §15C (`OIDCUserMapper`) and §15D (`OIDCUserProvisioner`) are **not absent — they
+are decomposed differently**, because the shipped design provisions *once at the callback*, not
+*per request*. The doc's classes were sketched for the stateless-JWT-bearer world (§15E
+`get_current_user` runs validator → mapper → provisioner on every request), so they are stateless
+components hung on the auth hot path. We have no such per-request path — the opaque session token
+short-circuits every request after login — so the natural seam is `handle_oidc_callback`, where
+steps 1–3 of `ensure_user` already existed before this phase.
+
+`OIDCUserProvisioner.ensure_user`'s 5-step docstring maps **line-for-line** onto the existing
+callback pipeline (`auth_service.py:207-210`):
+
+| `ensure_user` step (§15D)             | Where it lives now                         |
+| ------------------------------------- | ------------------------------------------ |
+| 1. Lookup by `external_user_id`       | `_resolve_user`                            |
+| 2. Auto-provision if not found        | `_sync_auto_provisioned`                   |
+| 3. Sync `is_admin` from roles         | **deliberately omitted** — Open Decision #2 (hard boundary) |
+| 4. Sync partition memberships         | `_sync_oidc_memberships` ← this phase (Part B) |
+| 5. Return full user                   | callback continues                         |
+
+Wrapping this in a new class would either duplicate working code (steps 1, 2, 4 already have homes)
+or force a second provisioning path. We add only the genuinely-missing step (4).
+
+`OIDCUserMapper.extract_partitions` becomes the **pure function** `extract_partition_roles`
+(`services/auth/oidc_groups.py`) rather than a class: it has no state and no I/O, so `self._config`
+ceremony buys nothing. A module-level function matches the existing `_parse_oidc_claim_mapping`
+style in `core/config/auth.py` and is unit-testable without instantiation.
+
+### No raw-JWT bearer format on the wire — and why we don't need one yet
+
+The strategy doc's §15E dispatches on token *shape* — a bearer starting `eyJ` (a raw Keycloak JWT)
+takes the JWKS-validation path; `or-` takes the DB path. **The shipped design never puts a raw JWT
+on the wire as a client credential**, so there is no third format to detect:
+
+- The IdP's `id_token` / `access_token` / `refresh_token` are obtained server-side at
+  `/auth/callback` and stored **Fernet-encrypted in `oidc_sessions`** — they never reach the
+  browser.
+- The client holds an **opaque** session token (`secrets.token_urlsafe(32)`, ~43 chars, *not* a
+  JWT). A bearer is resolved by DB lookup in `AuthMiddleware` (`auth.py:197-222`): first against
+  `oidc_sessions` (opaque session token), then against `users.token` (programmatic `or-` token).
+
+A raw JWT (`eyJ…`) matches neither table → 401/403.
+
+**Right now we don't need it.** The two audiences a JWT-bearer path would serve are already covered:
+browsers authenticate via the session cookie, and machine/CI clients via `users.token`. No current
+client holds a Keycloak access token it needs to present directly, so adding a third format would be
+surface area with no consumer. It stays **out of scope** (Part A.3) until a concrete caller — e.g. a
+service-to-service client that *already* obtains an access token from the IdP — requires it.
+
+**Implications if it is implemented later** (this is the §15B `jwt_validator` path). The code is
+small — the validation machinery already exists (`oidc_client.py` `_load_jwks` + `_verify_id_token`)
+and the user-resolution helpers (`_resolve_user`, `_sync_auto_provisioned`, `_sync_oidc_memberships`)
+already take raw `claims`. The cost is **semantic, not lines of code**:
+
+| Concern | Today (opaque session / `users.token`) | With raw-JWT bearer |
+| ------- | -------------------------------------- | ------------------- |
+| **Validation** | DB lookup on every request | **No DB lookup** — pure offline crypto: JWKS signature + `iss`/`aud`/`exp` claim checks against cached public keys. |
+| **Revocation** | Instant — delete the session/token row | **Cannot revoke** a still-valid JWT; it is trusted until its `exp`. Mitigations (short TTL, a denylist) reintroduce the state JWTs were meant to avoid. |
+| **Provisioning** | Runs **once** at `/auth/callback` | `_sync_oidc_memberships` would run **per request** unless gated/cached — a write + IdP-shaped round-trip on the hot path. |
+| **Audience** | n/a | Keycloak *access* tokens carry `aud = account`/resource, not `client_id`, so `_verify_id_token`'s rule can't be reused — needs a sibling `verify_access_token` plus the `OIDC_AUDIENCE` knob dropped in A.3, and a decision on *which* token (id vs access) clients present. |
+
+Net: bolting it on is cheap mechanically but is a real **policy change** — trading instant
+revocation for stateless validation, and accepting per-request provisioning cost. Defer until a
+client actually needs it.

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -153,3 +153,16 @@ PREFERRED_URL_SCHEME=https
 # the fly using the ID-token claims (display_name from `name`/`preferred_username`,
 # email from `email`). The new user inherits the default file quota.
 # OIDC_AUTO_PROVISION_LOGIN=false
+# --- Optional group → partition membership sync ---
+# Map IdP groups to OpenRag partition memberships on every login. OFF unless
+# OIDC_CLAIM_GROUPS names the claim that carries the user's group list (e.g.
+# Keycloak's `groups`). Each group is matched against OIDC_GROUP_PATTERN after
+# OIDC_GROUP_PREFIX is stripped, yielding (partition, role). Roles are the
+# usual viewer/editor/owner. is_admin is NEVER derived from groups.
+#   /openrag/project-alpha/editor  ->  partition "project-alpha", role "editor"
+# OIDC_CLAIM_GROUPS=groups
+# OIDC_GROUP_PREFIX=/openrag/
+# OIDC_GROUP_PATTERN=(.+)/(owner|editor|viewer)$
+# When true, memberships absent from the token are removed on login (the IdP
+# becomes the sole source of truth). Default keeps manually-granted memberships.
+# OIDC_GROUP_SYNC_PRUNE=false

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -20,6 +20,7 @@ here so the rules are configuration, not code:
 from __future__ import annotations
 
 import os
+import re
 from typing import ClassVar
 
 from pydantic import BaseModel
@@ -69,6 +70,36 @@ def _parse_oidc_claim_mapping(raw: str) -> dict[str, str]:
     return mapping
 
 
+# Default Keycloak group → (partition, role) pattern, applied to each group
+# *after* ``OIDC_GROUP_PREFIX`` is stripped. For a group ``/openrag/alpha/editor``
+# with the default prefix ``/openrag/`` it matches the remainder ``alpha/editor``
+# and captures ``("alpha", "editor")`` — group 1 = partition, group 2 = role.
+# The trailing ``$`` anchor is a deliberate refinement over the strategy doc so
+# trailing garbage cannot accidentally match (operators may override it).
+_DEFAULT_OIDC_GROUP_PATTERN: str = r"(.+)/(owner|editor|viewer)$"
+
+
+def _compile_group_pattern(raw: str) -> re.Pattern[str]:
+    """Compile ``OIDC_GROUP_PATTERN`` and assert it captures two groups.
+
+    Raises ``RuntimeError`` on an invalid regex, or one exposing fewer than
+    two capture groups (partition + role), so an operator typo trips at
+    startup rather than silently mapping zero groups at the next login. Run
+    unconditionally (like :func:`_parse_oidc_claim_mapping`) so a bad pattern
+    fails even before ``OIDC_CLAIM_GROUPS`` is set to switch the feature on.
+    """
+    try:
+        pattern = re.compile(raw)
+    except re.error as e:
+        raise RuntimeError(f"Invalid OIDC_GROUP_PATTERN {raw!r}: {e}") from e
+    if pattern.groups < 2:
+        raise RuntimeError(
+            f"OIDC_GROUP_PATTERN {raw!r} must expose at least two capture groups "
+            f"(partition, role); got {pattern.groups}"
+        )
+    return pattern
+
+
 class OIDCConfig(BaseModel):
     """OIDC configuration for Keycloak / external IdP integration.
 
@@ -90,6 +121,21 @@ class OIDCConfig(BaseModel):
     # non-admin user on the fly from the ID-token claims. Default keeps
     # the strict "admin pre-creates every user" policy.
     auto_provision_login: bool = False
+
+    # --- Group → partition membership sync (Phase 15) ---------------------
+    # Empty ``claim_groups`` disables the feature entirely, so every existing
+    # deployment is unaffected. When set, the named claim is read from the
+    # verified ID token at callback time, each group is matched against
+    # ``group_pattern`` (after ``group_prefix`` is stripped) to yield a
+    # (partition, role) pair, and the user's memberships are reconciled.
+    # ``is_admin`` is never derived from claims — that hard boundary (see the
+    # claim-mapping whitelist above) is preserved.
+    claim_groups: str = ""
+    group_prefix: str = "/openrag/"
+    group_pattern: str = _DEFAULT_OIDC_GROUP_PATTERN
+    # When True, memberships absent from the token are removed (the IdP is the
+    # sole source of truth). Default keeps manually-granted memberships.
+    group_sync_prune: bool = False
 
     # The five env vars required when AUTH_MODE=oidc; unset/empty values
     # trip the validator with a single error listing every missing key.
@@ -148,6 +194,12 @@ class OIDCConfig(BaseModel):
         # the moment they flipped AUTH_MODE=oidc.
         _parse_oidc_claim_mapping(claim_mapping)
 
+        # Same parse-and-discard philosophy for the group pattern: validate
+        # the regex compiles and exposes two capture groups regardless of
+        # whether group sync is currently active.
+        group_pattern = os.getenv("OIDC_GROUP_PATTERN", _DEFAULT_OIDC_GROUP_PATTERN)
+        _compile_group_pattern(group_pattern)
+
         return cls(
             enabled=enabled,
             issuer_url=env_values["OIDC_ENDPOINT"] or "",
@@ -160,6 +212,10 @@ class OIDCConfig(BaseModel):
             claim_mapping=claim_mapping,
             post_logout_redirect_uri=os.getenv("OIDC_POST_LOGOUT_REDIRECT_URI", "") or "",
             auto_provision_login=os.getenv("OIDC_AUTO_PROVISION_LOGIN", "false").strip().lower() == "true",
+            claim_groups=os.getenv("OIDC_CLAIM_GROUPS", "").strip(),
+            group_prefix=os.getenv("OIDC_GROUP_PREFIX", "/openrag/"),
+            group_pattern=group_pattern,
+            group_sync_prune=os.getenv("OIDC_GROUP_SYNC_PRUNE", "false").strip().lower() == "true",
         )
 
 

--- a/openrag/services/auth/oidc_groups.py
+++ b/openrag/services/auth/oidc_groups.py
@@ -1,0 +1,86 @@
+"""Map IdP group claims to OpenRAG (partition, role) pairs (Phase 15).
+
+Pure, I/O-free translation of a user's group memberships — as advertised in
+the OIDC ID token — into the partition memberships OpenRAG understands. The
+:class:`AuthService` membership-sync step calls :func:`extract_partition_roles`
+and reconciles the result against the database; everything here is a string
+transform so it is exhaustively unit-testable without a DB or an IdP.
+
+The strategy doc (``REFACTORING_STRATEGY_v1.md`` §15C) specified this mapping:
+
+    /openrag/project-alpha/editor  ->  ("project-alpha", "editor")
+
+i.e. strip ``group_prefix``, then match ``group_pattern`` to capture the
+partition (group 1) and role (group 2). ``is_admin`` is deliberately *not*
+derivable here — that boundary lives in :class:`AuthService`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from core.config.auth import OIDCConfig
+
+# Role precedence used to collapse duplicate grants for the same partition
+# (e.g. groups granting both viewer and editor → editor wins). Kept local so
+# this pure mapper carries no dependency on the orchestrator layer; the values
+# mirror ``AuthService.ROLE_HIERARCHY`` (the canonical source).
+_ROLE_RANK: dict[str, int] = {"viewer": 1, "editor": 2, "owner": 3}
+
+
+def _coerce_groups(raw: Any) -> list[str]:
+    """Normalise the groups claim to a list of strings.
+
+    IdPs vary: most emit a JSON array, some a single string. Anything else
+    (number, dict, ``None``) yields no groups rather than raising — a
+    malformed claim must never break the login.
+    """
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, (list, tuple)):
+        return [g for g in raw if isinstance(g, str)]
+    return []
+
+
+def extract_partition_roles(claims: Any, cfg: OIDCConfig) -> list[tuple[str, str]]:
+    """Return ``[(partition, role), ...]`` parsed from the group claim.
+
+    Returns an empty list when the feature is off (``claim_groups`` unset),
+    the claim is missing/malformed, or no group matches the pattern. Groups
+    not carrying ``group_prefix`` are ignored (they belong to other apps).
+    When several groups grant the same partition, the highest role wins. The
+    result is sorted for deterministic logging/testing.
+    """
+    claim_name = (cfg.claim_groups or "").strip()
+    if not claim_name:
+        return []
+    groups = _coerce_groups(claims.get(claim_name) if isinstance(claims, dict) else None)
+    if not groups:
+        return []
+
+    pattern = re.compile(cfg.group_pattern)
+    prefix = cfg.group_prefix or ""
+
+    best: dict[str, str] = {}
+    for group in groups:
+        candidate = group.strip()
+        if prefix:
+            if not candidate.startswith(prefix):
+                continue
+            candidate = candidate[len(prefix) :]
+        match = pattern.match(candidate)
+        if not match:
+            continue
+        partition = match.group(1).strip().strip("/")
+        role = match.group(2).strip().lower()
+        if not partition or role not in _ROLE_RANK:
+            continue
+        if partition not in best or _ROLE_RANK[role] > _ROLE_RANK[best[partition]]:
+            best[partition] = role
+
+    return sorted(best.items())
+
+
+__all__ = ["extract_partition_roles"]

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode, urlparse
 
-from core.models.user import OIDCSession, User
+from core.models.user import OIDCSession, PartitionRole, User, UserPartition
 from core.utils.exceptions import AuthError, OpenRAGError
 from core.utils.logging import get_logger, mask_email
 from services.auth import (
@@ -35,6 +35,7 @@ from services.auth import (
     hash_session_token,
     issue_session_token,
 )
+from services.auth.oidc_groups import extract_partition_roles
 
 if TYPE_CHECKING:
     from core.config.auth import OIDCConfig
@@ -206,6 +207,7 @@ class AuthService:
         user = await self._resolve_user(sub, bundle.claims)
         user = await self._sync_auto_provisioned(user, sub, bundle.claims)
         user = await self._apply_claim_mapping(user, bundle)
+        await self._sync_oidc_memberships(user, bundle.claims)
 
         now = _utcnow()
         expires_in = max(int(bundle.expires_in or 0), 60)
@@ -732,6 +734,85 @@ class AuthService:
             logger.warning(f"update_user failed for user_id={user.id}: {e}")
             return user
         return refreshed or user
+
+    async def _sync_oidc_memberships(self, user: User, claims: dict[str, Any]) -> None:
+        """Reconcile partition memberships from the IdP group claim (Phase 15).
+
+        Off unless ``OIDC_CLAIM_GROUPS`` names a claim. When on, the verified
+        ID-token groups are translated to ``(partition, role)`` pairs and the
+        user's memberships are brought in line: missing ones are added, changed
+        roles updated, and — only when ``OIDC_GROUP_SYNC_PRUNE`` is set *and*
+        the token actually carries the groups claim — memberships absent from
+        the token are removed (the IdP becomes the sole source of truth). A
+        missing claim never prunes, to avoid mass-revocation on a
+        misconfiguration. ``is_admin`` is never touched here.
+
+        Never raises: a single bad/unknown group (e.g. a partition that does
+        not exist yet, which trips the FK) is logged and skipped so it cannot
+        block an otherwise-valid login. Reads groups from the claims already in
+        hand — no extra IdP round-trip.
+        """
+        if not (self._config.claim_groups or "").strip():
+            return
+
+        desired = dict(extract_partition_roles(claims, self._config))  # {partition: role}
+
+        try:
+            current_memberships = await self._membership_repo.list_user_partitions(user.id)
+        except Exception as e:
+            logger.bind(user_id=user.id).warning(f"OIDC group sync: failed to read memberships: {e}")
+            return
+        current = {m.partition: m.role.value for m in current_memberships}
+
+        # Add missing / update changed roles from the token.
+        for partition, role in desired.items():
+            if current.get(partition) == role:
+                continue
+            try:
+                if partition in current:
+                    await self._membership_repo.update_partition_role(user.id, partition, PartitionRole(role))
+                    logger.bind(user_id=user.id, partition=partition, role=role).info(
+                        "OIDC group sync: updated partition role"
+                    )
+                else:
+                    await self._membership_repo.assign_partition(
+                        UserPartition(user_id=user.id, partition=partition, role=PartitionRole(role))
+                    )
+                    logger.bind(user_id=user.id, partition=partition, role=role).info(
+                        "OIDC group sync: added partition membership"
+                    )
+            except Exception as e:
+                logger.bind(user_id=user.id, partition=partition, role=role).warning(
+                    f"OIDC group sync: could not apply membership (partition may not exist or other error): {e}"
+                )
+
+        # Prune memberships not present in the token (opt-in).
+        #
+        # Mass-revocation guard: only prune when the IdP actually *asserted* a
+        # groups claim in this token. A missing claim (mapper disabled, wrong
+        # OIDC_CLAIM_GROUPS, scope not granted, transient omission) yields an
+        # empty ``desired`` that means "no signal" — NOT "revoke everything";
+        # pruning there would wipe every synced user's access on a single
+        # config mistake. An explicit empty list (``groups: []`` — user
+        # genuinely in no groups) is a real signal and still prunes.
+        if self._config.group_sync_prune:
+            groups_asserted = isinstance(claims, dict) and claims.get(self._config.claim_groups) is not None
+            if not groups_asserted:
+                logger.bind(user_id=user.id).warning(
+                    f"OIDC group sync: skipping prune — token carries no {self._config.claim_groups!r} "
+                    "claim (guard against mass-revocation on a missing/misconfigured claim)"
+                )
+                return
+            for partition in current:
+                if partition in desired:
+                    continue
+                try:
+                    await self._membership_repo.remove_partition(user.id, partition)
+                    logger.bind(user_id=user.id, partition=partition).info(
+                        "OIDC group sync: pruned partition membership"
+                    )
+                except Exception as e:
+                    logger.bind(user_id=user.id, partition=partition).warning(f"OIDC group sync: prune failed: {e}")
 
 
 __all__ = [

--- a/tests/unit/core/config/test_auth_env_validation.py
+++ b/tests/unit/core/config/test_auth_env_validation.py
@@ -32,6 +32,10 @@ def _clear_oidc_env(monkeypatch):
         "OIDC_SCOPES",
         "OIDC_POST_LOGOUT_REDIRECT_URI",
         "OIDC_AUTO_PROVISION_LOGIN",
+        "OIDC_CLAIM_GROUPS",
+        "OIDC_GROUP_PREFIX",
+        "OIDC_GROUP_PATTERN",
+        "OIDC_GROUP_SYNC_PRUNE",
     ]:
         monkeypatch.delenv(name, raising=False)
 
@@ -195,4 +199,64 @@ def test_claim_mapping_validated_even_in_token_mode(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "token")
     monkeypatch.setenv("OIDC_CLAIM_MAPPING", "is_admin:role")
     with pytest.raises(RuntimeError, match="is not writable"):
+        OIDCConfig.from_env()
+
+
+# ---------------------------------------------------------------------------
+# group → partition sync (Phase 15)
+# ---------------------------------------------------------------------------
+
+
+def test_group_sync_defaults_are_off_and_conventional(monkeypatch):
+    """Unset group vars: feature is OFF (empty claim) with the documented
+    defaults, so no existing deployment changes behaviour."""
+    _set_env(monkeypatch)
+    cfg = OIDCConfig.from_env()
+    assert cfg.claim_groups == ""
+    assert cfg.group_prefix == "/openrag/"
+    assert cfg.group_pattern == r"(.+)/(owner|editor|viewer)$"
+    assert cfg.group_sync_prune is False
+
+
+def test_group_sync_vars_round_trip(monkeypatch):
+    _set_env(
+        monkeypatch,
+        OIDC_CLAIM_GROUPS="groups",
+        OIDC_GROUP_PREFIX="/corp/",
+        OIDC_GROUP_PATTERN=r"(.+)/(owner|editor|viewer)$",
+        OIDC_GROUP_SYNC_PRUNE="true",
+    )
+    cfg = OIDCConfig.from_env()
+    assert cfg.claim_groups == "groups"
+    assert cfg.group_prefix == "/corp/"
+    assert cfg.group_sync_prune is True
+
+
+def test_group_sync_prune_is_truthy_only_for_literal_true(monkeypatch):
+    _set_env(monkeypatch, OIDC_GROUP_SYNC_PRUNE="yes")
+    assert OIDCConfig.from_env().group_sync_prune is False
+    _set_env(monkeypatch, OIDC_GROUP_SYNC_PRUNE="True")
+    assert OIDCConfig.from_env().group_sync_prune is True
+
+
+def test_uncompilable_group_pattern_raises(monkeypatch):
+    _set_env(monkeypatch, OIDC_GROUP_PATTERN="(.+/(owner|editor")
+    with pytest.raises(RuntimeError, match="Invalid OIDC_GROUP_PATTERN"):
+        OIDCConfig.from_env()
+
+
+def test_group_pattern_with_too_few_groups_raises(monkeypatch):
+    """A pattern that captures only the partition (no role group) is a
+    config error — it would map every group to an undefined role."""
+    _set_env(monkeypatch, OIDC_GROUP_PATTERN=r"(.+)/owner")
+    with pytest.raises(RuntimeError, match="at least two capture groups"):
+        OIDCConfig.from_env()
+
+
+def test_group_pattern_validated_even_in_token_mode(monkeypatch):
+    """Like claim mapping, a bad pattern must fail at startup before the
+    operator flips AUTH_MODE=oidc."""
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.setenv("OIDC_GROUP_PATTERN", "(unbalanced")
+    with pytest.raises(RuntimeError, match="Invalid OIDC_GROUP_PATTERN"):
         OIDCConfig.from_env()

--- a/tests/unit/services/auth/test_oidc_groups.py
+++ b/tests/unit/services/auth/test_oidc_groups.py
@@ -1,0 +1,90 @@
+"""Unit tests for :func:`services.auth.oidc_groups.extract_partition_roles`.
+
+Pure string-transform tests — no DB, no IdP. Pins the strategy-doc mapping
+(``/openrag/project-alpha/editor`` → ``("project-alpha", "editor")``) and the
+edge cases that must never raise (malformed claim, wrong prefix, unknown role).
+"""
+
+from __future__ import annotations
+
+from core.config.auth import OIDCConfig
+from services.auth.oidc_groups import extract_partition_roles
+
+
+def _cfg(**over) -> OIDCConfig:
+    base = {
+        "claim_groups": "groups",
+        "group_prefix": "/openrag/",
+        "group_pattern": r"(.+)/(owner|editor|viewer)$",
+    }
+    base.update(over)
+    return OIDCConfig(**base)
+
+
+def test_disabled_when_claim_groups_unset():
+    cfg = _cfg(claim_groups="")
+    assert extract_partition_roles({"groups": ["/openrag/alpha/owner"]}, cfg) == []
+
+
+def test_basic_prefix_strip_and_pattern_match():
+    cfg = _cfg()
+    claims = {"groups": ["/openrag/project-alpha/editor"]}
+    assert extract_partition_roles(claims, cfg) == [("project-alpha", "editor")]
+
+
+def test_groups_without_prefix_are_ignored():
+    """Groups belonging to other apps (no /openrag/ prefix) are skipped."""
+    cfg = _cfg()
+    claims = {"groups": ["/otherapp/x/editor", "noprefix", "/openrag/beta/owner"]}
+    assert extract_partition_roles(claims, cfg) == [("beta", "owner")]
+
+
+def test_non_matching_pattern_is_dropped():
+    cfg = _cfg()
+    # No role suffix → no match; unknown role → dropped.
+    claims = {"groups": ["/openrag/alpha", "/openrag/alpha/superuser"]}
+    assert extract_partition_roles(claims, cfg) == []
+
+
+def test_highest_role_wins_per_partition():
+    cfg = _cfg()
+    claims = {
+        "groups": [
+            "/openrag/alpha/viewer",
+            "/openrag/alpha/editor",
+            "/openrag/alpha/owner",
+        ]
+    }
+    assert extract_partition_roles(claims, cfg) == [("alpha", "owner")]
+
+
+def test_result_is_sorted_and_deduped():
+    cfg = _cfg()
+    claims = {"groups": ["/openrag/zeta/viewer", "/openrag/alpha/editor"]}
+    assert extract_partition_roles(claims, cfg) == [("alpha", "editor"), ("zeta", "viewer")]
+
+
+def test_scalar_string_groups_claim_is_accepted():
+    cfg = _cfg()
+    assert extract_partition_roles({"groups": "/openrag/alpha/editor"}, cfg) == [("alpha", "editor")]
+
+
+def test_missing_or_malformed_claim_returns_empty():
+    cfg = _cfg()
+    assert extract_partition_roles({}, cfg) == []
+    assert extract_partition_roles({"groups": None}, cfg) == []
+    assert extract_partition_roles({"groups": 42}, cfg) == []
+    assert extract_partition_roles({"groups": {"a": 1}}, cfg) == []
+    assert extract_partition_roles("not-a-dict", cfg) == []
+
+
+def test_empty_prefix_matches_any_group():
+    cfg = _cfg(group_prefix="")
+    claims = {"groups": ["team/alpha/editor"]}
+    # Greedy (.+) captures "team/alpha" as the partition.
+    assert extract_partition_roles(claims, cfg) == [("team/alpha", "editor")]
+
+
+def test_role_casing_is_normalised():
+    cfg = _cfg(group_pattern=r"(.+)/(OWNER|EDITOR|VIEWER|owner|editor|viewer)$")
+    assert extract_partition_roles({"groups": ["/openrag/alpha/EDITOR"]}, cfg) == [("alpha", "editor")]

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 from core.config.auth import OIDCConfig
-from core.models.user import User
+from core.models.user import PartitionRole, User, UserPartition
 from cryptography.fernet import Fernet
 from services.auth import StateCookieSerializer, hash_session_token
 from services.auth.oidc_client import LogoutTokenClaims, TokenBundle
@@ -137,11 +137,52 @@ def _cfg(**over) -> OIDCConfig:
     return OIDCConfig(**base)
 
 
-def _service(*, user_repo=None, session_repo=None, client=None, cfg=None) -> AuthService:
+class FakeMembershipRepo:
+    """In-memory ``partition_memberships`` keyed by (user_id, partition).
+
+    ``fk_missing`` names partitions that do not exist in ``partitions`` — an
+    ``assign_partition`` against one raises, mimicking the real FK violation so
+    the sync's per-membership isolation can be exercised.
+    """
+
+    def __init__(self, *, seed=None, fk_missing=None):
+        # seed: list of (user_id, partition, role-str)
+        self._rows: dict[tuple[int, str], str] = {(uid, part): role for uid, part, role in (seed or [])}
+        self._fk_missing = set(fk_missing or [])
+        self.assigned: list[tuple[int, str, str]] = []
+        self.updated: list[tuple[int, str, str]] = []
+        self.removed: list[tuple[int, str]] = []
+
+    async def list_user_partitions(self, user_id: int):
+        return [
+            UserPartition(user_id=uid, partition=part, role=PartitionRole(role))
+            for (uid, part), role in self._rows.items()
+            if uid == user_id
+        ]
+
+    async def assign_partition(self, assignment: UserPartition):
+        if assignment.partition in self._fk_missing:
+            raise RuntimeError("insert or update violates foreign key constraint")
+        self._rows[(assignment.user_id, assignment.partition)] = assignment.role.value
+        self.assigned.append((assignment.user_id, assignment.partition, assignment.role.value))
+        return assignment
+
+    async def update_partition_role(self, user_id: int, partition: str, role: PartitionRole) -> bool:
+        self._rows[(user_id, partition)] = role.value
+        self.updated.append((user_id, partition, role.value))
+        return True
+
+    async def remove_partition(self, user_id: int, partition: str) -> bool:
+        existed = self._rows.pop((user_id, partition), None) is not None
+        self.removed.append((user_id, partition))
+        return existed
+
+
+def _service(*, user_repo=None, session_repo=None, client=None, cfg=None, membership_repo=None) -> AuthService:
     return AuthService(
         user_repo=user_repo or FakeUserRepo(),
         oidc_session_repo=session_repo or FakeSessionRepo(),
-        membership_repo=object(),
+        membership_repo=membership_repo if membership_repo is not None else object(),
         oidc_client=client,
         config=cfg or _cfg(),
     )
@@ -471,3 +512,115 @@ def test_validate_file_quota():
         AuthService.validate_file_quota({"file_count": 3, "file_quota": 5}, pending_task_count=2, default_quota=10)
     # Under the limit is fine.
     AuthService.validate_file_quota({"file_count": 1, "file_quota": 5}, pending_task_count=1, default_quota=10)
+
+
+# --------------------------------------------------------------------------- #
+# _sync_oidc_memberships (Phase 15)
+# --------------------------------------------------------------------------- #
+
+
+def _group_cfg(**over) -> OIDCConfig:
+    return _cfg(
+        claim_groups="groups",
+        group_prefix="/openrag/",
+        group_pattern=r"(.+)/(owner|editor|viewer)$",
+        **over,
+    )
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_is_noop_when_disabled():
+    repo = FakeMembershipRepo()
+    svc = _service(cfg=_cfg(), membership_repo=repo)  # claim_groups unset
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/owner"]})
+    assert repo.assigned == [] and repo.updated == [] and repo.removed == []
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_adds_missing():
+    repo = FakeMembershipRepo(seed=[(1, "alpha", "viewer")])
+    svc = _service(cfg=_group_cfg(), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/viewer", "/openrag/beta/editor"]})
+    # alpha unchanged (already viewer); beta added.
+    assert repo.assigned == [(1, "beta", "editor")]
+    assert repo.updated == []
+    assert repo.removed == []
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_updates_changed_role():
+    repo = FakeMembershipRepo(seed=[(1, "alpha", "viewer")])
+    svc = _service(cfg=_group_cfg(), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/owner"]})
+    assert repo.updated == [(1, "alpha", "owner")]
+    assert repo.assigned == []
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_prune_off_keeps_stale():
+    repo = FakeMembershipRepo(seed=[(1, "stale", "editor")])
+    svc = _service(cfg=_group_cfg(group_sync_prune=False), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/viewer"]})
+    assert repo.assigned == [(1, "alpha", "viewer")]
+    assert repo.removed == []  # 'stale' kept
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_prune_on_removes_stale():
+    repo = FakeMembershipRepo(seed=[(1, "stale", "editor"), (1, "alpha", "viewer")])
+    svc = _service(cfg=_group_cfg(group_sync_prune=True), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/viewer"]})
+    assert repo.removed == [(1, "stale")]  # only the one absent from the token
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_prune_skips_when_groups_claim_absent():
+    """Mass-revocation guard: a missing groups claim (mapper disabled / wrong
+    claim name) must NOT prune — that's 'no signal', not 'revoke everything'."""
+    repo = FakeMembershipRepo(seed=[(1, "alpha", "editor"), (1, "beta", "viewer")])
+    svc = _service(cfg=_group_cfg(group_sync_prune=True), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"sub": "kc-1"})  # no 'groups' key
+    assert repo.removed == []  # nothing wiped
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_prune_skips_when_groups_claim_is_null():
+    """An explicit ``groups: null`` is also treated as no assertion."""
+    repo = FakeMembershipRepo(seed=[(1, "alpha", "editor")])
+    svc = _service(cfg=_group_cfg(group_sync_prune=True), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": None})
+    assert repo.removed == []
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_prune_runs_on_explicit_empty_group_list():
+    """``groups: []`` is a real signal (user genuinely in no groups) → prune."""
+    repo = FakeMembershipRepo(seed=[(1, "alpha", "editor"), (1, "beta", "viewer")])
+    svc = _service(cfg=_group_cfg(group_sync_prune=True), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": []})
+    assert sorted(repo.removed) == [(1, "alpha"), (1, "beta")]
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_unknown_partition_is_isolated():
+    """A group naming a non-existent partition (FK violation) is logged and
+    skipped; other valid memberships in the same token still apply."""
+    repo = FakeMembershipRepo(fk_missing=["ghost"])
+    svc = _service(cfg=_group_cfg(), membership_repo=repo)
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/ghost/owner", "/openrag/alpha/editor"]})
+    # ghost failed, alpha succeeded — the login is never blocked.
+    assert (1, "alpha", "editor") in repo.assigned
+    assert (1, "ghost") not in [(u, p) for (u, p, _) in repo.assigned]
+
+
+@pytest.mark.asyncio
+async def test_membership_sync_survives_list_failure():
+    class Boom(FakeMembershipRepo):
+        async def list_user_partitions(self, user_id):
+            raise RuntimeError("db down")
+
+    repo = Boom()
+    svc = _service(cfg=_group_cfg(), membership_repo=repo)
+    # Must not raise.
+    await svc._sync_oidc_memberships(User(id=1), {"groups": ["/openrag/alpha/owner"]})
+    assert repo.assigned == []


### PR DESCRIPTION
## Phase 15 — OIDC / Keycloak group → partition authorization

Implements the genuinely-missing half of strategy-doc Phase 15: **claim-driven authorization**. On OIDC login, an IdP groups claim is translated into partition memberships and reconciled against the database. SSO login itself already shipped (session-cookie Authorization Code + PKCE), so this phase is **variable uniformization (A)** + **group→partition sync (B)** — *not* a greenfield rebuild.

Full reconciliation plan, intentional deviations from the strategy doc, and design rationale: `docs/refactoring/phase-15.md`.

### Part A — config surface (`e7a3cc04`)
- Four new `OIDC_*` vars on `OIDCConfig`, named to the **shipped** convention (no renames of existing vars, no strategy-doc duplicates):
  - `OIDC_CLAIM_GROUPS` (`""` → feature OFF), `OIDC_GROUP_PREFIX` (`/openrag/`), `OIDC_GROUP_PATTERN` (`(.+)/(owner|editor|viewer)$`), `OIDC_GROUP_SYNC_PRUNE` (`false`).
- `from_env()` validates the pattern compiles + exposes ≥2 capture groups, at startup, regardless of `AUTH_MODE`.

### Part B — group → partition sync (`48be7557`)
- `services/auth/oidc_groups.py`: pure mapper, group → (partition, role) — strip prefix, match pattern, highest role wins per partition.
- `AuthService._sync_oidc_memberships`: called after claim mapping in `handle_oidc_callback`; adds missing, updates changed roles, and — only when `OIDC_GROUP_SYNC_PRUNE` is on — removes stale memberships. Reuses the already-injected membership repo and the verified ID-token claims (no extra IdP round-trip).
- **`is_admin` is never derived from groups** — preserves the documented hard boundary (role→is_admin deferred behind an Open Decision).
- Per-membership `try/except` so an unknown partition (FK violation) is logged + skipped and can never block login.
- **Mass-revocation guard:** prune runs only when the token actually asserts the groups claim. A missing/misconfigured claim is "no signal" and skips prune (an explicit `groups: []` still prunes), so a config typo cannot silently wipe every synced user's access.

### Behavior change
**None unless `OIDC_CLAIM_GROUPS` is set.** Every existing deployment is untouched.

### Tests
Unit coverage for the mapper (prefix/pattern/dedupe/scalar-vs-list/empty short-circuit), the config validator (round-trip, bad-regex, <2 groups, validated in token mode), and the service sync (add/role-change/prune-on-vs-off/unknown-partition isolation + the three guard cases).

### Out of scope (see `docs/refactoring/phase-15.md` → Key considerations)
- Stateless raw-JWT-bearer dual-auth (`jwt_validator`/`_is_jwt`) — redundant; session cookie + `users.token` already serve browser + machine clients. Documented with the implications (no DB lookup ↔ no instant revocation) for if it's ever needed.
- `role → is_admin` mapping — deferred (would breach the `is_admin`-never-claim-writable boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)