### PR TITLE
fix(deploy): remove API_NUM_WORKERS footgun, scale via Ray Serve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/charts/openrag-stack/values.yaml
+++ b/charts/openrag-stack/values.yaml
@@ -292,7 +292,8 @@ env:
 
     WITH_CHAINLIT_UI: "false"
     SAVE_UPLOADED_FILES: "false"
-    API_NUM_WORKERS: "8"
+    # HTTP scaling is handled by Ray Serve above (ENABLE_RAY_SERVE +
+    # RAY_SERVE_NUM_REPLICAS), not uvicorn workers — see entrypoint.sh.
     INDEXERUI_URL: "http://indexer-ui:3042"
 
     # Vector DB

--- a/docs/assets/env_example.env
+++ b/docs/assets/env_example.env
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/docs/assets/env_linux_gpu.env
+++ b/docs/assets/env_linux_gpu.env
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -391,7 +391,19 @@ Controls the maximum number of concurrent operations for different indexer tasks
 | `RAY_SEMAPHORE_CONCURRENCY` | int | 100000 | Global concurrency limit for Ray semaphore operations |
 
 #### Ray Serve Configuration
-Ray Serve enables deployment of the FastAPI as a scalable service. For simple deployment, without the intend to scale, one can usage the [uvicorn deployment mode](/openrag/documentation/env_vars/#ray-serve-configuration)
+
+Ray Serve enables deployment of the FastAPI app as a horizontally scalable service.
+
+By default (`ENABLE_RAY_SERVE=false`) OpenRAG runs under **uvicorn with a single worker**. This is intentional: the app initializes Ray and its named actors (`Indexer`, `Vectordb`, `TaskStateManager`, …) at import time, so a second uvicorn worker would start its **own isolated Ray cluster** with duplicate actors, fragmenting task state and vector-DB access. Concurrency within the single worker comes from the async app and from Ray itself — **not** from multiple uvicorn workers (there is intentionally no `API_NUM_WORKERS` knob).
+
+**To scale the HTTP layer, enable Ray Serve** — it runs `RAY_SERVE_NUM_REPLICAS` replicas inside one shared Ray cluster:
+
+```bash
+ENABLE_RAY_SERVE=true
+RAY_SERVE_NUM_REPLICAS=4
+```
+
+For multi-node distributed deployments, see [Distributed Deployment in a Ray Cluster](/openrag/documentation/deploy_ray_cluster/).
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -487,7 +499,6 @@ The following environment variables configure the FastAPI server and control acc
 | `AUTH_TOKEN` | `string` | `EMPTY` | An authentication token is required to access protected API endpoints. By default, this token corresponds to the API key of the created admin (see [Admin Bootstrapping](/openrag/documentation/user_auth/#2-admin-bootstrapping)). If left empty, authentication is disabled. |
 | `SUPER_ADMIN_MODE` | `boolean` | `false` | Enables super admin privileges when set to `true`, [granting unrestricted access](/openrag/documentation/data_model/#access-control) to all operations and bypassing standard access controls. This is for debugging |
 | `DEFAULT_FILE_QUOTA` | `int` | `-1` | Default per-user file quota. `<0` disables quotas globally; `>=0` sets the default limit when a user has no explicit quota. |
-|`API_NUM_WORKERS`|`int`|1|Number of uvicorn workers|
 | `PREFERRED_URL_SCHEME` | `string` | `null` | URL scheme (`http` or `https`) used when generating URLs in API responses (e.g., `task_status_url`). When running behind a reverse proxy that terminates SSL, set this to `https` to ensure generated URLs use the correct scheme. If unset, the scheme from the incoming request is used. |
 | `CORS_EXTRA_ORIGINS` | `string` | _(unset)_ | Semicolon-separated list of additional origins allowed by CORS (e.g. `https://app.example.com;https://other.example.com`). Extends the default list without replacing it. |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,12 +13,20 @@ if [[ "${ENABLE_RAY_SERVE}" == "true" ]]; then
   uv run "${ENV_ARGS[@]}" api.py
 else
   echo "🚀 Starting with Uvicorn..."
-  # --reload is dev-only (set UVICORN_RELOAD=true) and needs a single worker.
+  # This path always runs a SINGLE uvicorn worker. The app initializes Ray and
+  # its named actors (Indexer, Vectordb, TaskStateManager, ...) at import time,
+  # so each extra worker would be a separate process starting its own isolated
+  # Ray cluster with duplicate actors — fragmenting task state and the vector
+  # DB. Concurrency comes from the async app + Ray, not from uvicorn workers.
+  # To scale the HTTP layer horizontally, use Ray Serve (ENABLE_RAY_SERVE=true,
+  # RAY_SERVE_NUM_REPLICAS=N), which runs N replicas inside one Ray cluster.
+  if [[ -n "${API_NUM_WORKERS}" && "${API_NUM_WORKERS}" != "1" ]]; then
+    echo "⚠️  API_NUM_WORKERS=${API_NUM_WORKERS} is ignored: this app runs a single uvicorn worker (Ray provides concurrency). To scale, set ENABLE_RAY_SERVE=true with RAY_SERVE_NUM_REPLICAS." >&2
+  fi
+  # --reload is dev-only (set UVICORN_RELOAD=true); it also forces a single worker.
   RELOAD_ARGS=()
-  WORKERS="${API_NUM_WORKERS:-1}"
   if [[ "${UVICORN_RELOAD}" == "true" ]]; then
     RELOAD_ARGS+=("--reload")
-    WORKERS="1"
   fi
-  uv run --no-dev "${ENV_ARGS[@]}" uvicorn api:app --host 0.0.0.0 --port "${APP_iPORT:-8080}" "${RELOAD_ARGS[@]}" --workers "${WORKERS}"
+  uv run --no-dev "${ENV_ARGS[@]}" uvicorn api:app --host 0.0.0.0 --port "${APP_iPORT:-8080}" "${RELOAD_ARGS[@]}" --workers 1
 fi


### PR DESCRIPTION
## What & why

`API_NUM_WORKERS` is a footgun. In the uvicorn deployment path it fed `uvicorn --workers N`, but the app calls `ray.init()` at **import time** (`openrag/api.py`), so every uvicorn worker is a separate process that starts its **own isolated Ray cluster** with **duplicate named actors** (`Indexer`, `Vectordb`, `TaskStateManager`, the loader pools). Anything `> 1` silently breaks the shared-actor architecture: task state fragments across clusters, multiple `Indexer`/`Vectordb` actors contend on the same Milvus collection / Postgres DB, and resources multiply N×.

### Why it surfaced now

It was a **no-op** until v1.1.12. The entrypoint used to always pass `--reload`, and uvicorn dispatches `should_reload` before `workers > 1`, so `--reload` forced a single worker regardless of the value. Gating `--reload` behind `UVICORN_RELOAD=true` (#478, "N8") unmasked the setting — now all N workers actually start.

Full write-up in #500.

## Changes

- **`entrypoint.sh`** — the uvicorn path always runs a single worker (`--workers 1`). If `API_NUM_WORKERS` is set to a non-`1` value, it logs a warning pointing operators to Ray Serve instead of silently misbehaving.
- **`charts/openrag-stack/values.yaml`** — removed the **dead** `API_NUM_WORKERS: "8"`. The chart sets `ENABLE_RAY_SERVE: "true"`, which takes the `api.py` branch in the entrypoint and never reads `API_NUM_WORKERS` — so it was misleading, not live.
- **`.env.example` / `docs/.../env_vars.md`** — dropped the knob and documented the correct scaling path.

## The correct way to scale

Scale the HTTP layer with **Ray Serve** — N replicas inside **one** shared Ray cluster, so the named actors stay singletons:

```bash
ENABLE_RAY_SERVE=true
RAY_SERVE_NUM_REPLICAS=4
```

This is already what the Helm chart does. For multi-node, see the Ray cluster deployment guide.

## Notes

- No behavior change for existing single-worker deployments (the common case). Deployments that set `API_NUM_WORKERS > 1` will now correctly run one worker and print a warning.
- No migration needed.

Closes #500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that HTTP scaling is controlled via Ray Serve replicas (with sample Ray Serve configuration) rather than Uvicorn worker counts.
  * Updated environment variable documentation and example env files to reflect single Uvicorn worker behavior and removed guidance for `API_NUM_WORKERS`.
  * Added chart and `.env.example` comments directing users to scale using `ENABLE_RAY_SERVE=true` and `RAY_SERVE_NUM_REPLICAS`.

* **Chores**
  * Enforced running exactly one Uvicorn worker when not using Ray Serve.
  * If `API_NUM_WORKERS` is set to a value other than `"1"`, the app now warns that it’s ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->