### PR TITLE
fix(partitions): reserve the `all` partition name to prevent a metadata leak

### DIFF
--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -59,11 +59,18 @@ Returns a list of partitions you have access to, including:
 """,
 )
 async def list_existant_partitions(
+    request: Request,
     partitions=Depends(partitions_with_details),
     service=Depends(get_partition_service),
 ):
     """List partitions visible to the current user."""
-    if len(partitions) == 1 and partitions[0]["partition"] == "all":
+    # The ``all`` entry is the admin/SUPER_ADMIN_MODE sentinel from
+    # partitions_with_details. Gate the all-expansion on the caller actually being
+    # an admin, so a (legacy) partition literally named ``all`` owned by a regular
+    # user cannot leak every partition. New ``all`` partitions are already rejected
+    # at creation (_RESERVED_PARTITION_NAMES).
+    is_admin = bool(request.state.user.get("is_admin"))
+    if is_admin and len(partitions) == 1 and partitions[0]["partition"] == "all":
         partitions = await service.list_partitions()
     logger.debug("Returned list of existing partitions.", partition_count=len(partitions))
     return JSONResponse(status_code=status.HTTP_200_OK, content={"partitions": partitions})

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+# Names reserved as cross-partition sentinels (e.g. ``openrag-all`` /
+# ``?partitions=all``). A real partition named ``all`` collides with the sentinel
+# and the admin partition-list route would expand it to *every* partition — see
+# ``list_existant_partitions``. Matched case-insensitively.
+_RESERVED_PARTITION_NAMES = frozenset({"all"})
+
 
 def _validate_limit(limit: int | None) -> None:
     """Reject negative ``limit`` values before they reach ``rows[:limit]``.
@@ -153,6 +159,12 @@ class PartitionService:
         fast and atomically), the non-default config columns are persisted,
         and the in-memory partition cache is re-resolved.
         """
+        if partition.strip().lower() in _RESERVED_PARTITION_NAMES:
+            raise ValidationError(
+                f"Partition name '{partition}' is reserved.",
+                status_code=400,
+                code="RESERVED_PARTITION_NAME",
+            )
         if await self._partition_repo.partition_exists(name=partition):
             raise ValidationError(
                 f"Partition '{partition}' already exists.",

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from api.dependencies.auth import require_partition_owner, require_partition_viewer
+from api.dependencies.auth import (
+    partitions_with_details,
+    require_partition_owner,
+    require_partition_viewer,
+)
 from api.routers.admin import partitions
 from di.providers import get_partition_service
 from fastapi import FastAPI
@@ -56,6 +60,50 @@ def _build_app(service) -> FastAPI:
     app.dependency_overrides[require_partition_viewer] = lambda: {"id": "admin", "is_admin": True}
     app.dependency_overrides[get_partition_service] = lambda: service
     return app
+
+
+class FakeListService:
+    """Service double whose ``list_partitions`` returns the full set."""
+
+    async def list_partitions(self) -> list[dict[str, Any]]:
+        """Return every partition (the admin all-expansion target)."""
+        return [{"partition": "p1"}, {"partition": "p2"}]
+
+
+def _build_list_app(*, is_admin: bool) -> FastAPI:
+    """App for the list route, with a regular user whose sole membership is ``all``."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _set_user(request, call_next):
+        request.state.user = {"id": 1, "is_admin": is_admin}
+        return await call_next(request)
+
+    app.include_router(partitions.router, prefix="/partition")
+    app.dependency_overrides[partitions_with_details] = lambda: [{"partition": "all"}]
+    app.dependency_overrides[get_partition_service] = lambda: FakeListService()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_list_partitions_expands_all_only_for_admin(async_client_factory):
+    """An admin's ``all`` sentinel expands to every partition."""
+    app = _build_list_app(is_admin=True)
+    async with async_client_factory(app) as client:
+        response = await client.get("/partition/")
+    assert response.status_code == 200
+    assert [p["partition"] for p in response.json()["partitions"]] == ["p1", "p2"]
+
+
+@pytest.mark.asyncio
+async def test_list_partitions_does_not_expand_all_for_non_admin(async_client_factory):
+    """A regular user whose only membership is a partition named ``all`` must not
+    receive every partition — the all-expansion is gated on is_admin."""
+    app = _build_list_app(is_admin=False)
+    async with async_client_factory(app) as client:
+        response = await client.get("/partition/")
+    assert response.status_code == 200
+    assert [p["partition"] for p in response.json()["partitions"]] == ["all"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -154,6 +154,7 @@ async def test_create_partition_rejects_reserved_name(name):
     with pytest.raises(ValidationError) as ei:
         await _svc(prepo=prepo).create_partition(name, 1)
     assert ei.value.status_code == 400
+    assert ei.value.code == "RESERVED_PARTITION_NAME"
     assert prepo.created == []
 
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -145,6 +145,19 @@ async def test_create_partition_success():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["all", "ALL", "All", "  all  "])
+async def test_create_partition_rejects_reserved_name(name):
+    # ``all`` is the cross-partition sentinel — a real partition with that name
+    # would leak every partition to its owner. Rejected (400) before the row is
+    # written, case-insensitively and after trimming, even when it doesn't exist.
+    prepo = FakePartitionRepo()
+    with pytest.raises(ValidationError) as ei:
+        await _svc(prepo=prepo).create_partition(name, 1)
+    assert ei.value.status_code == 400
+    assert prepo.created == []
+
+
+@pytest.mark.asyncio
 async def test_delete_partition_missing_raises_404():
     with pytest.raises(PartitionNotFoundError):
         await _svc(prepo=FakePartitionRepo(existing=set())).delete_partition("ghost")


### PR DESCRIPTION
Closes #548.

## Problem
A regular (non-admin) user whose **sole partition membership is a partition literally named `all`** received **every partition's** config + document counts from `GET /partition/`.

`all` is overloaded as the cross-partition sentinel: `partitions_with_details` returns `[{"partition": "all"}]` for admins under `SUPER_ADMIN_MODE`, and the list route expanded that to every partition (`partitions.py:66`). The branch keyed on the **name** `"all"`, not on `is_admin` — and `create_partition` takes the name from the URL path with **no reserved-name guard**, so a regular user (who can create partitions) could create one named `all` and trigger the expansion.

## Fix
1. **Reserved-name guard (root fix)** — `PartitionService.create_partition` now rejects `all` (case-insensitive, trimmed) with `400 RESERVED_PARTITION_NAME`, at the service layer so it covers every caller. No new partition can collide with the sentinel.
2. **Defense-in-depth** — the all-expansion branch in the list route now also requires `is_admin`, so even a *legacy* `all` partition owned by a regular user can't leak every partition.

## Tests (+6)
- `create_partition` rejects `all` / `ALL` / `All` / `"  all  "` (never written)
- list route **expands** `all` for an admin
- list route does **not** expand `all` for a non-admin

`uv run pytest tests/unit/` → **1311 passed** · `ruff` clean.

## Notes
- Only **create** is guarded — there is no partition-rename endpoint.
- The reserved set is currently `{"all"}`, structured to extend if other sentinels appear.
- This also de-risks the `all` sentinel that the per-partition `chat_history_depth` resolver (#536) and partition-link encoding lean on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the special `all` partition behavior to admins, so non-admin users no longer trigger a full partition listing by using that value.
  * Prevented creation of partitions named `all` (including case-insensitive or whitespace variants), returning a validation error instead.
* **Tests**
  * Added unit and API route tests covering the admin vs non-admin `all` expansion behavior and rejection of the reserved partition name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->