### PR TITLE
Run OpenRAG as non-root (OpenShift compatible)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,17 @@ ENV HF_HUB_CACHE=${HF_HUB_CACHE:-/app/model_weights/hub}
 # Set workdir for uv
 WORKDIR /app
 
-# Set HOME before installing so uv's Python and cache land under /app (owned by
-# the non-root user below), not /root.
-ENV HOME=/app
+# Keep uv's managed Python and cache on stable, root-owned paths outside any
+# user $HOME, and put the project venv under /app so it can be made
+# group-writable for the arbitrary UID OpenShift assigns (see below). HOME is a
+# dedicated writable subdir (not /app) so libraries that fall back to $HOME
+# never need /app itself writable. UV_FROZEN keeps `uv run` from rewriting
+# uv.lock at runtime, so the project root can stay read-only.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_CACHE_DIR=/opt/uv/cache \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    UV_FROZEN=1 \
+    HOME=/app/home
 
 # Install uv & setup venv
 COPY pyproject.toml uv.lock ./
@@ -51,12 +59,34 @@ COPY conf/ /app/conf/
 ENV PYTHONPATH=/app/openrag/
 ENV APP_iPORT=${APP_iPORT:-8080}
 
-# Run as non-root. The app writes under /app (venv, data, logs, model_weights),
-# so the user owns /app.
-RUN groupadd --gid 10001 app \
-    && useradd --uid 10001 --gid 10001 --home-dir /app --no-create-home app \
-    && mkdir -p /app/data /app/logs /app/model_weights \
-    && chown -R 10001:10001 /app
-USER 10001:10001
+# --- Run as an unprivileged, OpenShift-compatible user ---------------------
+# OpenShift runs containers as an arbitrary, unpredictable UID that is always a
+# member of the root group (GID 0). For the app to start under that policy,
+# every path it writes at runtime must be group-owned by GID 0 and
+# group-writable (chmod g=u). We strip group-write from the whole tree first
+# (chmod -R g-w) and then grant it back ONLY on those exact paths: the venv,
+# the editable install's egg-info, $HOME, data, db, logs, the HF model cache,
+# and uv's cache. So /app and /opt/uv themselves, plus the copied code/config
+# and uv's managed Python (/app/openrag, /app/conf, /opt/uv/python), stay
+# group-readable but NOT group-writable regardless of their source mode — the
+# arbitrary UID cannot create, rename, or replace entries in them.
+# We also bake a fixed non-root UID for plain Docker/Kubernetes, where the
+# arbitrary-UID remap does not happen; APP_UID is a build arg so a compose
+# build can match the host user that owns the bind-mounted volumes. The user's
+# primary group is 0 so it shares the same group access on either platform.
+# /etc/passwd is made group-writable so the entrypoint can add an entry for the
+# arbitrary UID; libraries that call getpass.getuser()/pwd.getpwuid() (Ray, uv,
+# HF) otherwise crash when the running UID has no passwd entry.
+ARG APP_UID=10001
+RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
+        --home-dir /app/home --shell /sbin/nologin openrag \
+    && mkdir -p /app/home /app/data /app/db /app/logs /app/model_weights/hub \
+        /app/.venv /app/openrag.egg-info /opt/uv/cache \
+    && chgrp -R 0 /app /opt/uv \
+    && chmod -R g-w /app /opt/uv \
+    && chmod g=u /etc/passwd \
+    && chmod -R g=u /app/home /app/data /app/db /app/logs /app/model_weights \
+        /app/.venv /app/openrag.egg-info /opt/uv/cache
+USER ${APP_UID}
 
 ENTRYPOINT ../entrypoint.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,18 @@ include:
 
 x-openrag: &openrag_template
   image: linagoraai/openrag:1.1.11
+  # Run unprivileged with group 0. GID 0 (not PGID) matches the image, whose
+  # runtime-write paths are group-owned by the root group, and works whether
+  # this image was pulled or locally rebuilt. init-perms hands the bind-mounted
+  # volumes to PUID, so the UID still matches their owner.
+  user: "${PUID:-1000}:0"
   build:
     context: .
     dockerfile: Dockerfile
+    args:
+      # Bake the image's default UID to match the host user that owns the
+      # bind-mounted volumes (see init-perms below).
+      APP_UID: ${PUID:-1000}
   extra_hosts:
     # Let containers reach services running on the Docker host via
     # ``host.docker.internal`` (Linux Docker >= 20.10). Useful when an OIDC
@@ -44,8 +53,18 @@ x-openrag: &openrag_template
 x-vllm-env: &vllm_env
   HUGGING_FACE_HUB_TOKEN:
   VLLM_SLEEP_WHEN_IDLE: 1  # Avoid 100% CPU usage when idle
+  # Run unprivileged: point HOME and the HF cache at the writable mounted
+  # volume so vllm never needs to write under root-owned /root.
+  HOME: /cache
+  HF_HOME: /cache/huggingface
+  # vllm calls getpass.getuser() (torch.compile temp dir). With a UID that has
+  # no /etc/passwd entry it would fall back to pwd.getpwuid() and crash;
+  # setting USER/LOGNAME makes getuser() resolve without a passwd entry.
+  USER: openrag
+  LOGNAME: openrag
 
 x-vllm: &vllm_template
+  user: "${PUID:-1000}:${PGID:-1000}"
   networks:
     default:
       aliases:
@@ -55,7 +74,10 @@ x-vllm: &vllm_template
     <<: *vllm_env
   ipc: "host"
   volumes:
-    - ${VLLM_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface # put ./vllm_cache if you want to have the weights on the vllm_cache folder in your project
+    - ${VLLM_CACHE:-./.cache/huggingface}:/cache # HF + framework caches (HOME=/cache)
+  depends_on:
+    init-perms:
+      condition: service_completed_successfully
   command: >
     --model ${EMBEDDER_MODEL_NAME:-jinaai/jina-embeddings-v3}
     --trust-remote-code
@@ -74,7 +96,62 @@ x-vllm: &vllm_template
   # ports:
   #   - ${VLLM_PORT:-8000}:8000
 services:
+  # ---------------------------------------------------------------------------
+  # One-shot ownership bootstrap. This is the ONLY container that runs as root,
+  # and it runs no application code: it just creates the host bind-mount
+  # directories and chowns them to the unprivileged uid/gid the real services
+  # run as. Docker creates missing bind-mount sources as root, so without this
+  # the non-root services below could not write to their volumes. It exits
+  # immediately and every other service waits for it via depends_on.
+  # ---------------------------------------------------------------------------
+  init-perms:
+    image: busybox:1.37
+    user: "0:0"
+    environment:
+      # Passed in so the guard below can reject relative overrides.
+      VLLM_CACHE: ${VLLM_CACHE:-}
+      MILVUS_VOLUME_DIRECTORY: ${MILVUS_VOLUME_DIRECTORY:-}
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        # VLLM_CACHE and MILVUS_VOLUME_DIRECTORY are referenced from both this
+        # file and the `include`d ones (vdb/milvus.yaml, extern/reranker/*),
+        # where a relative value resolves against each file's own directory.
+        # The defaults are aligned, but a relative *override* would make this
+        # container chown one path while a service mounts another, leaving that
+        # volume root-owned. Require absolute paths for overrides.
+        for v in "$$VLLM_CACHE" "$$MILVUS_VOLUME_DIRECTORY"; do
+          case "$$v" in
+            ""|/*) : ;;
+            *) echo "init-perms: VLLM_CACHE and MILVUS_VOLUME_DIRECTORY must be absolute paths when overridden (got '$$v'); relative values resolve differently across the included compose files." >&2; exit 1 ;;
+          esac
+        done
+        mkdir -p /mnt/data /mnt/logs /mnt/db /mnt/hfcache /mnt/model_weights \
+                 /mnt/volumes/etcd /mnt/volumes/minio /mnt/volumes/milvus
+        chown -R ${PUID:-1000}:${PGID:-1000} /mnt/data /mnt/logs /mnt/hfcache /mnt/volumes
+        # model_weights defaults to the host user's shared ~/.cache/huggingface,
+        # so chown only the mount point (not -R): enough to fix a dir Docker
+        # created as root, without rewriting the user's whole model cache.
+        chown ${PUID:-1000}:${PGID:-1000} /mnt/model_weights
+        chown -R 999:999 /mnt/db
+    volumes:
+      - ${DATA_VOLUME:-./data}:/mnt/data
+      - ./logs:/mnt/logs
+      - ${DB_VOLUME:-./db}:/mnt/db
+      - ${VLLM_CACHE:-./.cache/huggingface}:/mnt/hfcache
+      - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/mnt/model_weights
+      # NB: vdb/milvus.yaml is `include`d, so its default ./volumes resolves
+      # relative to vdb/ — i.e. ./vdb/volumes from here. Keep these in sync.
+      - ${MILVUS_VOLUME_DIRECTORY:-./vdb/volumes}:/mnt/volumes
+    restart: "no"
+
   # OpenRAG Indexer UI
+  # NOTE: still runs as root. Its entrypoint writes /app/config.json into the
+  # image's root-owned /app at startup, so it can't drop privileges without an
+  # image-level fix in the indexer-ui repo (add a USER + a writable config
+  # path). Tracked as the remaining non-root gap.
   indexer-ui:
     image: linagoraai/indexer-ui:1.1.11
     build:
@@ -112,6 +189,8 @@ services:
     profiles:
       - ""
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       rdb:
         condition: service_started
       milvus:
@@ -126,6 +205,8 @@ services:
     profiles:
       - "cpu"
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       rdb:
         condition: service_started
       milvus:
@@ -135,6 +216,9 @@ services:
 
   rdb:
     image: postgres:15
+    # Run as the image's built-in `postgres` user (uid 999) instead of root;
+    # init-perms hands /var/lib/postgresql/data to 999.
+    user: "999:999"
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
       - POSTGRES_USER=${POSTGRES_USER:-root}
@@ -142,6 +226,9 @@ services:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data
     expose:
       - 5432
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   vllm-gpu:
     <<: *vllm_template

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+# OpenShift (and any runtime that injects an arbitrary UID) starts this
+# container with a UID that has no /etc/passwd entry. Dependencies that call
+# pwd.getpwuid()/getpass.getuser() (Ray, uv, Hugging Face) crash without one,
+# so add an entry on the fly. /etc/passwd is group-writable (GID 0) for exactly
+# this, per the OpenShift container guidelines. Use a UID-specific name so we
+# never collide with the image's baked-in `openrag` user (a different UID).
+if ! whoami >/dev/null 2>&1 && [[ -w /etc/passwd ]]; then
+  uid="$(id -u)"
+  printf 'openrag-%s:x:%s:0:OpenRAG:/app/home:/sbin/nologin\n' "$uid" "$uid" >> /etc/passwd
+fi
+
 ENV_ARGS=()
 if [[ -n "${SHARED_ENV}" ]]; then
   ENV_ARGS+=("--env-file=${SHARED_ENV}")

--- a/extern/reranker/infinity.yaml
+++ b/extern/reranker/infinity.yaml
@@ -1,10 +1,22 @@
 x-reranker: &reranker_template
+  user: "${PUID:-1000}:${PGID:-1000}"
   networks:
     default:
       aliases:
         - reranker
+  environment:
+    # Run unprivileged: keep HOME and the HF cache on the writable mounted
+    # volume so infinity never needs to write under root-owned /root.
+    HOME: /cache
+    HF_HOME: /cache/huggingface
   volumes:
-    - ${VLLM_CACHE:-/root/.cache/huggingface}:/app/.cache/huggingface # Model weights for RAG
+    # This file is `include`d, so a relative default resolves relative to
+    # extern/reranker/. ../../ points back at the project root so the cache
+    # matches vllm's and the dir init-perms chowns.
+    - ${VLLM_CACHE:-../../.cache/huggingface}:/cache # Model weights for RAG (HOME=/cache)
+  depends_on:
+    init-perms:
+      condition: service_completed_successfully
   # ports:
   #   - ${RERANKER_PORT:-7997}:7997
 

--- a/vdb/milvus.yaml
+++ b/vdb/milvus.yaml
@@ -1,6 +1,7 @@
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.5.25
+    user: "${PUID:-1000}:${PGID:-1000}"
     environment:
       - ETCD_AUTO_COMPACTION_MODE=revision
       - ETCD_AUTO_COMPACTION_RETENTION=1000
@@ -14,9 +15,13 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z
+    user: "${PUID:-1000}:${PGID:-1000}"
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
@@ -28,9 +33,16 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    depends_on:
+      init-perms:
+        condition: service_completed_successfully
 
   milvus:
     image: milvusdb/milvus:v2.6.11
+    # gid 0 (not PGID): the milvus binary/libs are root:root mode 0775, so an
+    # unprivileged uid needs group root to exec them. The data dir is owned by
+    # PUID, so the uid still matches its owner.
+    user: "${PUID:-1000}:0"
     command: ["milvus", "run", "standalone"]
     # Run under Docker's default seccomp profile (do not disable syscall
     # filtering). If a specific kernel needs a wider profile, supply a vetted
@@ -53,5 +65,9 @@ services:
     # ports:
     #   - "${VDB_PORT:-19530}:${VDB_iPORT:-19530}"
     depends_on:
-      - "etcd"
-      - "minio"
+      init-perms:
+        condition: service_completed_successfully
+      etcd:
+        condition: service_started
+      minio:
+        condition: service_started


### PR DESCRIPTION
## What this does

Lets OpenRAG run under OpenShift's restricted SCC, where the container runs as a random UID that is always in group 0. Also runs the rest of the docker-compose stack as non-root.

## Image (Dockerfile, entrypoint.sh)

- The paths the app writes at runtime (venv, the project dir for the editable install, data, db, logs, model cache, uv cache) are now group-owned by GID 0 and group-writable. App code, config, and uv's Python stay owned by root and read-only.
- Moved uv's Python and cache to /opt/uv. The venv lives at /app/.venv.
- Added /app/db to the writable paths. It was missing and the app writes there.
- Set a numeric non-root USER via the APP_UID build arg, for plain Docker and Kubernetes.
- Made /etc/passwd group-writable. The entrypoint adds an entry for the running UID so getpass.getuser() and pwd.getpwuid() (Ray, uv, Hugging Face) keep working.

## Compose stack (docker-compose.yaml, vdb/milvus.yaml, extern/reranker/infinity.yaml)

- Added an init-perms container that runs once. It is the only container that runs as root, and it runs no app code. It creates the host bind-mount folders and chowns them before the services start. Every service waits for it.
- openrag and milvus run as PUID:0 (milvus needs group root to run its 0775 binaries). vllm, reranker, etcd, and minio run as PUID:PGID. postgres runs as 999:999.
- vllm and reranker point HOME and the model cache at a writable /cache, and set USER/LOGNAME.
- indexer-ui still runs as root. It needs a fix in its own image. Left a note in the file.

Kept the existing hardening: pinned image tags, dev mount commented out, Ray dashboard bound to localhost, POSTGRES_PASSWORD and the MinIO keys required, default seccomp profile on.

## Testing

docker compose config passes for the default and cpu profiles. Built a small image with the same permission setup and ran it three ways:

- Baked UID 10001:0: writes work, code stays read-only.
- Random UID in group 0, like OpenShift: the passwd entry gets added, writes work, code stays read-only.
- Random UID not in group 0: writes are denied, which shows the access comes from group 0, not from world-write.

## Not in this PR

- Building the venv at image build time so startup needs no network or writes.
- Fixing indexer-ui to run as non-root, which needs a change in its own image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container compatibility for OpenShift and Kubernetes environments with updated permission handling and dynamic user configuration.
  * Enhanced initialization process for multi-container setups with dependency ordering and automatic directory preparation.
  * Updated cache and volume mount configurations for improved data persistence and write access across all services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->