### PR TITLE
feat(partitions): scope chunk listing to a single file (fix O(partition) detail view)

### DIFF
--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -20,7 +20,7 @@ from api.dependencies.auth import (
 from api.schemas.admin.partition_schemas import PartitionDetailResponse, UpdatePartitionRequest
 from core.utils.logging import get_logger
 from di.providers import get_partition_service
-from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 
 logger = get_logger()
@@ -166,7 +166,7 @@ async def get_file(
     request: Request,
     partition: str,
     file_id: str,
-    limit: int = 2000,
+    limit: int = Query(default=2000, ge=0),
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_partition_service),
 ):
@@ -215,7 +215,7 @@ async def list_all_chunks(
     partition: str,
     include_embedding: bool = True,
     file_id: str | None = None,
-    limit: int | None = None,
+    limit: int | None = Query(default=None, ge=0),
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_partition_service),
 ):

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -188,11 +188,14 @@ async def get_file(
 
 @router.get(
     "/{partition}/chunks",
-    description="""List all document chunks in a partition.
+    description="""List document chunks in a partition.
 
 **Parameters:**
 - `partition`: The partition name
 - `include_embedding`: Include vector embeddings in response (default: true)
+- `file_id`: Restrict to a single file's chunks (filtered server-side; recommended
+  for the document detail view to avoid loading the whole partition)
+- `limit`: Maximum number of chunks to return (default: unbounded)
 
 **Response:**
 Returns all chunks with:
@@ -211,11 +214,18 @@ async def list_all_chunks(
     request: Request,
     partition: str,
     include_embedding: bool = True,
+    file_id: str | None = None,
+    limit: int | None = None,
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_partition_service),
 ):
-    """List all chunks in a partition."""
-    items = await service.list_all_chunks(partition=partition, include_embedding=include_embedding)
+    """List chunks in a partition, optionally scoped to a single file."""
+    items = await service.list_all_chunks(
+        partition=partition,
+        include_embedding=include_embedding,
+        file_id=file_id,
+        limit=limit,
+    )
     chunks = [
         {
             "link": str(request.url_for("get_extract", extract_id=it["metadata"]["_id"])),

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -51,6 +51,16 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
+def _validate_limit(limit: int | None) -> None:
+    """Reject negative ``limit`` values before they reach ``rows[:limit]``.
+
+    A negative bound would silently drop tail rows (e.g. ``-1`` returns all but
+    the last chunk) instead of capping the result, so treat it as a 422.
+    """
+    if limit is not None and limit < 0:
+        raise ValidationError("`limit` must be greater than or equal to 0.", code="INVALID_LIMIT")
+
+
 class PartitionService:
     """Partition lifecycle, membership and read-through orchestration."""
 
@@ -341,6 +351,7 @@ class PartitionService:
         The router builds the extract links and strips ``_id`` from the
         surfaced metadata, exactly as before.
         """
+        _validate_limit(limit)
         if not await self.file_exists(file_id, partition):
             raise NotFoundError(
                 f"'{file_id}' not found in partition '{partition}'",
@@ -369,6 +380,7 @@ class PartitionService:
         O(partition). ``limit`` caps the number of chunks returned (a defensive
         bound for pathologically large files).
         """
+        _validate_limit(limit)
         await self._ensure_partition(partition)
         excluded = {"text"} if include_embedding else {"text", "vector"}
         output_fields = ["*", "vector"] if include_embedding else ["*"]

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -355,16 +355,33 @@ class PartitionService:
             rows = rows[:limit]
         return [{k: v for k, v in row.items() if k != "text"} for row in rows]
 
-    async def list_all_chunks(self, partition: str, include_embedding: bool = True) -> list[dict]:
-        """Return ``{"content", "metadata"}`` dicts for every chunk."""
+    async def list_all_chunks(
+        self,
+        partition: str,
+        include_embedding: bool = True,
+        file_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """Return ``{"content", "metadata"}`` dicts for chunks in a partition.
+
+        ``file_id`` scopes the query to a single file, pushing the filter down
+        to the vector store so the document detail view costs O(file) instead of
+        O(partition). ``limit`` caps the number of chunks returned (a defensive
+        bound for pathologically large files).
+        """
         await self._ensure_partition(partition)
         excluded = {"text"} if include_embedding else {"text", "vector"}
         output_fields = ["*", "vector"] if include_embedding else ["*"]
+        filters: dict[str, Any] = {"partition": partition}
+        if file_id is not None:
+            filters["file_id"] = file_id
         rows = await self._vector_store.query_chunks_by_filter(
             self._collection,
-            {"partition": partition},
+            filters,
             output_fields=output_fields,
         )
+        if limit is not None and len(rows) > limit:
+            rows = rows[:limit]
 
         def _meta(row: dict[str, Any]) -> dict[str, Any]:
             meta: dict[str, Any] = {}

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -79,6 +79,7 @@ class FakeVectorStore:
         self._ids = ids or []
         self._rows = rows or []
         self.deleted_ids: list[str] = []
+        self.last_chunk_filters: dict | None = None
 
     async def query_ids_by_filter(self, collection, filters):
         return list(self._ids)
@@ -88,6 +89,7 @@ class FakeVectorStore:
         return len(ids)
 
     async def query_chunks_by_filter(self, collection, filters, output_fields=None):
+        self.last_chunk_filters = dict(filters)
         return list(self._rows)
 
 
@@ -262,6 +264,31 @@ async def test_list_all_chunks_stringifies_vector_when_included():
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     out = await svc.list_all_chunks("p", include_embedding=True)
     assert isinstance(out[0]["metadata"]["vector"], str)
+
+
+@pytest.mark.asyncio
+async def test_list_all_chunks_without_file_id_filters_partition_only():
+    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1"}])
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=vstore)
+    await svc.list_all_chunks("p", include_embedding=False)
+    assert vstore.last_chunk_filters == {"partition": "p"}
+
+
+@pytest.mark.asyncio
+async def test_list_all_chunks_scopes_to_file_id_when_given():
+    """file_id is pushed down to the vector store so the detail view is O(file)."""
+    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1"}])
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=vstore)
+    await svc.list_all_chunks("p", include_embedding=False, file_id="f-123")
+    assert vstore.last_chunk_filters == {"partition": "p", "file_id": "f-123"}
+
+
+@pytest.mark.asyncio
+async def test_list_all_chunks_applies_limit():
+    rows = [{"text": str(i), "_id": str(i)} for i in range(5)]
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
+    out = await svc.list_all_chunks("p", include_embedding=False, limit=2)
+    assert len(out) == 2
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -291,6 +291,27 @@ async def test_list_all_chunks_applies_limit():
     assert len(out) == 2
 
 
+@pytest.mark.asyncio
+async def test_list_all_chunks_rejects_negative_limit():
+    rows = [{"text": str(i), "_id": str(i)} for i in range(5)]
+    svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
+    with pytest.raises(ValidationError) as ei:
+        await svc.list_all_chunks("p", include_embedding=False, limit=-1)
+    assert ei.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_file_chunks_rejects_negative_limit():
+    rows = [{"_id": str(i), "text": "body"} for i in range(5)]
+    svc = _svc(
+        drepo=FakeDocumentRepo(files={("f", "p")}),
+        vstore=FakeVectorStore(rows=rows),
+    )
+    with pytest.raises(ValidationError) as ei:
+        await svc.get_file_chunks("p", "f", limit=-1)
+    assert ei.value.status_code == 422
+
+
 # --------------------------------------------------------------------------- #
 # membership
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Adds an optional `file_id` (and `limit`) parameter to `GET /partition/{p}/chunks` so the document detail view can fetch a single file's chunks with content in one bounded, server-filtered call.

Fixes #514.

## Why

The detail view's chunk loading was O(partition): the only content-returning chunk endpoint was partition-wide, and the UI filtered client-side by `file_id` — so opening one document downloaded every chunk's text in the partition (the endpoint even warns about large payloads). This is the "Loading file…" lag that grows with partition size.

## Change

- `PartitionService.list_all_chunks(partition, include_embedding=True, file_id=None, limit=None)` — when `file_id` is set it's added to the vector-store filter (`query_chunks_by_filter({partition, file_id})`), pushing the work down to Milvus; `limit` caps the result. No `file_id` → identical behavior to before.
- `GET /partition/{p}/chunks` exposes `file_id` and `limit` query params (passthrough). Permissions unchanged (partition viewer+).

The data path already existed (`get_file_chunks` filters by `file_id` server-side but drops `text`); this exposes it on the content endpoint.

## Test

Adds service tests: partition-only filter when no `file_id`, `{partition, file_id}` filter when given, and `limit` capping. Suite: 23 passed, ruff clean.

## Frontend follow-up

Separate change on the UI branch: `listFileChunks` switches to `…/chunks?file_id=<id>&include_embedding=false` and drops the client-side filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin chunk listings now support optional filtering by file ID to scope results to a single file.
  * Optional `limit` is available to cap returned chunks for improved performance on large partitions.

* **Bug Fixes**
  * Negative `limit` values are now rejected for both chunk listing and file chunk retrieval.

* **Tests**
  * Added unit tests covering file ID filter pushdown, output limiting, and validation behavior for negative limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->