### PR TITLE
chore(docker): resolve username via USER/LOGNAME env instead of writable /etc/passwd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,17 @@ WORKDIR /app
 # dedicated writable subdir (not /app) so libraries that fall back to $HOME
 # never need /app itself writable. UV_FROZEN keeps `uv run` from rewriting
 # uv.lock at runtime, so the project root can stay read-only.
+# USER/LOGNAME are set because the arbitrary UID OpenShift assigns has no
+# /etc/passwd entry: getpass.getuser() reads these env vars first and so
+# resolves without a passwd lookup (the same approach used for the vllm
+# service in docker-compose.yaml). This avoids making /etc/passwd writable.
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
     UV_CACHE_DIR=/opt/uv/cache \
     UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_FROZEN=1 \
-    HOME=/app/home
+    HOME=/app/home \
+    USER=openrag \
+    LOGNAME=openrag
 
 # Install uv & setup venv
 COPY pyproject.toml uv.lock ./
@@ -74,9 +80,6 @@ ENV APP_iPORT=${APP_iPORT:-8080}
 # arbitrary-UID remap does not happen; APP_UID is a build arg so a compose
 # build can match the host user that owns the bind-mounted volumes. The user's
 # primary group is 0 so it shares the same group access on either platform.
-# /etc/passwd is made group-writable so the entrypoint can add an entry for the
-# arbitrary UID; libraries that call getpass.getuser()/pwd.getpwuid() (Ray, uv,
-# HF) otherwise crash when the running UID has no passwd entry.
 ARG APP_UID=10001
 RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
         --home-dir /app/home --shell /sbin/nologin openrag \
@@ -84,7 +87,6 @@ RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
         /app/.venv /app/openrag.egg-info /opt/uv/cache \
     && chgrp -R 0 /app /opt/uv \
     && chmod -R g-w /app /opt/uv \
-    && chmod g=u /etc/passwd \
     && chmod -R g=u /app/home /app/data /app/db /app/logs /app/model_weights \
         /app/.venv /app/openrag.egg-info /opt/uv/cache
 USER ${APP_UID}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
-# OpenShift (and any runtime that injects an arbitrary UID) starts this
-# container with a UID that has no /etc/passwd entry. Dependencies that call
-# pwd.getpwuid()/getpass.getuser() (Ray, uv, Hugging Face) crash without one,
-# so add an entry on the fly. /etc/passwd is group-writable (GID 0) for exactly
-# this, per the OpenShift container guidelines. Use a UID-specific name so we
-# never collide with the image's baked-in `openrag` user (a different UID).
-if ! whoami >/dev/null 2>&1 && [[ -w /etc/passwd ]]; then
-  uid="$(id -u)"
-  printf 'openrag-%s:x:%s:0:OpenRAG:/app/home:/sbin/nologin\n' "$uid" "$uid" >> /etc/passwd
-fi
+# The arbitrary UID OpenShift assigns has no /etc/passwd entry. Rather than
+# write one here (which would require a group-writable /etc/passwd), the image
+# sets USER/LOGNAME so getpass.getuser() resolves from the environment.
 
 ENV_ARGS=()
 if [[ -n "${SHARED_ENV}" ]]; then


### PR DESCRIPTION
## Summary

The OpenShift arbitrary-UID support (from #489) made `/etc/passwd` group-writable so `entrypoint.sh` could append a passwd entry at container start. This PR removes that mechanism in favor of setting `USER`/`LOGNAME` env vars — the same approach already used for the **vllm** service in `docker-compose.yaml`.

## Why

The stated justification — that **Ray, uv, and Hugging Face** crash without a passwd entry — no longer holds at the pinned versions. I verified each by running it as a real UID (12345) with a genuinely missing `/etc/passwd` entry:

| Component | Needs passwd entry? | Evidence |
|---|---|---|
| **uv** | No | `uv --version` / `cache dir` / `python dir` work even with `HOME` unset (cwd-relative fallback) |
| **huggingface_hub** | No | imports + cache + header build all succeed; zero `getpwuid`/`getuser` calls in the package |
| **Ray** (2.47.1) | No | full `ray.init()` + remote task succeeds; `get_user()` is guarded (`try/except → ""`) |

The only realistic caller is the stdlib **`getpass.getuser()`**, which reads `USER`/`LOGNAME` from the environment *before* falling back to `pwd.getpwuid()`. No reachable code path in this image calls `getpwuid()` directly:

- DB layer uses the **sync psycopg2 driver** with an explicit `username` (asyncpg's `getuser()` fallback is never reached).
- No `torch.compile` / `_inductor` runs in-process (Marker/loaders run eager).
- App logging is loguru, not coloredlogs.

The one genuine `getpass.getuser()` user in the repo is **vllm** (torch.compile temp dir) — a separate container already handled via `USER`/`LOGNAME` in `docker-compose.yaml`. This PR makes the openrag image consistent with that.

Verified empirically: with no passwd entry, `getpass.getuser()` raises without the env vars and returns `openrag` with `USER=openrag LOGNAME=openrag` set.

## Changes

- **`Dockerfile`**: drop `chmod g=u /etc/passwd`; add `USER=openrag` / `LOGNAME=openrag` to the runtime `ENV`; remove the inaccurate Ray/uv/HF comment.
- **`entrypoint.sh`**: remove the now-dead passwd-add block (could never fire once `/etc/passwd` is no longer group-writable).

## Security note

This also removes the group-writable `/etc/passwd`, which hardening scanners (Trivy/Checkov, CIS Docker Benchmark) flag as attack surface.

**Trade-off:** `USER`/`LOGNAME` covers `getpass.getuser()` but not raw `pwd.getpwuid()` — the same trade-off the existing vllm config accepts. If we later want robustness against transitive `getpwuid()` callers without a writable passwd, `nss_wrapper` is the canonical upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration for improved OpenShift environment compatibility.
  * Enhanced user resolution by leveraging environment variables instead of system file modifications.
  * Simplified container startup configuration while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->