### PR TITLE
fix(indexer): keep pool actor alive for queued batches

### DIFF
--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -53,6 +53,7 @@ class IndexerPool:
         rdb_cfg = cfg.rdb.model_copy(update={"database": f"partitions_for_collection_{cfg.vectordb.collection_name}"})
         self._catalog_store = PostgresStore(rdb_cfg, run_migrations=False)
         self._catalog_initialized = False
+        self._catalog_init_lock = asyncio.Lock()
         self._worker = IndexerWorker(
             pipeline=pipeline,
             task_state_manager=task_state_manager,
@@ -60,7 +61,11 @@ class IndexerPool:
         )
 
     async def _ensure_catalog(self) -> None:
-        if not self._catalog_initialized:
+        if self._catalog_initialized:
+            return
+        async with self._catalog_init_lock:
+            if self._catalog_initialized:
+                return
             await self._catalog_store.initialize()
             self._catalog_initialized = True
 
@@ -104,10 +109,16 @@ class IndexerPool:
 
 
 def build_indexer_pool(namespace: str = "openrag") -> Any:
+    from core.config import load_config
+
+    cfg = load_config()
+    max_concurrency = max(1, int(getattr(cfg.ray, "max_tasks_per_worker", 1)))
     return IndexerPool.options(  # type: ignore[attr-defined]
         name="IndexerPool",
         namespace=namespace,
         get_if_exists=True,
+        lifetime="detached",
+        max_concurrency=max_concurrency,
     ).remote()
 
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -112,7 +112,7 @@ def build_indexer_pool(namespace: str = "openrag") -> Any:
     from core.config import load_config
 
     cfg = load_config()
-    max_concurrency = max(1, int(getattr(cfg.ray, "max_tasks_per_worker", 1)))
+    max_concurrency = max(1, cfg.ray.max_tasks_per_worker)
     return IndexerPool.options(  # type: ignore[attr-defined]
         name="IndexerPool",
         namespace=namespace,

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -44,3 +47,54 @@ def test_build_chunker_rejects_non_callable_chunk_attr(monkeypatch: pytest.Monke
 
     with pytest.raises(TypeError, match="chunk"):
         _build_chunker(object())
+
+
+@pytest.mark.asyncio
+async def test_catalog_initialization_is_single_flight() -> None:
+    from services.workers.indexer_pool import IndexerPool
+
+    actor_class = IndexerPool.__ray_metadata__.modified_class
+    pool = actor_class.__new__(actor_class)
+
+    class Store:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def initialize(self) -> None:
+            self.calls += 1
+            await asyncio.sleep(0)
+
+    store = Store()
+    pool._catalog_store = store
+    pool._catalog_initialized = False
+    pool._catalog_init_lock = asyncio.Lock()
+
+    await asyncio.gather(*(pool._ensure_catalog() for _ in range(20)))
+
+    assert store.calls == 1
+    assert pool._catalog_initialized is True
+
+
+def test_build_indexer_pool_uses_detached_actor_with_configured_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import core.config
+    import services.workers.indexer_pool as module
+
+    calls = {}
+
+    class Options:
+        def remote(self):
+            return "actor"
+
+    def fake_options(**kwargs):
+        calls.update(kwargs)
+        return Options()
+
+    cfg = SimpleNamespace(ray=SimpleNamespace(max_tasks_per_worker=4))
+    monkeypatch.setattr(core.config, "load_config", lambda: cfg)
+    monkeypatch.setattr(module.IndexerPool, "options", fake_options)
+
+    assert module.build_indexer_pool() == "actor"
+    assert calls["lifetime"] == "detached"
+    assert calls["max_concurrency"] == 4


### PR DESCRIPTION
## Context
Large indexing benchmarks can submit more work than the indexer can process immediately. In that case, queued tasks must remain attached to a live worker actor until their turn starts.

## Problem
The indexer pool actor could be cleaned up by Ray while queued work still existed. Those tasks stayed visible as `QUEUED`, but nothing was left to consume them. A full dataset run could then stop after the first window of files.

Concurrent startup also let multiple tasks initialize the catalog store at the same time, which put unnecessary pressure on Postgres.

## Expected behavior
The indexer pool remains alive for queued batches, respects the configured worker concurrency, and initializes its catalog connection once under concurrent load.

## Validation
- `uv run pytest tests/unit/services/workers/test_indexer_pool.py -q`
- `uv run pytest tests/unit/services/workers -q`
- `uv run ruff format --check openrag/services/workers/indexer_pool.py tests/unit/services/workers/test_indexer_pool.py`
- `uv run ruff check openrag/services/workers/indexer_pool.py tests/unit/services/workers/test_indexer_pool.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved indexing pool initialization to be safe under concurrent startup, ensuring the catalog is initialized only once.
  * Updated worker pool creation to respect configured concurrency settings and run the actor as a detached Ray worker for more reliable background operation.
* **Tests**
  * Added unit coverage for single-flight catalog initialization under concurrent calls.
  * Added unit coverage verifying detached actor creation and correct concurrency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->