### PR TITLE
fix(security): validate file_id and partition names to block Milvus filter injection

### DIFF
--- a/openrag/routers/indexer.py
+++ b/openrag/routers/indexer.py
@@ -221,7 +221,7 @@ Returns 204 No Content on successful deletion.
 )
 async def delete_file(
     partition: str,
-    file_id: str,
+    file_id: str = Depends(validate_file_id),
     indexer=Depends(get_indexer),
     vectordb=Depends(get_vectordb),
     user=Depends(require_partition_editor),

--- a/openrag/routers/partition.py
+++ b/openrag/routers/partition.py
@@ -8,9 +8,11 @@ from utils.logger import get_logger
 
 from .utils import (
     ROLE_HIERARCHY,
+    assert_valid_partition_name,
     partitions_with_details,
     require_partition_owner,
     require_partition_viewer,
+    validate_file_id,
 )
 
 logger = get_logger()
@@ -143,7 +145,7 @@ Returns file information including:
 async def get_file(
     request: Request,
     partition: str,
-    file_id: str,
+    file_id: str = Depends(validate_file_id),
     limit: int = 2000,
     vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),
@@ -225,6 +227,7 @@ Returns 409 Conflict if partition already exists.
 """,
 )
 async def create_partition(request: Request, partition: str, vectordb=Depends(get_vectordb)):
+    assert_valid_partition_name(partition)
     if await vectordb.partition_exists.remote(partition):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -457,7 +460,7 @@ For email threads with parallel branches, each branch has its own ancestor path.
 async def get_file_ancestors(
     request: Request,
     partition: str,
-    file_id: str,
+    file_id: str = Depends(validate_file_id),
     max_ancestor_depth: int | None = None,  # Optional limit on ancestor depth
     vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),

--- a/openrag/routers/search.py
+++ b/openrag/routers/search.py
@@ -12,6 +12,7 @@ from .utils import (
     current_user_or_admin_partitions_list,
     require_partition_viewer,
     require_partitions_viewer,
+    validate_file_id,
 )
 
 _config = load_config()
@@ -329,8 +330,8 @@ Find specific information within a single document using semantic search.
 async def search_file(
     request: Request,
     partition: str,
-    file_id: str,
     search_params: Annotated[CommonSearchParams, Depends()],
+    file_id: str = Depends(validate_file_id),
     indexer=Depends(get_indexer),
     vectordb=Depends(get_vectordb),
     partition_viewer=Depends(require_partition_viewer),

--- a/openrag/routers/utils.py
+++ b/openrag/routers/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +20,11 @@ task_state_manager = get_task_state_manager()
 SUPER_ADMIN_MODE = os.getenv("SUPER_ADMIN_MODE", "false").lower() == "true"
 DATA_DIR = config.paths.data_dir
 
-FORBIDDEN_CHARS_IN_FILE_ID = set("/")  # set('"<>#%{}|\\^`[]')
+# Identifiers (file_id, partition name) are interpolated into Milvus filter
+# expression strings (e.g. `file_id == "..."`). Restrict them to a safe
+# allowlist so quotes / brackets / operators cannot break out of the literal
+# and inject boolean logic that escapes the partition scope.
+_VALID_IDENTIFIER_RE = re.compile(r"[A-Za-z0-9._:\-]+")
 LOG_FILE = Path(config.paths.log_dir or "logs") / "app.json"
 
 # supported file formats or mimetypes
@@ -86,6 +91,7 @@ async def ensure_partition_role(
     required_role: str,
 ):
     """Ensure the user has at least `required_role` for the partition."""
+    assert_valid_partition_name(partition)
     # Super-admin bypass
     vectordb = get_vectordb()
     if SUPER_ADMIN_MODE and user.get("is_admin"):
@@ -273,18 +279,32 @@ async def check_user_file_quota(
 
 
 def is_file_id_valid(file_id: str) -> bool:
-    return not any(c in file_id for c in FORBIDDEN_CHARS_IN_FILE_ID)
+    return bool(file_id) and _VALID_IDENTIFIER_RE.fullmatch(file_id) is not None
 
 
 async def validate_file_id(file_id: str):
+    if not file_id.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File ID cannot be empty.")
     if not is_file_id_valid(file_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"File ID contains forbidden characters: {', '.join(FORBIDDEN_CHARS_IN_FILE_ID)}",
+            detail="File ID may only contain letters, digits, '.', '_', ':' and '-'.",
         )
-    if not file_id.strip():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File ID cannot be empty.")
     return file_id
+
+
+def assert_valid_partition_name(partition: str) -> None:
+    """Reject partition names that could inject into Milvus filter expressions.
+
+    Raises HTTP 400 for names outside the safe identifier allowlist. Used both
+    when a partition is created and on every partition-scoped operation, so a
+    crafted name can never reach a filter string.
+    """
+    if not partition or _VALID_IDENTIFIER_RE.fullmatch(partition) is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Partition name may only contain letters, digits, '.', '_', ':' and '-'.",
+        )
 
 
 async def validate_metadata(metadata: Any | None = Form(None)):


### PR DESCRIPTION
## Issue (High)
`file_id` only forbade `/` (`FORBIDDEN_CHARS_IN_FILE_ID = set("/")`) and partition names were not validated at all. Both are interpolated by f-string into Milvus filter expressions:
```python
filter=f'partition == "{partition}" and file_id == "{file_id}"'
```
A `file_id` such as `x" or partition == "other` (no `/`, previously valid) breaks out of the quoted literal and injects boolean logic into delete/query/relationship-expansion filters — reading or deleting chunks outside the intended partition. A maliciously named partition gives the same primitive.

## Fix
- Restrict `file_id` and partition names to a safe identifier allowlist `[A-Za-z0-9._:-]`.
- Enforce the partition allowlist in `ensure_partition_role` (covers every role-gated partition operation) and in `create_partition`.
- Apply the existing `validate_file_id` dependency to the `delete_file`, `get_file`, `get_file_ancestors`, and `search_file` endpoints, which previously accepted a raw `file_id` path param.

## Notes
Defense-in-depth follow-up: convert the remaining f-string Milvus filters to parameterized expressions (`filter_params=`), the pattern already used by `list_all_chunk` / `get_file_chunk_ids`. Validation here closes the injection; parameterization would make it structurally impossible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened input validation for file identifiers and partition names across API endpoints.
  * Invalid identifiers are now rejected with HTTP 400 errors and descriptive messages.
  * Validation uses an allowlist of permitted characters to ensure safer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->