### PR TITLE
fix(security): stop fail-open in ensure_partition_role for missing partitions

### DIFF
--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -95,15 +95,24 @@ async def ensure_partition_role(
     membership = next((p for p in user_partitions if p["partition"] == partition), None)
 
     if not membership:
-        # Partition exists but no membership
         partition_exists = await vectordb.partition_exists.remote(partition)
         if partition_exists:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Access to partition '{partition}' forbidden",
             )
-        else:
+        # Partition does not exist. The only legitimate reason a non-member
+        # may act on a missing partition is the create-on-write path (file
+        # upload), which is `editor` and which later creates the partition
+        # with the uploader as owner. Reading or owning a partition that does
+        # not exist must NOT silently succeed — that previously let a
+        # non-member pass an owner/viewer check by naming an unknown partition.
+        if required_role == "editor":
             return True
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Partition '{partition}' not found",
+        )
 
     user_role = membership.get("role")
     if ROLE_HIERARCHY[user_role] < ROLE_HIERARCHY[required_role]:


### PR DESCRIPTION
## Issue (High)
`ensure_partition_role` (`routers/utils.py`) returned `True` whenever the partition did not exist:
```python
if not membership:
    if partition_exists: raise 403
    else: return True   # <-- role gate skipped
```
A non-member could pass an **owner** or **viewer** check simply by naming a partition that doesn't exist, skipping the role gate. Combined with operations that auto-create a partition (e.g. adding members), this let a user act on partitions they don't own.

## Fix
Preserve the one legitimate case — the create-on-write path (`editor`, used by file upload, which subsequently creates the partition with the uploader as owner) — and return **404** for `viewer`/`owner` checks against a non-existent partition instead of silently succeeding.

## Behavior preserved
First upload to a brand-new partition still works (editor → create → uploader becomes owner). Reads/owner-management against unknown partitions now 404.