### PR TITLE
fix(security): prevent Milvus filter injection escaping partition scope

### DIFF
--- a/openrag/components/indexer/vectordb/vectordb.py
+++ b/openrag/components/indexer/vectordb/vectordb.py
@@ -549,8 +549,10 @@ class MilvusDB(BaseVectorDB):
                 id_list = ", ".join(f'"{fid}"' for fid in file_ids)
                 expr_parts.append(f"file_id IN [{id_list}]")
 
-        # Join all parts with " and " only if there are multiple conditions
-        expr = " and ".join(expr_parts) if expr_parts else ""
+        # Join all parts with " and ", wrapping each in parentheses so a
+        # user-supplied filter cannot escape the partition scope via operator
+        # precedence (Milvus binds `and` tighter than `or`).
+        expr = " and ".join(f"({part})" for part in expr_parts) if expr_parts else ""
 
         try:
             query_vector = await self.embedder.aembed_query(query)


### PR DESCRIPTION
## Issue (Critical)
The semantic-search endpoints expose a raw `filter` Milvus expression (`CommonSearchParams.filter`). In `async_search` it was appended to the partition predicate and joined with `and` **without parentheses**:

```python
expr = " and ".join(expr_parts)   # partition in ['A'] and <USER FILTER>
```

Milvus binds `and` tighter than `or`, so a viewer authorized only on partition `A` could send:

```
GET /search/partition/A?text=x&filter=text != "" or partition == "B"
```

which evaluates as `(partition in ['A'] and text != "") or partition == "B"` and returns partition **B**'s chunk content — a cross-tenant read that defeats partition isolation.

## Fix
Wrap each expression part in parentheses when joining, so a user-supplied filter is always contained within the partition scope.

## Notes
Minimal containment fix. Hardening the `filter` param further (field/operator allowlist or a structured filter schema) is a recommended follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed database search queries to ensure user-provided filters respect intended partition boundaries and prevent unintended scope violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->