### PR TITLE
fix(cluster): only list OpenRag-namespace Ray actors in the system view

### DIFF
--- a/openrag/di/workers.py
+++ b/openrag/di/workers.py
@@ -17,6 +17,12 @@ def list_ray_actors() -> list[dict[str, str | None]]:
     ``_ray_internal_job_actor_raysubmit_*`` job supervisors, which appear dead
     once their job finishes and have no creation function to restart) don't show
     up in the admin system view.
+
+    The namespace is filtered server-side via ``list_actors(filters=...)`` so
+    that Ray's default ``limit=100`` applies *within* the ``openrag`` namespace
+    rather than across all namespaces — otherwise accumulated dead Ray-internal
+    job actors could push OpenRag's own actors out of the result window. The
+    in-comprehension check is kept as cheap defense-in-depth.
     """
     from ray.util.state import list_actors
 
@@ -28,7 +34,7 @@ def list_ray_actors() -> list[dict[str, str | None]]:
             "state": actor.state,
             "namespace": actor.ray_namespace,
         }
-        for actor in list_actors()
+        for actor in list_actors(filters=[("ray_namespace", "=", OPENRAG_NAMESPACE)])
         if actor.ray_namespace == OPENRAG_NAMESPACE
     ]
 

--- a/openrag/di/workers.py
+++ b/openrag/di/workers.py
@@ -5,9 +5,19 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
+# All OpenRag-managed actors are created in this Ray namespace (see
+# services/workers/bootstrap.py).
+OPENRAG_NAMESPACE = "openrag"
+
 
 def list_ray_actors() -> list[dict[str, str | None]]:
-    """List Ray actors without exposing Ray imports to API routers."""
+    """List OpenRag-managed Ray actors without exposing Ray imports to API routers.
+
+    Restricted to the ``openrag`` namespace so Ray-internal actors (e.g.
+    ``_ray_internal_job_actor_raysubmit_*`` job supervisors, which appear dead
+    once their job finishes and have no creation function to restart) don't show
+    up in the admin system view.
+    """
     from ray.util.state import list_actors
 
     return [
@@ -19,6 +29,7 @@ def list_ray_actors() -> list[dict[str, str | None]]:
             "namespace": actor.ray_namespace,
         }
         for actor in list_actors()
+        if actor.ray_namespace == OPENRAG_NAMESPACE
     ]
 
 
@@ -45,7 +56,7 @@ def restart_ray_actor(actor_name: str) -> str:
         raise KeyError(actor_name)
 
     try:
-        actor = ray.get_actor(actor_name, namespace="openrag")
+        actor = ray.get_actor(actor_name, namespace=OPENRAG_NAMESPACE)
         ray.kill(actor, no_restart=True)
     except ValueError:
         pass

--- a/tests/unit/di/test_workers.py
+++ b/tests/unit/di/test_workers.py
@@ -2,11 +2,44 @@ from __future__ import annotations
 
 import sys
 from importlib import import_module
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
 from core.config.root import Settings
-from di.workers import ensure_worker_bootstrap
+from di.workers import ensure_worker_bootstrap, list_ray_actors
+
+
+def _fake_actor(name: str, namespace: str):
+    return SimpleNamespace(
+        actor_id=f"id-{name}",
+        name=name,
+        class_name="SomeActor",
+        state="ALIVE",
+        ray_namespace=namespace,
+    )
+
+
+def test_list_ray_actors_filters_out_non_openrag_namespace() -> None:
+    """Ray-internal job actors live outside the ``openrag`` namespace and must be
+    hidden from the admin system view (they're dead once their job ends and
+    can't be restarted)."""
+    actors = [
+        _fake_actor("Indexer", "openrag"),
+        _fake_actor("WhisperPool", "openrag"),
+        _fake_actor("_ray_internal_job_actor_raysubmit_abc", "_ray_internal_job"),
+        _fake_actor("SomethingElse", "default"),
+    ]
+    module = ModuleType("ray.util.state")
+    module.list_actors = Mock(return_value=actors)
+    sys.modules["ray.util.state"] = module
+
+    try:
+        result = list_ray_actors()
+    finally:
+        sys.modules.pop("ray.util.state", None)
+
+    assert {a["name"] for a in result} == {"Indexer", "WhisperPool"}
+    assert all(a["namespace"] == "openrag" for a in result)
 
 
 def test_ensure_worker_bootstrap_initializes_explicitly() -> None:

--- a/tests/unit/di/test_workers.py
+++ b/tests/unit/di/test_workers.py
@@ -29,8 +29,9 @@ def test_list_ray_actors_filters_out_non_openrag_namespace() -> None:
         _fake_actor("_ray_internal_job_actor_raysubmit_abc", "_ray_internal_job"),
         _fake_actor("SomethingElse", "default"),
     ]
+    list_actors_mock = Mock(return_value=actors)
     module = ModuleType("ray.util.state")
-    module.list_actors = Mock(return_value=actors)
+    module.list_actors = list_actors_mock
     previous_module = sys.modules.get("ray.util.state")
     sys.modules["ray.util.state"] = module
 
@@ -42,6 +43,11 @@ def test_list_ray_actors_filters_out_non_openrag_namespace() -> None:
         else:
             sys.modules["ray.util.state"] = previous_module
 
+    # Namespace is filtered server-side so Ray's default limit=100 applies within
+    # the openrag namespace rather than across all namespaces.
+    list_actors_mock.assert_called_once_with(filters=[("ray_namespace", "=", "openrag")])
+    # Defense-in-depth: even if the mock ignores the filter, non-openrag actors
+    # are dropped by the in-comprehension guard.
     assert {a["name"] for a in result} == {"Indexer", "WhisperPool"}
     assert all(a["namespace"] == "openrag" for a in result)
 

--- a/tests/unit/di/test_workers.py
+++ b/tests/unit/di/test_workers.py
@@ -56,13 +56,17 @@ def test_ensure_worker_bootstrap_initializes_explicitly() -> None:
     """Startup calls the worker bootstrap function instead of relying on import side effects."""
     module = ModuleType("services.workers.bootstrap")
     module.initialize_worker_bootstrap = Mock()
+    previous_module = sys.modules.get("services.workers.bootstrap")
     sys.modules["services.workers.bootstrap"] = module
     settings = Settings()
 
     try:
         ensure_worker_bootstrap(settings)
     finally:
-        sys.modules.pop("services.workers.bootstrap", None)
+        if previous_module is None:
+            sys.modules.pop("services.workers.bootstrap", None)
+        else:
+            sys.modules["services.workers.bootstrap"] = previous_module
 
     module.initialize_worker_bootstrap.assert_called_once_with(settings)
 

--- a/tests/unit/di/test_workers.py
+++ b/tests/unit/di/test_workers.py
@@ -31,12 +31,16 @@ def test_list_ray_actors_filters_out_non_openrag_namespace() -> None:
     ]
     module = ModuleType("ray.util.state")
     module.list_actors = Mock(return_value=actors)
+    previous_module = sys.modules.get("ray.util.state")
     sys.modules["ray.util.state"] = module
 
     try:
         result = list_ray_actors()
     finally:
-        sys.modules.pop("ray.util.state", None)
+        if previous_module is None:
+            sys.modules.pop("ray.util.state", None)
+        else:
+            sys.modules["ray.util.state"] = previous_module
 
     assert {a["name"] for a in result} == {"Indexer", "WhisperPool"}
     assert all(a["namespace"] == "openrag" for a in result)


### PR DESCRIPTION
## What

The admin "System" view listed Ray-internal job actors (`_ray_internal_job_actor_raysubmit_*`) alongside OpenRag's own actors. These appear dead/red once their job finishes, and clicking restart failed with `404 Unknown actor`.

Fixes #510.

## Root cause

`list_ray_actors()` (`openrag/di/workers.py`) called `ray.util.state.list_actors()` with no filtering, returning actors from every namespace. Restart only works for OpenRag-managed actors (recreated via their `actor_creation_map` factory); internal actors are owned by Ray and have no factory, so restart is impossible by construction → `KeyError` → 404. Their dead state is also normal (completed job), not a fault.

## Fix

Filter `list_ray_actors()` to the `openrag` namespace, where all managed actors are created (`services/workers/bootstrap.py`). Internal/other-namespace actors no longer appear, so the system view only shows actors OpenRag can actually supervise and restart. Factored the namespace into a shared `OPENRAG_NAMESPACE` constant (also used by the existing restart path).

## Test

Adds `test_list_ray_actors_filters_out_non_openrag_namespace`: internal/other-namespace actors excluded, `openrag` actors retained. di/workers suite: 3 passed, ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized Ray namespace configuration for OpenRag-managed actors
  * Admin view now displays only OpenRag actors, filtering out Ray internal actors

* **Tests**
  * Expanded test coverage for actor namespace filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->