### PR TITLE
fix(security): require explicit ALLOW_NO_AUTH for the no-token admin bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ VLM_MODEL=
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234
+# If AUTH_MODE=token and AUTH_TOKEN is unset, authentication is DISABLED and
+# every request is treated as admin user 1. This now requires an explicit
+# opt-in so it can never happen by accident in production:
+# ALLOW_NO_AUTH=true   # DEV ONLY — never set this in production
 # Optional: semicolon-separated extra allowed origins
 # CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'  
 

--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -96,6 +96,14 @@ def is_bypass_path(path: str) -> bool:
     return path in _BYPASS_PATHS or path.startswith("/chainlit")
 
 
+def _allow_no_auth() -> bool:
+    """Whether the no-auth dev bypass (AUTH_TOKEN unset → admin) is allowed.
+
+    Read lazily so it can be toggled per-test, mirroring the other env reads.
+    """
+    return os.getenv("ALLOW_NO_AUTH", "false").strip().lower() == "true"
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """FastAPI middleware enforcing authentication for both token and oidc modes.
 
@@ -117,7 +125,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
         vectordb = self._get_vectordb()
 
         # --- Dev mode: AUTH_MODE=token + AUTH_TOKEN unset → user 1 bypass.
-        if auth_mode == "token" and auth_token is None:
+        #     This disables authentication entirely (every request becomes the
+        #     admin user), so it must be opted into explicitly via
+        #     ALLOW_NO_AUTH=true. Without that flag a missing AUTH_TOKEN no
+        #     longer fails open: requests fall through to normal Bearer auth
+        #     and unauthenticated callers get 401.
+        if auth_mode == "token" and auth_token is None and _allow_no_auth():
+            logger.warning(
+                "ALLOW_NO_AUTH=true and AUTH_TOKEN is unset: authentication is DISABLED — "
+                "every request is treated as admin user 1. Never use this in production."
+            )
             user = await vectordb.get_user.remote(1)
             user_partitions = await vectordb.list_user_partitions.remote(1)
             request.state.user = user

--- a/openrag/components/auth/test_middleware.py
+++ b/openrag/components/auth/test_middleware.py
@@ -171,11 +171,13 @@ class TestTokenModeLegacy:
 
 
 class TestTokenModeDevBypass:
-    """AUTH_MODE=token, AUTH_TOKEN unset → all requests resolve to user id=1."""
+    """AUTH_MODE=token, AUTH_TOKEN unset → admin bypass only when explicitly
+    opted into via ALLOW_NO_AUTH=true; otherwise it must NOT fail open."""
 
-    def test_no_token_resolves_user_1(self, monkeypatch):
+    def test_no_token_resolves_user_1_when_allowed(self, monkeypatch):
         monkeypatch.setenv("AUTH_MODE", "token")
         monkeypatch.delenv("AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("ALLOW_NO_AUTH", "true")
         vdb = _make_vectordb_mock(user={"id": 1, "display_name": "Admin"})
         app = _build_app(vdb)
         with TestClient(app) as client:
@@ -183,6 +185,18 @@ class TestTokenModeDevBypass:
         assert r.status_code == 200
         assert r.json() == {"user": 1}
         vdb.get_user.remote.assert_awaited_with(1)
+
+    def test_no_token_does_not_fail_open_without_flag(self, monkeypatch):
+        monkeypatch.setenv("AUTH_MODE", "token")
+        monkeypatch.delenv("AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ALLOW_NO_AUTH", raising=False)
+        vdb = _make_vectordb_mock(user={"id": 1, "display_name": "Admin"})
+        app = _build_app(vdb)
+        with TestClient(app) as client:
+            r = client.get("/v1/chat/completions")
+        # No token + no opt-in → not authenticated, never resolves to admin.
+        assert r.status_code in (401, 403)
+        vdb.get_user.remote.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue (Medium)
With `AUTH_MODE=token` (the default) and `AUTH_TOKEN` **unset**, the middleware bypassed authentication and bound every request to admin user 1:
```python
if auth_mode == "token" and auth_token is None:
    user = await vectordb.get_user.remote(1)   # admin
    return await call_next(request)
```
A single forgotten/empty env var turns the whole API (users, partitions, config, ingestion) into a world-open admin endpoint. This is a dangerous fail-open default.

## Fix
Gate the dev bypass behind an explicit `ALLOW_NO_AUTH=true` opt-in and log a prominent warning when it is active. Without the flag, a missing `AUTH_TOKEN` no longer fails open — requests fall through to normal Bearer auth and unauthenticated callers are denied.

Added a regression test asserting the no-token path does **not** resolve to admin without the flag; documented `ALLOW_NO_AUTH` in `.env.example`.

## Compatibility
CI sets `AUTH_TOKEN`, so it is unaffected. Local dev that relied on no-token admin access must now set `ALLOW_NO_AUTH=true`.