### PR TITLE
chore(deploy): bump openrag image tag to 1.1.12 in compose stacks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ include:
   - ${TRANSCRIBER_COMPOSE:-extern/dummy.yaml}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:1.1.11
+  image: linagoraai/openrag:1.1.12
   # Run unprivileged with group 0. GID 0 (not PGID) matches the image, whose
   # runtime-write paths are group-owned by the root group, and works whether
   # this image was pulled or locally rebuilt. init-perms hands the bind-mounted

--- a/quick_start/docker-compose.yaml
+++ b/quick_start/docker-compose.yaml
@@ -4,7 +4,7 @@ include:
 
 x-openrag: &openrag_template
   # image: ghcr.io/linagora/openrag:dev-latest
-  image: linagoraai/openrag:1.1.11
+  image: linagoraai/openrag:1.1.12
   build:
     context: .
     dockerfile: Dockerfile


### PR DESCRIPTION
Follow-up to #503 (which bumps the package version). Aligns the `linagoraai/openrag` image tag with the 1.1.12 release in the Docker Compose stacks:

- `docker-compose.yaml`
- `quick_start/docker-compose.yaml`

The `v1.1.12` image is published on Docker Hub, and these stacks build the image locally as well, so the bump is safe.

### Deliberately out of scope
Verified against the registries — these are **not** bumped here because a naive 1.1.11→1.1.12 would point at tags that don't exist:
- **indexer-ui** (`linagoraai/indexer-ui`) is versioned independently (latest published is `v1.1.1`); `1.1.12` does not exist.
- **Helm** `linagoraai/openrag` pulls and the registry only publishes `v`-prefixed tags, and **openrag-ray** on ghcr has no `1.1.x` tag at all. These pre-existing tag/convention issues need a dedicated cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated openrag container image to version 1.1.12 across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->