### PR TITLE
fix(partitions): tolerate missing Milvus collection on delete

### DIFF
--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -178,6 +178,17 @@ class PartitionService:
         """Drop a partition's vectors *and* relational rows (cross-cutting)."""
         await self._ensure_partition(partition)
         await self._partition_repo.delete_partition(name=partition)
+        # The shared Milvus collection is created lazily on the first insert
+        # system-wide, so on a fresh stack (nothing ever indexed) it doesn't
+        # exist; querying it would raise (e.g. DescribeCollectionException) and
+        # fail the whole delete *after* the relational rows are already gone.
+        # No collection means no chunks to clean up — skip the vector cleanup.
+        if not await self._vector_store.collection_exists(self._collection):
+            logger.info(
+                "Partition deleted; no vector collection to clean up",
+                partition=partition,
+            )
+            return
         ids = await self._vector_store.query_ids_by_filter(
             self._collection,
             {"partition": partition},

--- a/tests/integration/api/test_partition.py
+++ b/tests/integration/api/test_partition.py
@@ -41,6 +41,25 @@ class TestPartitionCRUD:
         response = api_client.delete(f"/partition/{test_partition_name}")
         assert response.status_code in [200, 204]
 
+    def test_delete_empty_partition_succeeds(self, api_client, test_partition_name):
+        """Regression for #505: deleting an empty partition must not 500.
+
+        Partitions are a Postgres concept; the shared Milvus collection is
+        created lazily on the first insert system-wide. An empty partition has
+        no chunks to clean up, so the delete must drop the relational rows and
+        return success instead of failing on the (possibly absent) collection.
+        """
+        create = api_client.post(f"/partition/{test_partition_name}")
+        assert create.status_code in [200, 201], create.text
+
+        response = api_client.delete(f"/partition/{test_partition_name}")
+        assert response.status_code in [200, 204], response.text
+
+        # The partition is actually gone.
+        listing = api_client.get("/partition/")
+        partitions = [p["partition"] for p in listing.json()["partitions"]]
+        assert test_partition_name not in partitions
+
     def test_list_partition_files_empty(self, api_client, created_partition):
         """Test listing files in empty partition."""
         response = api_client.get(f"/partition/{created_partition}")

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -75,10 +75,14 @@ class FakeDocumentRepo:
 
 
 class FakeVectorStore:
-    def __init__(self, ids=None, rows=None):
+    def __init__(self, ids=None, rows=None, exists=True):
         self._ids = ids or []
         self._rows = rows or []
+        self._exists = exists
         self.deleted_ids: list[str] = []
+
+    async def collection_exists(self, name) -> bool:
+        return self._exists
 
     async def query_ids_by_filter(self, collection, filters):
         return list(self._ids)
@@ -184,6 +188,24 @@ async def test_delete_partition_no_vectors_still_deletes_rows():
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
     assert vstore.deleted_ids == []
     assert prepo.deleted == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_skips_vectors_when_collection_absent():
+    """Regression for #505: on a fresh stack nothing has ever been indexed, so
+    the shared Milvus collection doesn't exist. Deleting a partition must still
+    drop the relational rows without querying (and 500-ing on) the missing
+    collection."""
+    prepo = FakePartitionRepo(existing={"p1"})
+
+    class ExplodingVectorStore(FakeVectorStore):
+        async def query_ids_by_filter(self, collection, filters):
+            raise AssertionError("must not query a collection that doesn't exist")
+
+    vstore = ExplodingVectorStore(exists=False)
+    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    assert prepo.deleted == ["p1"]
+    assert vstore.deleted_ids == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -199,13 +199,22 @@ async def test_delete_partition_skips_vectors_when_collection_absent():
     prepo = FakePartitionRepo(existing={"p1"})
 
     class ExplodingVectorStore(FakeVectorStore):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.delete_called = False
+
         async def query_ids_by_filter(self, collection, filters):
             raise AssertionError("must not query a collection that doesn't exist")
+
+        async def delete(self, ids, collection="default") -> int:
+            self.delete_called = True
+            raise AssertionError("must not delete vectors when collection doesn't exist")
 
     vstore = ExplodingVectorStore(exists=False)
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
     assert prepo.deleted == ["p1"]
     assert vstore.deleted_ids == []
+    assert vstore.delete_called is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`delete_partition` returns HTTP 500 when deleting a partition on a stack where nothing has ever been indexed.

Fixes #505.

## Root cause

Partitions are a pure Postgres concept; the shared Milvus collection (`config.vectordb.collection_name`) is created **lazily on the first insert system-wide**. `delete_partition` removed the relational rows and then **unconditionally** queried the vector store for chunks to clean up. When the collection doesn't exist, `query_ids_by_filter` → `query_iterator` → `describe_collection` raises `DescribeCollectionException`, surfacing as a 500 *after* the DB rows were already deleted.

(Note: "partition" is a scalar field on the single shared collection, not a Milvus-native partition — so this only triggers when the collection itself is absent, i.e. nothing indexed yet. With data present, the cleanup query just returns empty.)

## Fix

Guard the best-effort vector cleanup with the existing `VectorStore.collection_exists()` port method. No collection → no chunks to clean up → log and return. An explicit existence check (rather than swallowing the exception) avoids masking real Milvus errors like a connection failure.

## Test

Adds `test_delete_partition_skips_vectors_when_collection_absent`: with `collection_exists() == False`, delete still drops the relational rows and never queries the missing collection. Full suite: 21 passed, ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition deletion to gracefully handle cases where the configured vector-store collection was never created, preventing vector-related errors while still removing the relational partition data.

* **Tests**
  * Added a regression unit test ensuring vector querying/deletion are skipped when the vector-store collection is absent, while the relational row deletion still occurs.
  * Added an integration regression test confirming deleting an empty partition succeeds and the partition is removed from listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->