### PR TITLE
perf(caption): concurrent image captioning under the VLM semaphore

### DIFF
--- a/openrag/services/workers/stages/caption.py
+++ b/openrag/services/workers/stages/caption.py
@@ -61,18 +61,18 @@ async def _caption_document(
         async with get_vlm_semaphore():
             return await vlm.caption_image(image.image_bytes, prompt=prompt)
 
-    # One image failing propagates but leaves the other in-flight captions to drain
-    # (the VLM semaphore bounds them). Only a cancellation signal — task cancel on
-    # shutdown/reload — tears the siblings down, which tqdm.gather (built on
-    # as_completed) won't do on its own, so we cancel them explicitly.
+    # tqdm.gather is built on as_completed, so a failing child does not clean up
+    # sibling tasks for us. Drain them explicitly so failed documents do not keep
+    # using the shared VLM semaphore in the background.
     label = processed_document.metadata.get("filename") or processed_document.document_id
     tasks = [asyncio.ensure_future(caption_one(image)) for image in images]
     try:
         captions = await tqdm.gather(*tasks, desc=f"Captioning images of *{label}*")
     except asyncio.CancelledError:
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await _cancel_and_drain(tasks)
+        raise
+    except Exception:
+        await _cancel_and_drain(tasks)
         raise
 
     # Caption fetching fans out concurrently above; the text-block mutation
@@ -92,6 +92,13 @@ async def _caption_document(
             "images": captioned_images,
         }
     )
+
+
+async def _cancel_and_drain(tasks: list[asyncio.Task[str]]) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _replace_markdown_ref(text_blocks: list[TextBlock], image: ImageBlock, wrapped_caption: str) -> bool:

--- a/openrag/services/workers/stages/caption.py
+++ b/openrag/services/workers/stages/caption.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import MutableMapping
 from typing import Any
 
 from core.models.document import ImageBlock, ProcessedDocument, TextBlock
 from core.prompts.vlm_prompt_builder import wrap_caption
 from core.vlm.vlm import VLM
+from services.inference.runtime import get_vlm_semaphore
 from services.workers.stages._common import run_with_optional_timeout, scrub_credentials, stage_timeout
+from tqdm.asyncio import tqdm
 
 
 async def caption_stage(
@@ -49,14 +52,37 @@ async def _caption_document(
     prompt: str | None,
 ) -> ProcessedDocument:
     """Return a copy of ``processed_document`` with captions materialized."""
+    images = processed_document.images
+    if not images:
+        return processed_document
+
+    async def caption_one(image: ImageBlock) -> str:
+        # Bound the fan-out cluster-wide so every indexer actor shares one VLM budget.
+        async with get_vlm_semaphore():
+            return await vlm.caption_image(image.image_bytes, prompt=prompt)
+
+    # One image failing propagates but leaves the other in-flight captions to drain
+    # (the VLM semaphore bounds them). Only a cancellation signal — task cancel on
+    # shutdown/reload — tears the siblings down, which tqdm.gather (built on
+    # as_completed) won't do on its own, so we cancel them explicitly.
+    label = processed_document.metadata.get("filename") or processed_document.document_id
+    tasks = [asyncio.ensure_future(caption_one(image)) for image in images]
+    try:
+        captions = await tqdm.gather(*tasks, desc=f"Captioning images of *{label}*")
+    except asyncio.CancelledError:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+    # Caption fetching fans out concurrently above; the text-block mutation
+    # below stays sequential and in image order so the markdown-ref replacement
+    # and append ordering are deterministic.
     text_blocks = list(processed_document.text_blocks)
     captioned_images: list[ImageBlock] = []
-
-    for image in processed_document.images:
-        caption = await vlm.caption_image(image.image_bytes, prompt=prompt)
+    for image, caption in zip(images, captions, strict=True):
         wrapped = wrap_caption(caption)
-        captioned_image = image.model_copy(update={"caption": caption})
-        captioned_images.append(captioned_image)
+        captioned_images.append(image.model_copy(update={"caption": caption}))
         if not _replace_markdown_ref(text_blocks, image, wrapped):
             text_blocks.append(TextBlock(text=wrapped, page_number=image.page_number))
 

--- a/tests/unit/services/workers/stages/test_pipeline_stages.py
+++ b/tests/unit/services/workers/stages/test_pipeline_stages.py
@@ -208,6 +208,61 @@ async def test_caption_stage_captions_images_concurrently_and_in_order():
 
 
 @pytest.mark.asyncio
+async def test_caption_stage_cancels_sibling_captions_on_failure():
+    """Do not leave background VLM calls running after one caption fails."""
+
+    class FailingVLM(VLM):
+        def __init__(self) -> None:
+            self.started: set[bytes] = set()
+            self.cancelled: set[bytes] = set()
+            self.completed: set[bytes] = set()
+            self.all_started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+            self.started.add(image_bytes)
+            if len(self.started) == 3:
+                self.all_started.set()
+
+            if image_bytes == b"fail":
+                await self.all_started.wait()
+                raise RuntimeError("caption failed")
+
+            try:
+                await self.release.wait()
+            except asyncio.CancelledError:
+                self.cancelled.add(image_bytes)
+                raise
+            self.completed.add(image_bytes)
+            return image_bytes.decode()
+
+        async def caption_images_batch(self, images: list[bytes], prompt: str | None = None) -> list[str]:
+            return [await self.caption_image(image, prompt=prompt) for image in images]
+
+    processed = ProcessedDocument(
+        document_id="doc-1",
+        text_blocks=[TextBlock(text="body", page_number=1)],
+        images=[
+            ImageBlock(image_bytes=b"slow-1", page_number=1),
+            ImageBlock(image_bytes=b"fail", page_number=1),
+            ImageBlock(image_bytes=b"slow-2", page_number=1),
+        ],
+    )
+    row = {"processed_document": processed}
+    vlm = FailingVLM()
+
+    try:
+        with pytest.raises(RuntimeError, match="caption failed"):
+            await caption_stage(row, vlm)
+
+        assert vlm.cancelled == {b"slow-1", b"slow-2"}
+        assert vlm.completed == set()
+    finally:
+        vlm.release.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
 async def test_chunk_stage_mutates_row_and_scrubs_credentials():
     processed = ProcessedDocument(document_id="doc-1", text_blocks=[TextBlock(text="hello")])
     chunks = [Chunk(id="c1", text="hello", partition="p1")]

--- a/tests/unit/services/workers/stages/test_pipeline_stages.py
+++ b/tests/unit/services/workers/stages/test_pipeline_stages.py
@@ -1,4 +1,6 @@
+import asyncio
 import re
+from contextlib import asynccontextmanager
 
 import pytest
 from core.chunking.chunking_strategy import ChunkingStrategy
@@ -9,11 +11,23 @@ from core.models.document import ImageBlock, ProcessedDocument, TextBlock
 from core.prompts.vlm_prompt_builder import wrap_caption
 from core.vector_stores.vector_store import VectorStore
 from core.vlm.vlm import VLM
+from services.workers.stages import caption as caption_module
 from services.workers.stages.caption import caption_stage
 from services.workers.stages.chunk import chunk_stage
 from services.workers.stages.contextualize import contextualize_stage
 from services.workers.stages.embed import embed_stage
 from services.workers.stages.store import store_stage
+
+
+@pytest.fixture(autouse=True)
+def _noop_vlm_semaphore(monkeypatch):
+    """Stub the cluster-wide VLM semaphore so caption tests don't boot Ray."""
+
+    @asynccontextmanager
+    async def _noop():
+        yield
+
+    monkeypatch.setattr(caption_module, "get_vlm_semaphore", _noop)
 
 
 class FakeChunker(ChunkingStrategy):
@@ -146,6 +160,50 @@ async def test_caption_stage_appends_standalone_image_captions():
     await caption_stage(row, FakeVLM(["a diagram"]))
 
     assert row["processed_document"].text_blocks[-1] == TextBlock(text=wrap_caption("a diagram"), page_number=3)
+    assert row["stage"] == "captioned"
+
+
+@pytest.mark.asyncio
+async def test_caption_stage_captions_images_concurrently_and_in_order():
+    """Images fan out concurrently (bounded only by the VLM semaphore, stubbed
+    here), and each caption lands on its own image even though later images
+    finish their VLM call first."""
+
+    class TrackingVLM(VLM):
+        def __init__(self) -> None:
+            self.in_flight = 0
+            self.max_in_flight = 0
+
+        async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+            self.in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self.in_flight)
+            try:
+                # Earlier images sleep longer, so completion order is the
+                # reverse of submission order — a sequential loop would caption
+                # in submission order and never overlap.
+                idx = int(image_bytes.decode().rsplit("-", 1)[1])
+                await asyncio.sleep((3 - idx) * 0.01)
+                return f"caption:{image_bytes.decode()}"
+            finally:
+                self.in_flight -= 1
+
+        async def caption_images_batch(self, images: list[bytes], prompt: str | None = None) -> list[str]:
+            return [await self.caption_image(image, prompt=prompt) for image in images]
+
+    processed = ProcessedDocument(
+        document_id="doc-1",
+        text_blocks=[TextBlock(text="body", page_number=1)],
+        images=[ImageBlock(image_bytes=f"img-{i}".encode(), page_number=1) for i in range(3)],
+    )
+    row = {"processed_document": processed}
+    vlm = TrackingVLM()
+
+    await caption_stage(row, vlm)
+
+    out = row["processed_document"]
+    assert [img.caption for img in out.images] == ["caption:img-0", "caption:img-1", "caption:img-2"]
+    # All three VLM calls were in flight simultaneously: the fan-out is real.
+    assert vlm.max_in_flight == 3
     assert row["stage"] == "captioned"
 
 


### PR DESCRIPTION
## What

Replace the sequential per-image VLM loop in `caption_stage` with a **concurrent fan-out**, bounded by the cluster-wide VLM semaphore (`get_vlm_semaphore`) so parallelism is shared across every indexer actor — the same headroom the embedder already uses for its batched fan-out. This restores the concurrency the legacy `BaseLoader.caption_images` had before the hexagonal parser migration moved captioning into a dedicated stage.

## Behavior

- **Fan-out**: all images for a document are captioned concurrently; the cluster-wide semaphore (default `VLM_SEMAPHORE=10`) bounds total in-flight VLM calls across actors.
- **Deterministic assembly**: captions are zipped back in image order, so markdown-ref replacement and caption append ordering are unchanged from the sequential version.
- **Cancellation scoped to real cancel signals**: one image failing propagates the error but leaves the other in-flight captions to drain (semaphore-bounded). Only a `CancelledError` (task cancel on shutdown/reload) tears the siblings down — explicitly, because `tqdm.gather` runs on `as_completed`, which won't propagate cancellation to children on its own.
- Progress bar preserved (`tqdm.gather` with per-document `desc`).

## Tests

`test_caption_stage_captions_images_concurrently_and_in_order` asserts all three VLM calls are in flight simultaneously (`max_in_flight == 3`) and captions still land on the correct image even when completion order is the reverse of submission order. An autouse fixture stubs the cluster-wide semaphore so the unit tests don't boot Ray.

## Notes

Builds on the hexagonal pipeline-stage refactor; targets `refactor/hexagonal`. The semaphore infrastructure (`runtime.get_vlm_semaphore`, `DistributedSemaphore`, bootstrap init) already exists on the base branch — this PR only wires the caption stage to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in image captioning: when a caption operation fails, related tasks are now properly cancelled and cleaned up to prevent resource leaks.

* **Refactor**
  * Image captioning now runs concurrently with intelligent resource budgeting, improving performance while maintaining deterministic output order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->