### PR TITLE
fix(security): harden web-search content fetcher against SSRF and MITM

### DIFF
--- a/openrag/components/websearch/content_fetcher.py
+++ b/openrag/components/websearch/content_fetcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import socket
 from urllib.parse import urlparse
 
 import httpx
@@ -27,7 +28,7 @@ class ContentFetcher:
         max_results: int = 3,
         timeout: float = 1.0,
         max_tokens_per_page: int = 500,
-        verify_ssl: bool = False,
+        verify_ssl: bool = True,
     ):
         self.max_results = max_results
         self.timeout = timeout
@@ -48,13 +49,47 @@ class ContentFetcher:
 
     @staticmethod
     def _is_loopback_url(url: str) -> bool:
-        host = urlparse(url).hostname or ""
-        if host == "localhost":
+        """Block obviously-internal targets without a DNS lookup.
+
+        Rejects non-HTTP(S) schemes and any literal IP that is not globally
+        routable (loopback, private, link-local, etc.). Hostnames are passed
+        through here and validated against their *resolved* IPs in the request
+        hook below.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return True
+        host = parsed.hostname or ""
+        if not host or host == "localhost":
             return True
         try:
             return not ipaddress.ip_address(host).is_global
         except ValueError:
-            return False  # Regular hostname, let it through
+            return False  # Regular hostname → checked after DNS resolution
+
+    @staticmethod
+    async def _guard_request(request: httpx.Request) -> None:
+        """httpx request hook: block requests whose host resolves to a
+        non-global IP. Runs for the initial request and every redirect hop,
+        so a public hostname that resolves (or redirects) to an internal
+        address is rejected before the connection is used.
+        """
+        host = request.url.host
+        if not host:
+            raise httpx.RequestError("Blocked request with no host", request=request)
+        try:
+            infos = await asyncio.to_thread(socket.getaddrinfo, host, None)
+        except socket.gaierror as e:
+            raise httpx.RequestError(f"DNS resolution failed for {host}", request=request) from e
+        for info in infos:
+            ip = info[4][0]
+            try:
+                addr = ipaddress.ip_address(ip)
+            except ValueError:
+                raise httpx.RequestError(f"Unparseable address for {host}", request=request)
+            if not addr.is_global:
+                logger.warning("Blocked SSRF attempt to non-global address", host=host, ip=ip)
+                raise httpx.RequestError(f"Blocked non-global address {ip} for {host}", request=request)
 
     async def _fetch_single(self, client: httpx.AsyncClient, url: str) -> str | None:
         """Fetch a single URL and extract text. Returns None on any failure."""
@@ -64,8 +99,11 @@ class ContentFetcher:
             logger.warning("Blocked loopback URL in web search results", url=url)
             return None
         try:
+            # Redirects are NOT followed: a redirect to an internal address is
+            # a classic SSRF bypass. A 3xx response simply yields no usable
+            # content and is skipped.
             response = await asyncio.wait_for(
-                client.get(url, follow_redirects=True),
+                client.get(url, follow_redirects=False),
                 timeout=self.timeout,
             )
             response.raise_for_status()
@@ -123,7 +161,10 @@ class ContentFetcher:
                 pool=self.timeout,
             )
             async with httpx.AsyncClient(
-                timeout=timeout, verify=self.verify_ssl, headers={"User-Agent": _USER_AGENT}
+                timeout=timeout,
+                verify=self.verify_ssl,
+                headers={"User-Agent": _USER_AGENT},
+                event_hooks={"request": [self._guard_request]},
             ) as client:
                 tasks = [self._fetch_single(client, r.url) for r in to_fetch]
                 contents = await asyncio.gather(*tasks)

--- a/openrag/components/websearch/test_content_fetcher.py
+++ b/openrag/components/websearch/test_content_fetcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 
 import httpx
 import pytest
@@ -77,6 +78,38 @@ class TestFetchSingleURL:
             text = await fetcher._fetch_single(client, url)
 
         assert text is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url", ["ftp://example.com/x", "file:///etc/passwd", "gopher://example.com"])
+    async def test_skips_non_http_schemes(self, fetcher, url):
+        async def mock_handler(request):
+            return httpx.Response(200, text="<html><body>x</body></html>")
+
+        transport = httpx.MockTransport(mock_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            text = await fetcher._fetch_single(client, url)
+
+        assert text is None
+
+    @pytest.mark.asyncio
+    async def test_guard_request_blocks_host_resolving_to_private_ip(self, fetcher, monkeypatch):
+        # A public-looking hostname that resolves to an internal IP must be blocked.
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+
+        monkeypatch.setattr("components.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo)
+        req = httpx.Request("GET", "http://internal.example.com/")
+        with pytest.raises(httpx.RequestError):
+            await fetcher._guard_request(req)
+
+    @pytest.mark.asyncio
+    async def test_guard_request_allows_global_ip(self, fetcher, monkeypatch):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr("components.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo)
+        req = httpx.Request("GET", "http://example.com/")
+        await fetcher._guard_request(req)  # must not raise
 
     @pytest.mark.asyncio
     async def test_strips_boilerplate_html(self, fetcher):

--- a/openrag/config/models.py
+++ b/openrag/config/models.py
@@ -484,7 +484,9 @@ class _BaseWebSearchConfig(ConfigMixin):
     fetch_max_results: int = 3
     fetch_timeout: float = 1.0
     fetch_max_tokens: int = 500
-    fetch_verify_ssl: bool = False
+    # Verify TLS certificates on web-page fetches by default; disabling this
+    # exposes fetched content (which feeds the LLM) to MITM tampering.
+    fetch_verify_ssl: bool = True
 
 
 class StaanWebSearchConfig(_BaseWebSearchConfig):


### PR DESCRIPTION
## Issue (Medium)
`ContentFetcher` fetches URLs returned by the web-search provider. The SSRF guard was incomplete:
- `_is_loopback_url` checked only the literal hostname; a public hostname resolving to a private IP (DNS rebinding) passed (`ipaddress.ip_address(host)` raises for hostnames → returned `False`/allow).
- `follow_redirects=True` with no re-validation: a `302` to `http://169.254.169.254/...` or `http://localhost:8265` was followed.
- `fetch_verify_ssl` defaulted to `False` → fetched content (which feeds the LLM) was exposed to MITM.

## Fix
- Reject non-HTTP(S) schemes and literal non-global IPs up front.
- `follow_redirects=False` — a redirect to an internal address is no longer followed.
- New `event_hooks` request guard resolves the host and blocks any non-global resolved IP (initial request + would-be hops), closing the public-hostname→private-IP vector.
- Default `fetch_verify_ssl=True` (constructor + config).

Added tests for non-HTTP schemes and the resolve-to-private-IP guard.

## Note
A residual DNS-rebinding TOCTOU (resolve vs connect) remains; fully closing it requires pinning the resolved IP into the connection, which is out of scope here.