### PR TITLE
feat: Allow openAI response_format

### DIFF
--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -311,7 +311,7 @@ async def openai_chat_completion(
             try:
                 async for sse_line in service.chat_stream(
                     partitions=partitions,
-                    payload=request.model_dump(),
+                    payload=request.model_dump(exclude_none=True),
                     prepare_sources=prep,
                     model_name=model_name,
                 ):
@@ -330,7 +330,7 @@ async def openai_chat_completion(
 
     chunk = await service.chat(
         partitions=partitions,
-        payload=request.model_dump(),
+        payload=request.model_dump(exclude_none=True),
         prepare_sources=prep,
         model_name=model_name,
     )

--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -398,7 +398,7 @@ async def openai_completion(
 
     resp = await service.complete(
         partitions=partitions,
-        payload=request.model_dump(),
+        payload=request.model_dump(exclude_none=True),
         prepare_sources=lambda docs, _web: __prepare_sources(request2, docs),
     )
     log.debug("Returning completion response.")

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 def default_max_tokens():
@@ -15,6 +15,9 @@ class OpenAIMessage(BaseModel):
 
 
 class OpenAIChatCompletionRequest(BaseModel):
+    # Accept and forward vendor-specific OpenAI params
+    model_config = ConfigDict(extra="allow")
+
     model: str | None = Field(None, description="model name")
     messages: list[OpenAIMessage]
     temperature: float | None = Field(0.3)
@@ -22,6 +25,11 @@ class OpenAIChatCompletionRequest(BaseModel):
     stream: bool | None = Field(False)
     max_tokens: int | None = Field(default_factory=default_max_tokens)
     logprobs: int | None = Field(None)
+    response_format: dict[str, Any] | None = Field(
+        None,
+        description="OpenAI response_format, e.g. {'type': 'json_object'} or "
+        "{'type': 'json_schema', 'json_schema': {...}}. Forwarded to the LLM.",
+    )
     metadata: dict[str, Any] | None = Field(
         {
             "use_map_reduce": False,

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -28,7 +28,9 @@ class OpenAIChatCompletionRequest(BaseModel):
     response_format: dict[str, Any] | None = Field(
         None,
         description="OpenAI response_format, e.g. {'type': 'json_object'} or "
-        "{'type': 'json_schema', 'json_schema': {...}}. Forwarded to the LLM.",
+        "{'type': 'json_schema', 'json_schema': {...}}. Forwarded to the LLM. "
+        "Note: forcing JSON output on a partition (RAG) query suppresses the "
+        "inline [Sources: N] citations, so all retrieved sources are returned.",
     )
     metadata: dict[str, Any] | None = Field(
         {

--- a/tests/unit/api/schemas/test_api_schema_imports.py
+++ b/tests/unit/api/schemas/test_api_schema_imports.py
@@ -29,6 +29,48 @@ def test_openai_schemas_preserve_existing_defaults():
     assert completion.best_of == 1
 
 
+def test_chat_request_forwards_response_format():
+    """response_format is a declared field and must survive model_dump so the
+    router forwards it to the LLM (e.g. for JSON / structured outputs)
+    """
+    request = OpenAIChatCompletionRequest(
+        messages=[OpenAIMessage(role="user", content="hi")],
+        response_format={"type": "json_object"},
+    )
+    dump = request.model_dump(exclude_none=True)
+
+    assert request.response_format == {"type": "json_object"}
+    assert dump["response_format"] == {"type": "json_object"}
+
+
+def test_chat_request_omits_response_format_when_unset():
+    """With exclude_none, an unset response_format must NOT be emitted as null.
+    Strict downstream providers reject an explicit response_format: null
+    """
+    request = OpenAIChatCompletionRequest(messages=[OpenAIMessage(role="user", content="hi")])
+    dump = request.model_dump(exclude_none=True)
+
+    assert request.response_format is None
+    assert "response_format" not in dump
+
+
+def test_chat_request_passes_through_extra_openai_params():
+    """extra='allow' keeps vendor params (tools, seed, ...) that are not declared
+    on the model, so any OpenAI-compatible field reaches the downstream LLM
+    """
+    request = OpenAIChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "f"}}],
+            "seed": 42,
+        }
+    )
+    dump = request.model_dump(exclude_none=True)
+
+    assert dump["tools"] == [{"type": "function", "function": {"name": "f"}}]
+    assert dump["seed"] == 42
+
+
 def test_search_schema_preserves_existing_defaults():
     request = SearchRequest(query="hello")
 

--- a/tests/unit/api/schemas/test_api_schema_imports.py
+++ b/tests/unit/api/schemas/test_api_schema_imports.py
@@ -71,6 +71,17 @@ def test_chat_request_passes_through_extra_openai_params():
     assert dump["seed"] == 42
 
 
+def test_completion_request_omits_unset_nulls():
+    """The /completions router dumps with exclude_none=True (matching chat), so
+    optional params left unset are not sent as explicit null to strict providers
+    """
+    request = OpenAICompletionRequest(prompt="hi")
+    dump = request.model_dump(exclude_none=True)
+
+    for unset in ("seed", "stop", "logit_bias", "logprobs"):
+        assert unset not in dump
+
+
 def test_search_schema_preserves_existing_defaults():
     request = SearchRequest(query="hello")
 


### PR DESCRIPTION
This is typically useful to force JSON-formatted response, when supported by the LLM inference server.
We also allow extra parameters , so the client can use any extra openai-compatible parameter on the chat completion route, when
 openRAG is used as a pass-through for direct LLM calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat completion requests now support the `response_format` parameter for controlling response structure.
  * The chat API accepts and forwards extra OpenAI-compatible vendor parameters for improved compatibility.
* **Bug Fixes**
  * Streaming and non-streaming chat requests omit unset (`null`) fields from the payload sent to the model service.
  * Completion requests now omit unset (`null`) fields from the payload sent to the model service.
* **Tests**
  * Added unit tests covering `response_format` handling, omission of unset fields, and pass-through of extra OpenAI-compatible parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->