### PR TITLE
fix(quota): honor per-user file quota when global default is unlimited

### DIFF
--- a/openrag/api/dependencies/auth.py
+++ b/openrag/api/dependencies/auth.py
@@ -239,11 +239,9 @@ async def check_user_file_quota(
     default_file_quota = config.rdb.default_file_quota
     if user.get("is_admin", False):
         return user
-    # A per-user quota takes precedence; the global default is only the
-    # fallback for users with no override (resolved in validate_file_quota).
-    # An explicit per-user ``< 0`` means unlimited.
     user_quota = user.get("file_quota")
-    if user_quota is not None and user_quota < 0:
+    effective_quota = default_file_quota if user_quota is None else user_quota
+    if effective_quota < 0:
         return user
 
     user_id = user.get("id")

--- a/openrag/api/dependencies/auth.py
+++ b/openrag/api/dependencies/auth.py
@@ -239,8 +239,9 @@ async def check_user_file_quota(
     default_file_quota = config.rdb.default_file_quota
     if user.get("is_admin", False):
         return user
-    if default_file_quota < 0:
-        return user
+    # A per-user quota takes precedence; the global default is only the
+    # fallback for users with no override (resolved in validate_file_quota).
+    # An explicit per-user ``< 0`` means unlimited.
     user_quota = user.get("file_quota")
     if user_quota is not None and user_quota < 0:
         return user

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -491,13 +491,13 @@ class AuthService:
     ) -> None:
         """Pure quota check (the pending-task count is supplied by the caller).
 
-        Quota semantics are unchanged from ``check_user_file_quota``:
-        admins bypass; ``default_quota < 0`` disables; ``file_quota`` of
-        ``None`` falls back to the default; ``< 0`` means unlimited.
+        Quota semantics (shared with ``check_user_file_quota``): admins
+        bypass; a per-user ``file_quota`` of ``None`` falls back to the
+        global default; a *resolved* quota ``< 0`` means unlimited. So a
+        negative global default only disables quotas for users without a
+        per-user override — an explicit per-user limit is always honored.
         """
         if cls._uget(user, "is_admin", False):
-            return
-        if default_quota < 0:
             return
 
         user_quota = cls._uget(user, "file_quota")

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -124,19 +124,20 @@ class UserService:
 
         ``user`` is the request-state dict the auth middleware set (no DB
         fetch — identical to the legacy ``/users/info`` handler). Quota
-        rule, byte-for-byte: admins and a negative global default mean
-        unlimited; a ``None`` per-user quota falls back to the global
-        default; a negative per-user quota means unlimited. ``file_quota``
-        is surfaced as ``-1`` when unlimited.
+        rule: admins are unlimited; a per-user quota of ``None`` falls back
+        to the global default; a resolved quota ``< 0`` means unlimited (so
+        a negative *global default* only makes users unlimited when they
+        have no per-user override). ``file_quota`` is surfaced as ``-1``
+        when unlimited.
         """
         is_admin = user.get("is_admin", False)
-        if is_admin or self._default_file_quota < 0:
+        if is_admin:
             user_quota: float | int = float("inf")
         else:
             user_quota = user.get("file_quota", None)
             if user_quota is None:
                 user_quota = self._default_file_quota
-            elif user_quota < 0:
+            if user_quota < 0:
                 user_quota = float("inf")
 
         file_count = user.get("file_count", 0)

--- a/tests/unit/api/dependencies/test_auth.py
+++ b/tests/unit/api/dependencies/test_auth.py
@@ -175,6 +175,7 @@ async def test_check_user_file_quota_reads_pending_count_through_job_service():
 
 @pytest.mark.asyncio
 async def test_check_user_file_quota_skips_pending_count_when_default_is_unlimited():
+    """Skip queue I/O when the resolved quota is unlimited."""
     job_service = FakeJobService(pending_count=2)
 
     user = await check_user_file_quota(

--- a/tests/unit/api/dependencies/test_auth.py
+++ b/tests/unit/api/dependencies/test_auth.py
@@ -174,6 +174,21 @@ async def test_check_user_file_quota_reads_pending_count_through_job_service():
 
 
 @pytest.mark.asyncio
+async def test_check_user_file_quota_skips_pending_count_when_default_is_unlimited():
+    job_service = FakeJobService(pending_count=2)
+
+    user = await check_user_file_quota(
+        user={"id": 7, "file_count": 1, "file_quota": None},
+        auth_service=FakeAuthService,
+        job_service=job_service,
+        config=_config(default_file_quota=-1),
+    )
+
+    assert user["id"] == 7
+    assert job_service.pending_checks == []
+
+
+@pytest.mark.asyncio
 async def test_check_user_file_quota_default_zero_enforces_zero():
     allowed_job_service = FakeJobService(pending_count=0)
     user = await check_user_file_quota(

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 from core.config.auth import OIDCConfig
 from core.models.user import PartitionRole, User, UserPartition
+from core.utils.exceptions import OpenRAGError
 from cryptography.fernet import Fernet
 from services.auth import StateCookieSerializer, hash_session_token
 from services.auth.oidc_client import LogoutTokenClaims, TokenBundle
@@ -508,15 +509,17 @@ def test_validate_file_quota():
     # Disabled globally.
     AuthService.validate_file_quota({"file_count": 50}, pending_task_count=50, default_quota=-1)
     # Specific limit exceeded (3 indexed + 2 pending >= 5).
-    with pytest.raises(Exception):
+    with pytest.raises(OpenRAGError) as ei:
         AuthService.validate_file_quota({"file_count": 3, "file_quota": 5}, pending_task_count=2, default_quota=10)
+    assert ei.value.code == "FILE_QUOTA_EXCEEDED"
     # Under the limit is fine.
     AuthService.validate_file_quota({"file_count": 1, "file_quota": 5}, pending_task_count=1, default_quota=10)
     # Regression: a per-user limit is enforced even when the global default
     # is unlimited (-1). The negative default used to short-circuit to
     # "unlimited" and ignore the per-user quota entirely.
-    with pytest.raises(Exception):
+    with pytest.raises(OpenRAGError) as ei:
         AuthService.validate_file_quota({"file_count": 10, "file_quota": 10}, pending_task_count=0, default_quota=-1)
+    assert ei.value.code == "FILE_QUOTA_EXCEEDED"
     # ...but a user with no per-user quota still inherits the unlimited default.
     AuthService.validate_file_quota({"file_count": 999}, pending_task_count=0, default_quota=-1)
 

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -512,6 +512,13 @@ def test_validate_file_quota():
         AuthService.validate_file_quota({"file_count": 3, "file_quota": 5}, pending_task_count=2, default_quota=10)
     # Under the limit is fine.
     AuthService.validate_file_quota({"file_count": 1, "file_quota": 5}, pending_task_count=1, default_quota=10)
+    # Regression: a per-user limit is enforced even when the global default
+    # is unlimited (-1). The negative default used to short-circuit to
+    # "unlimited" and ignore the per-user quota entirely.
+    with pytest.raises(Exception):
+        AuthService.validate_file_quota({"file_count": 10, "file_quota": 10}, pending_task_count=0, default_quota=-1)
+    # ...but a user with no per-user quota still inherits the unlimited default.
+    AuthService.validate_file_quota({"file_count": 999}, pending_task_count=0, default_quota=-1)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_user_service.py
+++ b/tests/unit/services/orchestrators/test_user_service.py
@@ -294,6 +294,7 @@ async def test_current_user_info_none_quota_falls_back_to_default():
 
 @pytest.mark.asyncio
 async def test_current_user_info_per_user_quota_overrides_negative_default():
+    """Expose an explicit per-user quota even when the default is unlimited."""
     # Regression: an explicit per-user quota is surfaced even when the global
     # default is unlimited (-1). This previously returned -1 (unlimited),
     # silently ignoring the admin-set limit.
@@ -304,6 +305,7 @@ async def test_current_user_info_per_user_quota_overrides_negative_default():
 
 @pytest.mark.asyncio
 async def test_current_user_info_negative_default_unlimited_without_override():
+    """Keep the global unlimited default for users without an override."""
     # No per-user quota → inherits the unlimited global default.
     svc = _svc(FakeUserRepo(), default_quota=-1, job_service=FakeJobService())
     out = await svc.get_current_user_info({"id": 2, "is_admin": False, "file_count": 0})

--- a/tests/unit/services/orchestrators/test_user_service.py
+++ b/tests/unit/services/orchestrators/test_user_service.py
@@ -293,7 +293,18 @@ async def test_current_user_info_none_quota_falls_back_to_default():
 
 
 @pytest.mark.asyncio
-async def test_current_user_info_negative_default_is_unlimited():
+async def test_current_user_info_per_user_quota_overrides_negative_default():
+    # Regression: an explicit per-user quota is surfaced even when the global
+    # default is unlimited (-1). This previously returned -1 (unlimited),
+    # silently ignoring the admin-set limit.
     svc = _svc(FakeUserRepo(), default_quota=-1, job_service=FakeJobService())
     out = await svc.get_current_user_info({"id": 2, "is_admin": False, "file_quota": 3, "file_count": 0})
+    assert out["file_quota"] == 3
+
+
+@pytest.mark.asyncio
+async def test_current_user_info_negative_default_unlimited_without_override():
+    # No per-user quota → inherits the unlimited global default.
+    svc = _svc(FakeUserRepo(), default_quota=-1, job_service=FakeJobService())
+    out = await svc.get_current_user_info({"id": 2, "is_admin": False, "file_count": 0})
     assert out["file_quota"] == -1


### PR DESCRIPTION
## Problem
With `DEFAULT_FILE_QUOTA` negative (the default, `-1` = unlimited), an admin-set per-user `file_quota` was **silently ignored** — the user showed as "Unlimited" and uploads were never blocked. Verified on a live stack: a user with `file_quota=200` and 200 indexed files was still allowed to upload.

## Cause
All three quota code paths short-circuited to "unlimited" on `default < 0` **before** reading the per-user `file_quota`:
- `user_service.get_current_user_info` (the `/users/info` display)
- `dependencies/auth.check_user_file_quota` (the upload gate)
- `auth_service.validate_file_quota` (the pure check)

The per-user value was only consulted in the branch *after* that early return, which never ran.

## Fix
Drop the early `default < 0` return at each site. The existing `None → default`, then `< 0 → unlimited` resolution already handles every case correctly:
- per-user `None` + default `-1` → still unlimited (default users unchanged)
- per-user `100` + default `-1` → **now enforced** (the bug)
- per-user `-1` → unlimited · admin → bypass

The only behaviour that changes is the broken case; default-everyone-unlimited deployments are unaffected.

## Tests
- New `validate_file_quota` regression (per-user limit enforced even when global default is unlimited; a user with no per-user quota still inherits the unlimited default).
- Corrected `test_current_user_info_negative_default_is_unlimited`, which had **codified the bug** (asserted a per-user quota of 3 resolved to -1) — split into per-user-override-honored and no-override-unlimited cases.

Verified live (in-container): `200/200 @ default -1` now raises; `5/200` and no-override+default-1 do not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed file quota enforcement so per-user `file_quota` limits are correctly applied even when the global default quota is set to unlimited.
  * Refined unlimited quota behavior so negative quota values act as “unlimited” only after applying per-user overrides, while admins remain unlimited.
  * Improved quota checks to avoid unnecessary pending-task counting when the user effectively has unlimited quota.
* **Tests**
  * Expanded unit tests to cover per-user quota override scenarios and the new pending-count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->