### PR TITLE
fix(postgres): support managed database provisioning

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -63,13 +63,26 @@ vectordb:
   schema_version: 1 # Increment when the collection schema changes and a migration is required
 
 # --- Relational Database (PostgreSQL) ---
-# Env: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, DEFAULT_FILE_QUOTA
+# Env: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD,
+#      POSTGRES_DATABASE, POSTGRES_AUTO_CREATE_DB, POSTGRES_RUN_MIGRATIONS,
+#      DEFAULT_FILE_QUOTA, POSTGRES_POOL_MIN_SIZE, POSTGRES_POOL_MAX_SIZE,
+#      POSTGRES_COMMAND_TIMEOUT
 rdb:
   host: rdb
   port: 5432
   user: root
   password: "root_password"
   default_file_quota: -1
+  # Leave unset to derive partitions_for_collection_<VDB_COLLECTION_NAME>.
+  database: null
+  # Compose/dev convenience. Managed Postgres deployments should pre-create
+  # the database and set POSTGRES_AUTO_CREATE_DB=false.
+  auto_create_database: true
+  # Disable in the app when migrations run as a separate Job/init step.
+  run_migrations: true
+  pool_min_size: 5
+  pool_max_size: 20
+  command_timeout: 30
 
 # --- Reranker ---
 # Env: RERANKER_PROVIDER, RERANKER_ENABLED, RERANKER_MODEL, RERANKER_TOP_K, RERANKER_BASE_URL, RERANKER_API_KEY, RERANKER_TIMEOUT, RERANKER_SEMAPHORE

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -194,6 +194,12 @@ The PostgreSQL database is configured using the following environment variables:
 | `POSTGRES_PORT` | int | 5432 | Port on which the PostgreSQL database listens |
 | `POSTGRES_USER` | str | root | Username for database authentication |
 | `POSTGRES_PASSWORD` | str | root_password | Password for database authentication |
+| `POSTGRES_DATABASE` | str | `partitions_for_collection_<VDB_COLLECTION_NAME>` | Database used for OpenRAG relational metadata. If unset, OpenRAG derives the historical name from the vector collection. |
+| `POSTGRES_AUTO_CREATE_DB` | bool | true | Creates the database automatically when it is missing. Keep this for local compose; set it to `false` for managed Postgres where the app role has no `CREATEDB`. |
+| `POSTGRES_RUN_MIGRATIONS` | bool | true | Runs Alembic migrations during app startup. Set it to `false` when migrations are applied by a deployment Job or init step. |
+| `POSTGRES_POOL_MIN_SIZE` | int | 5 | Minimum size of the async PostgreSQL connection pool. |
+| `POSTGRES_POOL_MAX_SIZE` | int | 20 | Maximum size of the async PostgreSQL connection pool. |
+| `POSTGRES_COMMAND_TIMEOUT` | int | 30 | Timeout in seconds for PostgreSQL commands issued through the async pool. |
 
 ## Chat Pipeline
 ### LLM & VLM Configuration

--- a/docs/content/docs/documentation/kubernetes.md
+++ b/docs/content/docs/documentation/kubernetes.md
@@ -63,4 +63,6 @@ Pre-create the database before installing the release. If `POSTGRES_DATABASE` is
 
 In `values.yaml`, disable the bundled PostgreSQL chart, set `postgresProvisioning.autoCreateDatabase` to `false`, set `postgresProvisioning.runMigrationsInApp` to `false`, and enable `postgresProvisioning.migrationJob`. Then provide the managed database connection through `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_DATABASE`.
 
-With this setup, Helm runs the migration Job before install and upgrade. The OpenRAG API then starts against an already-created and already-migrated database.
+The migration Job (`templates/postgres-migration-job.yaml`) is a Helm hook, annotated with `helm.sh/hook: pre-install,pre-upgrade`. You never invoke it directly: Helm runs it automatically as part of each `helm install` and `helm upgrade`, before it creates or updates the OpenRAG Deployment, and waits for it to finish. It applies the Alembic migrations against the pre-created database (it migrates the schema but does not create the database). The OpenRAG API then starts against an already-migrated schema.
+
+When `postgresProvisioning.migrationJob` is disabled (the default), the Job is not rendered at all and the application runs migrations itself at startup instead.

--- a/docs/content/docs/documentation/kubernetes.md
+++ b/docs/content/docs/documentation/kubernetes.md
@@ -28,6 +28,7 @@ This guide explains how to deploy the **OpenRAG** stack on a Kubernetes cluster 
 
    - Edit the `env.config` and `env.secrets` sections in your `values.yaml`.
    - Secrets (API keys, tokens, Hugging Face credentials, etc.) will be mounted into the cluster as Kubernetes secrets.
+   - For managed PostgreSQL, point the `POSTGRES_*` values at the external database and disable database auto-creation.
 
 3. **Install or upgrade the release from GHCR**:
 
@@ -54,3 +55,12 @@ This guide explains how to deploy the **OpenRAG** stack on a Kubernetes cluster 
 
 - Ensure your GPU nodes have the correct NVIDIA drivers and `nvidia` `RuntimeClass` configured.
 
+## Managed PostgreSQL
+
+The chart can run against a database that is provisioned outside OpenRAG, which is the recommended setup on OpenShift or cloud-managed PostgreSQL.
+
+Pre-create the database before installing the release. If `POSTGRES_DATABASE` is not set, OpenRAG uses `partitions_for_collection_<VDB_COLLECTION_NAME>`. The app role does not need `CREATEDB` or superuser rights; it needs to connect to that database and own, or be allowed to create objects in, the target schema.
+
+In `values.yaml`, disable the bundled PostgreSQL chart, set `postgresProvisioning.autoCreateDatabase` to `false`, set `postgresProvisioning.runMigrationsInApp` to `false`, and enable `postgresProvisioning.migrationJob`. Then provide the managed database connection through `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_DATABASE`.
+
+With this setup, Helm runs the migration Job before install and upgrade. The OpenRAG API then starts against an already-created and already-migrated database.

--- a/docs/content/docs/documentation/sql_migration.mdx
+++ b/docs/content/docs/documentation/sql_migration.mdx
@@ -44,6 +44,8 @@ It will create a new migration script in the `openrag/services/persistence/migra
 
 Once you've reviewed the generated migration script and confirmed it looks correct, apply it to your database.
 
+For managed PostgreSQL, apply migrations before starting the API and set `POSTGRES_RUN_MIGRATIONS=false` on the app deployment. This keeps the API role least-privileged and makes schema changes an explicit deployment step. OpenRAG also provides the module `services.persistence.migrations.run` for migration Jobs and init steps; it uses the normal OpenRAG database configuration but does not try to create the database.
+
 #### Option A: Docker (production)
 
 Rebuilds the image to ensure the migration runs against the exact code being deployed:

--- a/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
+++ b/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.postgresProvisioning.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openrag-stack.fullname" . }}-postgres-migration
+  labels:
+    {{- include "openrag-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": {{ .Values.postgresProvisioning.migrationJob.hookDeletePolicy | quote }}
+spec:
+  backoffLimit: {{ .Values.postgresProvisioning.migrationJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "openrag-stack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-migration
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: "{{ .Values.openrag.image.repository }}:{{ .Values.openrag.image.tag }}"
+          workingDir: /app/openrag
+          command:
+            - sh
+            - -c
+            - |
+              UV_PROJECT_ENVIRONMENT=/tmp/openrag-migration-venv \
+                uv run python -m services.persistence.migrations.run
+          envFrom:
+            - configMapRef:
+                name: rag-env
+            - secretRef:
+                name: rag-env-secrets
+          env:
+            - name: POSTGRES_AUTO_CREATE_DB
+              value: "false"
+            - name: POSTGRES_RUN_MIGRATIONS
+              value: "true"
+            - name: UV_CACHE_DIR
+              value: /tmp/uv-cache
+          volumeMounts:
+            - name: uv-cache
+              mountPath: /tmp/uv-cache
+      volumes:
+        - name: uv-cache
+          emptyDir: {}
+{{- end }}

--- a/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
+++ b/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
@@ -6,8 +6,9 @@ This is a Helm *hook*, not a regular chart resource. The
 automatically before the OpenRAG Deployment on every `helm install` /
 `helm upgrade`, and wait for it to complete before continuing. It applies the
 Alembic migrations (`python -m services.persistence.migrations.run`) against the
-externally provisioned database — it migrates the schema but does not create the
-database (auto-creation is intentionally disabled here).
+externally provisioned database — it always migrates the schema and never
+creates the database (the runner does not open the app pool, so it ignores
+`POSTGRES_AUTO_CREATE_DB` / `POSTGRES_RUN_MIGRATIONS`).
 
 Disabled by default via `postgresProvisioning.migrationJob.enabled`. Enable it
 for managed Postgres and pair it with `runMigrationsInApp: false` so the app no
@@ -51,10 +52,10 @@ spec:
             - secretRef:
                 name: rag-env-secrets
           env:
-            - name: POSTGRES_AUTO_CREATE_DB
-              value: "false"
-            - name: POSTGRES_RUN_MIGRATIONS
-              value: "true"
+            # The runner (services.persistence.migrations.run) always runs
+            # migrations and never auto-creates the database, so it ignores
+            # POSTGRES_AUTO_CREATE_DB / POSTGRES_RUN_MIGRATIONS — no need to set
+            # them here. UV_CACHE_DIR points uv at the writable emptyDir below.
             - name: UV_CACHE_DIR
               value: /tmp/uv-cache
           volumeMounts:

--- a/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
+++ b/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
@@ -1,3 +1,19 @@
+{{/*
+PostgreSQL schema-migration Job (managed-Postgres provisioning).
+
+This is a Helm *hook*, not a regular chart resource. The
+`helm.sh/hook: pre-install,pre-upgrade` annotation makes Helm run it
+automatically before the OpenRAG Deployment on every `helm install` /
+`helm upgrade`, and wait for it to complete before continuing. It applies the
+Alembic migrations (`python -m services.persistence.migrations.run`) against the
+externally provisioned database — it migrates the schema but does not create the
+database (auto-creation is intentionally disabled here).
+
+Disabled by default via `postgresProvisioning.migrationJob.enabled`. Enable it
+for managed Postgres and pair it with `runMigrationsInApp: false` so the app no
+longer migrates at startup. When disabled, the application runs migrations
+itself during startup instead.
+*/}}
 {{- if .Values.postgresProvisioning.migrationJob.enabled }}
 apiVersion: batch/v1
 kind: Job

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -36,6 +36,19 @@ postgresql:
   service:
     port: &pgPort 5432
 
+postgresProvisioning:
+  # Keep the bundled PostgreSQL chart self-contained by default. Managed
+  # Postgres deployments should set this to false and point POSTGRES_* values
+  # at a pre-created database.
+  autoCreateDatabase: true
+  # Leave app-start migrations enabled for compose-like installs. Operators can
+  # disable this when they run migrations through the Helm hook below.
+  runMigrationsInApp: true
+  migrationJob:
+    enabled: false
+    backoffLimit: 3
+    hookDeletePolicy: before-hook-creation,hook-succeeded
+
 # === Milvus ===
 milvus:
   enabled: true
@@ -288,6 +301,8 @@ env:
     POSTGRES_PORT: *pgPort
     POSTGRES_USER: *pgUser
     POSTGRES_PASSWORD: *pgPass
+    POSTGRES_AUTO_CREATE_DB: "{{ .Values.postgresProvisioning.autoCreateDatabase }}"
+    POSTGRES_RUN_MIGRATIONS: "{{ .Values.postgresProvisioning.runMigrationsInApp }}"
 
     # Embedder
     EMBEDDER_MODEL_NAME: *embedderModel

--- a/openrag/core/config/infrastructure.py
+++ b/openrag/core/config/infrastructure.py
@@ -39,6 +39,8 @@ class RDBConfig(ConfigMixin):
     # by the caller wiring the catalog store. The connection manager raises if
     # this is still None at initialize() time.
     database: str | None = None
+    auto_create_database: bool = True
+    run_migrations: bool = True
     pool_min_size: int = 5
     pool_max_size: int = 20
     command_timeout: int = 30

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -57,6 +57,8 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("POSTGRES_PASSWORD", "rdb.password", str),
     ("DEFAULT_FILE_QUOTA", "rdb.default_file_quota", int),
     ("POSTGRES_DATABASE", "rdb.database", str),
+    ("POSTGRES_AUTO_CREATE_DB", "rdb.auto_create_database", bool),
+    ("POSTGRES_RUN_MIGRATIONS", "rdb.run_migrations", bool),
     ("POSTGRES_POOL_MIN_SIZE", "rdb.pool_min_size", int),
     ("POSTGRES_POOL_MAX_SIZE", "rdb.pool_max_size", int),
     ("POSTGRES_COMMAND_TIMEOUT", "rdb.command_timeout", int),

--- a/openrag/di/repositories.py
+++ b/openrag/di/repositories.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 def create_catalog_store(
     settings: Settings,
     *,
-    run_migrations: bool = True,
+    run_migrations: bool | None = None,
 ) -> CatalogStore:
     """Build the relational catalog store from the root settings.
 
@@ -43,6 +43,8 @@ def create_catalog_store(
                 "database": f"partitions_for_collection_{settings.vectordb.collection_name}",
             },
         )
+    if run_migrations is None:
+        run_migrations = getattr(rdb, "run_migrations", True)
     return PostgresStore(rdb, run_migrations=run_migrations)
 
 

--- a/openrag/di/repositories.py
+++ b/openrag/di/repositories.py
@@ -44,7 +44,7 @@ def create_catalog_store(
             },
         )
     if run_migrations is None:
-        run_migrations = getattr(rdb, "run_migrations", True)
+        run_migrations = rdb.run_migrations
     return PostgresStore(rdb, run_migrations=run_migrations)
 
 

--- a/openrag/services/persistence/connection.py
+++ b/openrag/services/persistence/connection.py
@@ -86,6 +86,7 @@ class ConnectionManager:
         self._min_size = config.pool_min_size
         self._max_size = config.pool_max_size
         self._command_timeout = config.command_timeout
+        self._auto_create_database = getattr(config, "auto_create_database", True)
         self._pool: asyncpg.Pool | None = None
 
     @property
@@ -105,7 +106,10 @@ class ConnectionManager:
         if self._pool is not None:
             return
 
-        await asyncio.to_thread(self._ensure_database_exists)
+        if self._auto_create_database:
+            await asyncio.to_thread(self._ensure_database_exists)
+        else:
+            logger.info(f"Skipping Postgres database auto-creation for {self._dsn_log}")
 
         last_exc: Exception | None = None
         for attempt in range(1, _RETRY_ATTEMPTS + 1):

--- a/openrag/services/persistence/connection.py
+++ b/openrag/services/persistence/connection.py
@@ -86,7 +86,7 @@ class ConnectionManager:
         self._min_size = config.pool_min_size
         self._max_size = config.pool_max_size
         self._command_timeout = config.command_timeout
-        self._auto_create_database = getattr(config, "auto_create_database", True)
+        self._auto_create_database = config.auto_create_database
         self._pool: asyncpg.Pool | None = None
 
     @property

--- a/openrag/services/persistence/migrations/alembic/schema_helpers.py
+++ b/openrag/services/persistence/migrations/alembic/schema_helpers.py
@@ -1,8 +1,8 @@
 """Shared inspection helpers for idempotent Alembic migrations.
 
-Needed because `Base.metadata.create_all()` at app startup may create the
-current-model schema directly on fresh (or older) deployments — so migrations
-must tolerate objects already existing.
+Needed because older deployments may already contain some objects when a
+newer release applies migrations. Migration scripts should tolerate objects
+already existing.
 """
 
 from alembic import op

--- a/openrag/services/persistence/migrations/alembic/versions/c224d4befe71_add_file_count_and_file_quota.py
+++ b/openrag/services/persistence/migrations/alembic/versions/c224d4befe71_add_file_count_and_file_quota.py
@@ -22,8 +22,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema.
 
-    Idempotent: Base.metadata.create_all() at app startup may have already
-    added these columns/indexes from the SQLAlchemy models on older deployments.
+    Idempotent: older deployments may already contain these columns/indexes.
     """
     if not column_exists("users", "file_quota"):
         op.add_column("users", sa.Column("file_quota", sa.Integer(), nullable=True))

--- a/openrag/services/persistence/migrations/alembic/versions/e7f8a9b0c1d2_add_workspaces.py
+++ b/openrag/services/persistence/migrations/alembic/versions/e7f8a9b0c1d2_add_workspaces.py
@@ -22,8 +22,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema.
 
-    Idempotent: Base.metadata.create_all() at app startup may have already
-    created these tables on older deployments.
+    Idempotent: older deployments may already contain these tables.
     """
     if not table_exists("workspaces"):
         op.create_table(

--- a/openrag/services/persistence/migrations/alembic/versions/f1a2b3c4d5e6_add_workspace_files_file_id_fk.py
+++ b/openrag/services/persistence/migrations/alembic/versions/f1a2b3c4d5e6_add_workspace_files_file_id_fk.py
@@ -28,9 +28,8 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Migrate workspace_files.file_id from string to integer FK referencing files.id.
 
-    Idempotent: Base.metadata.create_all() at app startup may have already
-    created workspace_files with file_id as INTEGER on older deployments — in
-    which case the conversion is a no-op.
+    Idempotent: older deployments may already have workspace_files with
+    file_id as INTEGER, in which case the conversion is a no-op.
     """
     if column_type_is("workspace_files", "file_id", sa.Integer):
         return

--- a/openrag/services/persistence/migrations/alembic/versions/f5b6c918f741_add_oidc_auth.py
+++ b/openrag/services/persistence/migrations/alembic/versions/f5b6c918f741_add_oidc_auth.py
@@ -22,8 +22,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema: add users.email column and create oidc_sessions table.
 
-    Idempotent: Base.metadata.create_all() at app startup may have already
-    created these on older deployments.
+    Idempotent: older deployments may already contain these objects.
     """
     # users.email (nullable, unique, indexed)
     if not column_exists("users", "email"):

--- a/openrag/services/persistence/migrations/run.py
+++ b/openrag/services/persistence/migrations/run.py
@@ -1,0 +1,35 @@
+"""Run Postgres catalog migrations without starting the OpenRAG API."""
+
+from __future__ import annotations
+
+import asyncio
+
+from core.config import load_config
+from core.config.infrastructure import RDBConfig
+from core.config.root import Settings
+from services.persistence.connection import ConnectionManager
+
+
+def _rdb_config_for_migrations(settings: Settings) -> RDBConfig:
+    rdb = settings.rdb
+    if rdb.database is not None:
+        return rdb
+    return rdb.model_copy(
+        update={
+            "database": f"partitions_for_collection_{settings.vectordb.collection_name}",
+        }
+    )
+
+
+async def _run() -> None:
+    manager = ConnectionManager(_rdb_config_for_migrations(load_config()))
+    await manager.run_migrations()
+
+
+def main() -> int:
+    asyncio.run(_run())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -3,10 +3,8 @@
 Defines the same 7 tables that ``components/indexer/vectordb/models.py`` declares
 with the SQLAlchemy ORM, but as :class:`sqlalchemy.Table` objects bound to a
 single :class:`sqlalchemy.MetaData`. The new persistence layer talks to
-Postgres through ``asyncpg`` with raw SQL; this module exists solely so that
-Alembic's autogenerate has a metadata target to diff against, and so the
-on-startup ``metadata.create_all()`` path keeps working until phase 9 retires
-the legacy actor.
+Postgres through ``asyncpg`` with raw SQL; this module exists so that Alembic's
+autogenerate has a metadata target to diff against.
 
 Column types, defaults, foreign keys, unique constraints, check constraints
 and indexes must stay identical to the ORM models — Alembic will treat any

--- a/openrag/services/storage/postgres_store.py
+++ b/openrag/services/storage/postgres_store.py
@@ -6,11 +6,9 @@ and the Phase 7C shim consume through the ``CatalogStore`` ABC.
 
 The store owns the lifecycle:
 
-* :meth:`initialize` opens the asyncpg pool, then runs Alembic migrations to
-  ``head``. The order matters — the legacy ORM's ``Base.metadata.create_all``
-  used to fast-forward the schema before migrations ran, which is why every
-  Alembic revision is idempotent (see ``CLAUDE.md`` "Alembic Migration
-  Idempotency"). The new store keeps that contract.
+* :meth:`initialize` opens the asyncpg pool, then optionally runs Alembic
+  migrations to ``head``. Migrations stay idempotent so they can be run either
+  during app startup or as a separate deployment step.
 * :meth:`shutdown` closes the pool. Repositories share the pool via a
   ``pool_getter`` callable, so the pool can be reinitialised in tests without
   rebuilding the repos.
@@ -113,11 +111,9 @@ class PostgresStore(CatalogStore):
         ``command.upgrade``, which under concurrent load starves the Postgres
         pool and surfaces as 500s.
 
-        Order matters: the pool must exist before Alembic runs because the
-        legacy ``PartitionFileManager`` bootstrapped tables synchronously via
-        ``Base.metadata.create_all`` *before* migrations. The Phase 7
-        migrations therefore guard every DDL with an inspector check, which
-        keeps re-runs safe regardless of pool state.
+        Migrations are still idempotent because the same revision can be
+        applied from app startup in local/dev or from a deployment job in
+        managed environments.
         """
         if self._initialized:
             return

--- a/tests/unit/core/config/test_rdb_env.py
+++ b/tests/unit/core/config/test_rdb_env.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from core.config import load_config
+
+
+def test_postgres_provisioning_flags_can_be_overridden_from_env(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("retriever:\n  type: single\n", encoding="utf-8")
+    monkeypatch.setenv("POSTGRES_AUTO_CREATE_DB", "false")
+    monkeypatch.setenv("POSTGRES_RUN_MIGRATIONS", "false")
+
+    settings = load_config(config_path=tmp_path)
+
+    assert settings.rdb.auto_create_database is False
+    assert settings.rdb.run_migrations is False

--- a/tests/unit/di/test_container.py
+++ b/tests/unit/di/test_container.py
@@ -302,6 +302,28 @@ class TestRepositoriesFactory:
         store = create_catalog_store(_settings(), run_migrations=False)
         assert store._run_migrations is False
 
+    def test_run_migrations_defaults_to_rdb_config(self):
+        """Use the RDB config migration policy when no override is provided."""
+        settings = Settings(
+            rdb=RDBConfig(password="x", run_migrations=False),
+            vectordb=VectorDBConfig(collection_name="vdb_test"),
+        )
+
+        store = create_catalog_store(settings)
+
+        assert store._run_migrations is False
+
+    def test_run_migrations_argument_overrides_rdb_config(self):
+        """Keep explicit factory overrides for tests and one-off callers."""
+        settings = Settings(
+            rdb=RDBConfig(password="x", run_migrations=False),
+            vectordb=VectorDBConfig(collection_name="vdb_test"),
+        )
+
+        store = create_catalog_store(settings, run_migrations=True)
+
+        assert store._run_migrations is True
+
     def test_does_not_mutate_input_settings(self):
         """Leave caller-owned settings unchanged when deriving defaults."""
         s = _settings(database=None, collection="abc")

--- a/tests/unit/infra/test_postgres_migration_job_template.py
+++ b/tests/unit/infra/test_postgres_migration_job_template.py
@@ -18,9 +18,20 @@ def test_postgres_migration_job_uses_secret_ref_instead_of_literal_secret_values
     assert 'value: "{{ $value }}"' not in template
 
 
-def test_postgres_migration_job_keeps_migration_specific_overrides() -> None:
+def test_postgres_migration_job_sets_uv_cache_dir() -> None:
     template = MIGRATION_JOB_TEMPLATE.read_text(encoding="utf-8")
 
-    assert "name: POSTGRES_AUTO_CREATE_DB" in template
-    assert "name: POSTGRES_RUN_MIGRATIONS" in template
     assert "name: UV_CACHE_DIR" in template
+
+
+def test_postgres_migration_job_omits_flags_the_runner_ignores() -> None:
+    """The migration runner never reads these, so they must not be set here.
+
+    ``services.persistence.migrations.run`` always runs migrations and never
+    opens the app pool, so ``POSTGRES_AUTO_CREATE_DB`` / ``POSTGRES_RUN_MIGRATIONS``
+    have no effect on it. Setting them on the Job only misleads readers.
+    """
+    template = MIGRATION_JOB_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "name: POSTGRES_AUTO_CREATE_DB" not in template
+    assert "name: POSTGRES_RUN_MIGRATIONS" not in template

--- a/tests/unit/infra/test_postgres_migration_job_template.py
+++ b/tests/unit/infra/test_postgres_migration_job_template.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_JOB_TEMPLATE = ROOT / "infra" / "charts" / "openrag-stack" / "templates" / "postgres-migration-job.yaml"
+
+
+def test_postgres_migration_job_uses_secret_ref_instead_of_literal_secret_values() -> None:
+    template = MIGRATION_JOB_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "envFrom:" in template
+    assert "configMapRef:" in template
+    assert "name: rag-env" in template
+    assert "secretRef:" in template
+    assert "name: rag-env-secrets" in template
+    assert ".Values.env.secrets" not in template
+    assert 'value: "{{ $value }}"' not in template
+
+
+def test_postgres_migration_job_keeps_migration_specific_overrides() -> None:
+    template = MIGRATION_JOB_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "name: POSTGRES_AUTO_CREATE_DB" in template
+    assert "name: POSTGRES_RUN_MIGRATIONS" in template
+    assert "name: UV_CACHE_DIR" in template

--- a/tests/unit/services/persistence/test_connection.py
+++ b/tests/unit/services/persistence/test_connection.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
+import pytest
 from services.persistence.connection import ConnectionManager
 
 
@@ -9,6 +10,7 @@ class RDBConfigStub:
     user = "root"
     password = "root_password"
     database = "partitions_for_collection_test"
+    auto_create_database = True
     pool_min_size = 1
     pool_max_size = 4
     command_timeout = 10
@@ -36,3 +38,21 @@ def test_ensure_database_exists_skips_existing_database(monkeypatch):
     manager._ensure_database_exists()
 
     create_database.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initialize_skips_database_creation_when_auto_create_is_disabled(monkeypatch):
+    class NoCreateDBConfig(RDBConfigStub):
+        auto_create_database = False
+
+    manager = ConnectionManager(NoCreateDBConfig())
+    ensure_database_exists = Mock()
+    create_pool = AsyncMock(return_value=object())
+
+    monkeypatch.setattr(manager, "_ensure_database_exists", ensure_database_exists)
+    monkeypatch.setattr("services.persistence.connection.asyncpg.create_pool", create_pool)
+
+    await manager.initialize()
+
+    ensure_database_exists.assert_not_called()
+    create_pool.assert_awaited_once()

--- a/tests/unit/services/persistence/test_migration_entrypoint.py
+++ b/tests/unit/services/persistence/test_migration_entrypoint.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from core.config.infrastructure import RDBConfig, VectorDBConfig
+from core.config.root import Settings
+
+
+def test_rdb_config_for_migrations_derives_database_from_collection() -> None:
+    from services.persistence.migrations.run import _rdb_config_for_migrations
+
+    settings = Settings(
+        rdb=RDBConfig(password="x", database=None),
+        vectordb=VectorDBConfig(collection_name="managed"),
+    )
+
+    rdb = _rdb_config_for_migrations(settings)
+
+    assert rdb.database == "partitions_for_collection_managed"
+
+
+def test_rdb_config_for_migrations_preserves_explicit_database() -> None:
+    from services.persistence.migrations.run import _rdb_config_for_migrations
+
+    settings = Settings(
+        rdb=RDBConfig(password="x", database="openrag_catalog"),
+        vectordb=VectorDBConfig(collection_name="managed"),
+    )
+
+    rdb = _rdb_config_for_migrations(settings)
+
+    assert rdb.database == "openrag_catalog"
+
+
+def test_migration_entrypoint_runs_alembic_without_initializing_pool(monkeypatch) -> None:
+    import services.persistence.migrations.run as migration_run
+
+    calls: list[str] = []
+    settings = Settings(
+        rdb=RDBConfig(password="x", database="openrag_catalog"),
+        vectordb=VectorDBConfig(collection_name="managed"),
+    )
+
+    class FakeConnectionManager:
+        def __init__(self, rdb):
+            assert rdb.database == "openrag_catalog"
+
+        async def initialize(self):  # pragma: no cover - should never be called
+            raise AssertionError("migration entrypoint must not open the application pool")
+
+        async def run_migrations(self):
+            calls.append("run_migrations")
+
+    monkeypatch.setattr(migration_run, "load_config", lambda: settings)
+    monkeypatch.setattr(migration_run, "ConnectionManager", FakeConnectionManager)
+
+    assert migration_run.main() == 0
+    assert calls == ["run_migrations"]


### PR DESCRIPTION
Closes #520

## Why
Managed PostgreSQL deployments usually do not allow the application role to create databases. OpenRAG should be able to start against a pre-provisioned database, with schema changes applied as an explicit deployment step.

## What changed
- Added Postgres provisioning flags so local compose keeps its current behavior while managed deployments can skip database creation and app-start migrations.
- Added a standalone migration runner and an optional Helm migration hook for install/upgrade flows.
- Updated the Kubernetes and migration docs to describe the least-privilege path.

## Validation
- `uv run --no-env-file ruff format --check openrag tests`
- `uv run --no-env-file ruff check openrag tests`
- `uv run --no-env-file pytest tests/unit/services/persistence/test_connection.py tests/unit/services/persistence/test_migration_entrypoint.py tests/unit/di/test_container.py::TestRepositoriesFactory tests/unit/core/config/test_rdb_env.py`
- Full `tests/unit` was also run locally: 1315 passed, 1 existing model-endpoint test failed because the local repo `.env` injects API keys into that test.

Note: I could not render the Helm chart locally because `helm` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to control automatic database creation and migration execution independently
  * Enabled migration jobs for Kubernetes deployments as separate pre-install/pre-upgrade hooks
  * New environment variables: `POSTGRES_AUTO_CREATE_DB`, `POSTGRES_RUN_MIGRATIONS`, `POSTGRES_POOL_MIN_SIZE`, `POSTGRES_POOL_MAX_SIZE`, `POSTGRES_COMMAND_TIMEOUT`, and `POSTGRES_DATABASE`

* **Documentation**
  * Updated guides for managed PostgreSQL database setup, migration strategies, and Kubernetes deployments
  * Enhanced environment variable documentation with new PostgreSQL configuration options

* **Tests**
  * Added test coverage for new configuration options and migration job behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->