### PR TITLE
docs(oidc): clarify OIDC_REDIRECT_URI is the UI front door, not the API port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,7 +385,7 @@ OpenRag supports two authentication modes, controlled by the `AUTH_MODE` environ
 | `OIDC_ENDPOINT` | Issuer URL for auto-discovery | `https://idp.example.com/realms/openrag` |
 | `OIDC_CLIENT_ID` | Client registered at IdP | `openrag` |
 | `OIDC_CLIENT_SECRET` | Client secret | (provided by IdP) |
-| `OIDC_REDIRECT_URI` | Callback URL (must match IdP config) | `https://openrag.example.com/auth/callback` |
+| `OIDC_REDIRECT_URI` | Callback URL — the **front door** that serves the UI *and* reaches the backend `/auth/callback` (the admin-ui / proxy port, **not necessarily** `APP_PORT`); must match IdP config | `https://openrag.example.com/auth/callback` |
 | `OIDC_TOKEN_ENCRYPTION_KEY` | Fernet key for token encryption | (generate via: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`) |
 
 **Optional Env Variables**:

--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -129,19 +129,19 @@ Pick the value by deployment shape:
 
 - **Bundled admin-ui (nginx) is the front door** — it serves the React SPA at `/app/` and proxies `/auth`, `/v1`, … to the backend. Use the **admin-ui port** (`ADMIN_UI_PORT`), **not** `APP_PORT`. Both ports host a working `/auth/callback`, but only the admin-ui port *also* serves `/app/`, so only it lands you back on the UI:
 
-  ```
+  ```bash
   OIDC_REDIRECT_URI=http://<ip_addr>:<ADMIN_UI_PORT>/auth/callback
   ```
 
 - **Backend is the front door** — it serves the Chainlit UI itself on `APP_PORT`. Address the backend directly:
 
-  ```
+  ```bash
   OIDC_REDIRECT_URI=http://<ip_addr>:<APP_PORT>/auth/callback
   ```
 
 - **Reverse proxy / single public hostname** (production, TLS terminated): the proxy serves the UI and forwards `/auth/*` to the backend, so use the public hostname:
 
-  ```
+  ```bash
   OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
   ```
 
@@ -843,6 +843,14 @@ Server logs record the attempted `sub` at `WARNING` level so admins can copy it 
 - Keycloak: Ensure `offline_access` scope is mapped to the client
   - **Clients** → `openrag` → **Client scopes** → Verify `offline_access` is in the assigned scopes
 - LemonLDAP::NG: Check the OIDC relying party configuration includes `offline_access`
+
+### 8. Login succeeds but lands on a blank / 404 / JSON page
+
+**Error**: The IdP login completes without error, but the browser ends up on an empty page, a 404, or raw JSON instead of the UI. No error is shown — this is a **silent** failure.
+
+**Cause**: `OIDC_REDIRECT_URI` points at an origin that *can* reach `/auth/callback` but does **not** serve the UI. The classic case is pointing at the bare backend `APP_PORT` when a separate front door (the admin-ui nginx, or a reverse proxy) actually serves the UI. The callback runs, but the post-login redirect is **relative** (e.g. `/app/`), so the browser resolves it against the backend origin — which has no `/app/` — and lands nowhere useful.
+
+**Solution**: Set `OIDC_REDIRECT_URI` to the origin that serves your UI *and* reaches `/auth/callback` (for the bundled admin-ui that's `http://<host>:<ADMIN_UI_PORT>/auth/callback`, **not** `APP_PORT`). See [Choosing `OIDC_REDIRECT_URI`](#choosing-oidc_redirect_uri).
 
 ---
 

--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -108,7 +108,7 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_ENDPOINT` | Yes* | — | Issuer URL (auto-discovery via `/.well-known/openid-configuration`) |
 | `OIDC_CLIENT_ID` | Yes* | — | Client ID registered at the IdP |
 | `OIDC_CLIENT_SECRET` | Yes* | — | Client secret (confidential clients only) |
-| `OIDC_REDIRECT_URI` | Yes* | — | Callback URL on OpenRag's backend, must match IdP configuration. Behind a proxy: `https://openrag.example.com/auth/callback`; direct access: `http://<ip_addr>:<APP_PORT>/auth/callback`. See [Choosing `OIDC_REDIRECT_URI`](#choosing-oidc_redirect_uri). |
+| `OIDC_REDIRECT_URI` | Yes* | — | Public URL of the **front door** that serves your UI *and* reaches the backend's `/auth/callback` — the reverse-proxy / admin-ui port, **not necessarily** the bare `APP_PORT`. Must match the IdP config byte-for-byte. See [Choosing `OIDC_REDIRECT_URI`](#choosing-oidc_redirect_uri). |
 | `OIDC_TOKEN_ENCRYPTION_KEY` | Yes* | — | Fernet key for encrypting tokens at rest (see [Generating the Fernet Key](#generating-the-fernet-key)) |
 | `OIDC_CLAIM_SOURCE` | No | `id_token` | Where to read claims for [Claim Mapping](#claim-mapping-optional): `id_token` (verified JWT) or `userinfo` (`/userinfo` endpoint) |
 | `OIDC_CLAIM_MAPPING` | No | — | Optional CSV of `db_field:claim` pairs to copy claims into user fields on every login (e.g., `display_name:name,email:email`). See [Claim Mapping](#claim-mapping-optional). |
@@ -120,21 +120,34 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 
 ### Choosing `OIDC_REDIRECT_URI`
 
-The value must be an absolute URL pointing at **OpenRag's backend** `/auth/callback` route, reachable from the user's browser, and registered verbatim in the IdP client configuration.
+`OIDC_REDIRECT_URI` is the URL the IdP sends the browser back to after login. It must point at the **origin that serves your UI _and_ can reach the backend's `/auth/callback` route**, registered verbatim in the IdP client configuration. Two things must be true of that origin, and both are easy to get subtly wrong:
 
-- **Behind a reverse proxy** (production, TLS terminated): UI and backend share the same public base URL, so use the public hostname directly:
+1. **It must host a working `/auth/callback`.** That route exists **only** on the backend (`openrag/api`). An origin satisfies this either by *being* the backend, or by *reverse-proxying* `/auth/*` to it.
+2. **It must also serve the UI you land on after login.** After the callback, the backend issues a **relative** redirect (e.g. `/app/` or `/chainlit/`). The browser resolves it against whichever origin handled the callback — so if that origin doesn't serve the UI path, login *succeeds* but you land on a blank/404/JSON page. **No error is shown — this is the silent failure.**
+
+Pick the value by deployment shape:
+
+- **Bundled admin-ui (nginx) is the front door** — it serves the React SPA at `/app/` and proxies `/auth`, `/v1`, … to the backend. Use the **admin-ui port** (`ADMIN_UI_PORT`), **not** `APP_PORT`. Both ports host a working `/auth/callback`, but only the admin-ui port *also* serves `/app/`, so only it lands you back on the UI:
 
   ```
-  OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+  OIDC_REDIRECT_URI=http://<ip_addr>:<ADMIN_UI_PORT>/auth/callback
   ```
 
-- **No reverse proxy** (local / bare-metal deployment): each service is reached on its own port, so the backend must be addressed explicitly by host and `APP_PORT`:
+- **Backend is the front door** — it serves the Chainlit UI itself on `APP_PORT`. Address the backend directly:
 
   ```
   OIDC_REDIRECT_URI=http://<ip_addr>:<APP_PORT>/auth/callback
   ```
 
-  The IdP redirects the browser to this URL, so `<ip_addr>` must be resolvable/reachable from the end user's machine — not `localhost` or `127.0.0.1` unless the browser runs on the same host as OpenRag.
+- **Reverse proxy / single public hostname** (production, TLS terminated): the proxy serves the UI and forwards `/auth/*` to the backend, so use the public hostname:
+
+  ```
+  OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
+  ```
+
+> ⚠ **Never point this at a _static_ UI front that has no `/auth/callback`** (a bare SPA with no reverse proxy). The callback 404s, the browser reads that as "not authenticated", and you get an **infinite login loop**. The bundled admin-ui does **not** have this problem — its nginx proxies `/auth/callback` to the backend, which is exactly why it is a valid (and recommended) redirect target.
+
+For direct (no-proxy) values, `<ip_addr>` must be reachable from the **end user's** browser — not `localhost` / `127.0.0.1` unless the browser runs on the OpenRag host.
 
 Whichever form you use, the string must match the IdP's **Valid redirect URIs** list byte-for-byte (scheme, host, port, path, trailing slash).
 

--- a/docs/content/docs/documentation/sso-quickstart.md
+++ b/docs/content/docs/documentation/sso-quickstart.md
@@ -11,13 +11,15 @@ Configure OpenRag to delegate authentication to your corporate SSO (LemonLDAP::N
 Give them the following information.
 
 > ⚠ **Point the IdP at the _front door_ that serves your UI AND reaches the backend's `/auth/callback`.**
-> The OIDC callback and back-channel-logout endpoints are hosted **only** on the backend (the container running `openrag/api.py`). So the redirect target must either *be* the backend, or be a **reverse proxy that forwards `/auth/*` to it**:
+> The OIDC callback and back-channel-logout endpoints are hosted **only** on the OpenRag API backend container. So the redirect target must either *be* the backend, or be a **reverse proxy that forwards `/auth/*` to it**:
 >
 > - **Bundled admin-ui (nginx)** or any reverse proxy → use **its** host/port. It serves the UI *and* proxies `/auth/callback` to the backend, so it is correct — and it's where you must land after login (the post-login redirect is relative). For the admin-ui that's `http://<host>:<ADMIN_UI_PORT>/auth/callback`.
 > - **Backend directly** (e.g. it serves the Chainlit UI on `APP_PORT`) → use the backend host + `APP_PORT`.
 > - **A _static_ UI front with no proxy** (a bare SPA) → ❌ **never.** It has no `/auth/callback`, so you get an **infinite redirect loop** (404 → "not authenticated" → new OIDC flow → back to the front → …).
 >
 > Common pitfall: pointing at the **bare backend port** when a separate proxy serves your UI. Login *completes* (the backend has the callback) but the relative post-login redirect drops you on the backend port, which doesn't serve the UI — a **silent** landing on a blank page. Match the redirect URI to the origin that serves the UI.
+>
+> **Back-channel logout is different.** Unlike the redirect URI (a *browser* redirect that must land on the UI), `/auth/backchannel-logout` is called **server-to-server by the IdP**, never by the browser. It therefore has no UI requirement — it just needs to reach the backend's logout endpoint. Reusing the same proxy origin is fine *as long as that origin forwards `/auth/backchannel-logout` to the backend and is reachable from the IdP server*; otherwise point it straight at the backend.
 
 | Field                         | Value to give                                                  |
 | ----------------------------- | -------------------------------------------------------------- |
@@ -25,7 +27,7 @@ Give them the following information.
 | **Grant type**                | `authorization_code`                                           |
 | **Response type**             | `code`                                                         |
 | **Valid redirect URIs**       | `<front-door-host>/auth/callback` _(the UI's proxy or the backend — see warning)_ |
-| **Back-channel logout URI**   | `<front-door-host>/auth/backchannel-logout` _(same origin as above)_ |
+| **Back-channel logout URI**   | `<host>/auth/backchannel-logout` _(server-to-server from the IdP — must reach the backend; see warning)_ |
 | **Post-logout redirect URIs** | an optional URL **outside** OpenRag (see §Step 4 below)        |
 | **Allowed scopes**            | `openid`, `email`, `profile`, `offline_access`                 |
 | **Include `sid` in tokens**   | ✅ enabled (required for back-channel logout)                  |

--- a/docs/content/docs/documentation/sso-quickstart.md
+++ b/docs/content/docs/documentation/sso-quickstart.md
@@ -10,18 +10,22 @@ Configure OpenRag to delegate authentication to your corporate SSO (LemonLDAP::N
 
 Give them the following information.
 
-> ⚠ **`<openrag-host>` is the OpenRag _backend_ URL, NOT the indexer-ui front.**
-> The OIDC callback and back-channel-logout endpoints are hosted **only** on the backend (the container running `openrag/api.py`). If you point the IdP at the front URL instead, you get an **infinite redirect loop**: the front has no `/auth/callback` route, returns 404/401, which is interpreted as "not authenticated", triggering a new OIDC flow, which again lands on the front, etc.
+> ⚠ **Point the IdP at the _front door_ that serves your UI AND reaches the backend's `/auth/callback`.**
+> The OIDC callback and back-channel-logout endpoints are hosted **only** on the backend (the container running `openrag/api.py`). So the redirect target must either *be* the backend, or be a **reverse proxy that forwards `/auth/*` to it**:
 >
-> In a typical deployment: `https://rag.mycorp.com` (the backend) vs `https://ui.mycorp.com` (the front). **Use the backend URL** for the OIDC endpoints below.
+> - **Bundled admin-ui (nginx)** or any reverse proxy → use **its** host/port. It serves the UI *and* proxies `/auth/callback` to the backend, so it is correct — and it's where you must land after login (the post-login redirect is relative). For the admin-ui that's `http://<host>:<ADMIN_UI_PORT>/auth/callback`.
+> - **Backend directly** (e.g. it serves the Chainlit UI on `APP_PORT`) → use the backend host + `APP_PORT`.
+> - **A _static_ UI front with no proxy** (a bare SPA) → ❌ **never.** It has no `/auth/callback`, so you get an **infinite redirect loop** (404 → "not authenticated" → new OIDC flow → back to the front → …).
+>
+> Common pitfall: pointing at the **bare backend port** when a separate proxy serves your UI. Login *completes* (the backend has the callback) but the relative post-login redirect drops you on the backend port, which doesn't serve the UI — a **silent** landing on a blank page. Match the redirect URI to the origin that serves the UI.
 
 | Field                         | Value to give                                                  |
 | ----------------------------- | -------------------------------------------------------------- |
 | **Client type**               | `confidential` (server-to-server token exchange)               |
 | **Grant type**                | `authorization_code`                                           |
 | **Response type**             | `code`                                                         |
-| **Valid redirect URIs**       | `<openrag-backend-host>/auth/callback` _(backend, not front!)_ |
-| **Back-channel logout URI**   | `<openrag-backend-host>/auth/backchannel-logout` _(backend!)_  |
+| **Valid redirect URIs**       | `<front-door-host>/auth/callback` _(the UI's proxy or the backend — see warning)_ |
+| **Back-channel logout URI**   | `<front-door-host>/auth/backchannel-logout` _(same origin as above)_ |
 | **Post-logout redirect URIs** | an optional URL **outside** OpenRag (see §Step 4 below)        |
 | **Allowed scopes**            | `openid`, `email`, `profile`, `offline_access`                 |
 | **Include `sid` in tokens**   | ✅ enabled (required for back-channel logout)                  |

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -70,7 +70,10 @@ RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 # critical with the newest version of UV
 ## 3. Replace INDEXERUI_PORT with its value in the INDEXERUI_URL variable
 
 INCLUDE_CREDENTIALS=false                       # set true if fastapi authentification is enabled, i.e AUTH_TOKEN is set
-INDEXERUI_PORT=8060                             # Port to expose the Indexer UI (default is 3042)
+# ADMIN_UI_PORT=8081                            # Port to expose the React admin UI (nginx). It serves /app/ and
+                                                # proxies /auth, /v1, … to the backend, so it's the OIDC front door
+                                                # (see OIDC_REDIRECT_URI below). Default is 8081.
+INDEXERUI_PORT=8060                             # Port to expose the legacy Indexer UI (default is 3042)
 INDEXERUI_URL='http://X.X.X.X:INDEXERUI_PORT'
 API_BASE_URL='http://X.X.X.X:APP_PORT'          # Base URL of your FastAPI backend.
 # Mount the indexer-ui under a subpath (e.g. `/indexerui`) on a shared vhost
@@ -126,9 +129,14 @@ PREFERRED_URL_SCHEME=https
 # OIDC_ENDPOINT=https://idp.example.com/realms/openrag
 # OIDC_CLIENT_ID=openrag
 # OIDC_CLIENT_SECRET=change-me
-# Callback URL on OpenRag's BACKEND. Must match the IdP client config byte-for-byte.
-# Behind a reverse proxy: use the public URL (e.g. https://openrag.example.com/auth/callback).
-# Direct access (no proxy): use host + APP_PORT (e.g. http://<ip_addr>:<APP_PORT>/auth/callback).
+# Public URL of the FRONT DOOR that serves your UI AND reaches the backend's /auth/callback.
+# Must match the IdP client config byte-for-byte. It's also where you land after login (the
+# post-login redirect is relative), so pick the origin that serves your UI:
+#   - Bundled admin-ui (nginx) front door:  http://<ip_addr>:<ADMIN_UI_PORT>/auth/callback
+#       NOT APP_PORT — the bare API has /auth/callback but does NOT serve the /app/ UI, so SSO
+#       would complete yet silently land you on a blank page.
+#   - Backend serves the UI itself (Chainlit):  http://<ip_addr>:<APP_PORT>/auth/callback
+#   - Reverse proxy / single hostname (prod):   https://openrag.example.com/auth/callback
 # OIDC_REDIRECT_URI=https://openrag.example.com/auth/callback
 # OIDC_SCOPES=openid email profile offline_access  # include offline_access for refresh tokens (persistent sessions)
 # Generate a Fernet key once: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -116,6 +116,13 @@ class OIDCConfig(BaseModel):
     issuer_url: str = ""
     client_id: str = ""
     client_secret: str = ""
+    # Public URL the IdP redirects back to after login. Must point at the
+    # *front door* that serves the UI AND can reach the backend's /auth/callback
+    # (e.g. the admin-ui / reverse-proxy port) — not necessarily the bare API
+    # port. The post-login redirect is relative, so the browser lands back on
+    # whichever origin handled the callback; if that origin doesn't serve the
+    # UI, login silently lands on a blank page. See docs oidc.md
+    # "Choosing OIDC_REDIRECT_URI".
     redirect_uri: str = ""
     scopes: str = "openid email profile offline_access"
     token_encryption_key: str = ""


### PR DESCRIPTION
## Why

`OIDC_REDIRECT_URI` has a silent footgun once the **admin-ui (nginx)** is the front door.

The rule people assume — *"it's the FastAPI backend's base URL"* — is only true when the backend also serves the UI you land on (e.g. Chainlit on `APP_PORT`). With the bundled admin-ui, the UI is served by **nginx** (which also proxies `/auth/*` to the backend), so the front door is the **admin-ui port, not `APP_PORT`**.

If you point the redirect at the bare API port anyway:
- login **completes** (the API does host `/auth/callback`), but
- the post-login redirect is **relative** (`/app/`), so the browser lands back on the API port, which **doesn't serve `/app/`** → a blank/JSON page.

**No error is shown.** That's the silent failure this PR documents.

## What changed

Docs-only — every place the variable is mentioned now states that `OIDC_REDIRECT_URI` is the **front door that serves the UI *and* reaches `/auth/callback`**, and names the silent failure mode:

| File | Change |
|------|--------|
| `docs/.../oidc.md` | Rewrote the **"Choosing `OIDC_REDIRECT_URI`"** section into three deployment shapes (admin-ui / backend / reverse proxy) with the two must-be-true conditions; updated the env-table row |
| `docs/.../sso-quickstart.md` | Distinguish a **reverse-proxy front (valid — the admin-ui)** from a **static SPA front (infinite loop)**; flag the bare-backend-port pitfall |
| `infra/compose/.env.example` | Expanded the `OIDC_REDIRECT_URI` comment with the 3 cases; documented `ADMIN_UI_PORT` |
| `CLAUDE.md` | Tightened the env-table description |
| `openrag/core/config/auth.py` | Comment on the `redirect_uri` config field pointing at the docs |

The prior docs said *"always the backend, never the front"* — correct only for a **dumb SPA** front. The admin-ui is a **reverse-proxy** front (serves `/app/` *and* proxies `/auth/callback`), so it's the **recommended** redirect target, not a forbidden one. The docs now say that explicitly.

## Notes
- No code/behavior change; the validator and runtime are untouched.
- Base is `feat/admin-ui` (same as the other admin-ui PRs, e.g. #537).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to set the OIDC redirect URI to the UI “front door” that routes to the backend `/auth/callback`, with guidance for bundled admin UI, reverse proxy, and backend-direct setups.
  * Expanded troubleshooting and failure-mode explanations for mispointed redirect URIs (e.g., blank/404/JSON pages and login loops).
  * Updated the SSO quickstart and configuration examples (including environment template comments) to reflect the corrected front-door vs backend routing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->