### PR TITLE
fix(query): apply per-partition chat_history_depth

### DIFF
--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -138,17 +138,23 @@ class QueryService:
         Honors a partition's configured ``chat_history_depth`` (set via the
         admin API) over the global default. A partition value of ``0`` means
         "inherit the global default" — it never reaches the ``messages[-depth:]``
-        slice, where ``0`` would otherwise select the *entire* history. For
-        multi-partition queries (e.g. ``openrag-all``) there is no single owning
-        partition, so the largest explicit value wins, falling back to the
-        global default when none is set.
+        slice, where ``0`` would otherwise select the *entire* history.
+
+        The ``"all"`` sentinel (``openrag-all``) reaches this layer un-expanded
+        (retrieval resolves it to concrete partitions downstream) and is a
+        cross-partition query with no single owning partition, so it uses the
+        global default. A request scoped to one or more named partitions takes
+        the largest explicit (>0) value among them.
         """
-        explicit = [
-            cfg.chat_history_depth
-            for name in (partition or [])
-            if (cfg := self._config.partitions.get(name)) is not None and cfg.chat_history_depth > 0
-        ]
-        return max(explicit) if explicit else self._default_chat_history_depth
+        if partition and "all" not in partition:
+            explicit = [
+                cfg.chat_history_depth
+                for name in partition
+                if (cfg := self._config.partitions.get(name)) is not None and cfg.chat_history_depth > 0
+            ]
+            if explicit:
+                return max(explicit)
+        return self._default_chat_history_depth
 
     # ------------------------------------------------------------------
     # Query generation (was RagPipeline.generate_query — no LangChain)

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -113,8 +113,12 @@ class QueryService:
         self._web = web_search_service
         self._workspace = workspace_service
 
+        # Keep a live reference so per-partition config (resolved into
+        # ``config.partitions`` and refreshed on every preset change) can be
+        # read at request time, not snapshotted once at startup.
+        self._config = config
         self._rag_mode = config.rag.mode
-        self._chat_history_depth = config.rag.chat_history_depth
+        self._default_chat_history_depth = config.rag.chat_history_depth
         self._max_contextualized_query_len = config.rag.max_contextualized_query_len
         self._max_context_tokens = config.reranker.top_k * config.chunker.chunk_size
 
@@ -127,6 +131,24 @@ class QueryService:
         self._query_contextualizer_prompt = load_template_by_key(prompts_dir, mapping, "query_contextualizer")
         self._spoken_style_answer_prompt = load_template_by_key(prompts_dir, mapping, "spoken_style_answer")
         self._sys_prompt_tmplt = load_template_by_key(prompts_dir, mapping, "sys_prompt")
+
+    def _resolve_chat_history_depth(self, partition: list[str] | None) -> int:
+        """Effective chat-history depth for this request.
+
+        Honors a partition's configured ``chat_history_depth`` (set via the
+        admin API) over the global default. A partition value of ``0`` means
+        "inherit the global default" — it never reaches the ``messages[-depth:]``
+        slice, where ``0`` would otherwise select the *entire* history. For
+        multi-partition queries (e.g. ``openrag-all``) there is no single owning
+        partition, so the largest explicit value wins, falling back to the
+        global default when none is set.
+        """
+        explicit = [
+            cfg.chat_history_depth
+            for name in (partition or [])
+            if (cfg := self._config.partitions.get(name)) is not None and cfg.chat_history_depth > 0
+        ]
+        return max(explicit) if explicit else self._default_chat_history_depth
 
     # ------------------------------------------------------------------
     # Query generation (was RagPipeline.generate_query — no LangChain)
@@ -219,7 +241,7 @@ class QueryService:
     # ------------------------------------------------------------------
 
     async def _prepare_chat(self, partition: list[str] | None, payload: dict):
-        messages = payload["messages"][-self._chat_history_depth :]
+        messages = payload["messages"][-self._resolve_chat_history_depth(partition) :]
         queries = await self.generate_query(messages)
 
         metadata = payload.get("metadata") or {}

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -95,6 +95,7 @@ def _config(mode="SimpleRag"):
         map_reduce=SimpleNamespace(initial_batch_size=2, expansion_batch_size=2, max_total_documents=4),
         paths=_PROMPT_CFG.paths,
         prompts=_PROMPT_CFG.prompts,
+        partitions={},
     )
 
 
@@ -106,6 +107,42 @@ def _svc(*, llm=None, retrieval=None, web=None, mode="SimpleRag") -> QueryServic
         web_search_service=web or FakeWeb(),
         workspace_service=FakeWorkspace(),
     )
+
+
+# --------------------------------------------------------------------------- #
+# chat history depth resolution (per-partition override of the global default)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_chat_history_depth_uses_partition_value():
+    svc = _svc()  # global default = 4
+    svc._config.partitions = {"p": SimpleNamespace(chat_history_depth=10)}
+    assert svc._resolve_chat_history_depth(["p"]) == 10
+
+
+def test_resolve_chat_history_depth_zero_inherits_global_default():
+    # 0 means "inherit" — never reaches the messages[-depth:] slice (where 0
+    # would select the entire history).
+    svc = _svc()
+    svc._config.partitions = {"p": SimpleNamespace(chat_history_depth=0)}
+    assert svc._resolve_chat_history_depth(["p"]) == 4
+
+
+def test_resolve_chat_history_depth_none_and_unknown_use_default():
+    svc = _svc()
+    svc._config.partitions = {"p": SimpleNamespace(chat_history_depth=9)}
+    assert svc._resolve_chat_history_depth(None) == 4
+    assert svc._resolve_chat_history_depth(["missing"]) == 4
+
+
+def test_resolve_chat_history_depth_multi_partition_takes_max_explicit():
+    svc = _svc()
+    svc._config.partitions = {
+        "a": SimpleNamespace(chat_history_depth=6),
+        "b": SimpleNamespace(chat_history_depth=2),
+        "c": SimpleNamespace(chat_history_depth=0),  # inherits → ignored
+    }
+    assert svc._resolve_chat_history_depth(["a", "b", "c"]) == 6
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -135,6 +135,15 @@ def test_resolve_chat_history_depth_none_and_unknown_use_default():
     assert svc._resolve_chat_history_depth(["missing"]) == 4
 
 
+def test_resolve_chat_history_depth_all_sentinel_uses_default():
+    # "all" (openrag-all) reaches this layer un-expanded and is not a real
+    # partition name → cross-partition query uses the global default, never a
+    # per-partition value.
+    svc = _svc()  # global default = 4
+    svc._config.partitions = {"a": SimpleNamespace(chat_history_depth=10)}
+    assert svc._resolve_chat_history_depth(["all"]) == 4
+
+
 def test_resolve_chat_history_depth_multi_partition_takes_max_explicit():
     svc = _svc()
     svc._config.partitions = {


### PR DESCRIPTION
Closes #534.

## Problem
A partition's `chat_history_depth` (set via the admin UI / `PATCH /partition/{name}`) was stored and round-tripped correctly, but **never applied to chat**. `QueryService` is a startup singleton that snapshotted the global `config.rag.chat_history_depth` (default `4`) once and used it for every completion (`query_service.py:117` → slice at `:222`), regardless of partition. Changing the per-partition value had no effect — same class of gap as #522.

## Fix
Resolve the depth **per request** instead of at startup:
- `QueryService` holds a live `config` reference and reads the partition's resolved `chat_history_depth` from `config.partitions` (refreshed on every preset change via `clear()+update()`).
- A partition value of `0` means **inherit the global default**, so it never reaches the `messages[-depth:]` slice — where `0` would otherwise select the *entire* history (`[-0:]` == `[0:]`).
- Multi-partition queries (`openrag-all`) take the largest explicit value, falling back to the global default when none is set.
- Purely additive: behavior is unchanged when no partition value is configured.

## Tests
+4 unit tests in `test_query_service.py` (explicit value used; `0` → inherit default; `None`/unknown → default; multi-partition → max explicit).

## Verification
- `uv run pytest tests/unit/` → **1289 passed**
- `uv run ruff check` → clean

## Note
The same gap likely exists on `main` — worth a separate follow-up check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat history depth is now resolved dynamically per request, with support for per-partition overrides and inheritance from global defaults when a partition sets `chat_history_depth` to `0`.
  * The `"all"`/`openrag-all` partition sentinel now uses the global default, and multi-partition requests use the maximum explicitly set depth.

* **Tests**
  * Added unit coverage for chat-history depth resolution across single partitions, unknown partitions, the `"all"` sentinel, and multi-partition inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->