### PR TITLE
fix(compose): avoid fixed Admin UI container name

### DIFF
--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -107,7 +107,6 @@ services:
         # Same-origin: nginx proxies the API, so the SPA uses relative calls.
         VITE_API_BASE_URL: ""
         VITE_BASE_PATH: "/app/"
-    container_name: openrag-admin-ui
     restart: unless-stopped
     ports:
       - "${ADMIN_UI_PORT:-8081}:80"

--- a/tests/unit/infra/test_admin_ui_compose.py
+++ b/tests/unit/infra/test_admin_ui_compose.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_admin_ui_compose_service_uses_project_scoped_container_name():
+    compose_path = Path(__file__).resolve().parents[3] / "infra/compose/docker-compose.yaml"
+
+    with compose_path.open(encoding="utf-8") as handle:
+        compose = yaml.safe_load(handle)
+
+    admin_ui = compose["services"]["admin-ui"]
+
+    assert "container_name" not in admin_ui
+    assert admin_ui["ports"] == ["${ADMIN_UI_PORT:-8081}:80"]


### PR DESCRIPTION
## Why

The Admin UI should be able to start from more than one compose project on the same machine. A fixed Docker container name makes that fragile: if the name already exists, the stack fails before the UI starts.

## What changed

This lets Docker Compose generate the Admin UI container name from the compose project, while keeping the existing Admin UI port behavior driven by the environment.

## Validation

- Added a regression test for the Admin UI compose service.
- Verified the compose render still publishes the configured Admin UI port.

Closes #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the admin UI deployment settings to avoid using a fixed container name, improving flexibility when running multiple instances.
* **Tests**
  * Added a unit test to verify the admin UI compose configuration no longer specifies a fixed container name and that its port mapping defaults to `8081` when not overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->