### PR TITLE
fix(security): authorize source-file downloads by partition

### DIFF
--- a/openrag/api.py
+++ b/openrag/api.py
@@ -14,7 +14,6 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.staticfiles import StaticFiles
 
 ray.init(dashboard_host="0.0.0.0")
 
@@ -26,6 +25,7 @@ ray.init(dashboard_host="0.0.0.0")
 from components.auth.middleware import AuthMiddleware
 from routers.actors import router as actors_router
 from routers.auth import router as auth_router
+from routers.download import router as download_router
 from routers.extract import router as extract_router
 from routers.indexer import router as indexer_router
 from routers.monitoring import MonitoringMiddleware
@@ -256,7 +256,6 @@ app.add_middleware(
 )
 
 app.state.app_state = AppState(config)
-app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")
 
 
 @app.get("/", include_in_schema=False)
@@ -296,6 +295,8 @@ def get_config():
 app.include_router(indexer_router, prefix="/indexer", tags=[Tags.INDEXER])
 # Mount the extract router
 app.include_router(extract_router, prefix="/extract", tags=[Tags.EXTRACT])
+# Authorized source-file download (replaces the open /static mount)
+app.include_router(download_router, tags=[Tags.EXTRACT])
 # Mount the search router
 app.include_router(search_router, prefix="/search", tags=[Tags.SEARCH])
 # Mount the partition router

--- a/openrag/routers/download.py
+++ b/openrag/routers/download.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from config import load_config
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import FileResponse
+from utils.dependencies import get_vectordb
+from utils.logger import get_logger
+
+from .utils import current_user_or_admin_partitions_list
+
+logger = get_logger()
+
+config = load_config()
+DATA_DIR = Path(config.paths.data_dir).resolve()
+
+router = APIRouter()
+
+
+@router.get("/static/{extract_id}", name="download_source")
+async def download_source(
+    request: Request,
+    extract_id: str,
+    vectordb=Depends(get_vectordb),
+    user_partitions=Depends(current_user_or_admin_partitions_list),
+):
+    """Download the source document a chunk came from.
+
+    Authorization mirrors ``/extract/{extract_id}``: the caller must have
+    access to the partition the chunk belongs to. This replaces the previous
+    open ``/static`` mount, which served every tenant's files to any
+    authenticated user with no partition check.
+    """
+    log = logger.bind(extract_id=extract_id)
+
+    chunk = await vectordb.get_chunk_by_id.remote(extract_id)
+    if chunk is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    chunk_partition = chunk.metadata.get("partition")
+    if chunk_partition not in user_partitions and user_partitions != ["all"]:
+        log.warning("User does not have access to this file.")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User does not have access to this file.",
+        )
+
+    source = chunk.metadata.get("source")
+    if not source:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    # Resolve and confine the path to DATA_DIR to defeat any traversal.
+    file_path = Path(source).resolve()
+    if not file_path.is_relative_to(DATA_DIR) or not file_path.is_file():
+        log.warning("Resolved source path is outside DATA_DIR or missing.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    return FileResponse(file_path, filename=file_path.name)

--- a/openrag/routers/openai.py
+++ b/openrag/routers/openai.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from pathlib import Path
 from urllib.parse import quote, urlparse
 
 import consts
@@ -115,8 +114,7 @@ def __prepare_sources(request: Request, docs: list[Document], web_results: list 
     links = []
     for doc in docs:
         doc_metadata = dict(doc.metadata)
-        filename = Path(doc_metadata.get("source")).name
-        file_url = str(request.url_for("static", path=filename))
+        file_url = str(request.url_for("download_source", extract_id=doc_metadata["_id"]))
         encoded_url = quote(file_url, safe=":/")
         links.append(
             {


### PR DESCRIPTION
## Issue (High)
`DATA_DIR` was served by an open static mount:
```python
app.mount("/static", StaticFiles(directory=DATA_DIR.resolve()), name="static")
```
`AuthMiddleware` only checks that the requester is *authenticated* for `/static` — there is **no partition membership check** (unlike `/extract/{id}`). Any authenticated user who learns a filename (filenames are disclosed in `extra.sources[].file_url` to partition members, in logs/Referer, or retained after a membership is revoked) can `GET /static/<filename>` and download any other tenant's raw source document — a cross-tenant read that bypasses partition RBAC.

## Fix
- New authorized route `GET /static/{extract_id}` (`routers/download.py`) that mirrors `/extract`'s authorization: resolve the chunk → its partition → require the caller to have access, then stream the file from the chunk's stored `source` path, confined to `DATA_DIR` (`is_relative_to` guard).
- Removed the open `StaticFiles` mount.
- `__prepare_sources` now builds `file_url` from the chunk id (`download_source` route) instead of a raw filename.

The URL remains under `/static`, so the middleware's browser token-query access is unchanged.

## Note
The `?token=` query-param browser auth for `/static` (token leakage via history/Referer) is a separate, lower-severity item handled outside this PR.