### PR TITLE
fix(workers): preserve Whisper GPU allocation from Ray resources

### DIFF
--- a/openrag/services/workers/parsers/whisper_workers.py
+++ b/openrag/services/workers/parsers/whisper_workers.py
@@ -20,7 +20,23 @@ logger = get_logger()
 
 
 def _whisper_num_gpus(config) -> float:
-    return config.loader.local_whisper.whisper_num_gpus if torch.cuda.is_available() else 0
+    """Return Whisper's Ray GPU reservation, falling back to CUDA detection.
+
+    Mirrors Marker's GPU selection (see ``_marker_num_gpus``): the
+    ``WhisperPool`` actor runs with ``num_gpus=0``, so Ray hides CUDA in its
+    process and ``torch.cuda.is_available()`` returns False even on a GPU
+    node — which would silently pin the ``WhisperActor``s to CPU. Ask whether
+    the Ray cluster has GPU capacity instead, keeping the CUDA check only as a
+    fallback for when Ray cannot report cluster resources yet.
+    """
+    requested_gpus = config.loader.local_whisper.whisper_num_gpus
+    if requested_gpus <= 0:
+        return 0
+    try:
+        return requested_gpus if ray.cluster_resources().get("GPU", 0) > 0 else 0
+    except Exception as exc:
+        logger.warning("Failed to query Ray cluster GPU resources; falling back to CUDA check", error=str(exc))
+        return requested_gpus if torch.cuda.is_available() else 0
 
 
 def whisper_actor_options(config) -> dict[str, float | int]:

--- a/tests/unit/services/workers/parsers/test_whisper_workers.py
+++ b/tests/unit/services/workers/parsers/test_whisper_workers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from services.workers.parsers import whisper_workers
+
+
+def _config(whisper_num_gpus: float = 0.25):
+    """Build the minimal config shape consumed by Whisper GPU selection."""
+    return SimpleNamespace(loader=SimpleNamespace(local_whisper=SimpleNamespace(whisper_num_gpus=whisper_num_gpus)))
+
+
+def test_whisper_num_gpus_uses_ray_cluster_resources_when_cuda_is_hidden(monkeypatch):
+    """Whisper should request GPUs from Ray even when local CUDA is hidden.
+
+    The ``WhisperPool`` actor runs with ``num_gpus=0``, so Ray hides CUDA in
+    its process; the GPU request must come from Ray cluster resources, not
+    from ``torch.cuda.is_available()``.
+    """
+    monkeypatch.setattr(whisper_workers.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(whisper_workers.ray, "cluster_resources", lambda: {"GPU": 1.0})
+
+    assert whisper_workers._whisper_num_gpus(_config()) == 0.25
+
+
+def test_whisper_num_gpus_is_zero_when_disabled_by_config(monkeypatch):
+    """A non-positive configured request keeps Whisper off the GPU."""
+    monkeypatch.setattr(whisper_workers.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(whisper_workers.ray, "cluster_resources", lambda: {"GPU": 1.0})
+
+    assert whisper_workers._whisper_num_gpus(_config(whisper_num_gpus=0)) == 0
+
+
+def test_whisper_num_gpus_falls_back_to_cuda_when_ray_lookup_fails(monkeypatch):
+    """If Ray cannot report resources, fall back to the local CUDA check."""
+
+    def _boom():
+        raise RuntimeError("ray not ready")
+
+    monkeypatch.setattr(whisper_workers.ray, "cluster_resources", _boom)
+    monkeypatch.setattr(whisper_workers.torch.cuda, "is_available", lambda: True)
+    assert whisper_workers._whisper_num_gpus(_config()) == 0.25
+
+    monkeypatch.setattr(whisper_workers.torch.cuda, "is_available", lambda: False)
+    assert whisper_workers._whisper_num_gpus(_config()) == 0


### PR DESCRIPTION
## The bug

`WhisperPool` silently runs Whisper transcription **on CPU even when the node has a GPU**, making audio/video indexing far slower than it should be.

## Root cause

Same failure mode as the Marker GPU regression (#451 / #452), now in the Whisper path.

`WhisperPool` is created with `num_gpus=0` (it's just a dispatcher — see `bootstrap.py`). Ray therefore clears `CUDA_VISIBLE_DEVICES` inside the pool actor's process, so `torch.cuda.is_available()` returns `False` there *even on a GPU node*.

`_whisper_num_gpus()` asked that question from inside the pool actor before deciding how many GPUs to request for the real `WhisperActor` workers:

```python
return config.loader.local_whisper.whisper_num_gpus if torch.cuda.is_available() else 0
```

Because CUDA is hidden in the pool process, this returned `0`, so the `WhisperActor`s were scheduled with `num_gpus=0` and loaded the model on CPU (`device = "cuda" if torch.cuda.is_available() else "cpu"` → `cpu`). Ray never reserved a GPU. The API still worked, so it looked like a performance issue rather than a misconfiguration.

The wrong question was *"can this pool actor see CUDA?"* — it should be *"does the Ray cluster have GPU capacity Whisper should request?"*

## The fix

`_whisper_num_gpus()` now decides from **Ray cluster resources**, mirroring `_marker_num_gpus()`:

- configured request `<= 0` → stays on CPU (explicit opt-out preserved)
- Ray reports GPU capacity → keep the configured GPU request (e.g. `0.25`)
- Ray lookup fails → log a warning and fall back to the old `torch.cuda.is_available()` check

Adds a regression test covering the hidden-CUDA case plus the config-disabled and Ray-lookup-failure fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GPU resource detection to increase reliability of GPU allocation.

* **Tests**
  * Added comprehensive test coverage for GPU selection behavior across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
