### PR TITLE
fix(security): whitelist writable fields in update_user (mass assignment)

### DIFF
--- a/openrag/components/indexer/vectordb/utils.py
+++ b/openrag/components/indexer/vectordb/utils.py
@@ -535,11 +535,18 @@ class PartitionFileManager:
         with self.Session() as s:
             return s.query(PartitionMembership).filter_by(user_id=user_id, partition_name=partition).first() is not None
 
+    # Fields a caller may set via update_user. Excludes identity/privilege and
+    # security-sensitive columns (token, file_count, id, created_at) so they can
+    # never be overwritten through the user-update payload (mass assignment).
+    _UPDATABLE_USER_FIELDS = frozenset({"display_name", "external_user_id", "email", "is_admin", "file_quota"})
+
     def update_user(self, user_id: int, body: UserUpdate) -> dict:
-        """Update user's profile fields. Only provided (non-None) fields are updated."""
+        """Update user's profile fields. Only whitelisted, provided fields are updated."""
         with self.Session() as s:
             user = s.query(User).filter(User.id == user_id).first()
             for field, value in body.model_dump(exclude_unset=True).items():
+                if field not in self._UPDATABLE_USER_FIELDS:
+                    continue
                 setattr(user, field, value)
 
             s.commit()

--- a/openrag/models/user.py
+++ b/openrag/models/user.py
@@ -10,11 +10,13 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    model_config = ConfigDict(extra="allow")
+    # Reject unknown fields so callers cannot smuggle extra column names.
+    model_config = ConfigDict(extra="ignore")
 
 
 class UserUpdate(UserBase):
-    model_config = ConfigDict(extra="allow")
+    # Reject unknown fields; update_user additionally whitelists writable columns.
+    model_config = ConfigDict(extra="ignore")
 
 
 class UserPublic(UserBase):


### PR DESCRIPTION
## Issue (Medium)
`UserUpdate` declared `extra="allow"` and `update_user` applied every field blindly:
```python
for field, value in body.model_dump(exclude_unset=True).items():
    setattr(user, field, value)
```
Because `extra="allow"` keeps arbitrary extra keys, any column name in the JSON body is `setattr`'d onto the ORM object — including `token` (overwrite a victim's auth token to a known value → account takeover), `file_count` (bypass quota), or `id`. The documented writable contract was not enforced at all.

## Fix
- `update_user` now applies only an explicit whitelist: `display_name`, `external_user_id`, `email`, `is_admin`, `file_quota`.
- `UserCreate`/`UserUpdate` use `extra="ignore"` so unknown fields are dropped.

(The endpoints are admin-gated, so this hardens against an over-broad write surface and the claim-mapping path; `token`/`file_count`/`id` are now never writable via the update payload.)