### PR TITLE
fix(security): ignore client-supplied LLM endpoint/credentials in llm_override

### DIFF
--- a/openrag/components/llm.py
+++ b/openrag/components/llm.py
@@ -32,12 +32,13 @@ class LLM:
         if llm_override.get("model"):
             payload["model"] = llm_override["model"]
 
-        base_url = (llm_override.get("base_url") or self._base_url).rstrip("/")
-        api_key = llm_override.get("api_key") or self._api_key
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}",
-        }
+        # Only `model` may be overridden by the client. `base_url` / `api_key`
+        # are deliberately NOT read from the request: honoring a client-supplied
+        # endpoint enables SSRF (the server would issue requests to an arbitrary
+        # host) and would leak the server's API key to that host. The endpoint
+        # and credentials always come from server configuration.
+        base_url = self._base_url.rstrip("/")
+        headers = self.headers
 
         return payload, base_url, headers
 

--- a/openrag/components/test_llm.py
+++ b/openrag/components/test_llm.py
@@ -29,15 +29,30 @@ class TestExtractLlmOverrides:
         assert base_url == "http://default-llm:8000/v1"
         assert headers["Authorization"] == "Bearer default-key"
 
-    def test_override_all_fields(self, llm):
+    def test_model_override_applied(self, llm):
         request = {
             "model": "openrag-my-partition",
             "messages": [{"role": "user", "content": "hello"}],
             "stream": False,
+            "metadata": {"llm_override": {"model": "custom-model"}},
+        }
+        payload, base_url, headers = llm._extract_llm_overrides(request)
+
+        assert payload["model"] == "custom-model"
+        # Endpoint and credentials always come from server config.
+        assert base_url == "http://default-llm:8000/v1"
+        assert headers["Authorization"] == "Bearer default-key"
+
+    def test_client_base_url_and_api_key_override_ignored(self, llm):
+        # SSRF / key-exfiltration guard: a client-supplied base_url/api_key
+        # must never be honored.
+        request = {
+            "model": "openrag-my-partition",
+            "stream": False,
             "metadata": {
                 "llm_override": {
-                    "base_url": "http://custom-llm:9000/v1",
-                    "api_key": "custom-key",
+                    "base_url": "http://169.254.169.254/latest/meta-data",
+                    "api_key": "attacker-key",
                     "model": "custom-model",
                 }
             },
@@ -45,18 +60,8 @@ class TestExtractLlmOverrides:
         payload, base_url, headers = llm._extract_llm_overrides(request)
 
         assert payload["model"] == "custom-model"
-        assert base_url == "http://custom-llm:9000/v1"
-        assert headers["Authorization"] == "Bearer custom-key"
-
-    def test_trailing_slash_stripped_from_base_url(self, llm):
-        request = {
-            "model": "openrag-my-partition",
-            "stream": False,
-            "metadata": {"llm_override": {"base_url": "http://custom:8000/v1///"}},
-        }
-        _, base_url, _ = llm._extract_llm_overrides(request)
-
-        assert base_url == "http://custom:8000/v1"
+        assert base_url == "http://default-llm:8000/v1"
+        assert headers["Authorization"] == "Bearer default-key"
 
     def test_request_params_forwarded_to_payload(self, llm):
         request = {

--- a/openrag/models/openai.py
+++ b/openrag/models/openai.py
@@ -32,7 +32,7 @@ class OpenAIChatCompletionRequest(BaseModel):
             "websearch": False,
             "llm_override": None,
         },
-        description="Extra custom parameters. Supports 'llm_override' object with optional 'base_url', 'api_key', and 'model' to override the downstream LLM endpoint.",
+        description="Extra custom parameters. Supports 'llm_override' object with an optional 'model' to override the downstream model name. The LLM endpoint and credentials are fixed by server configuration and cannot be overridden by the client.",
     )
 
 


### PR DESCRIPTION
## Issue (Critical)
`metadata.llm_override` let any authenticated user override `base_url` and `api_key` of the downstream LLM call (`components/llm.py`):

```python
base_url = (llm_override.get("base_url") or self._base_url).rstrip("/")
api_key  = llm_override.get("api_key")  or self._api_key
response = await client.post(url=f"{base_url}/chat/completions",
                             headers={"Authorization": f"Bearer {api_key}"}, ...)
```

- **SSRF:** point `base_url` at `http://169.254.169.254/...`, `http://localhost:8265` (Ray), internal services, etc. — the server makes the request from inside the trust boundary.
- **Credential theft:** set only `base_url` and omit `api_key` → the server's real LLM API key is sent in the `Authorization` header to the attacker's host.

No allowlist, scheme/host check, or role gate existed.

## Fix
Only `model` may be overridden by the client; `base_url` and `api_key` always come from server configuration. Updated the field description and tests (added a regression test asserting a client `base_url`/`api_key` is ignored).

## Breaking change
Clients can no longer redirect the LLM endpoint per-request. If a legitimate per-request endpoint feature is needed, it should be re-added behind admin auth + a server-side host allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model override behavior adjusted to accept only model name; client-supplied endpoint and credential values are no longer processed.

* **Documentation**
  * Updated LLM override documentation to clarify that only model name can be overridden.

* **Tests**
  * Updated test suite to validate model override functionality and confirm client-supplied endpoint and credential override values are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->