### PR TITLE
docs(usage): document Chainlit on CHAINLIT_PORT under Ray Serve

### DIFF
--- a/docs/content/docs/getting_started/usage.mdx
+++ b/docs/content/docs/getting_started/usage.mdx
@@ -15,4 +15,8 @@ By default, OpenRAG services are exposed on the following ports:
 | Ray Dashboard     | 8265           | Ray dashboard for monitoring and managing tasks                |
 | Indexer UI        | 3042/          | Main user interface for indexing and viewing indexed documents |
 
+:::note[Ray Serve mode]
+The table above is for the default (uvicorn) deployment, where the Chainlit UI is the `/chainlit` subroute of the API. When `ENABLE_RAY_SERVE=true`, the API is served by Ray Serve on `RAY_SERVE_PORT` and the **Chainlit UI runs on its own port, `CHAINLIT_PORT`** (default `8090`), instead of the subroute. Uncomment the `${CHAINLIT_PORT}:${CHAINLIT_PORT}` mapping in `docker-compose.yaml` to expose it. See [`CHAINLIT_PORT`](/openrag/documentation/env_vars/#ray-serve-configuration).
+:::
+
 More information about the different services can be found in their respective documentation pages.


### PR DESCRIPTION
The `CHAINLIT_PORT` env var doc points to the Usage *Default ports* section to explain Chainlit's location, but that table only covered the default (uvicorn) case — Chainlit at the `/chainlit` subroute — and never mentioned the Ray Serve behavior.

Adds a note to the Default ports section: when `ENABLE_RAY_SERVE=true`, the API is served by Ray Serve on `RAY_SERVE_PORT` and the Chainlit UI runs on its own `CHAINLIT_PORT` (default `8090`) instead of the subroute (confirmed in `openrag/api.py`, which starts `chainlit_app` via uvicorn on `config.ray.serve.chainlit_port`). Also flags that the `${CHAINLIT_PORT}:${CHAINLIT_PORT}` mapping in `docker-compose.yaml` is commented out by default and must be uncommented to expose it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified service routing behavior when using Ray Serve deployment. Ray Serve API now runs on a dedicated port (RAY_SERVE_PORT) while Chainlit UI runs on a separate port (CHAINLIT_PORT, default 8090) rather than a subroute. Added guidance for configuring port mappings in docker-compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->