### PR TITLE
feat(presets): expose parsing strategies via /presets/options

### DIFF
--- a/openrag/api/routers/admin/presets.py
+++ b/openrag/api/routers/admin/presets.py
@@ -1,5 +1,7 @@
 """Admin routes for the Phase 14 pipeline preset registry."""
 
+from typing import get_args
+
 from api.dependencies.auth import require_admin
 from api.schemas.admin.preset_schemas import (
     CreatePresetRequest,
@@ -9,6 +11,7 @@ from api.schemas.admin.preset_schemas import (
     UpdatePresetRequest,
 )
 from core.chunking import chunking_registry
+from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.rerankers.registry import reranker_registry
 from core.retrieval import retriever_registry
 from di.providers import get_preset_service
@@ -17,6 +20,10 @@ from fastapi import APIRouter, Depends, Response, status
 router = APIRouter(dependencies=[Depends(require_admin)])
 
 _DEFAULT_RERANKER_PROVIDERS = ["infinity", "openai"]
+
+# Derived from the validated Literal so the exposed options can never drift from
+# what IndexationPipelineConfig actually accepts.
+_PARSING_STRATEGIES = list(get_args(IndexationPipelineConfig.model_fields["parsing_strategy"].annotation))
 
 
 def _registered_or_default(registered: list[str], defaults: list[str]) -> list[str]:
@@ -29,6 +36,7 @@ async def get_preset_options():
     """Return available preset strategy choices."""
     return PresetOptionsResponse(
         chunking_strategies=chunking_registry.list_registered(),
+        parsing_strategies=_PARSING_STRATEGIES,
         retrieval_types=retriever_registry.list_registered(),
         reranker_providers=_registered_or_default(
             reranker_registry.list_registered(),

--- a/openrag/api/schemas/admin/preset_schemas.py
+++ b/openrag/api/schemas/admin/preset_schemas.py
@@ -83,6 +83,7 @@ class PresetOptionsResponse(BaseModel):
     """Response body listing allowed preset option values."""
 
     chunking_strategies: list[str]
+    parsing_strategies: list[str]
     retrieval_types: list[str]
     reranker_providers: list[str]
 

--- a/tests/integration/api/test_presets.py
+++ b/tests/integration/api/test_presets.py
@@ -61,6 +61,8 @@ def test_preset_options_crud_and_rename(api_client):
         option_data = options.json()
         assert "recursive_splitter" in option_data["chunking_strategies"]
         assert "single" in option_data["retrieval_types"]
+        # Parsing strategies are derived from IndexationPipelineConfig's Literal.
+        assert set(option_data["parsing_strategies"]) == {"pymupdf", "marker", "docling"}
 
         create_indexation = api_client.post(
             "/presets/",


### PR DESCRIPTION
## What

Exposes `parsing_strategies` on `GET /presets/options` so the admin preset editor can drive its parsing-strategy dropdown from the backend instead of a hardcoded list.

Closes #518.

## Why

The UI hardcoded `marker` + `pymupdf` and had drifted from `IndexationPipelineConfig.parsing_strategy = Literal["pymupdf", "marker", "docling"]` — `docling` was missing. Chunking/retrieval/reranker options already come from this endpoint; parsing didn't.

## Change

- `PresetOptionsResponse` gains `parsing_strategies: list[str]`.
- The `/options` handler populates it from `get_args(IndexationPipelineConfig.model_fields["parsing_strategy"].annotation)` — derived from the validated `Literal`, so the option list can never drift from what the config accepts.

## Test

`test_preset_options_crud_and_rename` now asserts `parsing_strategies == {pymupdf, marker, docling}`. Ruff clean; response model verified to build with the derived list.

## Follow-up

Frontend switch (read `parsing_strategies` from options instead of the hardcoded `<SelectItem>`s) lands separately on the admin-UI branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The preset options endpoint now exposes available parsing strategies (pymupdf, marker, and docling) in its response.

* **Tests**
  * Updated integration tests to validate parsing strategies in the preset options endpoint response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->