### PR TITLE
chore(release): bump version to 1.1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.12"
+version = "1.1.13"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Prepares the v1.1.13 release. `main` is ahead of the `v1.1.12` tag (the API_NUM_WORKERS fix #501, version/compose bumps #503/#504, and #493), so the next release is cut from `main` as 1.1.13 — leaving the published `v1.1.12` tag and image untouched.

Once merged, v1.1.13 will be tagged at the merge commit and a GitHub release created (auto-generated notes for the PRs since v1.1.12, plus the v1.1.12 credential breaking changes carried forward).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 1.1.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->