### PR TITLE
fix(llm): drop logprobs on streamed chat to avoid LiteLLM serialization crash

### DIFF
--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -13,6 +13,10 @@ class LLMParamsConfig(ConfigMixin):
     temperature: float = 0.1
     timeout: int = 60
     max_retries: int = 2
+    # Forwarded on non-streaming calls only. OpenRAG never reads logprobs back,
+    # and streaming them through a LiteLLM proxy triggers a pydantic
+    # serialization crash, so the client strips logprobs from streamed requests
+    # (see VLLMClient / linagora/openrag#563).
     logprobs: bool = True
     enable_thinking: bool | None = None
 

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -47,6 +47,13 @@ def _parse_response(resp: httpx.Response) -> dict:
 # LLM
 # ---------------------------------------------------------------------------
 
+# Knobs that travel inside ``settings.llm`` (and therefore the client
+# ``_defaults``) but are NOT OpenAI request-body fields. ``max_retries`` is a
+# client-side retry policy — retries are handled by ``@with_retry``, so
+# forwarding it on the wire does nothing useful and only risks tripping strict
+# downstream validators (e.g. a LiteLLM proxy).
+_NON_WIRE_DEFAULTS = frozenset({"max_retries"})
+
 
 @llm_registry.register("vllm")
 class VLLMClient(LLM):
@@ -71,7 +78,9 @@ class VLLMClient(LLM):
         self._model = model_name
         self._api_key = api_key
         self._enable_thinking = enable_thinking
-        self._defaults: dict = kwargs
+        # Drop non-OpenAI knobs (see ``_NON_WIRE_DEFAULTS``) so they never leak
+        # into request bodies for any code path (chat / completions / vision).
+        self._defaults: dict = {k: v for k, v in kwargs.items() if k not in _NON_WIRE_DEFAULTS}
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -103,8 +112,18 @@ class VLLMClient(LLM):
 
         return base_url, model, override_headers
 
-    def _chat_payload_kwargs(self, kwargs: dict) -> dict:
+    def _chat_payload_kwargs(self, kwargs: dict, *, stream: bool = False) -> dict:
         payload_kwargs = {**self._defaults, **kwargs}
+
+        # ``logprobs`` is never read back by OpenRAG, and streaming it through a
+        # LiteLLM proxy crashes the proxy while serializing the final chunk's
+        # ``ChoiceLogprobs`` ("'MockValSer' object cannot be converted to
+        # 'SchemaSerializer'"), surfacing as an opaque chat failure in the UI
+        # (linagora/openrag#563, BerriAI/litellm#24357). Drop it from streamed
+        # requests regardless of where it came from (config default or client).
+        if stream:
+            payload_kwargs.pop("logprobs", None)
+
         enable_thinking = payload_kwargs.pop("enable_thinking", self._enable_thinking)
         if enable_thinking is not None:
             chat_template_kwargs = dict(payload_kwargs.get("chat_template_kwargs") or {})
@@ -155,7 +174,12 @@ class VLLMClient(LLM):
     async def stream_chat(self, messages: list[dict[str, str]], **kwargs) -> AsyncIterator[str]:
         base_url, model, headers = self._resolve_overrides(kwargs)
         kwargs.pop("metadata", None)
-        payload = {**self._chat_payload_kwargs(kwargs), "model": model, "messages": messages, "stream": True}
+        payload = {
+            **self._chat_payload_kwargs(kwargs, stream=True),
+            "model": model,
+            "messages": messages,
+            "stream": True,
+        }
         try:
             async with self._client.stream(
                 "POST", f"{base_url}/chat/completions", json=payload, headers=headers

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -208,6 +208,52 @@ class TestVLLMClient:
         await self._make_client(handler).chat([{"role": "user", "content": "hi"}], temperature=0.9, max_tokens=100)
 
     @pytest.mark.asyncio
+    async def test_stream_chat_omits_logprobs(self):
+        """Streaming a logprobs request through a LiteLLM proxy crashes its
+        serializer (linagora/openrag#563), so logprobs is stripped on stream."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return httpx.Response(200, text="data: [DONE]\n")
+
+        client = self._make_client(capture, logprobs=True)
+        _ = [line async for line in client.stream_chat([{"role": "user", "content": "hi"}], logprobs=True)]
+
+        assert "logprobs" not in captured
+
+    @pytest.mark.asyncio
+    async def test_chat_keeps_logprobs_for_non_streaming(self):
+        """Non-streaming responses don't hit the LiteLLM streaming bug, so a
+        configured logprobs is still forwarded."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        await self._make_client(capture, logprobs=True).chat([{"role": "user", "content": "hi"}])
+        assert captured["logprobs"] is True
+
+    @pytest.mark.asyncio
+    async def test_max_retries_never_sent_on_wire(self):
+        """``max_retries`` is a client-side retry knob (handled by @with_retry),
+        not an OpenAI body field — it must never leak onto the wire."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response() if "/chat/" in str(req.url) else _completions_response()
+
+        client = self._make_client(capture, max_retries=5)
+        await client.chat([{"role": "user", "content": "hi"}])
+        assert "max_retries" not in captured
+
+        captured.clear()
+        await client.generate("say something")
+        assert "max_retries" not in captured
+
+    @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
         c = VLLMClient(endpoint="http://vllm:8000/v1/", model_name="m")
         assert c._endpoint == "http://vllm:8000/v1"


### PR DESCRIPTION
## Problem

Closes #563. A streamed chat completion fails with an opaque error from the downstream LiteLLM proxy:

> `'MockValSer' object cannot be converted to 'SchemaSerializer'`

The user only sees a generic chat failure even though the request reached the model service.

## Root cause

OpenRAG doesn't use LiteLLM as a library — `VLLMClient` POSTs raw OpenAI-style requests via `httpx` to the configured OpenAI-compatible endpoint (here, a LiteLLM proxy). The client is built from `settings.llm.model_dump()`, so two server-side config knobs leaked into `self._defaults` and were sent as request-body fields on **every** call:

- **`logprobs: true`** (config default) — yet OpenRAG **never reads logprobs back** anywhere. Per [BerriAI/litellm#24357](https://github.com/BerriAI/litellm/issues/24357), **streaming + logprobs** is exactly the break: the final stream chunk's `ChoiceLogprobs` still carries a `MockValSer` serializer, so LiteLLM crashes serializing it.
- **`max_retries: 2`** — not an OpenAI body field at all; retries are handled by `@with_retry` (which hardcodes attempts and ignores it). Dead weight on the wire that strict downstream validators can reject.

## Fix

At the single wire-building choke point (`VLLMClient`, covering RAG chat, direct chat, query-gen, map-reduce, completions, vision captioning, indexer contextualization):

1. **Strip `logprobs` from streamed requests** — regardless of source (config default or client-supplied). Non-streaming keeps it (that path doesn't hit the bug), so behavior is preserved for direct-vLLM users.
2. **Filter `max_retries` out of `_defaults` at construction** so it never reaches any payload.

## Testing

- 3 new unit tests in `test_vllm_client.py`: streaming omits `logprobs`; non-streaming keeps it; `max_retries` never sent (chat + completions).
- Full inference / query-service / DI / config unit suites green (324 passed); ruff lint + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming chat requests now avoid sending unsupported `logprobs` options, preventing request failures.
  * Retry settings are no longer included in outgoing request payloads, reducing incompatible request data.
* **Tests**
  * Added coverage for streaming and non-streaming chat behavior, including payload handling for `logprobs` and retry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->