### PR TITLE
Feat/indexing callback url

### DIFF
--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -122,6 +122,7 @@ async def add_file(
     file: UploadFile = Depends(validate_file_format),
     metadata: dict = Depends(validate_metadata),
     workspace_ids: str | None = Form(None, description="JSON array of workspace IDs to add the file to"),
+    callback_url: str | None = Form(None, description="Optional webhook URL notified when async indexing finishes"),
     user=Depends(require_partition_editor),
     _quota_check=Depends(check_user_file_quota),
     config=Depends(get_config),
@@ -172,6 +173,7 @@ async def add_file(
         original_filename=original_filename,
         user=user,
         workspace_ids=parsed_workspace_ids,
+        callback_url=callback_url,
     )
 
     return JSONResponse(
@@ -254,6 +256,7 @@ async def put_file(
     file_id: str = Depends(validate_file_id),
     file: UploadFile = Depends(validate_file_format),
     metadata: dict = Depends(validate_metadata),
+    callback_url: str | None = Form(None, description="Optional webhook URL notified when async indexing finishes"),
     user=Depends(require_partition_editor),
     config=Depends(get_config),
     service=Depends(get_indexing_service),
@@ -280,6 +283,7 @@ async def put_file(
         original_filename=original_filename,
         user=user,
         replace=True,
+        callback_url=callback_url,
     )
 
     return JSONResponse(

--- a/openrag/core/indexing/dispatcher.py
+++ b/openrag/core/indexing/dispatcher.py
@@ -37,6 +37,7 @@ class IndexingDispatcher(ABC):
         replace: bool,
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
+        callback_url: str | None = None,
     ) -> str:
         """Queue an (re)indexing job, register its task state, return its id."""
         ...

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -158,11 +158,16 @@ class IndexingService:
         user: dict | None,
         workspace_ids: list[str] | None = None,
         replace: bool = False,
+        callback_url: str | None = None,
     ) -> str:
         """Assemble metadata and queue an (re)indexing job; return its task id.
 
         Workspace association happens inside the worker's ``add_file``
         after a successful index — the router only pre-validates the ids.
+
+        When *callback_url* is provided it is forwarded to the worker, which
+        sends a best-effort ``POST`` notification once the task reaches a
+        terminal state.
         """
         full_metadata = self._build_metadata(
             metadata=metadata,
@@ -182,6 +187,7 @@ class IndexingService:
             replace=replace,
             indexation_config=indexation_config,
             embedder_name=embedder_name,
+            callback_url=callback_url,
         )
 
     async def delete_file(self, file_id: str, partition: str) -> None:

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -70,6 +70,7 @@ class WorkerDispatcher(IndexingDispatcher):
         replace: bool,
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
+        callback_url: str | None = None,
     ) -> str:
         task_id = uuid.uuid4().hex
 
@@ -100,6 +101,7 @@ class WorkerDispatcher(IndexingDispatcher):
             replace=replace,
             indexation_config=indexation_config,
             embedder_name=embedder_name,
+            callback_url=callback_url,
         )
 
         await self._call(

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -4,50 +4,13 @@ import traceback
 from pathlib import Path
 from typing import Any
 
-import httpx
 from core.models.document import Document
 from core.utils.logging import get_logger
 from services.workers.parsers.doc_serializer_bridge import INDEXATION_CONFIG_METADATA_KEY
 from services.workers.pipeline_builder import IndexingPipeline
+from services.workers.webhook import send_indexing_callback
 
 logger = get_logger()
-
-# Short client-side timeout for the best-effort indexing callback; we don't
-# retry internally if the receiver (e.g. cozy-stack) is unreachable.
-_CALLBACK_TIMEOUT = httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
-
-
-async def _send_indexing_callback(
-    callback_url: str | None,
-    partition: str,
-    file_id: str,
-    status: str,
-) -> None:
-    """Best-effort notification of the final indexing status to an external URL.
-
-    No-op when *callback_url* is ``None``.  Never raises — a callback failure
-    (network error, timeout, non-2xx response) must never affect the indexing
-    outcome, so any error is logged as a warning and swallowed.
-    """
-    if not callback_url:
-        return
-
-    try:
-        async with httpx.AsyncClient(timeout=_CALLBACK_TIMEOUT) as client:
-            response = await client.post(
-                callback_url,
-                json={"partition": partition, "file_id": file_id, "status": status},
-            )
-            response.raise_for_status()
-    except Exception as exc:
-        logger.warning(
-            "Failed to send indexing callback",
-            callback_url=callback_url,
-            partition=partition,
-            file_id=file_id,
-            status=status,
-            error=str(exc),
-        )
 
 
 class IndexerWorker:
@@ -103,6 +66,7 @@ class IndexerWorker:
         ``failed``).  The callback never affects the indexing outcome.
         """
         file_id = metadata.get("file_id", "")
+        log = logger.bind(file_id=file_id, partition=partition, task_id=task_id)
         await self._tsm.set_state.remote(task_id, "SERIALIZING")
         try:
             document = _load_document(path, metadata, partition, indexation_config=indexation_config)
@@ -128,16 +92,17 @@ class IndexerWorker:
                     indexation_config=indexation_config,
                 )
             await self._tsm.set_state.remote(task_id, "COMPLETED")
+            log.info("File indexed successfully.")
             # Notify external callback (e.g. cozy-stack) that indexing succeeded.
             # Best-effort: never raises, never affects the indexing outcome.
-            await _send_indexing_callback(callback_url, partition, file_id, "indexed")
+            await send_indexing_callback(callback_url, partition, file_id, "indexed")
             return {"stored_count": row.get("stored_count", 0), "stage": row.get("stage", "")}
         except Exception:
             tb = traceback.format_exc()
             was_failed = await self._tsm.set_failed_if_not_cancelled.remote(task_id, tb)
             # Only notify on an actual failure, not on a user-initiated cancellation.
             if was_failed:
-                await _send_indexing_callback(callback_url, partition, file_id, "failed")
+                await send_indexing_callback(callback_url, partition, file_id, "failed")
             raise
 
 

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -4,9 +4,50 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+import httpx
 from core.models.document import Document
+from core.utils.logging import get_logger
 from services.workers.parsers.doc_serializer_bridge import INDEXATION_CONFIG_METADATA_KEY
 from services.workers.pipeline_builder import IndexingPipeline
+
+logger = get_logger()
+
+# Short client-side timeout for the best-effort indexing callback; we don't
+# retry internally if the receiver (e.g. cozy-stack) is unreachable.
+_CALLBACK_TIMEOUT = httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
+
+
+async def _send_indexing_callback(
+    callback_url: str | None,
+    partition: str,
+    file_id: str,
+    status: str,
+) -> None:
+    """Best-effort notification of the final indexing status to an external URL.
+
+    No-op when *callback_url* is ``None``.  Never raises — a callback failure
+    (network error, timeout, non-2xx response) must never affect the indexing
+    outcome, so any error is logged as a warning and swallowed.
+    """
+    if not callback_url:
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=_CALLBACK_TIMEOUT) as client:
+            response = await client.post(
+                callback_url,
+                json={"partition": partition, "file_id": file_id, "status": status},
+            )
+            response.raise_for_status()
+    except Exception as exc:
+        logger.warning(
+            "Failed to send indexing callback",
+            callback_url=callback_url,
+            partition=partition,
+            file_id=file_id,
+            status=status,
+            error=str(exc),
+        )
 
 
 class IndexerWorker:
@@ -49,13 +90,19 @@ class IndexerWorker:
         replace: bool = False,
         indexation_config: dict[str, Any] | None = None,
         embedder_name: str | None = None,
+        callback_url: str | None = None,
     ) -> dict[str, Any]:
         """Run one file through the indexing pipeline.
 
         Returns a plain dict ``{"stored_count": int, "stage": "stored"}``
         on success.  On failure, state is set to FAILED and the exception
         is re-raised so the Ray task is marked as errored.
+
+        When *callback_url* is provided, a best-effort ``POST`` notification is
+        sent to that URL after the task reaches a terminal state (``indexed`` or
+        ``failed``).  The callback never affects the indexing outcome.
         """
+        file_id = metadata.get("file_id", "")
         await self._tsm.set_state.remote(task_id, "SERIALIZING")
         try:
             document = _load_document(path, metadata, partition, indexation_config=indexation_config)
@@ -81,10 +128,16 @@ class IndexerWorker:
                     indexation_config=indexation_config,
                 )
             await self._tsm.set_state.remote(task_id, "COMPLETED")
+            # Notify external callback (e.g. cozy-stack) that indexing succeeded.
+            # Best-effort: never raises, never affects the indexing outcome.
+            await _send_indexing_callback(callback_url, partition, file_id, "indexed")
             return {"stored_count": row.get("stored_count", 0), "stage": row.get("stage", "")}
         except Exception:
             tb = traceback.format_exc()
-            await self._tsm.set_failed_if_not_cancelled.remote(task_id, tb)
+            was_failed = await self._tsm.set_failed_if_not_cancelled.remote(task_id, tb)
+            # Only notify on an actual failure, not on a user-initiated cancellation.
+            if was_failed:
+                await _send_indexing_callback(callback_url, partition, file_id, "failed")
             raise
 
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -76,6 +76,7 @@ class IndexerPool:
         replace: bool = False,
         indexation_config: dict[str, Any] | None = None,
         embedder_name: str | None = None,
+        callback_url: str | None = None,
     ) -> dict[str, Any]:
         await self._ensure_catalog()
         result = await self._worker.process_file(
@@ -88,6 +89,7 @@ class IndexerPool:
             replace=replace,
             indexation_config=indexation_config,
             embedder_name=embedder_name,
+            callback_url=callback_url,
         )
         file_id = metadata.get("file_id", "")
         if workspace_ids and not replace and file_id:

--- a/openrag/services/workers/webhook.py
+++ b/openrag/services/workers/webhook.py
@@ -1,0 +1,53 @@
+"""Best-effort webhook notifications for async indexing outcomes.
+
+Called by ``IndexerWorker`` once a file reaches a terminal state so that
+external systems (e.g. cozy-stack) don't have to poll the task-status
+endpoint.
+
+Design constraints (kept identical to the main-branch implementation):
+- Never raises: a callback failure must never affect the indexing outcome.
+- No retries, single notification per file.
+- callback_url absent → strict no-op.
+- Timeout: 5 s on each of connect / read / write / pool.
+"""
+
+from __future__ import annotations
+
+import httpx
+from core.utils.logging import get_logger
+
+logger = get_logger()
+
+_TIMEOUT = httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
+
+
+async def send_indexing_callback(
+    callback_url: str | None,
+    partition: str,
+    file_id: str,
+    status: str,
+) -> None:
+    """POST ``{"partition": …, "file_id": …, "status": "indexed"|"failed"}`` to *callback_url*.
+
+    No-op when *callback_url* is ``None``.  Any network or HTTP error is
+    logged as a warning and swallowed so the caller's outcome is unaffected.
+    """
+    if not callback_url:
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            response = await client.post(
+                callback_url,
+                json={"partition": partition, "file_id": file_id, "status": status},
+            )
+            response.raise_for_status()
+    except Exception as exc:
+        logger.warning(
+            "Failed to send indexing callback",
+            callback_url=callback_url,
+            partition=partition,
+            file_id=file_id,
+            status=status,
+            error=str(exc),
+        )

--- a/openrag/services/workers/webhook.py
+++ b/openrag/services/workers/webhook.py
@@ -13,8 +13,9 @@ Design constraints (kept identical to the main-branch implementation):
 
 from __future__ import annotations
 
-import httpx
 from urllib.parse import urlparse
+
+import httpx
 
 from core.utils.logging import get_logger
 

--- a/openrag/services/workers/webhook.py
+++ b/openrag/services/workers/webhook.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from urllib.parse import urlparse
 
 import httpx
-
 from core.utils.logging import get_logger
 
 logger = get_logger()

--- a/openrag/services/workers/webhook.py
+++ b/openrag/services/workers/webhook.py
@@ -14,6 +14,8 @@ Design constraints (kept identical to the main-branch implementation):
 from __future__ import annotations
 
 import httpx
+from urllib.parse import urlparse
+
 from core.utils.logging import get_logger
 
 logger = get_logger()
@@ -43,9 +45,11 @@ async def send_indexing_callback(
             )
             response.raise_for_status()
     except Exception as exc:
+        parsed = urlparse(callback_url)
+        safe_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
         logger.warning(
             "Failed to send indexing callback",
-            callback_url=callback_url,
+            callback_url=safe_url,
             partition=partition,
             file_id=file_id,
             status=status,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "tenacity>=8.2.0",
     "aiobreaker>=1.2.0",
     "mcp>=1.11.0",
+    "httpx>=0.27.0",
 ]
 
 [dependency-groups]

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -49,6 +49,7 @@ class FakeDispatcher:
         replace,
         indexation_config=None,
         embedder_name=None,
+        callback_url=None,
     ):
         self.dispatched.append(
             {
@@ -60,6 +61,7 @@ class FakeDispatcher:
                 "replace": replace,
                 "indexation_config": indexation_config,
                 "embedder_name": embedder_name,
+                "callback_url": callback_url,
             }
         )
         return "task-abc"

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -141,6 +141,7 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         replace=True,
         indexation_config={"parsing_strategy": "pymupdf"},
         embedder_name="embed-fast",
+        callback_url=None,
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
 


### PR DESCRIPTION
Adding a callback Url in order to update the RAG_status category in Cozy using a webhook. The modifications were made in order not to change the functioning of the RAG if there is no callback_url in the doc received by OpenRAG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexing requests now support an optional webhook callback URL for completion notifications.
  * When provided, the system sends a best-effort webhook on terminal completion with the final status (indexed or failed).
  * Webhook delivery is resilient (errors are handled) and does not impact the indexing result.
  * Added support for passing the callback URL through indexing job dispatch, including file replacement flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->