### PR TITLE
fix(security): bind Ray dashboard to localhost in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,10 @@ x-openrag: &openrag_template
     - ./logs:/app/logs # For dev mode
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
-    - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
+    # Bind the Ray dashboard to localhost only: it has no authentication and
+    # its job-submission API allows arbitrary code execution on the cluster,
+    # so it must never be reachable from outside the host.
+    - 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
     - ${CHAINLIT_PORT:-8090}:${CHAINLIT_PORT:-8090}
   networks:
     default:


### PR DESCRIPTION
## Issue (High)
`docker-compose.yaml` published the Ray dashboard on all host interfaces:
```yaml
- ${RAY_DASHBOARD_PORT:-8265}:8265
```
The Ray dashboard has **no authentication** and its job-submission API allows **arbitrary code execution** on the cluster. Publishing it to the network exposes a direct RCE vector (and it's also the most valuable target for the `llm_override` SSRF in a separate PR).

## Fix
Bind the published port to `127.0.0.1` so the dashboard is reachable only from the host:
```yaml
- 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265
```
The in-container `dashboard_host=0.0.0.0` is unchanged (required for Docker's port forwarding to reach the process); the host-side localhost bind is what removes the external exposure.

## Note
The Helm chart exposes 8265 only as a container port (internal); network exposure there is governed by Service/Ingress and is out of scope for this PR.