### PR TITLE
fix(security): anchor /chainlit auth bypass to a path boundary

### DIFF
--- a/openrag/components/auth/middleware.py
+++ b/openrag/components/auth/middleware.py
@@ -92,8 +92,18 @@ def is_ui_path(path: str) -> bool:
     return False
 
 
+def is_chainlit_path(path: str) -> bool:
+    """Match the mounted Chainlit app exactly, with a path boundary.
+
+    Using a bare ``startswith("/chainlit")`` would also match unrelated routes
+    like ``/chainlitX``, widening the unauthenticated bypass beyond the
+    Chainlit mount.
+    """
+    return path == "/chainlit" or path.startswith("/chainlit/")
+
+
 def is_bypass_path(path: str) -> bool:
-    return path in _BYPASS_PATHS or path.startswith("/chainlit")
+    return path in _BYPASS_PATHS or is_chainlit_path(path)
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
@@ -137,7 +147,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # the bypass so Chainlit's own headerAuth callback can validate.
             if (
                 auth_mode == "oidc"
-                and path.startswith("/chainlit")
+                and is_chainlit_path(path)
                 and "text/html" in request.headers.get("accept", "").lower()
                 and not request.headers.get("authorization", "").lower().startswith("bearer ")
             ):


### PR DESCRIPTION
## Issue (Medium)
`is_bypass_path` skipped authentication using an unbounded prefix:
```python
return path in _BYPASS_PATHS or path.startswith("/chainlit")
```
`startswith("/chainlit")` matches any path beginning with those characters — e.g. `/chainlitX` or any future route sharing the prefix — widening the unauthenticated bypass beyond the actual Chainlit mount.

## Fix
Introduce `is_chainlit_path()` matching the mount exactly (`/chainlit` or `/chainlit/...`) and use it for both the bypass and the OIDC HTML-redirect special case.