### PR TITLE
fix(admin-ui): OIDC logout, same-origin API base, link encoding + numeric guards (with tests)

### DIFF
--- a/tests/unit/api/routers/admin/test_partition_list_route.py
+++ b/tests/unit/api/routers/admin/test_partition_list_route.py
@@ -1,0 +1,103 @@
+"""Authorization + shaping tests for ``GET /partition/`` (list_existant_partitions).
+
+The list route was reworked to return per-partition stored config +
+``document_count`` (via ``PartitionService.list_partition_summaries``). These
+tests pin the security-relevant branch: a regular user must see summaries for
+*only* their own partitions, while the super-admin ``"all"`` sentinel lists
+every partition.
+"""
+
+from __future__ import annotations
+
+import pytest
+from api.dependencies.auth import partitions_with_details
+from api.routers.admin import partitions
+from di.providers import get_partition_service
+from fastapi import FastAPI
+
+
+def _summary(name: str, **overrides) -> dict:
+    base = {
+        "partition": name,
+        "description": "",
+        "embedder": "default",
+        "indexation_preset": "default",
+        "retrieval_preset": "default",
+        "dimension": 1024,
+        "chat_history_depth": 0,
+        "chat_llm": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "document_count": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class _FakeService:
+    """Minimal partition service exposing only what the list route calls."""
+
+    def __init__(self, summaries: dict[str, dict]) -> None:
+        self._summaries = summaries
+
+    async def list_partition_summaries(self) -> dict[str, dict]:
+        return self._summaries
+
+
+def _build_app(service: _FakeService, principal_partitions: list[dict]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(partitions.router, prefix="/partition")
+    app.dependency_overrides[partitions_with_details] = lambda: principal_partitions
+    app.dependency_overrides[get_partition_service] = lambda: service
+    return app
+
+
+@pytest.mark.asyncio
+async def test_list_returns_only_the_callers_partitions(async_client_factory):
+    """A regular user gets summaries for only their partitions — never others."""
+    summaries = {
+        "legal": _summary("legal", document_count=3),
+        "hr": _summary("hr", document_count=1),
+        "secret": _summary("secret", document_count=9),  # NOT the caller's
+    }
+    principal = [
+        {"partition": "legal", "role": "owner"},
+        {"partition": "hr", "role": "viewer"},
+    ]
+    app = _build_app(_FakeService(summaries), principal)
+    async with async_client_factory(app) as client:
+        resp = await client.get("/partition/")
+
+    assert resp.status_code == 200
+    by_name = {r["partition"]: r for r in resp.json()["partitions"]}
+    assert set(by_name) == {"legal", "hr"}  # no cross-partition leak
+    assert "secret" not in by_name
+    assert by_name["legal"]["role"] == "owner"  # caller's role surfaced
+    assert by_name["hr"]["role"] == "viewer"
+    assert by_name["legal"]["document_count"] == 3  # summary carried through
+
+
+@pytest.mark.asyncio
+async def test_super_admin_all_sentinel_lists_every_partition(async_client_factory):
+    """The ``"all"`` sentinel (super-admin) returns every partition's summary."""
+    summaries = {n: _summary(n) for n in ("legal", "hr", "secret")}
+    principal = [{"partition": "all", "role": "owner"}]
+    app = _build_app(_FakeService(summaries), principal)
+    async with async_client_factory(app) as client:
+        resp = await client.get("/partition/")
+
+    assert resp.status_code == 200
+    assert {r["partition"] for r in resp.json()["partitions"]} == {"legal", "hr", "secret"}
+
+
+@pytest.mark.asyncio
+async def test_list_falls_back_when_summary_missing(async_client_factory):
+    """A partition the caller holds but absent from summaries still appears with a
+    zero ``document_count`` (the ``summaries.get(name) or {...}`` guard — no KeyError)."""
+    app = _build_app(_FakeService({}), [{"partition": "ghost", "role": "editor"}])
+    async with async_client_factory(app) as client:
+        resp = await client.get("/partition/")
+
+    assert resp.status_code == 200
+    assert resp.json()["partitions"] == [
+        {"partition": "ghost", "document_count": 0, "role": "editor"},
+    ]

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -262,6 +262,48 @@ async def test_validate_model_endpoint_uses_stored_api_key(async_client_factory)
 
 
 @pytest.mark.asyncio
+async def test_validate_endpoint_draft_forwards_body_without_lookup(async_client_factory):
+    """The draft-validate route probes arbitrary *unsaved* values: it forwards the
+    request body straight to the service with no prior endpoint lookup/persist."""
+    model_service = FakeModelEndpointService()
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post(
+            "/model-endpoints/validate",
+            json={
+                "endpoint": "http://candidate:8000/v1",
+                "model_name": "mistral-small",
+                "api_key": "draft-key",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["reachable"] is True
+    assert model_service.calls == [
+        ("validate", {"url": "http://candidate:8000/v1", "model_name": "mistral-small", "api_key": "draft-key"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_draft_defaults_optional_fields(async_client_factory):
+    """``model_name`` and ``api_key`` are optional in the draft body."""
+    model_service = FakeModelEndpointService()
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post(
+            "/model-endpoints/validate",
+            json={"endpoint": "http://candidate:8000/v1"},
+        )
+
+    assert response.status_code == 200
+    assert model_service.calls == [
+        ("validate", {"url": "http://candidate:8000/v1", "model_name": None, "api_key": None}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_set_default_model_endpoint_returns_promoted_endpoint(async_client_factory):
     """Default promotion should return the promoted endpoint row."""
     model_service = FakeModelEndpointService()

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -10,8 +10,14 @@ export function Header() {
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    logout();
-    navigate("/login");
+    const wasOidcSession = logout();
+    if (wasOidcSession) {
+      // Full-page navigation to the backend's RP-initiated logout: it revokes
+      // the server session, clears the cookie, and redirects on to the IdP.
+      window.location.assign("/auth/logout");
+    } else {
+      navigate("/login");
+    }
   };
 
   return (

--- a/ui/src/lib/api/client.test.ts
+++ b/ui/src/lib/api/client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { request, TOKEN_KEY } from "./client";
+
+// Build a minimal Response-like object covering exactly what `request` reads.
+function fakeResponse({
+  status = 200,
+  body = "",
+  contentType = "application/json",
+}: { status?: number; body?: string; contentType?: string } = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => (body ? JSON.parse(body) : {}),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  localStorage.clear();
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("api client", () => {
+  it("defaults to a same-origin (relative) URL — never an absolute localhost fallback", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: JSON.stringify({ ok: true }) }));
+    await request("/users/info");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("/users/info");
+    expect(url.startsWith("http")).toBe(false); // would leak the bearer token cross-origin
+  });
+
+  it("attaches the bearer token from localStorage", async () => {
+    localStorage.setItem(TOKEN_KEY, "or-secret");
+    fetchMock.mockResolvedValue(fakeResponse({ body: "{}" }));
+    await request("/users/info");
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer or-secret");
+  });
+
+  it("omits Authorization when noAuth is set", async () => {
+    localStorage.setItem(TOKEN_KEY, "or-secret");
+    fetchMock.mockResolvedValue(fakeResponse({ body: "{}" }));
+    await request("/health_check", { noAuth: true });
+    const headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("clears the stored token on 401", async () => {
+    localStorage.setItem(TOKEN_KEY, "or-secret");
+    fetchMock.mockResolvedValue(fakeResponse({ status: 401 }));
+    await expect(request("/users/info")).rejects.toMatchObject({ status: 401 });
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+  });
+
+  it("tolerates an empty 200 body (resolves undefined, no JSON parse crash)", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ status: 200, body: "" }));
+    await expect(request("/partition/x")).resolves.toBeUndefined();
+  });
+});

--- a/ui/src/lib/api/client.test.ts
+++ b/ui/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { request, TOKEN_KEY } from "./client";
+import { request, ApiError, TOKEN_KEY } from "./client";
 
 // Build a minimal Response-like object covering exactly what `request` reads.
 function fakeResponse({
@@ -63,5 +63,28 @@ describe("api client", () => {
   it("tolerates an empty 200 body (resolves undefined, no JSON parse crash)", async () => {
     fetchMock.mockResolvedValue(fakeResponse({ status: 200, body: "" }));
     await expect(request("/partition/x")).resolves.toBeUndefined();
+  });
+});
+
+describe("ApiError message parsing", () => {
+  it("uses the FastAPI {detail} envelope", () => {
+    expect(new ApiError(422, { detail: "bad input" }).message).toBe("bad input");
+  });
+
+  it("uses the domain {error:{message}} envelope", () => {
+    expect(new ApiError(500, { error: { message: "boom", type: "x" } }).message).toBe("boom");
+  });
+
+  it("falls back to 'HTTP <status>' for unrecognized / non-object bodies", () => {
+    expect(new ApiError(503, { something: "else" }).message).toBe("HTTP 503");
+    expect(new ApiError(503, null).message).toBe("HTTP 503");
+    expect(new ApiError(503, "plain string").message).toBe("HTTP 503");
+  });
+
+  it("retains status, body and name", () => {
+    const e = new ApiError(404, { detail: "nope" });
+    expect(e.status).toBe(404);
+    expect(e.body).toEqual({ detail: "nope" });
+    expect(e.name).toBe("ApiError");
   });
 });

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -1,4 +1,8 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+// Default to same-origin (empty base → relative fetch, proxied by nginx). A
+// missing env must fail closed: never fall back to an absolute host, which would
+// send the bearer token cross-origin. To target a remote API in dev, set
+// VITE_API_BASE_URL explicitly.
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 
 // OpenRag bearer token (the user's `or-…` token). Sent as Authorization for
 // token-mode auth; in OIDC mode the same-origin session cookie is used instead.

--- a/ui/src/lib/api/models.test.ts
+++ b/ui/src/lib/api/models.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { pickDefaultEndpoint, resolveEmbedderName } from "./models";
+import type { ModelEndpointResponse } from "./models";
+
+function ep(name: string, is_default = false): ModelEndpointResponse {
+  return {
+    name,
+    model_type: "embedder",
+    endpoint: "http://endpoint",
+    model_name: null,
+    batch_size: 32,
+    timeout: 30,
+    extra: {},
+    is_default,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
+  };
+}
+
+describe("pickDefaultEndpoint", () => {
+  it("returns undefined for empty / nullish input", () => {
+    expect(pickDefaultEndpoint(undefined)).toBeUndefined();
+    expect(pickDefaultEndpoint(null)).toBeUndefined();
+    expect(pickDefaultEndpoint([])).toBeUndefined();
+  });
+
+  it("returns the is_default endpoint when one is flagged", () => {
+    expect(pickDefaultEndpoint([ep("a"), ep("b", true)])?.name).toBe("b");
+  });
+
+  it("returns the sole endpoint when exactly one is registered", () => {
+    expect(pickDefaultEndpoint([ep("only")])?.name).toBe("only");
+  });
+
+  it("returns undefined when several exist and none is default (user must choose)", () => {
+    expect(pickDefaultEndpoint([ep("a"), ep("b")])).toBeUndefined();
+  });
+});
+
+describe("resolveEmbedderName", () => {
+  const endpoints = [ep("jina", true), ep("other")];
+
+  it("returns the value verbatim when it isn't the 'default' sentinel", () => {
+    expect(resolveEmbedderName("my-embedder", endpoints)).toBe("my-embedder");
+  });
+
+  it("shows an em dash for null / empty", () => {
+    expect(resolveEmbedderName(null, endpoints)).toBe("—");
+    expect(resolveEmbedderName(undefined, endpoints)).toBe("—");
+    expect(resolveEmbedderName("", endpoints)).toBe("—");
+  });
+
+  it("resolves the 'default' sentinel to the real default endpoint name", () => {
+    expect(resolveEmbedderName("default", endpoints)).toBe("jina");
+  });
+
+  it("falls back to 'default' when the default can't be resolved", () => {
+    expect(resolveEmbedderName("default", [ep("a"), ep("b")])).toBe("default");
+    expect(resolveEmbedderName("default", [])).toBe("default");
+    expect(resolveEmbedderName("default", null)).toBe("default");
+  });
+
+  it("keeps 'default' when the default endpoint is itself named 'default'", () => {
+    expect(resolveEmbedderName("default", [ep("default", true)])).toBe("default");
+  });
+});

--- a/ui/src/lib/auth.test.tsx
+++ b/ui/src/lib/auth.test.tsx
@@ -68,4 +68,35 @@ describe("useAuth (token model)", () => {
     expect(localStorage.getItem("openrag_token")).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
   });
+
+  it("logout returns false in token mode (a bearer token is stored)", async () => {
+    localStorage.setItem("openrag_token", "or-abc123");
+    mockInfo.mockResolvedValue(user(true));
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    let wasOidc: boolean | undefined;
+    act(() => {
+      wasOidc = result.current.logout();
+    });
+    // Token mode: clearing the local token IS the full logout — no server redirect.
+    expect(wasOidc).toBe(false);
+    expect(localStorage.getItem("openrag_token")).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("logout returns true for an OIDC session (no stored token) so the caller revokes it server-side", async () => {
+    // No token in localStorage → identity came from the OIDC `openrag_session`
+    // cookie, which JS can't clear; the header must hand off to GET /auth/logout.
+    mockInfo.mockResolvedValue(user(true));
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    let wasOidc: boolean | undefined;
+    act(() => {
+      wasOidc = result.current.logout();
+    });
+    expect(wasOidc).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
 });

--- a/ui/src/lib/auth.tsx
+++ b/ui/src/lib/auth.tsx
@@ -19,7 +19,12 @@ interface AuthContextType {
   isLoading: boolean;
   /** Store a bearer token and resolve identity; throws if the token is invalid. */
   loginWithToken: (token: string) => Promise<void>;
-  logout: () => void;
+  /**
+   * Clear local auth state. Returns `true` when this was an OIDC/SSO session
+   * (no stored bearer token) — the caller must then redirect to the backend's
+   * `/auth/logout` to revoke the httpOnly session cookie, which JS cannot clear.
+   */
+  logout: () => boolean;
   reload: () => Promise<void>;
 }
 
@@ -56,8 +61,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const logout = useCallback(() => {
+    // A stored bearer token means token-mode auth: clearing it IS the full
+    // logout. With no token, identity came from the OIDC `openrag_session`
+    // cookie — signal the caller to hand off to the backend RP-initiated logout
+    // so the server revokes the session (and ends the IdP SSO session).
+    const wasOidcSession = !localStorage.getItem(TOKEN_KEY);
     localStorage.removeItem(TOKEN_KEY);
     setUser(null);
+    return wasOidcSession;
   }, []);
 
   return (

--- a/ui/src/lib/permissions.test.tsx
+++ b/ui/src/lib/permissions.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// usePermissions reads only `isAdmin` from useAuth — mock it (vi.hoisted so the
+// factory may reference the shared state) instead of standing up AuthProvider.
+const auth = vi.hoisted(() => ({ isAdmin: false }));
+vi.mock("./auth", () => ({ useAuth: () => ({ isAdmin: auth.isAdmin }) }));
+
+import { usePermissions } from "./permissions";
+
+function perms(isAdmin: boolean) {
+  auth.isAdmin = isAdmin;
+  return renderHook(() => usePermissions()).result.current;
+}
+
+describe("usePermissions — platform scopes", () => {
+  it("grants every platform capability to admins", () => {
+    const p = perms(true);
+    expect(p.isAdmin).toBe(true);
+    expect(p.canViewPlatform).toBe(true);
+    expect(p.canViewSystem).toBe(true);
+    expect(p.canManageUsers).toBe(true);
+    expect(p.canManageModels).toBe(true);
+    expect(p.canManagePresets).toBe(true);
+    expect(p.canManagePartitions).toBe(true);
+  });
+
+  it("denies platform capabilities to non-admins", () => {
+    const p = perms(false);
+    expect(p.canViewSystem).toBe(false);
+    expect(p.canManageUsers).toBe(false);
+    expect(p.canManageModels).toBe(false);
+    expect(p.canManagePresets).toBe(false);
+    expect(p.canManagePartitions).toBe(false);
+  });
+
+  it("lets any authenticated user create a partition", () => {
+    expect(perms(false).canCreatePartition).toBe(true);
+    expect(perms(true).canCreatePartition).toBe(true);
+  });
+});
+
+describe("usePermissions — partition-scoped roles (non-admin)", () => {
+  it("canRead requires any role", () => {
+    expect(perms(false).canRead("viewer")).toBe(true);
+    expect(perms(false).canRead(null)).toBe(false);
+    expect(perms(false).canRead(undefined)).toBe(false);
+  });
+
+  it("canWrite requires editor or owner", () => {
+    expect(perms(false).canWrite("viewer")).toBe(false);
+    expect(perms(false).canWrite("editor")).toBe(true);
+    expect(perms(false).canWrite("owner")).toBe(true);
+    expect(perms(false).canWrite(null)).toBe(false);
+  });
+
+  it("canManageMembers requires owner", () => {
+    expect(perms(false).canManageMembers("viewer")).toBe(false);
+    expect(perms(false).canManageMembers("editor")).toBe(false);
+    expect(perms(false).canManageMembers("owner")).toBe(true);
+  });
+});
+
+describe("usePermissions — admin overrides every partition-role check", () => {
+  it("admin can read/write/manage regardless of (or absent) role", () => {
+    const p = perms(true);
+    expect(p.canRead(null)).toBe(true);
+    expect(p.canWrite(null)).toBe(true);
+    expect(p.canManageMembers(null)).toBe(true);
+  });
+});

--- a/ui/src/lib/routes.test.ts
+++ b/ui/src/lib/routes.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { partitionDetailPath } from "./routes";
+
+describe("partitionDetailPath", () => {
+  it("passes a plain name through", () => {
+    expect(partitionDetailPath("legal")).toBe("/partitions/legal");
+  });
+
+  it("encodes a slash so it doesn't create a nested route", () => {
+    expect(partitionDetailPath("a/b")).toBe("/partitions/a%2Fb");
+  });
+
+  it("encodes #, ?, space and % (would otherwise truncate or break the route)", () => {
+    expect(partitionDetailPath("x#y?z %")).toBe("/partitions/x%23y%3Fz%20%25");
+  });
+});

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -1,0 +1,8 @@
+// Client-side route builders. Centralizing these keeps dynamic-segment encoding
+// in one place: partition (and other) names are caller-chosen and may contain
+// `/ # ? %`, which break a route if interpolated raw.
+
+/** Route to a partition's detail page, with the name URL-encoded. */
+export function partitionDetailPath(name: string): string {
+  return `/partitions/${encodeURIComponent(name)}`;
+}

--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { intOr, numOr } from "./utils";
+
+// These guard against `parseInt("")` / `parseFloat("")` → NaN, which
+// JSON.stringify serializes as `null` when sent to the API.
+describe("intOr", () => {
+  it("parses a valid integer", () => {
+    expect(intOr("5", 0)).toBe(5);
+    expect(intOr("12", 0)).toBe(12);
+  });
+
+  it("returns 0 for '0' (not the fallback)", () => {
+    expect(intOr("0", 9)).toBe(0);
+  });
+
+  it("falls back on an empty string", () => {
+    expect(intOr("", 7)).toBe(7);
+  });
+
+  it("falls back on non-numeric input", () => {
+    expect(intOr("abc", 3)).toBe(3);
+  });
+});
+
+describe("numOr", () => {
+  it("parses a float", () => {
+    expect(numOr("1.5", 0)).toBe(1.5);
+  });
+
+  it("returns 0 for '0' (not the fallback)", () => {
+    expect(numOr("0", 9)).toBe(0);
+  });
+
+  it("falls back on an empty string", () => {
+    expect(numOr("", 30)).toBe(30);
+  });
+
+  it("falls back on non-numeric input", () => {
+    expect(numOr("x", 2.5)).toBe(2.5);
+  });
+});

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -20,6 +20,22 @@ export function formatBytes(bytes: number | null | undefined): string {
 }
 
 /**
+ * Parse an integer from a form-field string, falling back to `fallback` when the
+ * field is empty or non-numeric. Guards against `parseInt("")` → `NaN`, which
+ * `JSON.stringify` would serialize as `null` and send to the API.
+ */
+export function intOr(value: string, fallback: number): number {
+  const n = parseInt(value, 10);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+/** Float counterpart of {@link intOr} — never yields `NaN`. */
+export function numOr(value: string, fallback: number): number {
+  const n = parseFloat(value);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+/**
  * Copy text to the clipboard, working outside secure contexts too.
  * navigator.clipboard is only available over HTTPS/localhost; over plain HTTP
  * it's undefined, so fall back to a hidden textarea + execCommand("copy").

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -33,7 +33,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatDate } from "@/lib/utils";
+import { formatDate, intOr, numOr } from "@/lib/utils";
 
 const MODEL_TYPES = ["embedder", "reranker", "llm", "vlm"] as const;
 
@@ -347,8 +347,8 @@ function EndpointDialog({
       const updateData: UpdateModelEndpointRequest = {
         endpoint,
         model_name: modelName || undefined,
-        batch_size: parseInt(batchSize),
-        timeout: parseFloat(timeout),
+        batch_size: intOr(batchSize, 32),
+        timeout: numOr(timeout, 30),
         extra,
       };
       if (name !== editing.name) {
@@ -361,8 +361,8 @@ function EndpointDialog({
         model_type: activeTab as ModelType,
         endpoint,
         model_name: modelName || undefined,
-        batch_size: parseInt(batchSize),
-        timeout: parseFloat(timeout),
+        batch_size: intOr(batchSize, 32),
+        timeout: numOr(timeout, 30),
         extra,
       });
     }

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -49,7 +49,7 @@ import type { PartitionConfig, PartitionRole } from "@/lib/api/partitions";
 import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
-import { formatDate } from "@/lib/utils";
+import { formatDate, intOr } from "@/lib/utils";
 
 // --- General Tab ---
 
@@ -126,7 +126,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
     mutationFn: () =>
       updatePartition(partition.name, {
         description: description || undefined,
-        chat_history_depth: parseInt(chatHistoryDepth),
+        chat_history_depth: intOr(chatHistoryDepth, 0),
         indexation_preset: indexationPreset,
         retrieval_preset: retrievalPreset,
         chat_llm: chatLlm === "__default__" ? null : chatLlm,

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
 import { intOr } from "@/lib/utils";
+import { partitionDetailPath } from "@/lib/routes";
 
 type SortDir = "asc" | "desc" | null;
 
@@ -68,7 +69,7 @@ function RowActions({ partition }: { partition: PartitionResponse }) {
   return (
     <div className="flex items-center gap-1">
       <Button variant="ghost" size="sm" asChild>
-        <Link to={`/partitions/${encodeURIComponent(partition.name)}`}>
+        <Link to={partitionDetailPath(partition.name)}>
           <Pencil className="h-3 w-3" />
         </Link>
       </Button>
@@ -349,7 +350,7 @@ export default function PartitionListPage() {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <Link
-                          to={`/partitions/${encodeURIComponent(p.name)}`}
+                          to={partitionDetailPath(p.name)}
                           className="font-medium text-primary hover:underline"
                         >
                           {p.name}

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -47,6 +47,7 @@ import {
   resolveEmbedderName,
 } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
+import { intOr } from "@/lib/utils";
 
 type SortDir = "asc" | "desc" | null;
 
@@ -67,7 +68,7 @@ function RowActions({ partition }: { partition: PartitionResponse }) {
   return (
     <div className="flex items-center gap-1">
       <Button variant="ghost" size="sm" asChild>
-        <Link to={`/partitions/${partition.name}`}>
+        <Link to={`/partitions/${encodeURIComponent(partition.name)}`}>
           <Pencil className="h-3 w-3" />
         </Link>
       </Button>
@@ -252,7 +253,7 @@ export default function PartitionListPage() {
         embedder: embedder || undefined,
         indexation_preset: indexationPreset || undefined,
         retrieval_preset: retrievalPreset || undefined,
-        chat_history_depth: parseInt(chatHistoryDepth),
+        chat_history_depth: intOr(chatHistoryDepth, 0),
         chat_llm: chatLlm === "__default__" ? null : chatLlm,
       }),
     onSuccess: (data) => {
@@ -348,7 +349,7 @@ export default function PartitionListPage() {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <Link
-                          to={`/partitions/${p.name}`}
+                          to={`/partitions/${encodeURIComponent(p.name)}`}
                           className="font-medium text-primary hover:underline"
                         >
                           {p.name}


### PR DESCRIPTION
## Summary

Security/correctness fixes surfaced by an audit of the admin UI, each with a regression test. Branches off the current `feat/admin-ui` tip and contains **only these changes** (17 files, +524/−15).

## Bug fixes

- **Revoke the OIDC session on logout.** `logout()` only cleared the localStorage bearer token; in OIDC mode identity comes from the httpOnly `openrag_session` cookie, so the server/IdP session was never ended and `/users/info` re-authenticated on reload. `logout()` now reports whether it was an OIDC/cookie session and the header full-navigates to `GET /auth/logout` (token-mode logout unchanged — which also avoids the 400 `/auth/logout` returns when `AUTH_MODE != oidc`).
- **Default the API base to same-origin.** `API_BASE` fell back to `http://localhost:8000` when `VITE_API_BASE_URL` was undefined, which would send the bearer token cross-origin on a misconfigured build. Now defaults to `""` (relative, same-origin) — fails closed.
- **Encode partition names in detail links.** Raw interpolation broke routing for names containing `/ # ? %`; extracted a `partitionDetailPath()` helper that encodes (single source of truth).
- **Guard numeric form fields against `NaN`.** `parseInt("")`→`NaN`→`null` for `chat_history_depth` / `batch_size` / `timeout`; added `intOr`/`numOr` helpers that fall back to a sane default.

## Tests added

- Wired up a `test` script (`vitest run`) — the suite had no runner before.
- Frontend: logout contract, same-origin/bearer/401/empty-body + `ApiError` envelope parsing, route encoding, `intOr`/`numOr`, the `usePermissions` capability matrix, and `pickDefaultEndpoint`/`resolveEmbedderName`.
- Backend: `GET /partition/` list authorization (no cross-partition leak; super-admin `all`) and the draft `POST /model-endpoints/validate` route.

## Verification

- Frontend: **47 tests / 7 files pass**, `tsc -b` clean, `eslint` 0 warnings.
- Backend: the two router test files pass (15 tests), `ruff` clean.

> Note: no CI job runs `npm test` yet — happy to add a workflow step (`cd ui && npm ci && npm test`) if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logout flow to properly handle OIDC/SSO sessions with appropriate redirects.
  * Added support for special characters in partition names via proper URL encoding.
  * Improved numeric input validation with sensible fallback defaults.

* **Bug Fixes**
  * Fixed API client to use relative URLs by default for enhanced security.
  * Improved bearer token handling and cleared tokens on authentication failures.

* **Tests**
  * Added comprehensive test coverage for admin routes, API client, authentication, permissions, and utilities.

* **Chores**
  * Added npm test scripts to the UI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->