### PR TITLE
fix(docker): pre-create Chainlit's .files/.chainlit dirs as group-writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,11 @@ ENV APP_iPORT=${APP_iPORT:-8080}
 # and uv's managed Python (/app/openrag, /app/conf, /opt/uv/python), stay
 # group-readable but NOT group-writable regardless of their source mode — the
 # arbitrary UID cannot create, rename, or replace entries in them.
+# The two exceptions under the otherwise read-only /app/openrag are Chainlit's
+# runtime-writable dirs: it creates ./.files at import time and writes
+# ./.chainlit/config.toml + translations on startup (WORKDIR is /app/openrag),
+# so both are pre-created and granted group-write below or the app crashes with
+# PermissionError: '/app/openrag/.files'.
 # We also bake a fixed non-root UID for plain Docker/Kubernetes, where the
 # arbitrary-UID remap does not happen; APP_UID is a build arg so a compose
 # build can match the host user that owns the bind-mounted volumes. The user's
@@ -85,10 +90,12 @@ RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
         --home-dir /app/home --shell /sbin/nologin openrag \
     && mkdir -p /app/home /app/data /app/db /app/logs /app/model_weights/hub \
         /app/.venv /app/openrag.egg-info /opt/uv/cache \
+        /app/openrag/.files /app/openrag/.chainlit \
     && chgrp -R 0 /app /opt/uv \
     && chmod -R g-w /app /opt/uv \
     && chmod -R g=u /app/home /app/data /app/db /app/logs /app/model_weights \
-        /app/.venv /app/openrag.egg-info /opt/uv/cache
+        /app/.venv /app/openrag.egg-info /opt/uv/cache \
+        /app/openrag/.files /app/openrag/.chainlit
 USER ${APP_UID}
 
 ENTRYPOINT ../entrypoint.sh


### PR DESCRIPTION
## Problem

The `openrag` container crashes on startup with:

```
PermissionError: [Errno 13] Permission denied: '/app/openrag/.files'
```

The path comes from **Chainlit**, not OpenRAG code. Chainlit's `config.py` runs at import time:

```python
APP_ROOT = os.getenv("CHAINLIT_APP_ROOT", os.getcwd())   # = /app/openrag (the WORKDIR)
FILES_DIRECTORY = Path(APP_ROOT) / ".files"
FILES_DIRECTORY.mkdir(exist_ok=True)                      # ← EACCES
```

and `init_config()` later writes `./.chainlit/config.toml` + translations on startup.

The `Dockerfile` intentionally strips group-write from the whole `/app` tree and grants it back only on the runtime-writable paths (for the OpenShift arbitrary-UID / GID-0 model). `/app/openrag` is deliberately left read-only, so Chainlit can't create `.files`/`.chainlit` there.

## Fix

Pre-create `/app/openrag/.files` and `/app/openrag/.chainlit` and add them to the same `mkdir` + `chmod g=u` block that handles the other writable paths. Chainlit's `mkdir(exist_ok=True)` then becomes a no-op and its writes land in a GID-0-writable dir — works for both the baked `APP_UID` and an arbitrary OpenShift UID.

`Dockerfile.ray` is unaffected (it `chown -R`'s all of `/app` to the runtime user, so `/app/openrag` is already writable there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission errors that prevented the application from writing required configuration files in containerized environments. The application now correctly initializes with proper directory write permissions on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->