### PR TITLE
fix(security): bound upload size to prevent disk/memory exhaustion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ VLM_MODEL=
 # CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'  
 
 # SAVE_UPLOADED_FILES=true # usefull for chainlit (chat interface) source viewing
+# Maximum accepted upload size in MB (0 or negative = unlimited). Default 1024.
+# MAX_UPLOAD_SIZE_MB=1024
 
 # Set to true, it will mount chainlit chat ui to the fastapi app (Default: true)
 ## WITH_CHAINLIT_UI=true

--- a/openrag/components/indexer/utils/files.py
+++ b/openrag/components/indexer/utils/files.py
@@ -1,3 +1,4 @@
+import os
 import re
 import secrets
 import time
@@ -11,6 +12,11 @@ from fastapi import HTTPException, UploadFile, status
 
 config = load_config()
 SERIALIZE_TIMEOUT = config.ray.indexer.serialize_timeout
+
+# Maximum accepted upload size. Streamed writes are bounded so a single request
+# cannot exhaust disk/RAM (a file-count quota alone does not limit bytes).
+# 0 or negative disables the limit. Override with MAX_UPLOAD_SIZE_MB.
+MAX_UPLOAD_SIZE_BYTES = int(os.getenv("MAX_UPLOAD_SIZE_MB", "1024")) * 1024 * 1024
 
 
 def sanitize_filename(filename: str) -> str:
@@ -60,13 +66,25 @@ async def save_file_to_disk(
         filename = file.filename
     file_path = dest_dir / filename
 
-    async with aiofiles.open(file_path, "wb") as buffer:
-        # Non-blocking I/O
-        while True:
-            chunk = await file.read(chunk_size)
-            if not chunk:
-                break
-            await buffer.write(chunk)
+    total = 0
+    try:
+        async with aiofiles.open(file_path, "wb") as buffer:
+            # Non-blocking I/O
+            while True:
+                chunk = await file.read(chunk_size)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if MAX_UPLOAD_SIZE_BYTES > 0 and total > MAX_UPLOAD_SIZE_BYTES:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=f"File exceeds the maximum allowed size of {MAX_UPLOAD_SIZE_BYTES // (1024 * 1024)} MB.",
+                    )
+                await buffer.write(chunk)
+    except HTTPException:
+        # Remove the partially written file before propagating.
+        file_path.unlink(missing_ok=True)
+        raise
 
     return file_path
 

--- a/openrag/components/indexer/utils/test_files.py
+++ b/openrag/components/indexer/utils/test_files.py
@@ -30,6 +30,21 @@ async def test_save_file_to_disk_writes_content(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_save_file_to_disk_rejects_oversize_upload(tmp_path: Path, monkeypatch):
+    # Cap at ~8 bytes; a larger upload must be rejected and not left on disk.
+    monkeypatch.setattr("openrag.components.indexer.utils.files.MAX_UPLOAD_SIZE_BYTES", 8)
+    upload = UploadFile(file=io.BytesIO(b"x" * 100), filename="big.bin")
+    dest_dir = tmp_path / "uploads"
+
+    with pytest.raises(HTTPException) as exc:
+        await save_file_to_disk(file=upload, dest_dir=dest_dir, chunk_size=4)
+
+    assert exc.value.status_code == 413
+    # The partially written file must have been cleaned up.
+    assert not (dest_dir / "big.bin").exists()
+
+
+@pytest.mark.asyncio
 async def test_save_file_to_disk_with_random_prefix(tmp_path, monkeypatch):
     def fake_make_unique_filename(filename: str) -> str:
         assert filename == "test.txt"


### PR DESCRIPTION
## Issue (Medium)
`save_file_to_disk` streamed uploads to disk in 1 MB chunks with **no maximum size**. The per-user quota limits file *count*, not bytes, so any user with upload rights could send a multi-GB file (or many in parallel) and exhaust disk/RAM on the worker — a denial of service affecting all tenants.

## Fix
Enforce a configurable maximum during streaming (`MAX_UPLOAD_SIZE_MB`, default 1024 MB; 0/negative = unlimited). When exceeded, the partial file is removed and a `413 Request Entity Too Large` is returned. Applies to all upload paths (indexer `add_file`/`put_file`, `extractText`). Added a regression test.

## Note
Decompression/pixel bombs in office/image loaders (e.g. `Image.MAX_IMAGE_PIXELS`) are a related but separate concern, suitable for a follow-up.