### PR TITLE
chore(release): prep v1.1.13 (version bump + compose :latest)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ include:
   - ${TRANSCRIBER_COMPOSE:-extern/dummy.yaml}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:1.1.12
+  image: linagoraai/openrag:latest
   # Run unprivileged with group 0. GID 0 (not PGID) matches the image, whose
   # runtime-write paths are group-owned by the root group, and works whether
   # this image was pulled or locally rebuilt. init-perms hands the bind-mounted
@@ -153,7 +153,7 @@ services:
   # image-level fix in the indexer-ui repo (add a USER + a writable config
   # path). Tracked as the remaining non-root gap.
   indexer-ui:
-    image: linagoraai/indexer-ui:1.1.11
+    image: linagoraai/indexer-ui:latest
     build:
       context: ./extern/indexer-ui
       dockerfile: Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.12"
+version = "1.1.13"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/quick_start/docker-compose.yaml
+++ b/quick_start/docker-compose.yaml
@@ -4,7 +4,7 @@ include:
 
 x-openrag: &openrag_template
   # image: ghcr.io/linagora/openrag:dev-latest
-  image: linagoraai/openrag:1.1.12
+  image: linagoraai/openrag:latest
   build:
     context: .
     dockerfile: Dockerfile
@@ -56,7 +56,7 @@ x-vllm: &vllm_template
 services:
   # OpenRAG Indexer UI
   indexer-ui:
-    image: linagoraai/indexer-ui:1.1.11
+    image: linagoraai/indexer-ui:latest
     # build:
     #   context: ./extern/indexer-ui
     #   dockerfile: Dockerfile


### PR DESCRIPTION
Release prep for **v1.1.13**, in one PR. Two commits:

1. **`chore(release): bump version to 1.1.13`** — bumps `pyproject.toml` so the package version (and the `/version` endpoint) matches the upcoming release. `main` is ahead of the `v1.1.12` tag, so the next release is cut as 1.1.13.
2. **`chore(deploy): use :latest for app images in compose stacks`** — switches `linagoraai/openrag` and `linagoraai/indexer-ui` to `:latest` in `docker-compose.yaml` and `quick_start/docker-compose.yaml`, so the dev compose no longer lags every release. Helm stays version-pinned for reproducible prod. (Also fixes indexer-ui, which was pinned to `1.1.11` — a tag never published; its registry tops out at `v1.1.1`.)

Supersedes #506 (folded in here).