### PR TITLE
fix(embedder): batch embedding requests to fix timeouts on big PDFs

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -38,13 +38,17 @@ semaphore:
   vlm_semaphore: 10
 
 # --- Embedder ---
-# Env: EMBEDDER_MODEL_NAME, EMBEDDER_BASE_URL, EMBEDDER_API_KEY, MAX_MODEL_LEN
+# Env: EMBEDDER_MODEL_NAME, EMBEDDER_BASE_URL, EMBEDDER_API_KEY, MAX_MODEL_LEN,
+#      EMBEDDER_TIMEOUT, EMBEDDER_BATCH_SIZE, EMBEDDER_CONCURRENCY
 embedder:
   provider: openai
   model_name: jinaai/jina-embeddings-v3
   base_url: http://vllm:8000/v1
   api_key: EMPTY
   max_model_len: 8192
+  timeout: 120.0       # per-request HTTP timeout (s); raise for slow remote endpoints
+  batch_size: 64       # chunks per embedding request (big docs are split into batches)
+  embed_concurrency: 4 # max embedding requests in flight at once
 
 # --- Vector Database (Milvus) ---
 # Env: VDB_HOST, VDB_PORT, VDB_CONNECTOR_NAME, VDB_COLLECTION_NAME, VDB_HYBRID_SEARCH,

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -40,6 +40,11 @@ class EmbedderConfig(ConfigMixin):
     base_url: str = "http://vllm:8000/v1"
     api_key: str = Field(default="EMPTY", repr=False)
     max_model_len: int = 8192
+    timeout: float = 120.0
+    # Big documents are embedded in slices of `batch_size`, at most
+    # `embed_concurrency` requests in flight, to stay within the timeout above.
+    batch_size: int = 64
+    embed_concurrency: int = 4
 
 
 class SemaphoreConfig(ConfigMixin):

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -40,11 +40,15 @@ class EmbedderConfig(ConfigMixin):
     base_url: str = "http://vllm:8000/v1"
     api_key: str = Field(default="EMPTY", repr=False)
     max_model_len: int = 8192
-    timeout: float = 120.0
+    # Constrained > 0: a bad env var should fail at config load, not silently
+    # degrade into surprising runtime behavior (VLLMEmbedder rewrites a
+    # non-positive batch_size/embed_concurrency to 1 and would pass a <= 0
+    # timeout straight into httpx).
+    timeout: float = Field(default=120.0, gt=0)
     # Big documents are embedded in slices of `batch_size`, at most
     # `embed_concurrency` requests in flight, to stay within the timeout above.
-    batch_size: int = 64
-    embed_concurrency: int = 4
+    batch_size: int = Field(default=64, gt=0)
+    embed_concurrency: int = Field(default=4, gt=0)
 
 
 class SemaphoreConfig(ConfigMixin):

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -39,6 +39,9 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("EMBEDDER_BASE_URL", "embedder.base_url", str),
     ("EMBEDDER_API_KEY", "embedder.api_key", str),
     ("MAX_MODEL_LEN", "embedder.max_model_len", int),
+    ("EMBEDDER_TIMEOUT", "embedder.timeout", float),
+    ("EMBEDDER_BATCH_SIZE", "embedder.batch_size", int),
+    ("EMBEDDER_CONCURRENCY", "embedder.embed_concurrency", int),
     # VectorDB
     ("VDB_HOST", "vectordb.host", str),
     ("VDB_iPORT", "vectordb.port", int),

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -465,6 +465,9 @@ class ServiceContainer:
                 model_name=embed_cfg.model_name,
                 api_key=embed_cfg.api_key,
                 max_model_len=embed_cfg.max_model_len,
+                timeout=embed_cfg.timeout,
+                batch_size=embed_cfg.batch_size,
+                embed_concurrency=embed_cfg.embed_concurrency,
             )
             searcher = VectorStoreSearcher(
                 vector_store=self.vector_store,

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -28,6 +28,7 @@ from core.utils.exceptions import (
 )
 from core.utils.logging import get_logger
 from core.vlm import VLM, vlm_registry
+from tqdm.asyncio import tqdm
 
 from ._circuit_breaker import with_circuit_breaker
 from ._retry import with_retry
@@ -184,7 +185,9 @@ class VLLMEmbedder(Embedder):
         *,
         max_model_len: int | None = None,
         dimension: int | None = None,
-        timeout: float = 60.0,
+        timeout: float = 120.0,
+        batch_size: int = 64,
+        embed_concurrency: int = 4,
         api_key: str = "",
         **_kwargs,
     ) -> None:
@@ -192,14 +195,48 @@ class VLLMEmbedder(Embedder):
         self._model = model_name
         self._max_model_len = max_model_len
         self._dimension: int | None = dimension
+        # Big documents produce thousands of chunks; sending them in one request
+        # overruns the endpoint's time budget. Split into `batch_size` slices and
+        # run at most `embed_concurrency` of them at once to bound remote load.
+        self._batch_size = max(1, batch_size)
+        self._embed_concurrency = max(1, embed_concurrency)
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         self._client = httpx.AsyncClient(timeout=timeout, headers=headers)
 
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed *texts*, splitting large inputs into bounded-concurrent batches.
+
+        A single request for thousands of chunks (e.g. a big PDF) overruns the
+        embedder's time budget and trips the client timeout. We slice the input
+        into ``batch_size`` chunks and run at most ``embed_concurrency`` requests
+        at once, then concatenate the vectors back in input order.
+        """
+        if not texts:
+            return []
+        if len(texts) <= self._batch_size:
+            return await self._embed_batch(texts)
+
+        batches = [texts[i : i + self._batch_size] for i in range(0, len(texts), self._batch_size)]
+        semaphore = asyncio.Semaphore(self._embed_concurrency)
+
+        async def _run(batch: list[str]) -> list[list[float]]:
+            async with semaphore:
+                return await self._embed_batch(batch)
+
+        results = await tqdm.gather(
+            *(_run(batch) for batch in batches),
+            desc=f"Embedding {len(texts)} chunks ({len(batches)} batches of {self._batch_size})",
+        )
+        vectors: list[list[float]] = []
+        for batch_vectors in results:
+            vectors.extend(batch_vectors)
+        return vectors
+
     @with_circuit_breaker("embedder")
     @with_retry(max_attempts=3)
-    async def embed(self, texts: list[str]) -> list[list[float]]:
+    async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
         body: dict = {"model": self._model, "input": texts}
         if self._max_model_len is not None:
             body["truncate_prompt_tokens"] = self._max_model_len

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -225,10 +225,22 @@ class VLLMEmbedder(Embedder):
             async with semaphore:
                 return await self._embed_batch(batch)
 
-        results = await tqdm.gather(
-            *(_run(batch) for batch in batches),
-            desc=f"Embedding {len(texts)} chunks ({len(batches)} batches of {self._batch_size})",
-        )
+        # Explicit tasks so that when one batch fails we can cancel the rest.
+        # tqdm.gather (like asyncio.gather) propagates the first exception but
+        # leaves the other in-flight batches running, where they would keep
+        # consuming embedder capacity after embed() has already failed.
+        tasks = [asyncio.ensure_future(_run(batch)) for batch in batches]
+        try:
+            results = await tqdm.gather(
+                *tasks,
+                desc=f"Embedding {len(texts)} chunks ({len(batches)} batches of {self._batch_size})",
+            )
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
         vectors: list[list[float]] = []
         for batch_vectors in results:
             vectors.extend(batch_vectors)

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -36,6 +36,9 @@ class IndexerPool:
             model_name=embed_cfg.model_name,
             api_key=embed_cfg.api_key,
             max_model_len=embed_cfg.max_model_len,
+            timeout=embed_cfg.timeout,
+            batch_size=embed_cfg.batch_size,
+            embed_concurrency=embed_cfg.embed_concurrency,
         )
         self._vector_store = MilvusVectorStore(cfg.vectordb)
         task_state_manager = ray.get_actor("TaskStateManager", namespace="openrag")

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock
 
@@ -282,6 +283,34 @@ class TestVLLMEmbedder:
         # 10 texts split into batches of 4; completion order is non-deterministic
         # under concurrency, so compare the multiset of request sizes.
         assert sorted(request_sizes) == [2, 4, 4]
+
+    @pytest.mark.asyncio
+    async def test_embed_cancels_pending_batches_on_failure(self):
+        """When one batch fails, the other in-flight batches are cancelled
+        instead of being left running and consuming embedder capacity."""
+        embedder = VLLMEmbedder(endpoint="http://x", model_name="m", batch_size=1, embed_concurrency=5)
+        started: list[str] = []
+        cancelled: list[str] = []
+
+        async def fake_embed_batch(texts: list[str]) -> list[list[float]]:
+            value = texts[0]
+            started.append(value)
+            if value == "fail":
+                raise EmbeddingAPIError("boom", model_name="m", base_url="http://x", error="boom")
+            try:
+                await asyncio.sleep(10)  # slow batch, still in flight when 'fail' raises
+                return [[0.0]]
+            except asyncio.CancelledError:
+                cancelled.append(value)
+                raise
+
+        embedder._embed_batch = fake_embed_batch  # type: ignore[method-assign]
+
+        with pytest.raises(EmbeddingAPIError):
+            await embedder.embed(["slow1", "fail", "slow2"])
+
+        assert "fail" in started
+        assert sorted(cancelled) == ["slow1", "slow2"]  # both slow batches were cancelled
 
     @pytest.mark.asyncio
     async def test_embed_empty_returns_empty(self):

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -262,6 +262,35 @@ class TestVLLMEmbedder:
         assert result == [[0.1, 0.2], [0.3, 0.4]]
 
     @pytest.mark.asyncio
+    async def test_embed_splits_large_input_into_batches(self):
+        """Inputs larger than batch_size are split into multiple requests and
+        the vectors are reassembled in the original input order."""
+        request_sizes: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            inputs = json.loads(request.content)["input"]
+            request_sizes.append(len(inputs))
+            # Echo each text's int value back as a 1-d vector so we can assert order.
+            data = [{"index": i, "embedding": [float(t)]} for i, t in enumerate(inputs)]
+            return httpx.Response(200, json={"data": data})
+
+        texts = [str(i) for i in range(10)]
+        embedder = self._make_embedder(handler, batch_size=4, embed_concurrency=2)
+        result = await embedder.embed(texts)
+
+        assert result == [[float(i)] for i in range(10)]  # order preserved across batches
+        # 10 texts split into batches of 4; completion order is non-deterministic
+        # under concurrency, so compare the multiset of request sizes.
+        assert sorted(request_sizes) == [2, 4, 4]
+
+    @pytest.mark.asyncio
+    async def test_embed_empty_returns_empty(self):
+        def handler(req: httpx.Request) -> httpx.Response:  # pragma: no cover - must not be called
+            raise AssertionError("no request should be sent for empty input")
+
+        assert await self._make_embedder(handler).embed([]) == []
+
+    @pytest.mark.asyncio
     async def test_embed_single(self):
         def handler(req: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.5, 0.6, 0.7]}]})


### PR DESCRIPTION
## Problem

Ingesting big PDFs fails with:

```
core.utils.exceptions.EmbeddingAPIError: EMBEDDING_API_ERROR: Embedder request timed out at https://chat.lucie.ovh.linagora.com/v1
```

A big document produces thousands of chunks, and `embed_stage` sends **all of them in a single HTTP request** (`texts = [chunk.text for chunk in chunks]`). Against a slow/remote embedding endpoint that one request blows past the client timeout.

Two compounding gaps:
1. **No batching.** `VLLMEmbedder.embed()` never split the input. Worse, `batch_size` *was* read from config and passed to the constructor but silently swallowed in `**_kwargs` and never used.
2. **Timeout hardcoded at 60s**, not configurable.

## Changes

- **Batched, bounded-concurrent embedding.** `embed()` splits input into `batch_size` slices and runs at most `embed_concurrency` requests at once (semaphore-bounded), reassembling vectors in input order. The per-batch HTTP call moves into `_embed_batch()` so retry + circuit-breaker apply per batch.
- **Configurable timeout** (default `120s`, was hardcoded `60s`).
- **tqdm progress bar** reporting embedding progress per document.
- **New `EmbedderConfig` fields** with env overrides:
  | Field | Env var | Default |
  |-------|---------|---------|
  | `timeout` | `EMBEDDER_TIMEOUT` | `120.0` |
  | `batch_size` | `EMBEDDER_BATCH_SIZE` | `64` |
  | `embed_concurrency` | `EMBEDDER_CONCURRENCY` | `4` |
- Threaded through both embedder construction sites (indexer pool + retrieval container).

## Tests

- New `test_embed_splits_large_input_into_batches` (order preserved, correct batch sizes) and `test_embed_empty_returns_empty`.
- Full inference/config/di unit suites pass (`286 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable embedder runtime controls: timeout, batch size, and concurrency limits. These can be set via config files or environment variables (EMBEDDER_TIMEOUT, EMBEDDER_BATCH_SIZE, EMBEDDER_CONCURRENCY) to tune embedding request behavior.

* **Tests**
  * Added unit tests for batched embedding, concurrent request handling, cancellation on failure, and empty-input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->