### PR TITLE
fix(helm): harden chart security defaults

### DIFF
--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/infra/charts/openrag-stack/templates/indexer-ui.yaml
+++ b/infra/charts/openrag-stack/templates/indexer-ui.yaml
@@ -18,10 +18,15 @@ spec:
         app.kubernetes.io/name: indexer-ui
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: {{ .Values.security.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.security.podSecurityContext | nindent 8 }}
       containers:
         - name: indexer-ui
           image: {{ .Values.indexerUi.image }}
           imagePullPolicy: {{ .Values.indexerUi.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.security.containerSecurityContext | nindent 12 }}
           env:
             {{- range $key, $value := .Values.indexerUi.env }}
             - name: {{ $key }}

--- a/infra/charts/openrag-stack/templates/infinity.yaml
+++ b/infra/charts/openrag-stack/templates/infinity.yaml
@@ -17,11 +17,16 @@ spec:
         app.kubernetes.io/name: reranker
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: {{ .Values.security.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.security.podSecurityContext | nindent 8 }}
       runtimeClassName: {{ .Values.reranker.runtimeClassName }}
       nodeSelector: {{- toYaml .Values.reranker.nodeSelector | nindent 8 }}
       containers:
         - name: reranker
           image: "{{ .Values.reranker.image.repository }}:{{ .Values.reranker.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.security.containerSecurityContext | nindent 12 }}
           args:
             - "v2"
             - "--model-id"

--- a/infra/charts/openrag-stack/templates/ingress.yaml
+++ b/infra/charts/openrag-stack/templates/ingress.yaml
@@ -10,8 +10,17 @@ metadata:
 
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ required "ingress.host must be set when ingress.tls.enabled=true" .Values.ingress.host | quote }}
+      {{- with .Values.ingress.tls.secretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
+  {{- end }}
   rules:
-    - http:
+    - host: {{ required "ingress.host must be set when ingress.enabled=true" .Values.ingress.host | quote }}
+      http:
         paths:
           {{- if .Values.ingress.paths.openrag.enabled }}
           - path: /(.*)
@@ -22,7 +31,4 @@ spec:
                 port:
                   number: {{ .Values.env.config.RAY_SERVE_PORT }}
           {{- end }}
-      {{- with .Values.ingress.host }}
-      host: {{ . | quote }}
-      {{- end }}
 {{- end }}

--- a/infra/charts/openrag-stack/templates/openrag.yaml
+++ b/infra/charts/openrag-stack/templates/openrag.yaml
@@ -17,9 +17,14 @@ spec:
         app.kubernetes.io/name: openrag
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: {{ .Values.security.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.security.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-venv
           image: "{{ .Values.openrag.image.repository }}:{{ .Values.openrag.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.security.containerSecurityContext | nindent 12 }}
           command:
             - sh
             - -c
@@ -35,6 +40,8 @@ spec:
       containers:
         - name: openrag
           image: "{{ .Values.openrag.image.repository }}:{{ .Values.openrag.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.security.containerSecurityContext | nindent 12 }}
           ports:
             - containerPort: {{ .Values.openrag.service.port }}
           resources:

--- a/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
+++ b/infra/charts/openrag-stack/templates/postgres-migration-job.yaml
@@ -36,9 +36,14 @@ spec:
         app.kubernetes.io/component: postgres-migration
     spec:
       restartPolicy: Never
+      automountServiceAccountToken: {{ .Values.security.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.security.podSecurityContext | nindent 8 }}
       containers:
         - name: migrate
           image: "{{ .Values.openrag.image.repository }}:{{ .Values.openrag.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.security.containerSecurityContext | nindent 12 }}
           workingDir: /app/openrag
           command:
             - sh

--- a/infra/charts/openrag-stack/templates/raycluster.yaml
+++ b/infra/charts/openrag-stack/templates/raycluster.yaml
@@ -12,10 +12,15 @@ spec:
     serviceType: ClusterIP
     template:
       spec:
+        automountServiceAccountToken: {{ .Values.security.automountServiceAccountToken }}
+        securityContext:
+          {{- toYaml .Values.security.podSecurityContext | nindent 10 }}
         nodeSelector: {{- toYaml .Values.ray.nodeSelector | nindent 12 }}
         initContainers:
           - name: init-venv-sync
             image: {{ .Values.ray.image.repository }}:{{ .Values.ray.image.tag }}
+            securityContext:
+              {{- toYaml .Values.security.containerSecurityContext | nindent 14 }}
             command:
               - sh
               - -c
@@ -35,6 +40,8 @@ spec:
         containers:
           - name: ray-head
             image: {{ .Values.ray.image.repository }}:{{ .Values.ray.image.tag }}
+            securityContext:
+              {{- toYaml .Values.security.containerSecurityContext | nindent 14 }}
             command: ["uv"]
             args:
               - "run"
@@ -95,9 +102,14 @@ spec:
       maxReplicas: {{ $.Values.ray.workers.maxReplicas }}
       template:
         spec:
+          automountServiceAccountToken: {{ $.Values.security.automountServiceAccountToken }}
+          securityContext:
+            {{- toYaml $.Values.security.podSecurityContext | nindent 12 }}
           initContainers:
             - name: init-venv
               image: ghcr.io/linagora/openrag:dev-latest
+              securityContext:
+                {{- toYaml $.Values.security.containerSecurityContext | nindent 16 }}
               command:
                 - sh
                 - -c
@@ -113,6 +125,8 @@ spec:
           containers:
             - name: ray-worker
               image: {{ $.Values.ray.image.repository }}:{{ $.Values.ray.image.tag }}
+              securityContext:
+                {{- toYaml $.Values.security.containerSecurityContext | nindent 16 }}
               command: ["/bin/bash", "-lc", "--"]
               args:
                 - uv run $KUBERAY_GEN_RAY_START_CMD

--- a/infra/charts/openrag-stack/templates/secrets-env.yaml
+++ b/infra/charts/openrag-stack/templates/secrets-env.yaml
@@ -4,6 +4,15 @@ metadata:
   name: rag-env-secrets
 type: Opaque
 stringData:
+{{- $requiredSecrets := list "AUTH_TOKEN" "POSTGRES_PASSWORD" }}
+{{- $placeholderSecrets := list "sk-xxxx" "hf_xxxx" "CHANGE_ME_STRONG_PASSWORD" "root_password" }}
 {{- range $key, $value := .Values.env.secrets }}
-  {{ $key }}: "{{ $value }}"
+  {{- $stringValue := tpl (printf "%v" $value) $ }}
+  {{- if and (has $key $requiredSecrets) (empty $stringValue) }}
+  {{- fail (printf "env.secrets.%s must be set before installing the chart" $key) }}
+  {{- end }}
+  {{- if has $stringValue $placeholderSecrets }}
+  {{- fail (printf "env.secrets.%s still uses an unsafe placeholder value" $key) }}
+  {{- end }}
+  {{ $key }}: {{ $stringValue | quote }}
 {{- end }}

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -27,7 +27,7 @@ postgresql:
   enabled: true
   auth:
     username: &pgUser root
-    password: &pgPass root_password
+    password: &pgPass ""
   primary:
     persistence:
       enabled: true
@@ -85,6 +85,19 @@ vllm:
   llmModelName: &llmModel "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8"
   servingEngineSpec:
     enableEngine: true
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     modelSpec:
       - name: "embedder"
         repository: "vllm/vllm-openai"
@@ -259,13 +272,31 @@ openrag:
   replicas: 1
 
 ingress:
-  enabled: true
+  enabled: false
   className: "nginx"
   host: ""
+  tls:
+    enabled: false
+    secretName: ""
 
   paths:
     openrag:
       enabled: true
+
+security:
+  automountServiceAccountToken: false
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 # === Shared env (config + secrets) ===
 env:
@@ -300,7 +331,6 @@ env:
     POSTGRES_HOST: "{{ .Release.Name }}-postgresql"
     POSTGRES_PORT: *pgPort
     POSTGRES_USER: *pgUser
-    POSTGRES_PASSWORD: *pgPass
     POSTGRES_AUTO_CREATE_DB: "{{ .Values.postgresProvisioning.autoCreateDatabase }}"
     POSTGRES_RUN_MIGRATIONS: "{{ .Values.postgresProvisioning.runMigrationsInApp }}"
 
@@ -340,9 +370,10 @@ env:
     UV_CACHE_DIR: "/tmp/uv-cache"
 
   secrets:
-    API_KEY: "sk-xxxx" # LLM API KEY
-    VLM_API_KEY: "sk-xxxx" # VLM API KEY
+    API_KEY: "" # LLM API KEY
+    VLM_API_KEY: "" # VLM API KEY
     EMBEDDER_API_KEY: "EMPTY"
     TRANSCRIBER_API_KEY: "EMPTY"
-    AUTH_TOKEN: "sk-xxxx" # API KEY for OpenRAG
-    HF_TOKEN: "hf_xxxx" # HuggingFace token
+    POSTGRES_PASSWORD: "{{ .Values.postgresql.auth.password }}"
+    AUTH_TOKEN: "" # API KEY for OpenRAG
+    HF_TOKEN: "" # HuggingFace token

--- a/tests/unit/infra/test_helm_security_hardening.py
+++ b/tests/unit/infra/test_helm_security_hardening.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+CHART_DIR = ROOT / "infra" / "charts" / "openrag-stack"
+VALUES = CHART_DIR / "values.yaml"
+TEMPLATES = CHART_DIR / "templates"
+
+
+def _values() -> dict:
+    return yaml.safe_load(VALUES.read_text(encoding="utf-8"))
+
+
+def _template(name: str) -> str:
+    return (TEMPLATES / name).read_text(encoding="utf-8")
+
+
+def _all_templates() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in TEMPLATES.glob("*.yaml"))
+
+
+def test_helm_defaults_do_not_ship_known_placeholder_secrets() -> None:
+    values = _values()
+    secrets = values["env"]["secrets"]
+
+    assert values["postgresql"]["auth"]["password"] in ("", None)
+    assert values["env"]["config"].get("POSTGRES_PASSWORD") is None
+    assert secrets["POSTGRES_PASSWORD"] == "{{ .Values.postgresql.auth.password }}"
+
+    for key in ("API_KEY", "VLM_API_KEY", "AUTH_TOKEN", "HF_TOKEN"):
+        assert secrets[key] in ("", "EMPTY", None)
+
+
+def test_secret_template_fails_on_required_or_placeholder_secrets() -> None:
+    template = _template("secrets-env.yaml")
+
+    assert "fail" in template
+    assert "requiredSecrets" in template
+    assert "AUTH_TOKEN" in template
+    assert "POSTGRES_PASSWORD" in template
+    assert "sk-xxxx" in template
+    assert "hf_xxxx" in template
+    assert "CHANGE_ME_STRONG_PASSWORD" in template
+
+
+def test_chart_workloads_apply_restricted_security_contexts() -> None:
+    values = _values()
+    security = values["security"]
+
+    assert security["automountServiceAccountToken"] is False
+    assert security["podSecurityContext"]["runAsNonRoot"] is True
+    assert security["podSecurityContext"]["seccompProfile"]["type"] == "RuntimeDefault"
+    assert security["containerSecurityContext"]["allowPrivilegeEscalation"] is False
+    assert security["containerSecurityContext"]["capabilities"]["drop"] == ["ALL"]
+    assert values["vllm"]["servingEngineSpec"]["containerSecurityContext"]["runAsNonRoot"] is True
+
+    templates = _all_templates()
+    assert templates.count("automountServiceAccountToken:") >= 5
+    assert templates.count(".Values.security.podSecurityContext") >= 5
+    assert templates.count(".Values.security.containerSecurityContext") >= 7
+
+
+def test_ingress_is_not_exposed_by_default_and_supports_tls() -> None:
+    values = _values()
+    template = _template("ingress.yaml")
+
+    assert values["ingress"]["enabled"] is False
+    assert values["ingress"]["host"] == ""
+    assert values["ingress"]["tls"]["enabled"] is False
+
+    assert "required" in template
+    assert "ingress.host" in template
+    assert "tls:" in template
+    assert "secretName:" in template


### PR DESCRIPTION
## Summary

This hardens the OpenRAG Helm chart so a default install can no longer accidentally expose known placeholder credentials or deploy chart-owned workloads without basic restricted security settings.

The chart now fails fast when required secrets are missing or still use common placeholder values. The PostgreSQL password is no longer rendered through the shared ConfigMap, ingress is opt-in instead of wildcard-by-default, and TLS can be configured when ingress is enabled.

The chart-owned workloads also get restricted pod/container security defaults, including non-root execution, no service account token mount by default, no privilege escalation, dropped capabilities, and a runtime seccomp profile. The vLLM dependency is overridden through values so its engine pods follow the same non-root default.

Closes #482

## Validation

- ............                                                             [100%]
12 passed in 0.09s
- All checks passed!
- 3 files already formatted
- 
- Dockerized Helm lint with required secrets and ingress values
- Dockerized Helm render with required secrets and ingress TLS values