### PR TITLE
fix(indexer): hydrate model-endpoint registry so admin-UI-registered LLM endpoints resolve

### DIFF
--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -9,6 +10,11 @@ import ray
 from services.workers.indexer_actor import IndexerWorker
 
 from openrag.core.config.root import Settings
+
+# The indexer reloads the DB-backed model-endpoint registry at most once per
+# this window (and on a miss), bounding both staleness and DB load regardless
+# of indexing throughput.
+_MODEL_REGISTRY_TTL_SECONDS = 60.0
 
 
 @ray.remote
@@ -20,6 +26,7 @@ class IndexerPool:
         import services.inference.vllm_client  # noqa: F401
         from core.config import load_config
         from core.embeddings import embedder_registry
+        from core.utils.logging import get_logger
         from services.storage.milvus_store import MilvusVectorStore
         from services.storage.postgres_store import PostgresStore
         from services.workers.parsers.parser_dispatcher import build_caption_vlm, build_parser_dispatcher
@@ -63,6 +70,27 @@ class IndexerPool:
         self._catalog_store = PostgresStore(rdb_cfg, run_migrations=False)
         self._catalog_initialized = False
         self._catalog_init_lock = asyncio.Lock()
+        # Model-endpoint registry hydration. Unlike the API process, the indexer
+        # never runs ModelEndpointService at startup, so cfg.models starts empty
+        # and named endpoints (registered via the admin UI) can't resolve here.
+        # We hydrate cfg.models from the DB lazily on first use — see
+        # _ensure_registry_fresh. The factories above hold a live reference to
+        # cfg.models.* so in-place hydration becomes visible to them.
+        # Instance-level logger: kept off the module so Ray's by-value pickling
+        # of this actor class never drags in loguru's enqueue SimpleQueue (a
+        # module-global logger referenced by a method makes the class
+        # unpicklable). Created here, in the actor process, it is never pickled.
+        self._logger = get_logger()
+        self._cfg = cfg
+        # Whether "default" resolves via the global cfg.llm fallback (static —
+        # cfg.llm doesn't change). Lets _reload_decision avoid a perpetual
+        # reload-on-miss for "default" when no is_default row exists in the DB.
+        self._has_default_fallback = _global_llm_endpoint_config(cfg) is not None
+        self._model_endpoint_service: Any = None
+        self._registry_loaded_at: float | None = None
+        self._last_miss_reload_at: float | None = None
+        self._registry_lock = asyncio.Lock()
+        self._registry_reload_task: asyncio.Task[None] | None = None
         self._worker = IndexerWorker(
             pipeline=pipeline,
             task_state_manager=task_state_manager,
@@ -79,6 +107,72 @@ class IndexerPool:
             await self._catalog_store.initialize()
             self._catalog_initialized = True
 
+    async def _ensure_registry_fresh(self, required_llm_names: list[str]) -> None:
+        """Hydrate ``cfg.models`` from the DB so named endpoints resolve here.
+
+        The hit path is lock-free and does no I/O. A reload happens only on first
+        use (``initial``), once the registry goes stale (``ttl``), or when a
+        requested name is missing (``miss``, rate-limited to once per window so a
+        deleted/typo'd name can't storm the DB). Reloads are single-flight via
+        ``_registry_lock``.
+
+        Latency: ``ttl`` refreshes run **in the background** — the current
+        registry is still valid, so no file waits on the DB. Only ``initial`` and
+        ``miss`` block, because the triggering file needs an endpoint that isn't
+        loaded yet; both are rare and rate-limited.
+        """
+        decision = self._reload_decision(required_llm_names)
+        if decision is None:
+            return
+        if decision == "ttl":
+            if self._registry_reload_task is None or self._registry_reload_task.done():
+                self._registry_reload_task = asyncio.create_task(self._reload_registry(required_llm_names))
+            return
+        await self._reload_registry(required_llm_names)
+
+    async def _reload_registry(self, required_llm_names: list[str]) -> None:
+        """Single-flight reload of the model-endpoint registry from the DB."""
+        async with self._registry_lock:
+            decision = self._reload_decision(required_llm_names)
+            if decision is None:  # another reload refreshed it while we waited
+                return
+            try:
+                if self._model_endpoint_service is None:
+                    from services.orchestrators.model_endpoint_service import ModelEndpointService
+
+                    self._model_endpoint_service = ModelEndpointService(
+                        model_endpoint_repo=self._catalog_store.model_endpoint_repo,
+                        config=self._cfg,
+                    )
+                await self._model_endpoint_service.load_all()
+            except Exception as exc:  # noqa: BLE001 - a reload must never fail (or crash) a file
+                self._logger.warning(f"Model endpoint registry reload failed ({decision}): {exc}")
+            # Stamp the clock even on failure so a persistent error degrades to
+            # one retry per window rather than one attempt per file.
+            now = time.monotonic()
+            self._registry_loaded_at = now
+            if decision == "miss":
+                self._last_miss_reload_at = now
+
+    def _reload_decision(self, required_llm_names: list[str]) -> str | None:
+        models = getattr(self._cfg, "models", None)
+        llm_registry = getattr(models, "llm", {}) if models is not None else {}
+        # The factory also resolves "default" via the global cfg.llm fallback, even
+        # when no is_default row puts a "default" alias in the registry. Treating it
+        # as missing in that case would block-reload every window forever without
+        # ever converging, so mirror the factory's fallback here.
+        missing = any(
+            name not in llm_registry and not (name == "default" and self._has_default_fallback)
+            for name in required_llm_names
+        )
+        return _registry_reload_decision(
+            loaded_at=self._registry_loaded_at,
+            last_miss_at=self._last_miss_reload_at,
+            now=time.monotonic(),
+            ttl=_MODEL_REGISTRY_TTL_SECONDS,
+            missing=missing,
+        )
+
     async def process_file(
         self,
         *,
@@ -93,6 +187,7 @@ class IndexerPool:
         embedder_name: str | None = None,
     ) -> dict[str, Any]:
         await self._ensure_catalog()
+        await self._ensure_registry_fresh(_required_llm_names(indexation_config))
         result = await self._worker.process_file(
             task_id=task_id,
             path=path,
@@ -130,6 +225,50 @@ def build_indexer_pool(namespace: str = "openrag") -> Any:
         lifetime="detached",
         max_concurrency=max_concurrency,
     ).remote()
+
+
+def _required_llm_names(indexation_config: dict[str, Any] | None) -> list[str]:
+    """LLM endpoint names this file will request, for the reload-on-miss check.
+
+    Mirrors the pipeline's selection logic: contextualization and topic tagging
+    each resolve their configured endpoint name (falling back to ``default``).
+    """
+    if indexation_config is None:
+        return []
+    names: list[str] = []
+    if indexation_config.get("enable_contextualization"):
+        names.append(indexation_config.get("contextualization_llm") or "default")
+    if indexation_config.get("enable_topic_tagging", True):
+        names.append(indexation_config.get("topic_tagging_llm") or "default")
+    return names
+
+
+def _registry_reload_decision(
+    *,
+    loaded_at: float | None,
+    last_miss_at: float | None,
+    now: float,
+    ttl: float,
+    missing: bool,
+) -> str | None:
+    """Decide whether (and why) to reload the model-endpoint registry.
+
+    Returns ``"initial"`` / ``"ttl"`` / ``"miss"``, or ``None`` for the hit path
+    (no reload). The ``miss`` branch is rate-limited to once per ``ttl`` so an
+    unresolvable name cannot trigger a reload on every file.
+
+    ``miss`` is checked before ``ttl``: a missing required endpoint must trigger
+    a *blocking* reload so the current file can resolve it, even when the
+    registry is also stale (otherwise the stale-registry ``ttl`` path would
+    schedule a background refresh and the file would skip the LLM stage).
+    """
+    if loaded_at is None:
+        return "initial"
+    if missing and (last_miss_at is None or now - last_miss_at >= ttl):
+        return "miss"
+    if now - loaded_at >= ttl:
+        return "ttl"
+    return None
 
 
 def _build_chunker(cfg: Any) -> Any:
@@ -182,11 +321,19 @@ def _build_embedder_factory(cfg: Settings) -> Any:
 def _build_contextualizer_factory(cfg: Settings) -> Any:
     """Build a cached factory yielding ``ChunkContextualizer`` instances.
 
-    Each requested LLM name is resolved against the named-endpoint registry
-    (``cfg.models.llm``), falling back to the global ``cfg.llm`` block for the
-    ``default`` name. Returns ``None`` when no LLM is configured. Every
-    contextualizer shares the cluster-wide ``llmSemaphore`` so contextualization
-    LLM calls obey the same global concurrency limit as query-time calls.
+    Each requested LLM name is resolved at call time against the named-endpoint
+    registry (``cfg.models.llm``), falling back to the global ``cfg.llm`` block
+    for the ``default`` name. The registry is hydrated from the DB lazily by the
+    indexer actor *after* this factory is built, so we hold a live reference to
+    ``cfg.models.llm`` rather than a snapshot. A name with no entry and no
+    fallback raises ``KeyError`` — the pipeline catches it and skips the stage.
+    One client is cached per name and rebuilt when that endpoint's full config
+    (URL, model, or any ``extra`` such as the api_key) changes, so an edit yields
+    a fresh client after the registry reloads. The superseded client is dropped
+    from the cache but not explicitly closed — acceptable since endpoint edits
+    are rare and the actor reclaims it on exit. Every contextualizer shares the
+    cluster-wide ``llmSemaphore`` so contextualization LLM calls obey the same
+    global concurrency limit as query-time calls.
     """
     import services.inference.ollama_client  # noqa: F401
     import services.inference.vllm_client  # noqa: F401
@@ -195,32 +342,46 @@ def _build_contextualizer_factory(cfg: Settings) -> Any:
     from core.prompts import load_template_by_key
     from services.inference.distributed_semaphore import DistributedSemaphore
 
-    named_llms = getattr(getattr(cfg, "models", None), "llm", {}) or {}
+    models = getattr(cfg, "models", None)
+    named_llms = models.llm if models is not None else {}
     fallback_cfg = _global_llm_endpoint_config(cfg)
-    if not named_llms and fallback_cfg is None:
-        return None
 
-    system_prompt = load_template_by_key(cfg.paths.prompts_dir, cfg.prompts, "chunk_contextualizer")
-    # Rate-limit contextualization LLM calls with the cluster-wide "llmSemaphore"
-    # (the same one get_llm_semaphore() / bootstrap.py manage) so a large indexing
-    # job can't flood the vLLM endpoint. Built directly from config to avoid
-    # importing services.inference.runtime, which eagerly constructs a LangDetector.
-    llm_semaphore = DistributedSemaphore(name="llmSemaphore", max_concurrent_ops=cfg.semaphore.llm_semaphore)
-    cache: dict[str, ChunkContextualizer] = {}
+    # name -> (endpoint-identity, instance). Bounded to one entry per name; a
+    # changed identity replaces (not accumulates) the cached client.
+    cache: dict[str, tuple[str, ChunkContextualizer]] = {}
+    # Prompt + semaphore are built lazily on first successful resolve so a pool
+    # with no resolvable LLM does no startup work (and an unknown name raises
+    # before touching them).
+    shared: dict[str, Any] = {}
     lock = threading.Lock()
 
     def factory(name: str = "default") -> ChunkContextualizer:
-        if name in cache:
-            return cache[name]
+        model_cfg = named_llms.get(name)
+        if model_cfg is None:
+            if name == "default" and fallback_cfg is not None:
+                model_cfg = fallback_cfg
+            else:
+                raise KeyError(f"Unknown llm '{name}'. Available: {list(named_llms)}")
+        identity = _endpoint_identity(model_cfg)
+        entry = cache.get(name)
+        if entry is not None and entry[0] == identity:
+            return entry[1]
         with lock:
-            if name in cache:
-                return cache[name]
-            model_cfg = named_llms.get(name)
-            if model_cfg is None:
-                if name == "default" and fallback_cfg is not None:
-                    model_cfg = fallback_cfg
-                else:
-                    raise KeyError(f"Unknown llm '{name}'. Available: {list(named_llms)}")
+            entry = cache.get(name)
+            if entry is not None and entry[0] == identity:
+                return entry[1]
+            if "system_prompt" not in shared:
+                # Build both before publishing to `shared` so a failure can't
+                # leave it half-initialised (which would later raise a stray
+                # KeyError on the missing key, misread as an unresolvable LLM).
+                system_prompt = load_template_by_key(cfg.paths.prompts_dir, cfg.prompts, "chunk_contextualizer")
+                # Built directly from config to avoid importing
+                # services.inference.runtime, which eagerly constructs a LangDetector.
+                llm_semaphore = DistributedSemaphore(
+                    name="llmSemaphore", max_concurrent_ops=cfg.semaphore.llm_semaphore
+                )
+                shared["system_prompt"] = system_prompt
+                shared["llm_semaphore"] = llm_semaphore
             impl_kwargs = {key: value for key, value in model_cfg.extra.items() if key != "implementation"}
             impl = model_cfg.extra.get("implementation", "vllm")
             llm = llm_registry.create(
@@ -232,46 +393,57 @@ def _build_contextualizer_factory(cfg: Settings) -> Any:
             )
             contextualizer = ChunkContextualizer(
                 llm,
-                system_prompt,
+                shared["system_prompt"],
                 timeout_seconds=cfg.chunker.contextualization_timeout,
                 batch_size=cfg.chunker.max_concurrent_contextualization,
-                llm_semaphore=llm_semaphore,
+                llm_semaphore=shared["llm_semaphore"],
             )
-            cache[name] = contextualizer
+            cache[name] = (identity, contextualizer)
             return contextualizer
 
     return factory
 
 
 def _build_topic_tagger_factory(cfg: Settings) -> Any:
-    """Build a cached factory yielding ``TopicTagger`` instances."""
+    """Build a cached factory yielding ``TopicTagger`` instances.
+
+    Mirrors :func:`_build_contextualizer_factory`: a live reference to the
+    DB-hydrated ``cfg.models.llm`` registry, global fallback for ``default``,
+    a ``KeyError`` on an unresolvable name (skipped by the pipeline), a
+    one-entry-per-name client cache replaced on endpoint change, and a lazily
+    loaded prompt.
+    """
     import services.inference.ollama_client  # noqa: F401
     import services.inference.vllm_client  # noqa: F401
     from core.indexing.topic_tags import TopicTagger
     from core.llm import llm_registry
     from core.prompts import load_template_by_key
 
-    named_llms = getattr(getattr(cfg, "models", None), "llm", {}) or {}
+    models = getattr(cfg, "models", None)
+    named_llms = models.llm if models is not None else {}
     fallback_cfg = _global_llm_endpoint_config(cfg)
-    if not named_llms and fallback_cfg is None:
-        return None
 
-    system_prompt = load_template_by_key(cfg.paths.prompts_dir, cfg.prompts, "topic_tagger")
-    cache: dict[str, TopicTagger] = {}
+    cache: dict[str, tuple[str, TopicTagger]] = {}
+    shared: dict[str, Any] = {}
     lock = threading.Lock()
 
     def factory(name: str = "default") -> TopicTagger:
-        if name in cache:
-            return cache[name]
+        model_cfg = named_llms.get(name)
+        if model_cfg is None:
+            if name == "default" and fallback_cfg is not None:
+                model_cfg = fallback_cfg
+            else:
+                raise KeyError(f"Unknown llm '{name}'. Available: {list(named_llms)}")
+        identity = _endpoint_identity(model_cfg)
+        entry = cache.get(name)
+        if entry is not None and entry[0] == identity:
+            return entry[1]
         with lock:
-            if name in cache:
-                return cache[name]
-            model_cfg = named_llms.get(name)
-            if model_cfg is None:
-                if name == "default" and fallback_cfg is not None:
-                    model_cfg = fallback_cfg
-                else:
-                    raise KeyError(f"Unknown llm '{name}'. Available: {list(named_llms)}")
+            entry = cache.get(name)
+            if entry is not None and entry[0] == identity:
+                return entry[1]
+            if "system_prompt" not in shared:
+                shared["system_prompt"] = load_template_by_key(cfg.paths.prompts_dir, cfg.prompts, "topic_tagger")
             impl_kwargs = {key: value for key, value in model_cfg.extra.items() if key != "implementation"}
             impl = model_cfg.extra.get("implementation", "vllm")
             llm = llm_registry.create(
@@ -281,11 +453,27 @@ def _build_topic_tagger_factory(cfg: Settings) -> Any:
                 timeout=model_cfg.timeout,
                 **impl_kwargs,
             )
-            tagger = TopicTagger(llm, system_prompt, timeout_seconds=model_cfg.timeout)
-            cache[name] = tagger
+            tagger = TopicTagger(llm, shared["system_prompt"], timeout_seconds=model_cfg.timeout)
+            cache[name] = (identity, tagger)
             return tagger
 
     return factory
+
+
+def _endpoint_identity(model_cfg: Any) -> str:
+    """Stable identity of a resolved endpoint config for client-cache keying.
+
+    Covers the full config — endpoint, model **and** every ``extra`` key
+    (``api_key``, ``temperature``, ...) — so any edit (including an api-key
+    rotation that keeps the same URL/model) yields a new identity and rebuilds
+    the cached client on the next reload, matching the API process's
+    invalidate-on-any-change behaviour.
+    """
+    import hashlib
+    import json
+
+    payload = json.dumps(model_cfg.model_dump(mode="json"), sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _global_llm_endpoint_config(cfg: Any) -> Any | None:

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -11,6 +11,7 @@ from core.indexing.contextualize import ChunkContextualizer
 from core.indexing.parsers.document_parser import DocumentParser
 from core.indexing.topic_tags import TopicTagger
 from core.models.document import Document, DocumentType
+from core.utils.logging import get_logger
 from core.vector_stores.vector_store import VectorStore
 from core.vlm.vlm import VLM
 from services.workers.stages.caption import caption_stage
@@ -20,6 +21,8 @@ from services.workers.stages.embed import embed_stage
 from services.workers.stages.parse import parse_stage
 from services.workers.stages.store import store_stage
 from services.workers.stages.topic_tag import topic_tag_stage
+
+logger = get_logger()
 
 
 @dataclass(slots=True, frozen=True)
@@ -165,7 +168,16 @@ class IndexingPipeline:
             if not config.enable_contextualization:
                 return None
             if self.contextualizer_factory is not None:
-                return self.contextualizer_factory(config.contextualization_llm or "default")
+                name = config.contextualization_llm or "default"
+                try:
+                    return self.contextualizer_factory(name)
+                except KeyError as exc:
+                    # Only an unresolvable endpoint name (the factory raises KeyError)
+                    # is skipped — contextualization is an enhancement and must not fail
+                    # the file over a missing/typo'd LLM. Any other factory error (prompt
+                    # load, bad client config, ...) is a real fault and is left to surface.
+                    logger.warning(f"Skipping contextualization: cannot resolve LLM '{name}' ({exc})")
+                    return None
         return self.contextualizer
 
     def _select_topic_tagger(self, config: IndexationPipelineConfig | None) -> TopicTagger | None:
@@ -173,7 +185,14 @@ class IndexingPipeline:
             if not config.enable_topic_tagging:
                 return None
             if self.topic_tagger_factory is not None:
-                return self.topic_tagger_factory(config.topic_tagging_llm or "default")
+                name = config.topic_tagging_llm or "default"
+                try:
+                    return self.topic_tagger_factory(name)
+                except KeyError as exc:
+                    # Only an unresolvable endpoint name (KeyError) is skipped; any other
+                    # factory error is a real fault and is left to surface, not masked.
+                    logger.warning(f"Skipping topic tagging: cannot resolve LLM '{name}' ({exc})")
+                    return None
         return self.topic_tagger
 
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -135,7 +135,11 @@ def test_build_topic_tagger_factory_resolves_named_llm(monkeypatch: pytest.Monke
     assert tagger._llm.kwargs["temperature"] == 0.1
 
 
-def test_build_contextualizer_factory_returns_none_without_llm_config(tmp_path) -> None:
+def test_build_contextualizer_factory_returns_factory_for_later_hydration(tmp_path) -> None:
+    # With no LLM configured at build time the factory is still returned (the
+    # registry is hydrated from the DB later) — resolving an unknown name raises
+    # KeyError, which the pipeline catches and skips. It must raise *before*
+    # touching the prompt/semaphore, so neither is needed in this cfg.
     from services.workers.indexer_pool import _build_contextualizer_factory
 
     cfg = SimpleNamespace(
@@ -146,7 +150,287 @@ def test_build_contextualizer_factory_returns_none_without_llm_config(tmp_path) 
         prompts=SimpleNamespace(chunk_contextualizer="chunk_contextualizer_tmpl.txt"),
     )
 
-    assert _build_contextualizer_factory(cfg) is None
+    factory = _build_contextualizer_factory(cfg)
+    assert factory is not None
+    with pytest.raises(KeyError):
+        factory("default")
+
+
+def test_contextualizer_factory_reads_live_registry(tmp_path) -> None:
+    # The factory holds a live reference to cfg.models.llm: a name added to the
+    # registry AFTER the factory is built (mimicking the indexer's lazy DB
+    # hydration) must resolve without rebuilding the factory.
+    from core.config.model_endpoints import ModelEndpointConfig
+    from core.llm import llm_registry
+    from services.workers.indexer_pool import _build_contextualizer_factory
+
+    class ProbeLLM:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    llm_registry.register("live-probe-llm")(ProbeLLM)
+    try:
+        (tmp_path / "ctx.txt").write_text("Context prompt", encoding="utf-8")
+        registry: dict = {}
+        cfg = SimpleNamespace(
+            models=SimpleNamespace(llm=registry),
+            llm=SimpleNamespace(base_url="", model="", api_key=""),
+            chunker=SimpleNamespace(contextualization_timeout=12, max_concurrent_contextualization=3),
+            semaphore=SimpleNamespace(llm_semaphore=4),
+            paths=SimpleNamespace(prompts_dir=str(tmp_path)),
+            prompts=SimpleNamespace(chunk_contextualizer="ctx.txt"),
+        )
+
+        factory = _build_contextualizer_factory(cfg)
+        with pytest.raises(KeyError):
+            factory("late")
+
+        # Hydration mutates the same dict in place (dict.clear()+update()).
+        registry["late"] = ModelEndpointConfig(
+            endpoint="http://late.example/v1",
+            model_name="late-model",
+            extra={"implementation": "live-probe-llm"},
+        )
+
+        contextualizer = factory("late")
+        assert contextualizer._llm.kwargs["endpoint"] == "http://late.example/v1"
+        assert contextualizer._llm.kwargs["model_name"] == "late-model"
+    finally:
+        llm_registry._registry.pop("live-probe-llm", None)
+
+
+def test_required_llm_names_mirrors_pipeline_selection() -> None:
+    from services.workers.indexer_pool import _required_llm_names
+
+    assert _required_llm_names(None) == []
+    # Topic tagging defaults on, contextualization defaults off.
+    assert _required_llm_names({}) == ["default"]
+    assert _required_llm_names({"enable_topic_tagging": False}) == []
+    assert _required_llm_names(
+        {
+            "enable_contextualization": True,
+            "contextualization_llm": "ctx",
+            "enable_topic_tagging": True,
+            "topic_tagging_llm": "tags",
+        }
+    ) == ["ctx", "tags"]
+
+
+def test_registry_reload_decision_guards() -> None:
+    from services.workers.indexer_pool import _registry_reload_decision
+
+    # First use always loads.
+    assert _registry_reload_decision(loaded_at=None, last_miss_at=None, now=100.0, ttl=60.0, missing=False) == "initial"
+    # Hit path: fresh and nothing missing → no reload, no I/O.
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=None, now=110.0, ttl=60.0, missing=False) is None
+    # TTL expiry refreshes (catches edits to existing endpoints).
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=None, now=161.0, ttl=60.0, missing=False) == "ttl"
+    # A missing name within the window triggers one reload...
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=None, now=110.0, ttl=60.0, missing=True) == "miss"
+    # ...but is rate-limited: a still-missing name can't reload again until the
+    # next window, so a deleted/typo'd name can't storm the DB.
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=105.0, now=120.0, ttl=60.0, missing=True) is None
+    # A missing name takes priority over a stale registry: it must block ("miss"),
+    # not fall through to a background "ttl" refresh that would skip the stage.
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=None, now=200.0, ttl=60.0, missing=True) == "miss"
+    # Rate-limited miss while ALSO stale → still refresh the stale registry in the
+    # background ("ttl") rather than nothing.
+    assert _registry_reload_decision(loaded_at=100.0, last_miss_at=150.0, now=200.0, ttl=60.0, missing=True) == "ttl"
+
+
+def test_reload_decision_treats_default_global_fallback_as_resolvable() -> None:
+    # "default" resolves via the global cfg.llm fallback even when the registry
+    # has no is_default row → it must NOT be treated as missing, otherwise we'd
+    # block-reload every window forever without converging.
+    import time as _time
+
+    from services.workers.indexer_pool import IndexerPool
+
+    actor_class = IndexerPool.__ray_metadata__.modified_class
+
+    def _pool(has_fallback: bool):
+        pool = actor_class.__new__(actor_class)
+        pool._cfg = SimpleNamespace(models=SimpleNamespace(llm={}))  # registry lacks "default"
+        pool._has_default_fallback = has_fallback
+        pool._registry_loaded_at = _time.monotonic()  # fresh, not stale
+        pool._last_miss_reload_at = None
+        return pool
+
+    # Fallback present → "default" resolvable → hit path, no reload.
+    assert _pool(True)._reload_decision(["default"]) is None
+    # No fallback and not in registry → genuinely missing → reload.
+    assert _pool(False)._reload_decision(["default"]) == "miss"
+    # A *named* endpoint (not "default") is never covered by the fallback.
+    assert _pool(True)._reload_decision(["acme-llm"]) == "miss"
+
+
+@pytest.mark.asyncio
+async def test_ensure_registry_fresh_is_single_flight() -> None:
+    from services.workers.indexer_pool import IndexerPool
+
+    actor_class = IndexerPool.__ray_metadata__.modified_class
+    pool = actor_class.__new__(actor_class)
+
+    class Service:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def load_all(self) -> None:
+            self.calls += 1
+            await asyncio.sleep(0)
+
+    pool._cfg = SimpleNamespace(models=SimpleNamespace(llm={}))
+    pool._model_endpoint_service = Service()
+    pool._registry_loaded_at = None
+    pool._last_miss_reload_at = None
+    pool._registry_lock = asyncio.Lock()
+    pool._registry_reload_task = None
+
+    await asyncio.gather(*(pool._ensure_registry_fresh([]) for _ in range(20)))
+
+    assert pool._model_endpoint_service.calls == 1
+    assert pool._registry_loaded_at is not None
+
+
+@pytest.mark.asyncio
+async def test_ttl_refresh_runs_in_background_without_blocking() -> None:
+    # A periodic TTL refresh must not sit on a file's critical path: the current
+    # registry is still valid, so _ensure_registry_fresh returns immediately and
+    # the reload runs in the background.
+    import time as _time
+
+    from services.workers.indexer_pool import _MODEL_REGISTRY_TTL_SECONDS, IndexerPool
+
+    actor_class = IndexerPool.__ray_metadata__.modified_class
+    pool = actor_class.__new__(actor_class)
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class SlowService:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def load_all(self) -> None:
+            self.calls += 1
+            started.set()
+            await release.wait()
+
+    pool._cfg = SimpleNamespace(models=SimpleNamespace(llm={"default": object()}))
+    pool._model_endpoint_service = SlowService()
+    pool._registry_loaded_at = _time.monotonic() - _MODEL_REGISTRY_TTL_SECONDS - 1  # stale → "ttl"
+    pool._last_miss_reload_at = None
+    pool._registry_lock = asyncio.Lock()
+    pool._registry_reload_task = None
+
+    # Returns promptly even though load_all is still blocked.
+    await asyncio.wait_for(pool._ensure_registry_fresh(["default"]), timeout=0.5)
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+    assert pool._registry_reload_task is not None and not pool._registry_reload_task.done()
+
+    release.set()
+    await pool._registry_reload_task
+    assert pool._model_endpoint_service.calls == 1
+
+
+def test_contextualizer_factory_rebuilds_on_endpoint_edit(tmp_path) -> None:
+    # An edited endpoint (changed identity) must yield a fresh client; the cache
+    # holds one entry per name (replaced, not accumulated), so it can't leak a
+    # stale client per edit over the long-lived actor.
+    from core.config.model_endpoints import ModelEndpointConfig
+    from core.llm import llm_registry
+    from services.workers.indexer_pool import _build_contextualizer_factory
+
+    class ProbeLLM:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    llm_registry.register("edit-probe-llm")(ProbeLLM)
+    try:
+        (tmp_path / "ctx.txt").write_text("Context prompt", encoding="utf-8")
+        registry = {
+            "ep": ModelEndpointConfig(
+                endpoint="http://v1.example/v1", model_name="m1", extra={"implementation": "edit-probe-llm"}
+            )
+        }
+        cfg = SimpleNamespace(
+            models=SimpleNamespace(llm=registry),
+            llm=SimpleNamespace(base_url="", model="", api_key=""),
+            chunker=SimpleNamespace(contextualization_timeout=12, max_concurrent_contextualization=3),
+            semaphore=SimpleNamespace(llm_semaphore=4),
+            paths=SimpleNamespace(prompts_dir=str(tmp_path)),
+            prompts=SimpleNamespace(chunk_contextualizer="ctx.txt"),
+        )
+
+        factory = _build_contextualizer_factory(cfg)
+        first = factory("ep")
+        assert factory("ep") is first  # unchanged identity → cached
+
+        # Edit the endpoint in place (mimicking a registry reload after a change).
+        registry["ep"] = ModelEndpointConfig(
+            endpoint="http://v2.example/v1", model_name="m2", extra={"implementation": "edit-probe-llm"}
+        )
+        second = factory("ep")
+        assert second is not first
+        assert second._llm.kwargs["endpoint"] == "http://v2.example/v1"
+    finally:
+        llm_registry._registry.pop("edit-probe-llm", None)
+
+
+def test_endpoint_identity_covers_full_config() -> None:
+    # The cache identity must change for ANY config edit — including an
+    # extra-only change like an api-key rotation (same URL + model) — so the
+    # client is rebuilt after a reload, matching the API's invalidate-on-change.
+    from core.config.model_endpoints import ModelEndpointConfig
+    from services.workers.indexer_pool import _endpoint_identity
+
+    base = ModelEndpointConfig(endpoint="http://e/v1", model_name="m", extra={"api_key": "k1"})
+    same = ModelEndpointConfig(endpoint="http://e/v1", model_name="m", extra={"api_key": "k1"})
+    rotated_key = ModelEndpointConfig(endpoint="http://e/v1", model_name="m", extra={"api_key": "k2"})
+
+    assert _endpoint_identity(base) == _endpoint_identity(same)
+    assert _endpoint_identity(base) != _endpoint_identity(rotated_key)
+
+
+def test_contextualizer_factory_rebuilds_on_api_key_rotation(tmp_path) -> None:
+    # Same endpoint + model, only the api_key changes → the cached client must
+    # still be rebuilt (the old key would otherwise persist until restart).
+    from core.config.model_endpoints import ModelEndpointConfig
+    from core.llm import llm_registry
+    from services.workers.indexer_pool import _build_contextualizer_factory
+
+    class ProbeLLM:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    llm_registry.register("key-probe-llm")(ProbeLLM)
+    try:
+        (tmp_path / "ctx.txt").write_text("Context prompt", encoding="utf-8")
+        registry = {
+            "ep": ModelEndpointConfig(
+                endpoint="http://e/v1", model_name="m", extra={"implementation": "key-probe-llm", "api_key": "k1"}
+            )
+        }
+        cfg = SimpleNamespace(
+            models=SimpleNamespace(llm=registry),
+            llm=SimpleNamespace(base_url="", model="", api_key=""),
+            chunker=SimpleNamespace(contextualization_timeout=12, max_concurrent_contextualization=3),
+            semaphore=SimpleNamespace(llm_semaphore=4),
+            paths=SimpleNamespace(prompts_dir=str(tmp_path)),
+            prompts=SimpleNamespace(chunk_contextualizer="ctx.txt"),
+        )
+
+        factory = _build_contextualizer_factory(cfg)
+        first = factory("ep")
+
+        registry["ep"] = ModelEndpointConfig(
+            endpoint="http://e/v1", model_name="m", extra={"implementation": "key-probe-llm", "api_key": "k2"}
+        )
+        second = factory("ep")
+        assert second is not first
+        assert second._llm.kwargs["api_key"] == "k2"
+    finally:
+        llm_registry._registry.pop("key-probe-llm", None)
 
 
 def test_build_contextualizer_factory_uses_global_llm_fallback(tmp_path) -> None:

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -248,6 +248,61 @@ async def test_pipeline_row_indexation_config_selects_components():
 
 
 @pytest.mark.asyncio
+async def test_pipeline_skips_contextualization_when_llm_unresolvable():
+    # An enabled contextualization LLM the factory can't resolve must NOT fail the
+    # whole file — the stage is skipped and indexing completes.
+    def _raise(name: str):
+        raise KeyError(f"Unknown llm '{name}'. Available: []")
+
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(ProcessedDocument(document_id="d", text_blocks=[TextBlock(text="t")])),
+        chunker=FakeChunker([Chunk(id="c", text="t", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=FakeVectorStore(),
+        contextualizer_factory=_raise,
+    )
+    row = {
+        "document": Document(filename="note.txt", text="hello", partition="tenant-a"),
+        "partition": "tenant-a",
+        "filename": "note.txt",
+        "indexation_config": {
+            "enable_contextualization": True,
+            "contextualization_llm": "missing-endpoint",
+        },
+    }
+    result = await pipeline.run(row)  # must not raise
+    assert result is row
+
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_non_keyerror_contextualizer_factory_error():
+    # Only an unresolvable-endpoint KeyError is skipped. A different factory
+    # error (e.g. a broken prompt/client config) is a real fault and must
+    # surface, not be silently swallowed (the file should fail loudly).
+    def _raise(name: str):
+        raise ValueError("prompt template failed to load")
+
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(ProcessedDocument(document_id="d", text_blocks=[TextBlock(text="t")])),
+        chunker=FakeChunker([Chunk(id="c", text="t", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=FakeVectorStore(),
+        contextualizer_factory=_raise,
+    )
+    row = {
+        "document": Document(filename="note.txt", text="hello", partition="tenant-a"),
+        "partition": "tenant-a",
+        "filename": "note.txt",
+        "indexation_config": {
+            "enable_contextualization": True,
+            "contextualization_llm": "ctx",
+        },
+    }
+    with pytest.raises(ValueError, match="prompt template"):
+        await pipeline.run(row)
+
+
+@pytest.mark.asyncio
 async def test_pipeline_always_captions_standalone_image_even_when_globally_off():
     # A standalone image file's caption is its only text content, so it is
     # captioned even when global image captioning is off (legacy parity).


### PR DESCRIPTION
## Problem
Contextualization or topic tagging configured with an LLM endpoint **registered via the admin UI** (i.e. stored in the DB) made indexing fail with `KeyError: Unknown llm '<name>'`. The global/default LLM path worked; only DB-registered named endpoints failed.

Root cause: the indexer Ray actor builds its enhancement-LLM factories from `Settings.models`, but that registry is hydrated from the DB **only in the API process at startup** — never in the indexer process. So a named endpoint never resolved there, and a restart didn't help.

## Fix
- Hydrate `cfg.models` from the DB inside the indexer actor, lazily: once on first use, on a 60s TTL refresh (run in the background, off the file's critical path), and on a cache miss (rate-limited so an unknown/typo'd name can't storm the DB). Reloads are single-flight.
- The contextualizer/topic-tagger factories read the live registry and cache one client per endpoint. The cache key is a **hash of the full endpoint config** — endpoint URL, model, *and* every `extra` key (`api_key`, `temperature`, …) — so any edit, including an api-key rotation that keeps the same URL/model, yields a new identity and rebuilds the client on the next reload (≤60s), without leaking the old one. This matches the API process's invalidate-on-any-change behaviour.
- A missing/unresolvable enhancement LLM degrades gracefully (warn + skip) rather than failing the whole file.
- The actor logger is an instance attribute, not a module global, so Ray's by-value pickling of the actor class doesn't pull in loguru's `enqueue=True` `SimpleQueue`.

## Freshness semantics
- **New endpoint, used immediately** → resolved on first use via reload-on-miss (not gated by the TTL).
- **Edit / delete / change-default of an existing endpoint** → propagates within ≤60s (TTL); the client rebuilds because the cache key covers the full config.
- Instant (sub-60s) propagation via an API→actor reload signal is possible but intentionally deferred (it would couple the orchestrator to Ray).

## Testing
- Unit tests: registry-reload decisions (initial / hit / ttl / miss + rate-limit), single-flight and background TTL reload, live-registry resolution, edit-aware client cache (URL/model change **and** api-key-only rotation), full-config identity hashing, and graceful-degrade skip.
- Verified on a running stack: named-endpoint contextualization and topic tagging index to completion, and indexing is performance-neutral vs. the pre-fix path (identical per-stage timings).

Refs #554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexing now resolves required LLM endpoint settings on demand, allowing processing to begin even if full LLM configuration becomes available later.
  * Contextualization and topic tagging now initialize lazily and refresh automatically when endpoint settings change, including API key updates.

* **Bug Fixes**
  * Improved LLM registry refresh with TTL-based background updates, rate-limited retries for missing endpoints, and single-flight reloads to avoid spikes.
  * If an LLM can’t be resolved, contextualization/topic tagging are skipped with warnings; other contextualization errors still surface instead of being suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->