### PR TITLE
chore(release): bump version to 1.1.12 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.11"
+version = "1.1.12"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
The v1.1.12 release was tagged without bumping the project version. `pyproject.toml` still reads `1.1.11` on `main` — and even at the `v1.1.12` tag itself — so `importlib.metadata.version("openrag")` (used for the `/version` endpoint and OpenAPI) reports the wrong version.

This bumps `version` to `1.1.12` to match the released tag.

No code or dependency changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.12

This release contains no user-facing changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->