### PR TITLE
fix(prompt): require a non-empty answer body in the RAG system prompt

### DIFF
--- a/prompts/example1/sys_prompt_tmpl.txt
+++ b/prompts/example1/sys_prompt_tmpl.txt
@@ -11,6 +11,7 @@ Prioritize **clarity, accuracy, and completeness** in your responses.
    * Base your answer **exclusively** on the information contained in the `Context`.
    * **Never infer**, assume, or rely on any external knowledge.
    * If the context is **insufficient**, **invite the user** to clarify their query or provide additional keywords.
+   * **Always answer with at least one sentence of text.** Your response body must **never be empty**, even when no source is relevant — in that case briefly explain (in the user's language) that the documents do not cover the question, then end with `[Sources: none]`.
 
 2. Citations
    * Never place citations, source numbers, or references **inside** your answer text: citation is only at the end


### PR DESCRIPTION
## Problem

A streamed RAG answer can collapse to **empty content** — e.g. the model emits little more than the mandated `[Sources: ...]` line, which `extract_and_strip_sources_block()` then strips to `""`. This yields a blank `assistant` turn.

On the **next** request the client (e.g. Twake) replays that blank turn in the chat history, and the upstream LLM (Mistral via litellm) rejects it:

```
litellm.BadRequestError: OpenAIException - Invalid assistant message:
role='assistant' content='' tool_calls=None  (HTTP 400)
```

Observed in production: sending `test` to a partition triggers the 400 on the follow-up turn.

## Fix

Add a rule to `sys_prompt_tmpl.txt` requiring the model to always produce at least one sentence of text — and, when no source is relevant, to briefly say the documents don't cover the question before ending with `[Sources: none]` — rather than returning an empty body.

## Scope / follow-up

This is a **prompt-level mitigation** and reduces (does not eliminate) blank turns. The robust fix is a **server-side guard** that drops/coalesces empty `assistant` messages before forwarding history to the LLM (the inbound check in `routers/openai.py` only validates the *last* message). Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the assistant always provides at least one sentence in responses, preventing empty response bodies. Added a fallback explanation when insufficient context is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->