### PR TITLE
fix(embedder): avoid vLLM exact-max_model_len hang; tune batch_size default

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -47,7 +47,7 @@ embedder:
   api_key: EMPTY
   max_model_len: 8192
   timeout: 120.0       # per-request HTTP timeout (s); raise for slow remote endpoints
-  batch_size: 64       # chunks per embedding request (big docs are split into batches)
+  batch_size: 32       # chunks per embedding request (big docs are split into batches)
   embed_concurrency: 4 # max embedding requests in flight at once
 
 # --- Vector Database (Milvus) ---

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -47,7 +47,7 @@ class EmbedderConfig(ConfigMixin):
     timeout: float = Field(default=120.0, gt=0)
     # Big documents are embedded in slices of `batch_size`, at most
     # `embed_concurrency` requests in flight, to stay within the timeout above.
-    batch_size: int = Field(default=64, gt=0)
+    batch_size: int = Field(default=32, gt=0)
     embed_concurrency: int = Field(default=4, gt=0)
 
 

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -186,7 +186,7 @@ class VLLMEmbedder(Embedder):
         max_model_len: int | None = None,
         dimension: int | None = None,
         timeout: float = 120.0,
-        batch_size: int = 64,
+        batch_size: int = 32,
         embed_concurrency: int = 4,
         api_key: str = "",
         **_kwargs,
@@ -251,7 +251,13 @@ class VLLMEmbedder(Embedder):
     async def _embed_batch(self, texts: list[str]) -> list[list[float]]:
         body: dict = {"model": self._model, "input": texts}
         if self._max_model_len is not None:
-            body["truncate_prompt_tokens"] = self._max_model_len
+            # Truncate one token *below* max_model_len. vLLM pooling models
+            # (e.g. Qwen3-Embedding) hang indefinitely on a request whose input
+            # is exactly max_model_len tokens long (vllm-project/vllm#29496).
+            # Any chunk >= max_model_len would otherwise be truncated straight
+            # onto that boundary, wedging the batch forever while other batches
+            # and files keep embedding.
+            body["truncate_prompt_tokens"] = max(1, self._max_model_len - 1)
         try:
             resp = await self._client.post(f"{self._endpoint}/embeddings", json=body)
             resp.raise_for_status()

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -344,12 +344,22 @@ class TestVLLMEmbedder:
         assert VLLMEmbedder(endpoint="http://x", model_name="m", dimension=768).dimension == 768
 
     @pytest.mark.asyncio
-    async def test_truncate_prompt_tokens_included(self):
+    async def test_truncate_prompt_tokens_is_one_below_max_model_len(self):
+        # One token below max_model_len: vLLM pooling models hang on input that
+        # is exactly max_model_len tokens long (vllm-project/vllm#29496).
         def handler(request: httpx.Request) -> httpx.Response:
-            assert json.loads(request.content)["truncate_prompt_tokens"] == 8192
+            assert json.loads(request.content)["truncate_prompt_tokens"] == 8191
             return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1]}]})
 
         await self._make_embedder(handler, max_model_len=8192).embed(["test"])
+
+    @pytest.mark.asyncio
+    async def test_truncate_prompt_tokens_floors_at_one(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content)["truncate_prompt_tokens"] == 1
+            return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.1]}]})
+
+        await self._make_embedder(handler, max_model_len=1).embed(["test"])
 
     @pytest.mark.asyncio
     async def test_truncate_prompt_tokens_absent_when_none(self):


### PR DESCRIPTION
## Problem

When indexing certain files, embedding completes every batch **except one**, which hangs indefinitely — systematically reproducible for the same file, while other files index fine in parallel (the server keeps serving). So it's **content-related**, not load or client.

Root cause: vLLM issue [#29496](https://github.com/vllm-project/vllm/issues/29496) — Qwen3-Embedding (and other vLLM pooling models) **hang forever on an embedding request whose input is exactly `max_model_len` tokens long**. Reducing the input by a single token fixes it; the issue was closed "not planned".

Our embedder sent `truncate_prompt_tokens = max_model_len`, so **any chunk ≥ `max_model_len` was truncated straight onto that hang boundary**, wedging that one batch while the rest of the document (and other files) embedded normally.

## Changes

1. **Truncate one token below the boundary.** `_embed_batch` now sends `truncate_prompt_tokens = max(1, max_model_len - 1)` so a truncated chunk lands at `max_model_len - 1`, never on the hang boundary. Applies to every `VLLMEmbedder` (default and named-endpoint paths). Floored at 1 for safety.

2. **Lower the default embedder `batch_size` 64 → 32** across the three sources of truth (`conf/config.yaml`, `EmbedderConfig`, `VLLMEmbedder` constructor). Smaller batches shrink each request and the blast radius of any single slow/stuck batch, and align the legacy embedder default with the named-endpoint `ModelEndpointConfig` default (also 32). `timeout` (120s) and `embed_concurrency` (4) are unchanged — already reasonable; all three remain overridable via `EMBEDDER_TIMEOUT` / `EMBEDDER_BATCH_SIZE` / `EMBEDDER_CONCURRENCY`.

## Tests

- `test_truncate_prompt_tokens_is_one_below_max_model_len` (8192 → 8191) and a new `test_truncate_prompt_tokens_floors_at_one`.
- Full inference / config / di unit suites pass (280 passed); ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token truncation logic to properly handle edge cases when processing inputs near model token limits.

* **Chores**
  * Optimized default embedding batch size to improve resource efficiency and processing stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->