### PR TITLE
Forward-port main's security & bug fixes onto refactor/hexagonal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,4 +454,4 @@ New table `oidc_sessions`:
   - **OIDC mode** → `401 {"detail": "Unauthenticated"}` (no usable session/bearer and the path isn't a UI redirect target).
 - Programmatic access: Bearer `users.token` accepted in both modes
 
-**See Also**: Full configuration and troubleshooting guide at `docs/oidc.md`.
+**See Also**: Full configuration and troubleshooting guide at `docs/content/docs/documentation/oidc.md` (quick start: `docs/content/docs/documentation/sso-quickstart.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ The system uses token-based authentication with role-based access control (RBAC)
 1. Token extracted from `Authorization: Bearer <token>` header (or `?token=` query param for `/static` routes)
 2. Token hashed with SHA-256, looked up in database
 3. User info and accessible partitions set on `request.state.user` and `request.state.user_partitions`
-4. Bypassed for: `/docs`, `/openapi.json`, `/redoc`, `/health_check`, `/version`, `/chainlit/*`
+4. Bypassed for: `/docs`, `/openapi.json`, `/redoc`, `/health_check`, `/version`, `/chainlit/*` — except in OIDC mode the three docs paths (`/docs`, `/redoc`, `/openapi.json`) are login-gated instead of public (see Middleware Behavior below)
 5. If `AUTH_TOKEN` env var is not set, defaults to admin user (id=1) for all requests
 
 **Role Hierarchy** (`openrag/services/orchestrators/auth_service.py`):
@@ -449,6 +449,7 @@ New table `oidc_sessions`:
 **Middleware Behavior**:
 
 - UI paths (`/`, `/chainlit`, `/static`) in OIDC mode without auth → 302 redirect to `/auth/login?next=...`
+- Interactive docs (`/docs`, `/redoc`, `/openapi.json`): **public in token mode** (bypassed), but **login-gated in OIDC mode** — an unauthenticated browser is 302-redirected to `/auth/login`; a valid session renders them. This stops the full API surface + schema from being served anonymously in production. The set is `AuthBypassConfig.oidc_gated_paths` (default `("/docs", "/redoc", "/openapi.json")`); override it to `()` to keep docs public under OIDC.
 - API paths (`/v1`, `/indexer`, `/search`, etc.) without auth:
   - **Token mode** → `403 {"detail": "Missing token"}` (no bearer) or `403 {"detail": "Invalid token"}` (unknown bearer). The 403 status is a legacy contract the robot suite asserts (`tests/api/`).
   - **OIDC mode** → `401 {"detail": "Unauthenticated"}` (no usable session/bearer and the path isn't a UI redirect target).

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -53,6 +53,12 @@ docs last.
 | `52be26f1` | non-empty RAG answer body | `openrag/prompts/templates/sys_prompt_tmpl.txt` |
 | `6bc898e9` | surrounding-chunk partition scope (N6) | `services/storage/vector_store_searcher.py` (+ tests) |
 | `86c9b51d` | ensure_partition_role fail-open → 404 | `api/dependencies/auth.py` (+ tests) |
+| `bf4ae134` | Milvus filter scope-escape via precedence | `services/storage/milvus_store.py` `_build_filter_expr` (paren-wrap multi-part) (+ tests) |
+| `f079efa5` | validate file_id / partition allowlist | `core/indexing/validators.py`, `api/dependencies/auth.py`, `partition_service.py`, `api/routers/{user/search,admin/partitions}.py` (+ tests). Defense-in-depth atop `_format_value` escaping. |
+| `db92875d` | strip client llm_override endpoint/creds | `services/inference/vllm_client.py` `_resolve_overrides`, `api/schemas/user/chat.py` (+ tests) |
+| `e3c7eac2` + `81bccf08` | control-token neutralizer (H8, #487) | `core/utils/text.py` `neutralize_prompt_control_tokens`, `core/prompts/chat_prompt_builder.py` (+ tests) |
+| `818d5446` | stop leaking stack traces / FS paths (M7) | `api/routers/admin/indexing.py` (generic save error; admin-gated traceback) |
+| `54165900` | token limit in RAG mode + bound n/best_of (M12) | `api/routers/user/chat.py`, `api/schemas/user/chat.py` (+ tests) |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -66,11 +72,16 @@ docs last.
 | `73acb1c9` | both halves already present: `sanitize_next_url` rejects CR/LF/NUL + the `/\` protocol-relative vector (#360 regression test), and the callback already verifies userinfo.sub == id_token.sub (OIDC Core §5.3.2). |
 | `cdb3edc9` | test-only follow-up to M9 on main's `test_oidc_client.py` (no equivalent file); subsumed by the new replay test which carries exp. |
 | `199424bf` | empty-stream 502 (#363): obviated by the refactor architecture — non-streaming uses `self._llm.chat()`/`.generate()` (materialized dicts, not a stream's first chunk), and the inference client already raises `InferenceError(status_code=502)` on invalid upstream responses. No `__anext__`/`StopAsyncIteration` path remains. |
+| `70a2db36` | CustomDocLoader page accumulation (#376): obviated — the parser-shim removal deleted `CustomDocLoader`; `.doc` now goes through the docling/marker workers, which produce whole-document markdown and have no single-page-overwrite bug. |
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI (~14 left):**
-`bf4ae134` + `f079efa5` Milvus filter-injection guards → `services/storage/*` (`_build_filter_expr`/`_format_value`), `api/routers/*` + `api/dependencies`; `db92875d` llm_override credential strip → `services/inference/vllm_client.py` (`_resolve_overrides`) + `api/schemas/user/chat.py`; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py`; `e3c7eac2` + `81bccf08` control-token neutralizer → `core/utils/` + sources-tag parser; `818d5446` stack-trace leak → `api/routers/admin/indexing.py`; `54165900` token-limit + n/best_of bounds (note: `check_tokens_limit` already wired in `/completions`; verify `/chat/completions` + n/best_of) → `api/schemas/user/chat.py` + `api/routers/user/chat.py`; `63a857af` image-URL SSRF → parsers; `8ea723ca` SVG external-fetch guard → image parser; `70a2db36` CustomDocLoader page accumulation (#376) → `services/workers/parsers/legacy_loaders/`; `761f47a0` copy-endpoint source_file_id validation (#477); `221f8ed8` parser DoS caps (M8) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13).
+**Batch 4 — RAG / retrieval / loaders / OpenAI (7 left):**
+`8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py` (DNS-resolution-time IP guard, block non-HTTP(S)/literal-private IPs, verify_ssl default); `63a857af` image-URL SSRF on captioning → parsers/base + a fetch-as-data-uri guard; `8ea723ca` explicit SVG external-fetch guard (cairosvg `unsafe=False`) → image parser; `221f8ed8` parser DoS caps (M8: max attachments/eml-depth/archive-entries/pdf-pages) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13) → `.env` + partition_service/router; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `761f47a0` copy-endpoint source_file_id validation (#477) → `api/routers/admin/indexing.py`.
+
+**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
+
+**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework, `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc trim, final ruff pass.
 
 **Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests (`pyproject.toml`, `uv.lock`, new `openrag/...rate_limit`, `.env.example`).
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -67,6 +67,9 @@ docs last.
 | `761f47a0` | validate copy-endpoint source_file_id (#477) | `api/routers/admin/indexing.py` + `docs/assets/compose_linux_gpu.yaml` |
 | `74de8232` | Starlette>=0.47.2 / FastAPI>=0.116.1 (CVE-2025-54121) | `pyproject.toml` + `uv.lock` regen (starlette 0.46.2->0.47.3, fastapi->0.116.2, chainlit->2.11.1) |
 | `0e6e7836` + `4d8bca01` | path-tiered rate limiting (M6) | new `api/middleware/rate_limit.py` (registered before AuthMiddleware), `limits>=3.6` dep, `.env.example`, API-test compose disable (+ tests). Refactor never had slowapi, so the 4d8bca01 swap is folded in. |
+| `701fcf9e` | document Chainlit on CHAINLIT_PORT under Ray Serve | `docs/.../getting_started/usage.mdx` |
+| `8849fe7d` | OIDC/SSO docs move deltas (frontmatter + links + README/CLAUDE pointers) | the file move was already done in the refactor; ported the remaining deltas |
+| (final) | ruff-format the ported lines | `style:` commit, mirrors main's 355a6305 / ee86fd47 |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -85,14 +88,25 @@ docs last.
 
 ### Remaining (TODO — not yet ported)
 
-**Batches 1 (infra core), 2 (deps), 3 (auth/OIDC), 4 (RAG/retrieval): ✅ COMPLETE.**
-All security-relevant package code and dependencies are ported or obviated.
+**Batches 1 (infra core), 2 (deps), 3 (auth/OIDC), 4 (RAG/retrieval), docs, final
+ruff pass: ✅ COMPLETE.** All security-relevant package code, dependencies and
+docs are ported or obviated. `ruff check` + `ruff format --check` clean,
+layer-import guard OK, `tests/unit/` green (1355 passed).
 
-**Deferred (user-requested, do last — the ONLY remaining work):**
-- `4bbefd41` compose non-root rework (init-perms bootstrap container + per-service `user:` mappings — needs careful adaptation to the `infra/compose/` volume paths)
-- `701fcf9e` docs: Chainlit on CHAINLIT_PORT under Ray Serve
-- `8849fe7d` docs: move OIDC/SSO quick-start guides into the docs site
-- `563907ad` doc comment trim, plus a final `ruff format`/`check` pass.
+**Not ported — one item, by deliberate choice:**
+- `4bbefd41` **compose non-root rework** (init-perms bootstrap container + per-service
+  `user:` mappings). This is all-or-nothing: the per-service `user:` mappings only work
+  with the init-perms container that pre-creates and chowns the bind-mount dirs, and those
+  paths must be mapped exactly onto the refactor's `infra/compose/` layout (`../../data`,
+  `../../logs`, the `milvus/milvus.yaml` include, `../../extern/reranker/*`, the
+  named-volumes variant). It is **runtime-only** (no unit-test feedback; compose isn't
+  exercised in CI) and is the least security-critical item — the images already *build*
+  non-root via the ported Dockerfiles. Committing it on faith risks a silently broken
+  stack, so it is left for a follow-up that can `docker compose up` to verify init-perms
+  ownership and non-root writes. Target files: `infra/compose/docker-compose.yaml`,
+  `infra/compose/milvus/milvus.yaml`, `extern/reranker/*.yaml`, `infra/quick_start`.
+- `563907ad` (doc comment trim) — cosmetic; the ported comments are already condensed and
+  differ from main's verbose originals, so the trim doesn't map cleanly. Skipped.
 
 > Note: the suite shows one pre-existing **false-alarm** failure,
 > `test_seed_defaults_preserves_endpoint_api_keys` — `seed_defaults` reads

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -11,8 +11,8 @@ to the cutover re-implementation queue.
 
 ## `main` → `refactor/hexagonal` security forward-port (2026-06-24)
 
-Working branch: `forward-port/main-to-hexagonal` (off `origin/refactor/hexagonal`,
-local only). Porting the 68 non-merge commits that landed on `main` after the
+Working branch: `forward-port/main-to-hexagonal` (off `origin/refactor/hexagonal`).
+Porting the 68 non-merge commits that landed on `main` after the
 merge-base (`c9d53cc0`, 2026-05-21) — mostly a one-shot security-hardening audit
 plus loader/OpenAI fixes, deploy hardening, deps and release chores. Each port is
 one commit carrying the original subject/body + a `Forward-ported from <hash>`
@@ -90,8 +90,8 @@ docs last.
 
 **Batches 1 (infra core), 2 (deps), 3 (auth/OIDC), 4 (RAG/retrieval), docs, final
 ruff pass: ✅ COMPLETE.** All security-relevant package code, dependencies and
-docs are ported or obviated. `ruff check` + `ruff format --check` clean,
-layer-import guard OK, `tests/unit/` green (1355 passed).
+docs are ported or obviated. Targeted security/infra tests, ruff and diff checks
+are clean on the forward-port branch.
 
 **Not ported — one item, by deliberate choice:**
 - `4bbefd41` **compose non-root rework** (init-perms bootstrap container + per-service
@@ -107,12 +107,6 @@ layer-import guard OK, `tests/unit/` green (1355 passed).
   `infra/compose/milvus/milvus.yaml`, `extern/reranker/*.yaml`, `infra/quick_start`.
 - `563907ad` (doc comment trim) — cosmetic; the ported comments are already condensed and
   differ from main's verbose originals, so the trim doesn't map cleanly. Skipped.
-
-> Note: the suite shows one pre-existing **false-alarm** failure,
-> `test_seed_defaults_preserves_endpoint_api_keys` — `seed_defaults` reads
-> `os.getenv("API_KEY", ...)` and this worktree is nested under the main checkout,
-> so `load_dotenv()` walks up and picks up the real `.env`. Not caused by this
-> port (passes from a checkout outside the main tree). Everything else: 1317 pass.
 
 ---
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -62,6 +62,9 @@ docs last.
 | `d66cf029` | cap partitions per non-admin user (M13) | `services/orchestrators/partition_service.py`, `api/routers/admin/partitions.py`, `.env.example` (+ tests) |
 | `8ecbc781` | web-search SSRF/MITM deltas (verify_ssl default True + DNS-resolution guard hook) | `services/websearch/content_fetcher.py` (+ tests). The refactor already had per-hop redirect revalidation (#383). |
 | `8ea723ca` | explicit cairosvg `unsafe=False` (SSRF/XXE) | `core/indexing/parsers/image_parser.py` |
+| `221f8ed8` | EML attachment fan-out cap (M8) | `core/indexing/parsers/eml_parser.py` (+ test). eml-depth already bounded by the dispatcher; docx/pptx/pdf caps N/A (docling/marker delegate). |
+| `67ec4199` | authorize source-file downloads by partition | new `api/routers/user/download.py` (replaces the open `/static` mount), `api/main.py`, `chat.py`/`source_links.py` rekeyed to chunk id (+ tests) |
+| `761f47a0` | validate copy-endpoint source_file_id (#477) | `api/routers/admin/indexing.py` + `docs/assets/compose_linux_gpu.yaml` |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -80,10 +83,7 @@ docs last.
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI (3 left):**
-- `221f8ed8` parser DoS caps (M8). Applies *partially* to the refactor's different parser architecture: the clear surface is `core/indexing/parsers/eml_parser.py` (uncapped attachment fan-out via `msg.walk()` + potential nested-`.eml` recursion through the DI attachment dispatch) → add `max_attachments` + an eml-depth guard + `core/config/indexation.py` keys. The docx/pptx/pdf caps target the *legacy* loaders' manual zip/page iteration, which the refactor delegates to docling/marker (no equivalent manual-iteration memory-bomb surface) — verify per worker before porting.
-- `67ec4199` source-download authz (partial — open `/static` mount already gone in the refactor) → confirm `api/routers/user/source_links.py` authorizes chunk/file downloads by partition membership.
-- `761f47a0` copy-endpoint `source_file_id` validation (#477) → `api/routers/admin/indexing.py` copy endpoint; likely largely covered now that `validate_file_id` is allowlist-based — confirm the copy endpoint runs it.
+**Batch 4 — RAG / retrieval / loaders / OpenAI: ✅ COMPLETE** (all ported or obviated).
 
 **Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -65,6 +65,8 @@ docs last.
 | `221f8ed8` | EML attachment fan-out cap (M8) | `core/indexing/parsers/eml_parser.py` (+ test). eml-depth already bounded by the dispatcher; docx/pptx/pdf caps N/A (docling/marker delegate). |
 | `67ec4199` | authorize source-file downloads by partition | new `api/routers/user/download.py` (replaces the open `/static` mount), `api/main.py`, `chat.py`/`source_links.py` rekeyed to chunk id (+ tests) |
 | `761f47a0` | validate copy-endpoint source_file_id (#477) | `api/routers/admin/indexing.py` + `docs/assets/compose_linux_gpu.yaml` |
+| `74de8232` | Starlette>=0.47.2 / FastAPI>=0.116.1 (CVE-2025-54121) | `pyproject.toml` + `uv.lock` regen (starlette 0.46.2->0.47.3, fastapi->0.116.2, chainlit->2.11.1) |
+| `0e6e7836` + `4d8bca01` | path-tiered rate limiting (M6) | new `api/middleware/rate_limit.py` (registered before AuthMiddleware), `limits>=3.6` dep, `.env.example`, API-test compose disable (+ tests). Refactor never had slowapi, so the 4d8bca01 swap is folded in. |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -83,19 +85,14 @@ docs last.
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI: ✅ COMPLETE** (all ported or obviated).
+**Batches 1 (infra core), 2 (deps), 3 (auth/OIDC), 4 (RAG/retrieval): ✅ COMPLETE.**
+All security-relevant package code and dependencies are ported or obviated.
 
-**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
-
-**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework, `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc trim, final ruff pass.
-
-**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
-
-**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework, `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc trim, final ruff pass.
-
-**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests (`pyproject.toml`, `uv.lock`, new `openrag/...rate_limit`, `.env.example`).
-
-**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework (init-perms + per-service `user:` — needs careful adaptation to `infra/compose/` paths), `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc comment trim, plus a final `ruff format`/`check` pass.
+**Deferred (user-requested, do last — the ONLY remaining work):**
+- `4bbefd41` compose non-root rework (init-perms bootstrap container + per-service `user:` mappings — needs careful adaptation to the `infra/compose/` volume paths)
+- `701fcf9e` docs: Chainlit on CHAINLIT_PORT under Ray Serve
+- `8849fe7d` docs: move OIDC/SSO quick-start guides into the docs site
+- `563907ad` doc comment trim, plus a final `ruff format`/`check` pass.
 
 > Note: the suite shows one pre-existing **false-alarm** failure,
 > `test_seed_defaults_preserves_endpoint_api_keys` — `seed_defaults` reads

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -48,6 +48,11 @@ docs last.
 | `2b34a0d1` | clock-skew leeway + nbf (crypto) | `services/auth/oidc_client.py` |
 | `c2fde135` | logout CSRF Fetch-Metadata guard (N3) | `api/routers/auth/oidc.py` (+ tests) |
 | `9a73200a` | revoke OIDC sessions on token regen (#361, #486) | `services/orchestrators/{auth_service,user_service}.py` (startup-rotation guard + revoke_by_user already present) |
+| `714f2a84` | streaming finish_reason not on content chunk | `core/utils/source_filtering.py` (+ test) |
+| `0bc6157e` | stop logging raw query text (#481) | `api/routers/user/search.py` (query_len) |
+| `52be26f1` | non-empty RAG answer body | `openrag/prompts/templates/sys_prompt_tmpl.txt` |
+| `6bc898e9` | surrounding-chunk partition scope (N6) | `services/storage/vector_store_searcher.py` (+ tests) |
+| `86c9b51d` | ensure_partition_role fail-open → 404 | `api/dependencies/auth.py` (+ tests) |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -60,11 +65,12 @@ docs last.
 | `47b8cd32` | refactor already fail-fasts on missing CHAINLIT_AUTH_SECRET (stricter, #380/`b63a9825`, with a regression test). 47b8cd32 only re-adds an ALLOW_NO_AUTH-gated default-secret fallback — a loosening intentionally NOT ported. |
 | `73acb1c9` | both halves already present: `sanitize_next_url` rejects CR/LF/NUL + the `/\` protocol-relative vector (#360 regression test), and the callback already verifies userinfo.sub == id_token.sub (OIDC Core §5.3.2). |
 | `cdb3edc9` | test-only follow-up to M9 on main's `test_oidc_client.py` (no equivalent file); subsumed by the new replay test which carries exp. |
+| `199424bf` | empty-stream 502 (#363): obviated by the refactor architecture — non-streaming uses `self._llm.chat()`/`.generate()` (materialized dicts, not a stream's first chunk), and the inference client already raises `InferenceError(status_code=502)` on invalid upstream responses. No `__anext__`/`StopAsyncIteration` path remains. |
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI (~21 commits):**
-`714f2a84` streaming finish_reason → `core/utils/source_filtering.py`; `bf4ae134` + `f079efa5` Milvus filter-injection guards → `services/storage/*`, `api/routers/*` + `api/dependencies`; `db92875d` llm_override credential strip → `services/inference/vllm_client.py` + `api/schemas/user/chat.py`; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `86c9b51d` ensure_partition_role fail-open → `api/dependencies/auth.py`; `8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py`; `e3c7eac2` + `81bccf08` control-token neutralizer → `core/utils/` + sources-tag parser; `818d5446` stack-trace leak → `api/routers/admin/indexing.py`; `54165900` token-limit + n/best_of bounds → `api/schemas/user/chat.py` + `api/routers/user/chat.py`; `6bc898e9` surrounding-chunk partition scope → `services/storage/vector_store_searcher.py`; `63a857af` image-URL SSRF → parsers; `8ea723ca` SVG external-fetch guard → image parser; `70a2db36` CustomDocLoader page accumulation (#376) → `services/workers/parsers/legacy_loaders/`; `199424bf` empty-stream 502 (#363) → `api/routers/user/chat.py`; `0bc6157e` stop logging raw query (#481) → `api/routers/user/search.py`; `761f47a0` copy-endpoint source_file_id validation (#477); `221f8ed8` parser DoS caps (M8) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13); `52be26f1` non-empty RAG answer → `openrag/prompts/templates/`.
+**Batch 4 — RAG / retrieval / loaders / OpenAI (~14 left):**
+`bf4ae134` + `f079efa5` Milvus filter-injection guards → `services/storage/*` (`_build_filter_expr`/`_format_value`), `api/routers/*` + `api/dependencies`; `db92875d` llm_override credential strip → `services/inference/vllm_client.py` (`_resolve_overrides`) + `api/schemas/user/chat.py`; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py`; `e3c7eac2` + `81bccf08` control-token neutralizer → `core/utils/` + sources-tag parser; `818d5446` stack-trace leak → `api/routers/admin/indexing.py`; `54165900` token-limit + n/best_of bounds (note: `check_tokens_limit` already wired in `/completions`; verify `/chat/completions` + n/best_of) → `api/schemas/user/chat.py` + `api/routers/user/chat.py`; `63a857af` image-URL SSRF → parsers; `8ea723ca` SVG external-fetch guard → image parser; `70a2db36` CustomDocLoader page accumulation (#376) → `services/workers/parsers/legacy_loaders/`; `761f47a0` copy-endpoint source_file_id validation (#477); `221f8ed8` parser DoS caps (M8) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13).
 
 **Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests (`pyproject.toml`, `uv.lock`, new `openrag/...rate_limit`, `.env.example`).
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -59,6 +59,7 @@ docs last.
 | `e3c7eac2` + `81bccf08` | control-token neutralizer (H8, #487) | `core/utils/text.py` `neutralize_prompt_control_tokens`, `core/prompts/chat_prompt_builder.py` (+ tests) |
 | `818d5446` | stop leaking stack traces / FS paths (M7) | `api/routers/admin/indexing.py` (generic save error; admin-gated traceback) |
 | `54165900` | token limit in RAG mode + bound n/best_of (M12) | `api/routers/user/chat.py`, `api/schemas/user/chat.py` (+ tests) |
+| `d66cf029` | cap partitions per non-admin user (M13) | `services/orchestrators/partition_service.py`, `api/routers/admin/partitions.py`, `.env.example` (+ tests) |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -76,8 +77,8 @@ docs last.
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI (7 left):**
-`8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py` (DNS-resolution-time IP guard, block non-HTTP(S)/literal-private IPs, verify_ssl default); `63a857af` image-URL SSRF on captioning → parsers/base + a fetch-as-data-uri guard; `8ea723ca` explicit SVG external-fetch guard (cairosvg `unsafe=False`) → image parser; `221f8ed8` parser DoS caps (M8: max attachments/eml-depth/archive-entries/pdf-pages) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13) → `.env` + partition_service/router; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `761f47a0` copy-endpoint source_file_id validation (#477) → `api/routers/admin/indexing.py`.
+**Batch 4 — RAG / retrieval / loaders / OpenAI (5 left, the most complex/multi-file):**
+`8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py` (DNS-resolution-time IP guard, block non-HTTP(S)/literal-private IPs, verify_ssl default) — note the refactor already has `url_safety`/`test_url_safety.py`, so check what's already mitigated; `63a857af` image-URL SSRF on captioning → parsers/base + a fetch-as-data-uri guard; `8ea723ca` explicit SVG external-fetch guard (cairosvg `unsafe=False`) → image parser; `221f8ed8` parser DoS caps (M8: max attachments/eml-depth/archive-entries/pdf-pages) → `core/config/indexation.py` + parsers; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `761f47a0` copy-endpoint source_file_id validation (#477) → `api/routers/admin/indexing.py` (likely largely covered now that `validate_file_id` is allowlist-based).
 
 **Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -9,19 +9,78 @@ to the cutover re-implementation queue.
 
 ---
 
+## `main` → `refactor/hexagonal` security forward-port (2026-06-24)
+
+Working branch: `forward-port/main-to-hexagonal` (off `origin/refactor/hexagonal`,
+local only). Porting the 68 non-merge commits that landed on `main` after the
+merge-base (`c9d53cc0`, 2026-05-21) — mostly a one-shot security-hardening audit
+plus loader/OpenAI fixes, deploy hardening, deps and release chores. Each port is
+one commit carrying the original subject/body + a `Forward-ported from <hash>`
+trailer. Order chosen by the user: package security code first, infra non-root +
+docs last.
+
+### Ported
+
+| source (main) | subject | target location(s) |
+|---|---|---|
+| `c1079d7f` | Ray dashboard → localhost (compose) | `infra/compose/docker-compose.yaml` |
+| `8914dfbb` | non-root Ray container (H4) | `infra/docker/ray.Dockerfile` |
+| `8914dfbb`+`6860341c`+`26a70dbc`+`c0847d8f` | non-root OpenShift app image (consolidated — later commits rewrote earlier) | `infra/docker/api.Dockerfile` |
+| `645128dc` | no prod bind-mount / gate --reload (N8) | `infra/compose/docker-compose.yaml`, `infra/scripts/entrypoint.sh` |
+| `0e5687bc` | remove API_NUM_WORKERS footgun | `infra/scripts/entrypoint.sh`, `infra/compose/.env.example`, `infra/charts/.../values.yaml`, `docs/.../env_vars.md` |
+| `319bc5cd` | drop API_NUM_WORKERS from doc env assets | `docs/assets/env_example.env`, `env_linux_gpu.env` |
+| `c558dd1f` / `d69be1da` | version bump → 1.1.12 / 1.1.13 | `pyproject.toml` |
+| `2af1d76f` | harden Ansible deploy (#488) | `infra/ansible/ansible.cfg`, `playbooks/openrag.yml` |
+| `34dc3a2f` | Ray dashboard localhost default (C3) | `openrag/api/main.py`, `openrag/api/mcp/server.py`, `infra/cluster.yaml`, `infra/quick_start/docker-compose.yaml`, `docs/assets/compose_ollama_cpu.yaml` |
+| `aa015bdd` | external Ray cluster via RAY_ADDRESS | `openrag/api/main.py`, `openrag/api/mcp/server.py`, `.env.example`, docs |
+| `0515f705` | require MinIO creds (H3) | `infra/compose/milvus/milvus.yaml`, `infra/quick_start/vdb/milvus.yaml`, `.env.example` |
+| `0164b829` | remove weak DB/AUTH defaults (M2/M3) | `conf/config.yaml`, compose stacks, `docs/assets/compose_ollama_cpu.yaml`, `.env.example` |
+| `b8002ef0` | drop seccomp:unconfined (N11) | `infra/compose/milvus/milvus.yaml` + `.named-volumes.yaml`, `infra/quick_start/vdb/milvus.yaml` |
+| `24efaa66` | Helm DB password → Secret (N7) | `infra/charts/openrag-stack/values.yaml` |
+| `c8f2d47f` | default-deny NetworkPolicy (N12) | `infra/charts/.../templates/networkpolicy.yaml` (new), `values.yaml` |
+| `5caec50b` | restrict metrics exposure (N9) | `infra/compose/monitoring.docker-compose.yaml` |
+| `d7fc3130` | pin image tags (N10) | `infra/charts/.../values.yaml` (openrag-owned → 1.1.13), `infra/compose/monitoring.docker-compose.yaml` (third-party pins). Compose app-image pins skipped (reverted by 64c3e722). |
+| `7bc46696` | require ALLOW_NO_AUTH for no-token admin bypass | `openrag/api/middleware/auth.py`, `.env.example`, `tests/unit/api/middleware/test_bypass_config.py` |
+| `202433d7` | update_user mass-assignment whitelist | `openrag/core/models/user.py` (extra="ignore"), `openrag/services/orchestrators/user_service.py` (whitelist), tests |
+| `edd2c7ce` | external_user_id empty→NULL (#121) | `openrag/core/models/user.py` (validator; covers update path the repo missed) |
+| `229503b4` | no session token in UI file URLs (N13) | `openrag/app_front.py` |
+
+### Skipped (already present / superseded on refactor)
+
+| source (main) | reason |
+|---|---|
+| `f9e0c394` | /chainlit path-boundary anchor already in `api/middleware/auth.py` |
+| `9b82996c` | azp on multi-aud tokens already in `services/auth/oidc_client.py` |
+| `64c3e722` | compose `:latest` tags already the refactor state |
+| `f9b8a776` | de-flake `test_cancel_*` superseded by refactor `cca5f415` |
+| `47b8cd32` | refactor already fail-fasts on missing CHAINLIT_AUTH_SECRET (stricter, #380/`b63a9825`, with a regression test). 47b8cd32 only re-adds an ALLOW_NO_AUTH-gated default-secret fallback — a loosening intentionally NOT ported. |
+
+### Remaining (TODO — not yet ported)
+
+**Batch 3 — OIDC crypto (services/auth/oidc_client.py, api/routers/auth/oidc.py):**
+- `2b34a0d1` clock-skew leeway + nbf check → `openrag/services/auth/oidc_client.py`
+- `97c624ef` back-channel logout exp/jti + replay cache → `services/auth/oidc_client.py` + `api/routers/auth/oidc.py` (+ test `cdb3edc9`)
+- `c2fde135` logout CSRF (Sec-Fetch / Fetch-Metadata) → `api/routers/auth/oidc.py`
+- `73acb1c9` next-URL backslash/CRLF reject + userinfo-sub bind to ID token → `api/routers/auth/oidc.py`, `services/auth`
+- `9a73200a` stop admin token rotation on startup + revoke OIDC sessions on token regen → `services/persistence/user_repo.py`, `services/auth`
+
+**Batch 4 — RAG / retrieval / loaders / OpenAI (~21 commits):**
+`714f2a84` streaming finish_reason → `core/utils/source_filtering.py`; `bf4ae134` + `f079efa5` Milvus filter-injection guards → `services/storage/*`, `api/routers/*` + `api/dependencies`; `db92875d` llm_override credential strip → `services/inference/vllm_client.py` + `api/schemas/user/chat.py`; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `86c9b51d` ensure_partition_role fail-open → `api/dependencies/auth.py`; `8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py`; `e3c7eac2` + `81bccf08` control-token neutralizer → `core/utils/` + sources-tag parser; `818d5446` stack-trace leak → `api/routers/admin/indexing.py`; `54165900` token-limit + n/best_of bounds → `api/schemas/user/chat.py` + `api/routers/user/chat.py`; `6bc898e9` surrounding-chunk partition scope → `services/storage/vector_store_searcher.py`; `63a857af` image-URL SSRF → parsers; `8ea723ca` SVG external-fetch guard → image parser; `70a2db36` CustomDocLoader page accumulation (#376) → `services/workers/parsers/legacy_loaders/`; `199424bf` empty-stream 502 (#363) → `api/routers/user/chat.py`; `0bc6157e` stop logging raw query (#481) → `api/routers/user/search.py`; `761f47a0` copy-endpoint source_file_id validation (#477); `221f8ed8` parser DoS caps (M8) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13); `52be26f1` non-empty RAG answer → `openrag/prompts/templates/`.
+
+**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests (`pyproject.toml`, `uv.lock`, new `openrag/...rate_limit`, `.env.example`).
+
+**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework (init-perms + per-service `user:` — needs careful adaptation to `infra/compose/` paths), `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc comment trim, plus a final `ruff format`/`check` pass.
+
+> Note: the suite shows one pre-existing **false-alarm** failure,
+> `test_seed_defaults_preserves_endpoint_api_keys` — `seed_defaults` reads
+> `os.getenv("API_KEY", ...)` and this worktree is nested under the main checkout,
+> so `load_dotenv()` walks up and picks up the real `.env`. Not caused by this
+> port (passes from a checkout outside the main tree). Everything else: 1317 pass.
+
+---
+
 ## Forward-ported (critical)
 
-_Security fixes, data-loss bugs, production outages re-implemented against
-the new architecture. Each entry pairs the dev commit with the refactor
-commit so a reviewer can audit equivalence._
+_(legacy template section — superseded by the dated section above.)_
 
-(none yet)
-
-## Deferred to cutover (features)
-
-_Non-critical changes that landed on `dev` during MODE 2. These will be
-re-implemented directly in the new architecture during MODE 3 (Phases
-10-12) or post-cutover. List the dev PR number / commit and the target
-location in the new layout._
-
-(none yet)
+(none recorded under the original Phase 5–9 process)

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -60,6 +60,8 @@ docs last.
 | `818d5446` | stop leaking stack traces / FS paths (M7) | `api/routers/admin/indexing.py` (generic save error; admin-gated traceback) |
 | `54165900` | token limit in RAG mode + bound n/best_of (M12) | `api/routers/user/chat.py`, `api/schemas/user/chat.py` (+ tests) |
 | `d66cf029` | cap partitions per non-admin user (M13) | `services/orchestrators/partition_service.py`, `api/routers/admin/partitions.py`, `.env.example` (+ tests) |
+| `8ecbc781` | web-search SSRF/MITM deltas (verify_ssl default True + DNS-resolution guard hook) | `services/websearch/content_fetcher.py` (+ tests). The refactor already had per-hop redirect revalidation (#383). |
+| `8ea723ca` | explicit cairosvg `unsafe=False` (SSRF/XXE) | `core/indexing/parsers/image_parser.py` |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -74,11 +76,18 @@ docs last.
 | `cdb3edc9` | test-only follow-up to M9 on main's `test_oidc_client.py` (no equivalent file); subsumed by the new replay test which carries exp. |
 | `199424bf` | empty-stream 502 (#363): obviated by the refactor architecture — non-streaming uses `self._llm.chat()`/`.generate()` (materialized dicts, not a stream's first chunk), and the inference client already raises `InferenceError(status_code=502)` on invalid upstream responses. No `__anext__`/`StopAsyncIteration` path remains. |
 | `70a2db36` | CustomDocLoader page accumulation (#376): obviated — the parser-shim removal deleted `CustomDocLoader`; `.doc` now goes through the docling/marker workers, which produce whole-document markdown and have no single-page-overwrite bug. |
+| `63a857af` | image-URL SSRF on captioning (H2): obviated — the refactor captions extracted image *bytes* (`vlm.caption_image(image_bytes)`); a document's remote `![](http://…)` becomes an `ImageBlock(source_url=…)` with empty bytes that nothing fetches, and the URL is never forwarded to the VLM. No SSRF gadget. (`image_captioning_url` is a dormant unread knob.) The SVG sub-fix is ported separately as `8ea723ca`. |
 
 ### Remaining (TODO — not yet ported)
 
-**Batch 4 — RAG / retrieval / loaders / OpenAI (5 left, the most complex/multi-file):**
-`8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py` (DNS-resolution-time IP guard, block non-HTTP(S)/literal-private IPs, verify_ssl default) — note the refactor already has `url_safety`/`test_url_safety.py`, so check what's already mitigated; `63a857af` image-URL SSRF on captioning → parsers/base + a fetch-as-data-uri guard; `8ea723ca` explicit SVG external-fetch guard (cairosvg `unsafe=False`) → image parser; `221f8ed8` parser DoS caps (M8: max attachments/eml-depth/archive-entries/pdf-pages) → `core/config/indexation.py` + parsers; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `761f47a0` copy-endpoint source_file_id validation (#477) → `api/routers/admin/indexing.py` (likely largely covered now that `validate_file_id` is allowlist-based).
+**Batch 4 — RAG / retrieval / loaders / OpenAI (3 left):**
+- `221f8ed8` parser DoS caps (M8). Applies *partially* to the refactor's different parser architecture: the clear surface is `core/indexing/parsers/eml_parser.py` (uncapped attachment fan-out via `msg.walk()` + potential nested-`.eml` recursion through the DI attachment dispatch) → add `max_attachments` + an eml-depth guard + `core/config/indexation.py` keys. The docx/pptx/pdf caps target the *legacy* loaders' manual zip/page iteration, which the refactor delegates to docling/marker (no equivalent manual-iteration memory-bomb surface) — verify per worker before porting.
+- `67ec4199` source-download authz (partial — open `/static` mount already gone in the refactor) → confirm `api/routers/user/source_links.py` authorizes chunk/file downloads by partition membership.
+- `761f47a0` copy-endpoint `source_file_id` validation (#477) → `api/routers/admin/indexing.py` copy endpoint; likely largely covered now that `validate_file_id` is allowlist-based — confirm the copy endpoint runs it.
+
+**Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
+
+**Deferred (user-requested, do last):** `4bbefd41` compose non-root rework, `701fcf9e` + `8849fe7d` docs moves, `563907ad` doc trim, final ruff pass.
 
 **Batch 2 — deps:** `74de8232` Starlette/FastAPI bump, `4d8bca01` `limits` not slowapi, `0e6e7836` rate-limit module + tests. Need `uv.lock` regen.
 

--- a/FORWARD_PORT_LOG.md
+++ b/FORWARD_PORT_LOG.md
@@ -44,6 +44,10 @@ docs last.
 | `202433d7` | update_user mass-assignment whitelist | `openrag/core/models/user.py` (extra="ignore"), `openrag/services/orchestrators/user_service.py` (whitelist), tests |
 | `edd2c7ce` | external_user_id empty→NULL (#121) | `openrag/core/models/user.py` (validator; covers update path the repo missed) |
 | `229503b4` | no session token in UI file URLs (N13) | `openrag/app_front.py` |
+| `97c624ef` | back-channel logout exp/jti + replay (M9) | `services/auth/oidc_client.py`, `services/orchestrators/auth_service.py` (+ replay test) |
+| `2b34a0d1` | clock-skew leeway + nbf (crypto) | `services/auth/oidc_client.py` |
+| `c2fde135` | logout CSRF Fetch-Metadata guard (N3) | `api/routers/auth/oidc.py` (+ tests) |
+| `9a73200a` | revoke OIDC sessions on token regen (#361, #486) | `services/orchestrators/{auth_service,user_service}.py` (startup-rotation guard + revoke_by_user already present) |
 
 ### Skipped (already present / superseded on refactor)
 
@@ -54,15 +58,10 @@ docs last.
 | `64c3e722` | compose `:latest` tags already the refactor state |
 | `f9b8a776` | de-flake `test_cancel_*` superseded by refactor `cca5f415` |
 | `47b8cd32` | refactor already fail-fasts on missing CHAINLIT_AUTH_SECRET (stricter, #380/`b63a9825`, with a regression test). 47b8cd32 only re-adds an ALLOW_NO_AUTH-gated default-secret fallback — a loosening intentionally NOT ported. |
+| `73acb1c9` | both halves already present: `sanitize_next_url` rejects CR/LF/NUL + the `/\` protocol-relative vector (#360 regression test), and the callback already verifies userinfo.sub == id_token.sub (OIDC Core §5.3.2). |
+| `cdb3edc9` | test-only follow-up to M9 on main's `test_oidc_client.py` (no equivalent file); subsumed by the new replay test which carries exp. |
 
 ### Remaining (TODO — not yet ported)
-
-**Batch 3 — OIDC crypto (services/auth/oidc_client.py, api/routers/auth/oidc.py):**
-- `2b34a0d1` clock-skew leeway + nbf check → `openrag/services/auth/oidc_client.py`
-- `97c624ef` back-channel logout exp/jti + replay cache → `services/auth/oidc_client.py` + `api/routers/auth/oidc.py` (+ test `cdb3edc9`)
-- `c2fde135` logout CSRF (Sec-Fetch / Fetch-Metadata) → `api/routers/auth/oidc.py`
-- `73acb1c9` next-URL backslash/CRLF reject + userinfo-sub bind to ID token → `api/routers/auth/oidc.py`, `services/auth`
-- `9a73200a` stop admin token rotation on startup + revoke OIDC sessions on token regen → `services/persistence/user_repo.py`, `services/auth`
 
 **Batch 4 — RAG / retrieval / loaders / OpenAI (~21 commits):**
 `714f2a84` streaming finish_reason → `core/utils/source_filtering.py`; `bf4ae134` + `f079efa5` Milvus filter-injection guards → `services/storage/*`, `api/routers/*` + `api/dependencies`; `db92875d` llm_override credential strip → `services/inference/vllm_client.py` + `api/schemas/user/chat.py`; `67ec4199` source-download authz (partial — `/static` mount already gone) → `api/routers/user/source_links.py`; `86c9b51d` ensure_partition_role fail-open → `api/dependencies/auth.py`; `8ecbc781` web-search SSRF/MITM → `services/websearch/content_fetcher.py`; `e3c7eac2` + `81bccf08` control-token neutralizer → `core/utils/` + sources-tag parser; `818d5446` stack-trace leak → `api/routers/admin/indexing.py`; `54165900` token-limit + n/best_of bounds → `api/schemas/user/chat.py` + `api/routers/user/chat.py`; `6bc898e9` surrounding-chunk partition scope → `services/storage/vector_store_searcher.py`; `63a857af` image-URL SSRF → parsers; `8ea723ca` SVG external-fetch guard → image parser; `70a2db36` CustomDocLoader page accumulation (#376) → `services/workers/parsers/legacy_loaders/`; `199424bf` empty-stream 502 (#363) → `api/routers/user/chat.py`; `0bc6157e` stop logging raw query (#481) → `api/routers/user/search.py`; `761f47a0` copy-endpoint source_file_id validation (#477); `221f8ed8` parser DoS caps (M8) → `core/config/indexation.py` + parsers; `d66cf029` cap partitions per user (M13); `52be26f1` non-empty RAG answer → `openrag/prompts/templates/`.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ OpenRag supports two authentication modes:
 
 To enable OIDC, set `AUTH_MODE=oidc` and configure the required OIDC variables (see [`infra/compose/.env.example`](./infra/compose/.env.example) for the full list).
 
-For comprehensive OIDC setup and configuration, see the [OIDC Authentication Guide](./docs/oidc.md).
+For comprehensive OIDC setup and configuration, see the [OIDC Authentication Guide](./docs/content/docs/documentation/oidc.md) (or the [SSO Quick Start](./docs/content/docs/documentation/sso-quickstart.md) for a faster path).
 
 3. `http://localhost:INDEXERUI_PORT` to access the indexer ui for easy document ingestion, indexing, and management
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -71,7 +71,9 @@ rdb:
   host: rdb
   port: 5432
   user: root
-  password: "root_password"
+  # No default: supply via the POSTGRES_PASSWORD env var. Shipping a known
+  # password would be a usable default credential on any exposed deployment.
+  password: ""
   default_file_quota: -1
   # Leave unset to derive partitions_for_collection_<VDB_COLLECTION_NAME>.
   database: null

--- a/docs/assets/compose_linux_gpu.yaml
+++ b/docs/assets/compose_linux_gpu.yaml
@@ -16,7 +16,7 @@ x-openrag: &openrag_template
     - ./ray_mount/logs:/app/logs
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
-    - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
+    - 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265 # Localhost only: Ray dashboard/Jobs API is unauthenticated. Disable when in cluster mode
   networks:
     default:
       aliases:

--- a/docs/assets/compose_ollama_cpu.yaml
+++ b/docs/assets/compose_ollama_cpu.yaml
@@ -7,7 +7,8 @@ x-openrag: &openrag_template
     - ./ray_mount/logs:/app/logs
   ports:
     - 8090:8080
-    - 8265:8265 # Disable when in cluster mode
+    # Localhost only: Ray dashboard/Jobs API is unauthenticated (CVE-2023-48022). Disable when in cluster mode
+    - 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265
   networks:
     default:
       aliases:

--- a/docs/assets/compose_ollama_cpu.yaml
+++ b/docs/assets/compose_ollama_cpu.yaml
@@ -17,7 +17,7 @@ x-openrag: &openrag_template
     - .env
   environment:
     - APP_PORT=8090
-    - AUTH_TOKEN=OpenRAG
+    - AUTH_TOKEN=${AUTH_TOKEN:?Set a strong AUTH_TOKEN in your .env}
     - RERANKER_ENABLED=false
     - MARKER_MAX_PROCESSES=1
     - INDEXERUI_COMPOSE_FILE=true           # Does not serve any purpose but needs to be enabled until PR is merged
@@ -39,7 +39,7 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=root
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
       - POSTGRES_USER=root
     volumes:
       - ./db:/var/lib/postgresql/data
@@ -73,8 +73,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ./volumes/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"

--- a/docs/assets/compose_ollama_cpu.yaml
+++ b/docs/assets/compose_ollama_cpu.yaml
@@ -92,6 +92,8 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ./volumes/milvus:/var/lib/milvus
     healthcheck:

--- a/docs/assets/env_example.env
+++ b/docs/assets/env_example.env
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/docs/assets/env_example.env
+++ b/docs/assets/env_example.env
@@ -44,6 +44,11 @@ RAY_DEDUP_LOGS=0 # turns off ray log deduplication that appear across multiple p
 RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING=1 # # to enable logs at task level in ray dashboard
 RAY_task_retry_delay_ms=3000
 RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 # critical with the newest version of UV
+# Attach to an external Ray cluster instead of starting an embedded one (disables the local dashboard).
+# RAY_ADDRESS=ray://X.X.X.X:10001
+# Interface the embedded Ray dashboard binds to. Defaults to 127.0.0.1 (loopback) because the
+# dashboard/job API is unauthenticated (CVE-2023-48022). Set 0.0.0.0 only behind a firewall/auth proxy.
+# RAY_DASHBOARD_HOST=127.0.0.1
 
 # Indexer UI 
 ## 1. replace X.X.X.X with localhost if launching local or with your server IP

--- a/docs/assets/env_linux_gpu.env
+++ b/docs/assets/env_linux_gpu.env
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/docs/assets/env_linux_gpu.env
+++ b/docs/assets/env_linux_gpu.env
@@ -40,6 +40,11 @@ RAY_DEDUP_LOGS=0 # turns off ray log deduplication that appear across multiple p
 RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING=1 # # to enable logs at task level in ray dashboard
 RAY_task_retry_delay_ms=3000
 RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 # critical with the newest version of UV
+# Attach to an external Ray cluster instead of starting an embedded one (disables the local dashboard).
+# RAY_ADDRESS=ray://X.X.X.X:10001
+# Interface the embedded Ray dashboard binds to. Defaults to 127.0.0.1 (loopback) because the
+# dashboard/job API is unauthenticated (CVE-2023-48022). Set 0.0.0.0 only behind a firewall/auth proxy.
+# RAY_DASHBOARD_HOST=127.0.0.1
 
 # Indexer UI 
 ## 1. replace X.X.X.X with localhost if launching local or with your server IP

--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -7,13 +7,13 @@ The FastAPI-powered backend provides a comprehensive document-based question ans
 
 ## 🔐 Authentication
 
-All endpoints require authentication when **enabled** (by adding a authorization token `AUTH_TOKEN` in your **`.env`**). Include your **`AUTH_TOKEN`** in the HTTP request header:
+Protected endpoints require authentication by default. Set `AUTH_TOKEN` in your `.env` and include it in the HTTP request header:
 
 ```http
 Authorization: Bearer YOUR_AUTH_TOKEN
 ```
 
-For OpenAI-compatible endpoints, `AUTH_TOKEN` serves as the `api_key` parameter. Use a placeholder like `'sk-1234'` when authentication is disabled (necessary for when using OpenAI client).
+For OpenAI-compatible endpoints, `AUTH_TOKEN` serves as the `api_key` parameter. Local no-auth development requires the explicit `ALLOW_NO_AUTH=true` opt-in; otherwise an empty token fails closed.
 
 ---
 
@@ -586,7 +586,7 @@ from openai import OpenAI, AsyncOpenAI
 api_base_url = "http://localhost:8080" # fastapi base url of 'openrag'
 base_url = f"{api_base_url}/v1"
 
-auth_key = ... # your api authentification key AUTH_TOKEN in your .env. Is authentification is disabled, use a placeholder like 'sk-1234'
+auth_key = ... # your API authentication key AUTH_TOKEN from .env
 client = OpenAI(api_key=auth_key, base_url=base_url)
 
 your_partition= 'my_partition' # name of your partition

--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -433,7 +433,7 @@ OpenAI-compatible text completion endpoint.
 | `websearch` | `bool` | `false` | Augments the RAG context with live web search results. When used with a partition (`openrag-{partition}`), document and web results are combined. When used without a partition (direct LLM mode), web results are the sole context. Requires `WEBSEARCH_API_TOKEN` to be configured. See [web search configuration](/openrag/documentation/env_vars/#web-search-configuration). |
 | `spoken_style_answer` | `bool` | `false` | Generates a succinct spoken-style conversational answer based on the retrieved documents. |
 | `use_map_reduce` | `bool` | `false` | Uses a map-reduce strategy to aggregate information from multiple documents. See [map-reduce configuration](/openrag/documentation/env_vars/#map--reduce-configuration). |
-| `llm_override` | `object` | `null` | Routes the request to a different LLM endpoint while still using OpenRAG's RAG pipeline (retrieval, reranking, prompt construction). Accepts: `base_url` (string), `api_key` (string), `model` (string). Any field not provided falls back to the default OpenRAG LLM configuration. |
+| `llm_override` | `object` | `null` | Overrides only the downstream LLM model name while still using OpenRAG's configured LLM endpoint and credentials. Accepts: `model` (string). Endpoint URL and API key are server-side configuration and cannot be changed by a client request. |
 
 Examples:
 
@@ -498,7 +498,7 @@ curl -X 'POST' 'http://localhost:8080/v1/chat/completions' \
 }'
 ```
 
-```bash title="Using a custom LLM endpoint with OpenRAG's RAG pipeline"
+```bash title="Using another configured LLM model with OpenRAG's RAG pipeline"
 curl -X 'POST' 'http://localhost:8080/v1/chat/completions' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer YOUR_AUTH_TOKEN' \
@@ -514,8 +514,6 @@ curl -X 'POST' 'http://localhost:8080/v1/chat/completions' \
   "stream": false,
   "metadata": {
     "llm_override": {
-      "base_url": "https://api.openai.com/v1",
-      "api_key": "sk-your-openai-key",
       "model": "gpt-4o"
     }
   }

--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -136,6 +136,10 @@ docker compose up -d
 
 Once running, **OpenRAG will auto-connect** to the Ray cluster using `RAY_ADDRESS` from `.env`.
 
+:::note
+When `RAY_ADDRESS` is set, the app **attaches** to the external cluster and does **not** start its own embedded Ray dashboard — the head node owns it (started above via `--dashboard-host 0.0.0.0 --dashboard-port ${RAY_DASHBOARD_PORT:-8265}`). The app-side `RAY_DASHBOARD_HOST` setting is only used in embedded (single-node) mode, where it defaults to `127.0.0.1` because the dashboard API is unauthenticated ([CVE-2023-48022](https://nvd.nist.gov/vuln/detail/CVE-2023-48022)).
+:::
+
 ---
 
 With this setup, your app is now fully distributed and ready to handle concurrent tasks across your Ray cluster.

--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -112,7 +112,7 @@ auth:
 
 head_start_ray_commands:
     - uv run ray stop
-    - uv run ray start --head --dashboard-host 0.0.0.0 --dashboard-port ${RAY_DASHBOARD_PORT:-8265} --node-ip-address ${HEAD_NODE_IP} --autoscaling-config=~/ray_bootstrap_config.yaml
+    - uv run ray start --head --dashboard-host ${RAY_DASHBOARD_HOST:-127.0.0.1} --dashboard-port ${RAY_DASHBOARD_PORT:-8265} --node-ip-address ${HEAD_NODE_IP} --autoscaling-config=~/ray_bootstrap_config.yaml
 worker_start_ray_commands:
     - uv run ray stop
     - uv run ray start --address ${HEAD_NODE_IP:-10.0.0.1}:6379
@@ -137,7 +137,7 @@ docker compose up -d
 Once running, **OpenRAG will auto-connect** to the Ray cluster using `RAY_ADDRESS` from `.env`.
 
 :::note
-When `RAY_ADDRESS` is set, the app **attaches** to the external cluster and does **not** start its own embedded Ray dashboard — the head node owns it (started above via `--dashboard-host 0.0.0.0 --dashboard-port ${RAY_DASHBOARD_PORT:-8265}`). The app-side `RAY_DASHBOARD_HOST` setting is only used in embedded (single-node) mode, where it defaults to `127.0.0.1` because the dashboard API is unauthenticated ([CVE-2023-48022](https://nvd.nist.gov/vuln/detail/CVE-2023-48022)).
+When `RAY_ADDRESS` is set, the app **attaches** to the external cluster and does **not** start its own embedded Ray dashboard — the head node owns it. Keep the dashboard bound to `127.0.0.1` by default because the dashboard API is unauthenticated ([CVE-2023-48022](https://nvd.nist.gov/vuln/detail/CVE-2023-48022)). If operators need remote dashboard access, expose it only through a private network, SSH tunnel, or authenticated proxy.
 :::
 
 ---

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -416,7 +416,19 @@ Controls the maximum number of concurrent operations for different indexer tasks
 | `RAY_SEMAPHORE_CONCURRENCY` | int | 100000 | Global concurrency limit for Ray semaphore operations |
 
 #### Ray Serve Configuration
-Ray Serve enables deployment of the FastAPI as a scalable service. For simple deployment, without the intend to scale, one can usage the [uvicorn deployment mode](/openrag/documentation/env_vars/#ray-serve-configuration)
+
+Ray Serve enables deployment of the FastAPI app as a horizontally scalable service.
+
+By default (`ENABLE_RAY_SERVE=false`) OpenRAG runs under **uvicorn with a single worker**. This is intentional: the app initializes Ray and its named actors (`Indexer`, `Vectordb`, `TaskStateManager`, …) at import time, so a second uvicorn worker would start its **own isolated Ray cluster** with duplicate actors, fragmenting task state and vector-DB access. Concurrency within the single worker comes from the async app and from Ray itself — **not** from multiple uvicorn workers (there is intentionally no `API_NUM_WORKERS` knob).
+
+**To scale the HTTP layer, enable Ray Serve** — it runs `RAY_SERVE_NUM_REPLICAS` replicas inside one shared Ray cluster:
+
+```bash
+ENABLE_RAY_SERVE=true
+RAY_SERVE_NUM_REPLICAS=4
+```
+
+For multi-node distributed deployments, see [Distributed Deployment in a Ray Cluster](/openrag/documentation/deploy_ray_cluster/).
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -512,7 +524,6 @@ The following environment variables configure the FastAPI server and control acc
 | `AUTH_TOKEN` | `string` | `EMPTY` | An authentication token is required to access protected API endpoints. By default, this token corresponds to the API key of the created admin (see [Admin Bootstrapping](/openrag/documentation/user_auth/#2-admin-bootstrapping)). If left empty, authentication is disabled. |
 | `SUPER_ADMIN_MODE` | `boolean` | `false` | Enables super admin privileges when set to `true`, [granting unrestricted access](/openrag/documentation/data_model/#access-control) to all operations and bypassing standard access controls. This is for debugging |
 | `DEFAULT_FILE_QUOTA` | `int` | `-1` | Default per-user file quota. `<0` disables quotas globally; `>=0` sets the default limit when a user has no explicit quota. |
-|`API_NUM_WORKERS`|`int`|1|Number of uvicorn workers|
 | `PREFERRED_URL_SCHEME` | `string` | `null` | URL scheme (`http` or `https`) used when generating URLs in API responses (e.g., `task_status_url`). When running behind a reverse proxy that terminates SSL, set this to `https` to ensure generated URLs use the correct scheme. If unset, the scheme from the incoming request is used. |
 | `CORS_EXTRA_ORIGINS` | `string` | _(unset)_ | Semicolon-separated list of additional origins allowed by CORS (e.g. `https://app.example.com;https://other.example.com`). Extends the default list without replacing it. |
 

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -375,6 +375,8 @@ Ray is used for distributed task processing and parallel execution in the RAG pi
 | `RAY_POOL_SIZE` | `int` | 1 | Number of serializer actor instances (typically 1 actor per cluster node) |
 | `RAY_MAX_TASKS_PER_WORKER` | `int` | 8 | Maximum number of concurrent tasks (serialization tasks) per serializer actor instance |
 | `RAY_DASHBOARD_PORT` | `int` | 8265 | Ray Dashboard port used for monitoring. In production, [comment out this line](https://github.com/linagora/openrag/blob/ee732ea8e080dcde0107d62d12703a7525f810cd/docker-compose.yaml#L21C1-L22C1) to avoid exposing the port, as it may introduce security vulnerabilities. |
+| `RAY_DASHBOARD_HOST` | `str` | `127.0.0.1` | Interface the **embedded** Ray dashboard binds to. Defaults to loopback because the Ray dashboard/job-submission API is **unauthenticated** ([CVE-2023-48022](https://nvd.nist.gov/vuln/detail/CVE-2023-48022)). Set to `0.0.0.0` only when the dashboard port is firewalled or sits behind an authenticating proxy. Ignored when `RAY_ADDRESS` is set. |
+| `RAY_ADDRESS` | `str` | (unset) | When set, attach to an **external** Ray cluster at this address (e.g. `ray://HEAD_IP:10001`) instead of starting an embedded cluster in-process. In this mode the app does not start a local dashboard — the head node owns it. See [Ray Cluster deployment](/openrag/documentation/deploy_ray_cluster/). |
 
 :::danger[Attention]
 The following environment variables control Ray's logging behavior, task retry settings. These are not set by default and must be supplied [as suggested in the .env](/openrag/getting_started/quickstart#2-create-a-env-file)

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -206,6 +206,8 @@ The PostgreSQL database is configured using the following environment variables:
 
 The main Docker Compose stack keeps the historical host-path defaults. Set these variables when you want to move state elsewhere, including Docker named volumes.
 
+When using host paths with the non-root API image, make sure the mounted directories are writable by the container user. If that is not practical for your deployment, use the named-volume profile instead.
+
 For an opt-in named-volume profile, copy the values from `infra/compose/.env.named-volumes.example` into your `.env`.
 
 | Variable | Default | Description |
@@ -526,7 +528,8 @@ The following environment variables configure the FastAPI server and control acc
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `APP_PORT` | `number` | `8000` | Port number on which the FastAPI application listens for incoming requests. |
-| `AUTH_TOKEN` | `string` | `EMPTY` | An authentication token is required to access protected API endpoints. By default, this token corresponds to the API key of the created admin (see [Admin Bootstrapping](/openrag/documentation/user_auth/#2-admin-bootstrapping)). If left empty, authentication is disabled. |
+| `AUTH_TOKEN` | `string` | `EMPTY` | Authentication token used to bootstrap the admin user and access protected API endpoints. If it is empty, the API fails closed unless `ALLOW_NO_AUTH=true` is explicitly set for local development. |
+| `ALLOW_NO_AUTH` | `boolean` | `false` | Enables the no-auth local development bypass when `AUTH_MODE=token` and `AUTH_TOKEN` is unset. Never enable this in production. |
 | `SUPER_ADMIN_MODE` | `boolean` | `false` | Enables super admin privileges when set to `true`, [granting unrestricted access](/openrag/documentation/data_model/#access-control) to all operations and bypassing standard access controls. This is for debugging |
 | `DEFAULT_FILE_QUOTA` | `int` | `-1` | Default per-user file quota. `<0` disables quotas globally; `>=0` sets the default limit when a user has no explicit quota. |
 | `PREFERRED_URL_SCHEME` | `string` | `null` | URL scheme (`http` or `https`) used when generating URLs in API responses (e.g., `task_status_url`). When running behind a reverse proxy that terminates SSL, set this to `https` to ensure generated URLs use the correct scheme. If unset, the scheme from the incoming request is used. |

--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -1,4 +1,6 @@
-# OpenID Connect (OIDC) Authentication Guide
+---
+title: OpenID Connect (OIDC) Authentication Guide
+---
 
 This guide walks you through configuring and using OpenRag's OIDC authentication mode.
 

--- a/docs/content/docs/documentation/sso-quickstart.md
+++ b/docs/content/docs/documentation/sso-quickstart.md
@@ -1,4 +1,6 @@
-# SSO Quick Start (OIDC)
+---
+title: SSO Quick Start (OIDC)
+---
 
 Configure OpenRag to delegate authentication to your corporate SSO (LemonLDAP::NG, Keycloak, Auth0, Azure AD, Okta…) in five steps.
 
@@ -127,7 +129,7 @@ By default OpenRag reads the claims from the verified ID token (`OIDC_CLAIM_SOUR
 If your IdP models access as groups (e.g. Keycloak groups like `/openrag/project-alpha/editor`),
 OpenRag can map them to partition memberships automatically on every login — set
 `OIDC_CLAIM_GROUPS` and friends. See `docs/oidc.md` →
-[Group → Partition Mapping](./oidc.md#group--partition-mapping-optional). (`is_admin` is never
+[Group → Partition Mapping](/openrag/documentation/oidc/#group--partition-mapping-optional). (`is_admin` is never
 derived from groups.)
 
 ---
@@ -136,7 +138,7 @@ derived from groups.)
 
 By default, OpenRag **does not auto-create users** on first login. Each user must exist in the database with their OIDC `sub` stored in `external_user_id`.
 
-> **Skip this step entirely** by setting `OIDC_AUTO_PROVISION_LOGIN=true` in your `.env`. The callback then creates a non-admin user from the ID-token claims on first login and keeps `display_name` + `email` in sync with the IdP on every subsequent login. The trade-off: your IdP's user list becomes the source of truth for OpenRag accounts. See `docs/oidc.md` → [Auto-provisioning](./oidc.md#auto-provisioning-optional) for the full trust-model.
+> **Skip this step entirely** by setting `OIDC_AUTO_PROVISION_LOGIN=true` in your `.env`. The callback then creates a non-admin user from the ID-token claims on first login and keeps `display_name` + `email` in sync with the IdP on every subsequent login. The trade-off: your IdP's user list becomes the source of truth for OpenRag accounts. See `docs/oidc.md` → [Auto-provisioning](/openrag/documentation/oidc/#auto-provisioning-optional) for the full trust-model.
 
 Ask the IdP admin for each user's `sub` claim value (stable identifier, NOT the username). Then create the user via the OpenRag admin API — you'll need an admin `AUTH_TOKEN` for this:
 
@@ -174,7 +176,7 @@ docker compose logs openrag --tail 50 | grep -i OIDC
 
 Open your browser at `https://rag.mycorp.com/` → it redirects to your SSO → you log in → you come back authenticated.
 
-If something goes wrong, see the full **[troubleshooting section in `docs/oidc.md`](./oidc.md#troubleshooting)**. Most issues fall into one of three categories:
+If something goes wrong, see the full **[troubleshooting section in `docs/oidc.md`](/openrag/documentation/oidc/#troubleshooting)**. Most issues fall into one of three categories:
 
 1. **Issuer mismatch** (Step 2 — trailing slash).
 2. **Invalid redirect URI** (Step 1 — must match byte-for-byte).

--- a/docs/content/docs/documentation/user_auth.md
+++ b/docs/content/docs/documentation/user_auth.md
@@ -10,8 +10,9 @@ It covers admin behavior, user tokens, and partition-level permissions.
 ## **1. Authentication Activation**
 
 ### `AUTH_TOKEN`
-- The presence of the environment variable **`AUTH_TOKEN`** activates authentication.  
-- If **`AUTH_TOKEN`** is **absent**, the middleware **bypasses all authentication checks**, allowing open access (useful for local or testing environments).
+- **`AUTH_TOKEN`** is the token used to bootstrap the admin user and authenticate protected API calls.
+- If **`AUTH_TOKEN`** is absent, OpenRAG fails closed by default.
+- Local open mode requires **`ALLOW_NO_AUTH=true`** together with `AUTH_MODE=token`. This should never be used in production.
 
 :::danger[Attention !!!]
 **`SUPER_ADMIN_MODE=true`** must be activated if you want admin users to access all existing partitions, not just the admin's own partitions.
@@ -105,8 +106,8 @@ Role-based restrictions are enforced via dependency guards:
 ## **7. Authorization Flow Summary**
 
 1. Request arrives with optional `Authorization: Bearer <token>`.
-2. If `AUTH_TOKEN` is **unset**, authentication is skipped (open mode).  
-3. If set:
+2. If `AUTH_TOKEN` is **unset**, authentication is rejected unless `ALLOW_NO_AUTH=true` is explicitly enabled for local development.
+3. If a token is configured:
    - Middleware hashes the token.
    - Looks up the user by hash.
    - Loads their partition memberships.
@@ -156,4 +157,3 @@ Role-based restrictions are enforced via dependency guards:
 - Configurable **`SUPER_ADMIN_MODE`** for system-wide debugging or admin override.
 
 ---
-

--- a/docs/content/docs/documentation/user_auth.md
+++ b/docs/content/docs/documentation/user_auth.md
@@ -11,7 +11,8 @@ It covers admin behavior, user tokens, and partition-level permissions.
 
 ### `AUTH_TOKEN`
 - **`AUTH_TOKEN`** is the token used to bootstrap the admin user and authenticate protected API calls.
-- If **`AUTH_TOKEN`** is absent, OpenRAG fails closed by default.
+- In **`AUTH_MODE=token`**, if **`AUTH_TOKEN`** is absent, OpenRAG fails closed by default.
+- In **`AUTH_MODE=oidc`**, human login uses the OIDC session flow; **`AUTH_TOKEN`** is not the OIDC login mechanism.
 - Local open mode requires **`ALLOW_NO_AUTH=true`** together with `AUTH_MODE=token`. This should never be used in production.
 
 :::danger[Attention !!!]
@@ -106,7 +107,7 @@ Role-based restrictions are enforced via dependency guards:
 ## **7. Authorization Flow Summary**
 
 1. Request arrives with optional `Authorization: Bearer <token>`.
-2. If `AUTH_TOKEN` is **unset**, authentication is rejected unless `ALLOW_NO_AUTH=true` is explicitly enabled for local development.
+2. In `AUTH_MODE=token`, if `AUTH_TOKEN` is **unset**, authentication is rejected unless `ALLOW_NO_AUTH=true` is explicitly enabled for local development.
 3. If a token is configured:
    - Middleware hashes the token.
    - Looks up the user by hash.

--- a/docs/content/docs/getting_started/usage.mdx
+++ b/docs/content/docs/getting_started/usage.mdx
@@ -15,4 +15,8 @@ By default, OpenRAG services are exposed on the following ports:
 | Ray Dashboard     | 8265           | Ray dashboard for monitoring and managing tasks                |
 | Indexer UI        | 3042/          | Main user interface for indexing and viewing indexed documents |
 
+:::note[Ray Serve mode]
+The table above is for the default (uvicorn) deployment, where the Chainlit UI is the `/chainlit` subroute of the API. When `ENABLE_RAY_SERVE=true`, the API is served by Ray Serve on `RAY_SERVE_PORT` and the **Chainlit UI runs on its own port, `CHAINLIT_PORT`** (default `8090`), instead of the subroute. Uncomment the `${CHAINLIT_PORT}:${CHAINLIT_PORT}` mapping in `docker-compose.yaml` to expose it. See [`CHAINLIT_PORT`](/openrag/documentation/env_vars/#ray-serve-configuration).
+:::
+
 More information about the different services can be found in their respective documentation pages.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,10 +1,10 @@
 [defaults]
 inventory = inventory.ini
-host_key_checking = False
+host_key_checking = True
 retry_files_enabled = False
 stdout_callback = default
 gathering = smart
 fact_caching = memory
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=accept-new

--- a/infra/ansible/playbooks/openrag.yml
+++ b/infra/ansible/playbooks/openrag.yml
@@ -104,7 +104,7 @@
             dest: "{{ project_path }}/.env"
             owner: "{{ project_user }}"
             group: "{{ project_user }}"
-            mode: "0644"
+            mode: "0600"
           when:
             - not env_file.stat.exists
             - local_env_file.stat.exists
@@ -124,8 +124,11 @@
     - name: Setup Python environment
       block:
         - name: Install uv (Python package manager)
-          shell: curl -LsSf https://astral.sh/uv/install.sh | sh
+          shell: |
+            set -euo pipefail
+            curl -LsSf https://astral.sh/uv/0.5.11/install.sh | sh
           args:
+            executable: /bin/bash
             creates: "/home/{{ project_user }}/.cargo/bin/uv"
 
         - name: Add uv to PATH in .bashrc

--- a/infra/ansible/playbooks/openrag.yml
+++ b/infra/ansible/playbooks/openrag.yml
@@ -129,12 +129,12 @@
             curl -LsSf https://astral.sh/uv/0.5.11/install.sh | sh
           args:
             executable: /bin/bash
-            creates: "/home/{{ project_user }}/.cargo/bin/uv"
+            creates: "/home/{{ project_user }}/.local/bin/uv"
 
         - name: Add uv to PATH in .bashrc
           lineinfile:
             path: "/home/{{ project_user }}/.bashrc"
-            line: 'export PATH="$HOME/.cargo/bin:$PATH"'
+            line: 'export PATH="$HOME/.local/bin:$PATH"'
             create: true
       become_user: "{{ project_user }}"
 

--- a/infra/charts/openrag-stack/templates/networkpolicy.yaml
+++ b/infra/charts/openrag-stack/templates/networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicy.enabled }}
+# Default-deny ingress baseline: applies to every pod in the namespace
+# (podSelector: {}). Two allowances:
+#   1. any pod in the same namespace (intra-stack traffic), and
+#   2. the public HTTP ports, reachable from anywhere (Ingress controller).
+# Everything else — notably the unauthenticated Ray dashboard (8265), GCS
+# (6379), Ray client (10001), Postgres and Milvus — is only reachable from
+# within the namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openrag-stack.fullname" . }}-default-deny
+  labels:
+    {{- include "openrag-stack.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # 1. Allow all traffic originating from pods in this namespace.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # 2. Allow the public HTTP ports from any source (e.g. the Ingress controller).
+    {{- with .Values.networkPolicy.externalPorts }}
+    - ports:
+        {{- range . }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/infra/charts/openrag-stack/templates/raycluster.yaml
+++ b/infra/charts/openrag-stack/templates/raycluster.yaml
@@ -48,7 +48,7 @@ spec:
               - "ray"
               - "start"
               - "--head"
-              - "--dashboard-host=0.0.0.0"
+              - "--dashboard-host={{ .Values.ray.dashboardHost }}"
               - "--dashboard-agent-listen-port=52365"
               - "--metrics-export-port=8080"
               - "--block"

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -1,3 +1,15 @@
+# === Network isolation ===
+# Default-deny ingress for all pods in the release namespace, allowing only
+# intra-namespace traffic plus the public HTTP ports below. This isolates the
+# unauthenticated Ray dashboard (8265), GCS (6379), Postgres, Milvus, etc. from
+# outside the namespace. Disable only if you manage isolation elsewhere.
+networkPolicy:
+  enabled: true
+  # Ports reachable from outside the namespace (e.g. via the Ingress controller).
+  externalPorts:
+    - 8080  # openrag API/UI
+    - 3000  # indexer-ui
+
 # === Global shared persistence ===
 persistence:
   enabled: true

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -32,7 +32,8 @@ ray:
     gpu-role: serving
   image:
     repository: ghcr.io/linagora/openrag-ray
-    tag: latest
+    # Pin to a release tag (ideally a digest) for reproducible deploys.
+    tag: "1.1.13"
 
 # === PostgreSQL (bitnami) ===
 postgresql:
@@ -100,6 +101,9 @@ vllm:
   llmModelName: &llmModel "RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8"
   servingEngineSpec:
     enableEngine: true
+    # NOTE: the per-model `tag: "latest"` entries below are operator-supplied
+    # serving images — pin each to a specific vLLM release tag (or digest)
+    # before production use for reproducible deploys (see vlm, pinned to v0.11.2).
     modelSpec:
       - name: "embedder"
         repository: "vllm/vllm-openai"
@@ -210,6 +214,8 @@ reranker:
   servicePort: &rerankerPort 7997
   image:
     repository: michaelf34/infinity
+    # Operator-supplied serving image: pin to a specific infinity release tag
+    # (or digest) before production use rather than tracking latest.
     tag: latest
   nodeSelector:
     gpu-role: serving
@@ -237,7 +243,7 @@ reranker:
 indexerUi:
   enabled: true
 
-  image: "linagoraai/indexer-ui:latest"
+  image: "linagoraai/indexer-ui:1.1.13"
   imagePullPolicy: IfNotPresent
 
   replicaCount: 1
@@ -260,7 +266,8 @@ indexerUi:
 openrag:
   image:
     repository: linagoraai/openrag
-    tag: latest
+    # Pin to a release tag (ideally a digest) for reproducible deploys.
+    tag: "1.1.13"
   service:
     type: ClusterIP
     port: 8080

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -27,7 +27,10 @@ postgresql:
   enabled: true
   auth:
     username: &pgUser root
-    password: &pgPass root_password
+    # MUST be overridden at install time, e.g.
+    #   --set postgresql.auth.password=$(openssl rand -hex 16)
+    # Shipping a known password is a usable default credential.
+    password: &pgPass "CHANGE_ME_STRONG_PASSWORD"
   primary:
     persistence:
       enabled: true
@@ -301,7 +304,8 @@ env:
     POSTGRES_HOST: "{{ .Release.Name }}-postgresql"
     POSTGRES_PORT: *pgPort
     POSTGRES_USER: *pgUser
-    POSTGRES_PASSWORD: *pgPass
+    # POSTGRES_PASSWORD is a secret — defined under env.secrets, not here in the
+    # (world-readable) ConfigMap.
     POSTGRES_AUTO_CREATE_DB: "{{ .Values.postgresProvisioning.autoCreateDatabase }}"
     POSTGRES_RUN_MIGRATIONS: "{{ .Values.postgresProvisioning.runMigrationsInApp }}"
 
@@ -347,3 +351,6 @@ env:
     TRANSCRIBER_API_KEY: "EMPTY"
     AUTH_TOKEN: "sk-xxxx" # API KEY for OpenRAG
     HF_TOKEN: "hf_xxxx" # HuggingFace token
+    # DB password lives in the Secret (not the ConfigMap). Reuses the same
+    # value as postgresql.auth.password via the *pgPass anchor.
+    POSTGRES_PASSWORD: *pgPass

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -23,6 +23,7 @@ persistence:
     venv: { size: 10Gi }
 
 ray:
+  dashboardHost: "127.0.0.1"
   workers:
     count: 1
     replicas: 1

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -288,7 +288,8 @@ env:
 
     WITH_CHAINLIT_UI: "false"
     SAVE_UPLOADED_FILES: "false"
-    API_NUM_WORKERS: "8"
+    # HTTP scaling is handled by Ray Serve above (ENABLE_RAY_SERVE +
+    # RAY_SERVE_NUM_REPLICAS), not uvicorn workers — see entrypoint.sh.
     INDEXERUI_URL: "http://indexer-ui:3042"
 
     # Vector DB

--- a/infra/cluster.yaml
+++ b/infra/cluster.yaml
@@ -20,7 +20,8 @@ auth:
 
 head_start_ray_commands:
     - uv run ray stop
-    - uv run ray start --head --dashboard-host 0.0.0.0 --dashboard-port ${RAY_DASHBOARD_PORT:-8265} --node-ip-address ${HEAD_NODE_IP} --autoscaling-config=~/ray_bootstrap_config.yaml
+    # Dashboard/Jobs API is unauthenticated (CVE-2023-48022); bind to localhost by default and front with an auth proxy if remote access is needed.
+    - uv run ray start --head --dashboard-host ${RAY_DASHBOARD_HOST:-127.0.0.1} --dashboard-port ${RAY_DASHBOARD_PORT:-8265} --node-ip-address ${HEAD_NODE_IP} --autoscaling-config=~/ray_bootstrap_config.yaml
 worker_start_ray_commands:
     - uv run ray stop
     - uv run ray start --address ${HEAD_NODE_IP:-10.0.0.1}:6379

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -10,7 +10,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
-# API_NUM_WORKERS=1 # Number of uvicorn workers for the FastAPI app
+# The uvicorn path runs a single worker by design (Ray provides concurrency).
+# To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
+# RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -113,6 +113,12 @@ API_BASE_URL='http://X.X.X.X:APP_PORT'          # Base URL of your FastAPI backe
 # Max partitions a non-admin user may own (-1 = unlimited; admins bypass).
 # MAX_PARTITIONS_PER_USER=100
 
+# Rate limiting (per-worker moving window, keyed on user id then client IP)
+# RATE_LIMIT_ENABLED=true
+# RATE_LIMIT_DEFAULT=300/minute   # all paths except those below
+# RATE_LIMIT_AUTH=20/minute       # /auth/* (login/callback/logout)
+# RATE_LIMIT_CHAT=60/minute       # /v1/* (chat completions, tools)
+
 # MCP SERVER
 # Standalone Model Context Protocol server (openrag/api/mcp/server.py).
 # OPENRAG_MCP_SERVER_NAME="OpenRAG MCP"

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -25,9 +25,8 @@ VLM_MODEL=
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234
-# If AUTH_MODE=token and AUTH_TOKEN is unset, authentication is DISABLED and
-# every request is treated as admin user 1. This requires an explicit opt-in
-# so it can never happen by accident in production:
+# If AUTH_MODE=token and AUTH_TOKEN is unset, authentication fails closed by
+# default. Local open mode requires an explicit opt-in:
 # ALLOW_NO_AUTH=true   # DEV ONLY — never set this in production
 # Optional: semicolon-separated extra allowed origins
 # CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -110,6 +110,9 @@ API_BASE_URL='http://X.X.X.X:APP_PORT'          # Base URL of your FastAPI backe
 # WEBSEARCH_TOP_K=5         # Number of web results to include (default: 5)
 # WEBSEARCH_LANG=fr-FR      # Search language/market (default: fr-FR)
 
+# Max partitions a non-admin user may own (-1 = unlimited; admins bypass).
+# MAX_PARTITIONS_PER_USER=100
+
 # MCP SERVER
 # Standalone Model Context Protocol server (openrag/api/mcp/server.py).
 # OPENRAG_MCP_SERVER_NAME="OpenRAG MCP"

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -65,6 +65,14 @@ RAY_task_retry_delay_ms=3000
 RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 # critical with the newest version of UV
 # # To disable worker killing
 # RAY_memory_monitor_refresh_ms=0
+# Connect to an external Ray cluster instead of starting an embedded one.
+# When set, the app attaches to this cluster and does NOT start a local dashboard
+# (the head node owns it). See docs/documentation/deploy_ray_cluster.
+# RAY_ADDRESS=ray://X.X.X.X:10001
+# Interface the embedded Ray dashboard binds to. Defaults to 127.0.0.1 (loopback)
+# because the dashboard/job API is unauthenticated (CVE-2023-48022). Set to 0.0.0.0
+# only when the port is firewalled or behind an auth proxy. Ignored when RAY_ADDRESS is set.
+# RAY_DASHBOARD_HOST=127.0.0.1
 
 # Indexer UI 
 ## 1. replace X.X.X.X with localhost if launching local or with your server IP

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -60,6 +60,11 @@ RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base # or jinaai/jina-reran
 MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 
+# PostgreSQL — REQUIRED, no default. The compose stacks fail to start if unset.
+# Generate a strong value, e.g. `openssl rand -hex 16`.
+POSTGRES_PASSWORD=
+# POSTGRES_USER=root
+
 # Prompts (templates ship inside the package at openrag/prompts/templates;
 # set PROMPTS_DIR only to override with a custom template directory)
 # PROMPTS_DIR=/path/to/custom/templates

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -7,8 +7,8 @@ MODEL=
 # LLM_ENABLE_THINKING=false
 
 # VLM (Visual Language Model) you can set it to the same as LLM if your LLM supports images
-VLM_BASE_URL=
 VLM_API_KEY=
+VLM_BASE_URL=
 VLM_MODEL=
 # Optional: same behavior as LLM_ENABLE_THINKING for VLM chat templates.
 # VLM_ENABLE_THINKING=false

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -19,6 +19,9 @@ VLM_MODEL=
 
 ## FastAPI App (no need to change it)
 # APP_PORT=8080 # this is the forwarded port
+# Local compose builds run OpenRAG as a non-root user. Override this if your
+# host user is not UID 1000 and bind-mounted folders are not writable.
+# APP_UID=1000
 # The uvicorn path runs a single worker by design (Ray provides concurrency).
 # To scale the HTTP layer, use Ray Serve: ENABLE_RAY_SERVE=true with
 # RAY_SERVE_NUM_REPLICAS=N (see the Ray Serve configuration section).

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -54,6 +54,12 @@ RERANKER_MODEL=Alibaba-NLP/gte-multilingual-reranker-base # or jinaai/jina-reran
 # API accepts natively. Override to restrict (e.g. to ".wav" only for vLLM deployments).
 # TRANSCRIBER_DIRECT_UPLOAD_SUFFIXES=.wav|.flac|.ogg|.mp3|.mp4|.m4a|.webm|.mpeg|.mpga
 
+# Object storage (MinIO, used by Milvus) — REQUIRED, no default.
+# Generate strong random values, e.g. `openssl rand -hex 16`. These are shared
+# between the minio service and Milvus; both must match.
+MINIO_ACCESS_KEY=
+MINIO_SECRET_KEY=
+
 # Prompts (templates ship inside the package at openrag/prompts/templates;
 # set PROMPTS_DIR only to override with a custom template directory)
 # PROMPTS_DIR=/path/to/custom/templates

--- a/infra/compose/.env.example
+++ b/infra/compose/.env.example
@@ -16,6 +16,10 @@ VLM_MODEL=
 
 ## To enable API HTTP authentication via HTTPBearer
 # AUTH_TOKEN=sk-openrag-1234
+# If AUTH_MODE=token and AUTH_TOKEN is unset, authentication is DISABLED and
+# every request is treated as admin user 1. This requires an explicit opt-in
+# so it can never happen by accident in production:
+# ALLOW_NO_AUTH=true   # DEV ONLY — never set this in production
 # Optional: semicolon-separated extra allowed origins
 # CORS_EXTRA_ORIGINS='https://app.example.com;https://other.example.com'
 

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -24,9 +24,12 @@ x-openrag: &openrag_template
     - ${DATA_VOLUME:-../../data}:/app/data
     - ../../i8n:/app/openrag/.chainlit/translations
     - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights # Model weights for RAG
-    - ../../openrag:/app/openrag # For dev mode
+    # Dev only: bind-mounting the source tree over the image lets host changes
+    # (or a writable host path) override the running code. Uncomment for local
+    # development; keep it off in production.
+    # - ../../openrag:/app/openrag # For dev mode
     - /$SHARED_ENV:/ray_mount/.env # Shared environment variables
-    - ${LOG_VOLUME:-../../logs}:/app/logs # For dev mode
+    - ${LOG_VOLUME:-../../logs}:/app/logs
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
     # Bind the Ray dashboard to localhost only: it has no authentication and

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -11,6 +11,11 @@ x-openrag: &openrag_template
     # uv.lock, openrag/, conf/ and infra/scripts/entrypoint.sh directly.
     context: ../..
     dockerfile: infra/docker/api.Dockerfile
+    args:
+      # Local compose bind-mounts repo-owned paths (data, logs, i8n). Build the
+      # image with the host user's UID by default so the non-root container can
+      # still write those mounts; OpenShift builds keep the Dockerfile default.
+      APP_UID: ${APP_UID:-1000}
   extra_hosts:
     # Let containers reach services running on the Docker host via
     # ``host.docker.internal`` (Linux Docker >= 20.10). Useful when an OIDC

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -6,6 +6,12 @@ include:
 
 x-openrag: &openrag_template
   image: linagoraai/openrag:latest
+  # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
+  # writable dirs (data/, logs/, the HF cache) — which a non-root container
+  # can't write when Docker auto-creates them root-owned — then it immediately
+  # drops to the non-root app user (UID in GID 0) via setpriv before launching.
+  # The image's USER stays non-root for non-compose/OpenShift runs.
+  user: "0:0"
   build:
     # Build context is the repo root so the Dockerfile can COPY pyproject.toml,
     # uv.lock, openrag/, conf/ and infra/scripts/entrypoint.sh directly.

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -29,7 +29,10 @@ x-openrag: &openrag_template
     - ${LOG_VOLUME:-../../logs}:/app/logs # For dev mode
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
-    - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
+    # Bind the Ray dashboard to localhost only: it has no authentication and
+    # its job-submission API allows arbitrary code execution on the cluster,
+    # so it must never be reachable from outside the host.
+    - 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
     - ${CHAINLIT_PORT:-8090}:${CHAINLIT_PORT:-8090}
   networks:
     default:

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -140,7 +140,7 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
       - POSTGRES_USER=${POSTGRES_USER:-root}
     volumes:
       - ${DB_VOLUME:-../../db}:/var/lib/postgresql/data

--- a/infra/compose/milvus/milvus.named-volumes.yaml
+++ b/infra/compose/milvus/milvus.named-volumes.yaml
@@ -32,8 +32,9 @@ services:
   milvus:
     image: milvusdb/milvus:v2.6.11
     command: ["milvus", "run", "standalone"]
-    security_opt:
-    - seccomp:unconfined
+    # Run under Docker's default seccomp profile (do not disable syscall
+    # filtering). If a specific kernel needs a wider profile, supply a vetted
+    # custom profile rather than seccomp:unconfined.
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000

--- a/infra/compose/milvus/milvus.named-volumes.yaml
+++ b/infra/compose/milvus/milvus.named-volumes.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MINIO_VOLUME:-minio}:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -38,8 +38,8 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
-      MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
-      MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME:-milvus}:/var/lib/milvus
     healthcheck:

--- a/infra/compose/milvus/milvus.named-volumes.yaml
+++ b/infra/compose/milvus/milvus.named-volumes.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
     volumes:
       - ${MINIO_VOLUME:-minio}:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -38,6 +38,8 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
+      MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
     volumes:
       - ${MILVUS_VOLUME:-milvus}:/var/lib/milvus
     healthcheck:

--- a/infra/compose/milvus/milvus.yaml
+++ b/infra/compose/milvus/milvus.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -37,6 +37,10 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
+      # Milvus must authenticate to MinIO with the same credentials; otherwise
+      # it falls back to the built-in minioadmin default and fails to connect.
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus
     healthcheck:

--- a/infra/compose/milvus/milvus.yaml
+++ b/infra/compose/milvus/milvus.yaml
@@ -32,8 +32,9 @@ services:
   milvus:
     image: milvusdb/milvus:v2.6.11
     command: ["milvus", "run", "standalone"]
-    security_opt:
-    - seccomp:unconfined
+    # Run under Docker's default seccomp profile (do not disable syscall
+    # filtering). If a specific kernel needs a wider profile, supply a vetted
+    # custom profile rather than seccomp:unconfined.
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000

--- a/infra/compose/monitoring.docker-compose.yaml
+++ b/infra/compose/monitoring.docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.54.1
     container_name: openrag-prometheus
     ports:
       # Localhost only: the Prometheus API is unauthenticated.
@@ -19,7 +19,7 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.2.2
     container_name: openrag-grafana
     ports:
       - "3000:3000"
@@ -36,7 +36,7 @@ services:
     restart: unless-stopped
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.8.2
     container_name: openrag-node-exporter
     ports:
       # Localhost only: Prometheus scrapes it over the compose network by name,

--- a/infra/compose/monitoring.docker-compose.yaml
+++ b/infra/compose/monitoring.docker-compose.yaml
@@ -3,7 +3,8 @@ services:
     image: prom/prometheus:latest
     container_name: openrag-prometheus
     ports:
-      - "9090:9090"
+      # Localhost only: the Prometheus API is unauthenticated.
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/openrag_token:/etc/prometheus/openrag_token:ro
@@ -11,7 +12,8 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.retention.time=30d"
-      - "--web.enable-lifecycle"
+      # --web.enable-lifecycle is intentionally NOT set: it exposes unauthenticated
+      # /-/reload and /-/quit endpoints. Re-enable only behind an auth proxy.
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
@@ -37,7 +39,9 @@ services:
     image: prom/node-exporter:latest
     container_name: openrag-node-exporter
     ports:
-      - "9100:9100"
+      # Localhost only: Prometheus scrapes it over the compose network by name,
+      # so it needn't be exposed on all interfaces (it surfaces host metrics).
+      - "127.0.0.1:9100:9100"
     pid: host
     volumes:
       - /proc:/host/proc:ro
@@ -54,7 +58,8 @@ services:
     image: utkuozdemir/nvidia_gpu_exporter:1.2.0
     container_name: openrag-nvidia-gpu-exporter
     ports:
-      - "9835:9835"
+      # Localhost only: scraped over the compose network by name.
+      - "127.0.0.1:9835:9835"
     volumes:
       - /usr/lib/x86_64-linux-gnu/libnvidia-ml.so:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so:ro
       - /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1:ro

--- a/infra/docker/api.Dockerfile
+++ b/infra/docker/api.Dockerfile
@@ -28,6 +28,24 @@ ENV HF_HUB_CACHE=${HF_HUB_CACHE:-/app/model_weights/hub}
 # Set workdir for uv
 WORKDIR /app
 
+# Keep uv's managed Python and cache on stable, root-owned paths outside any
+# user $HOME, and put the project venv under /app so it can be made
+# group-writable for the arbitrary UID OpenShift assigns (see below). HOME is a
+# dedicated writable subdir (not /app) so libraries that fall back to $HOME
+# never need /app itself writable. UV_FROZEN keeps `uv run` from rewriting
+# uv.lock at runtime, so the project root can stay read-only.
+# USER/LOGNAME are set because the arbitrary UID OpenShift assigns has no
+# /etc/passwd entry: getpass.getuser() reads these env vars first and so
+# resolves without a passwd lookup (the same approach used for the vllm
+# service in docker-compose.yaml). This avoids making /etc/passwd writable.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_CACHE_DIR=/opt/uv/cache \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    UV_FROZEN=1 \
+    HOME=/app/home \
+    USER=openrag \
+    LOGNAME=openrag
+
 # Install uv & setup venv
 COPY pyproject.toml uv.lock ./
 RUN pip3 install uv && \
@@ -47,4 +65,39 @@ COPY scripts/ /app/scripts/
 COPY conf/ /app/conf/
 ENV PYTHONPATH=/app/openrag/
 ENV APP_iPORT=${APP_iPORT:-8080}
+
+# --- Run as an unprivileged, OpenShift-compatible user ---------------------
+# OpenShift runs containers as an arbitrary, unpredictable UID that is always a
+# member of the root group (GID 0). For the app to start under that policy,
+# every path it writes at runtime must be group-owned by GID 0 and
+# group-writable (chmod g=u). We strip group-write from the whole tree first
+# (chmod -R g-w) and then grant it back ONLY on those exact paths: the venv,
+# the editable install's egg-info, $HOME, data, db, logs, the HF model cache,
+# and uv's cache. So /app and /opt/uv themselves, plus the copied code/config
+# and uv's managed Python (/app/openrag, /app/conf, /app/scripts,
+# /opt/uv/python), stay group-readable but NOT group-writable regardless of
+# their source mode — the arbitrary UID cannot create, rename, or replace
+# entries in them.
+# The two exceptions under the otherwise read-only /app/openrag are Chainlit's
+# runtime-writable dirs: it creates ./.files at import time and writes
+# ./.chainlit/config.toml + translations on startup (WORKDIR is /app/openrag),
+# so both are pre-created and granted group-write below or the app crashes with
+# PermissionError: '/app/openrag/.files'.
+# We also bake a fixed non-root UID for plain Docker/Kubernetes, where the
+# arbitrary-UID remap does not happen; APP_UID is a build arg so a compose
+# build can match the host user that owns the bind-mounted volumes. The user's
+# primary group is 0 so it shares the same group access on either platform.
+ARG APP_UID=10001
+RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
+        --home-dir /app/home --shell /sbin/nologin openrag \
+    && mkdir -p /app/home /app/data /app/db /app/logs /app/model_weights/hub \
+        /app/.venv /app/openrag.egg-info /opt/uv/cache \
+        /app/openrag/.files /app/openrag/.chainlit \
+    && chgrp -R 0 /app /opt/uv \
+    && chmod -R g-w /app /opt/uv \
+    && chmod -R g=u /app/home /app/data /app/db /app/logs /app/model_weights \
+        /app/.venv /app/openrag.egg-info /opt/uv/cache \
+        /app/openrag/.files /app/openrag/.chainlit
+USER ${APP_UID}
+
 ENTRYPOINT ../entrypoint.sh

--- a/infra/docker/api.Dockerfile
+++ b/infra/docker/api.Dockerfile
@@ -98,6 +98,10 @@ RUN useradd --uid ${APP_UID} --gid 0 --no-log-init --no-create-home \
     && chmod -R g=u /app/home /app/data /app/db /app/logs /app/model_weights \
         /app/.venv /app/openrag.egg-info /opt/uv/cache \
         /app/openrag/.files /app/openrag/.chainlit
+# Expose APP_UID at runtime so entrypoint.sh can drop back to this user after
+# fixing bind-mount permissions (when the container is started as root, e.g.
+# compose `user: "0:0"`). USER below keeps the image's default non-root.
+ENV APP_UID=${APP_UID}
 USER ${APP_UID}
 
 ENTRYPOINT ../entrypoint.sh

--- a/infra/docker/ray.Dockerfile
+++ b/infra/docker/ray.Dockerfile
@@ -32,6 +32,10 @@ ENV HF_HUB_CACHE=${HF_HUB_CACHE:-/app/model_weights/hub}
 # Set workdir for uv
 WORKDIR /app
 
+# Set HOME before installing so uv's Python and cache land under /app (owned by
+# the non-root user below), not /root.
+ENV HOME=/app
+
 # Install uv & setup venv
 COPY pyproject.toml uv.lock ./
 RUN pip3 install uv && \
@@ -54,3 +58,11 @@ COPY conf/ /app/conf/
 RUN ln -s /app/.venv/bin/ray /usr/local/bin/ray
 
 ENV PYTHONPATH=/app/openrag/
+
+# Run as non-root. The app writes under /app (venv, data, logs, model_weights),
+# so the user owns /app.
+RUN groupadd --gid 10001 app \
+    && useradd --uid 10001 --gid 10001 --home-dir /app --no-create-home app \
+    && mkdir -p /app/data /app/logs /app/model_weights \
+    && chown -R 10001:10001 /app
+USER 10001:10001

--- a/infra/quick_start/docker-compose.yaml
+++ b/infra/quick_start/docker-compose.yaml
@@ -16,7 +16,7 @@ x-openrag: &openrag_template
     # - ./logs:/app/logs
   ports:
     - ${APP_PORT:-8080}:${APP_iPORT:-8080}
-    - ${RAY_DASHBOARD_PORT:-8265}:8265 # Disable when in cluster mode
+    - 127.0.0.1:${RAY_DASHBOARD_PORT:-8265}:8265 # Localhost only: Ray dashboard/Jobs API is unauthenticated. Disable when in cluster mode
   networks:
     default:
       aliases:

--- a/infra/quick_start/docker-compose.yaml
+++ b/infra/quick_start/docker-compose.yaml
@@ -105,7 +105,7 @@ services:
   rdb:
     image: postgres:15
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-root_password}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
       - POSTGRES_USER=${POSTGRES_USER:-root}
     volumes:
       - ${DB_VOLUME:-./db}:/var/lib/postgresql/data

--- a/infra/quick_start/vdb/milvus.yaml
+++ b/infra/quick_start/vdb/milvus.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -37,6 +37,9 @@ services:
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
+      # Keep Milvus's MinIO credentials in sync with the minio service above.
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus
     healthcheck:

--- a/infra/quick_start/vdb/milvus.yaml
+++ b/infra/quick_start/vdb/milvus.yaml
@@ -32,8 +32,7 @@ services:
   milvus:
     image: milvusdb/milvus:v2.5.4
     command: ["milvus", "run", "standalone"]
-    security_opt:
-    - seccomp:unconfined
+    # Run under Docker's default seccomp profile (do not disable syscall filtering).
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000

--- a/infra/quick_start/vdb/milvus.yaml
+++ b/infra/quick_start/vdb/milvus.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     environment:
-      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
-      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -37,8 +37,8 @@ services:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
       # Keep Milvus's MinIO credentials in sync with the minio service above.
-      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
-      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
+      MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus
     healthcheck:

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -9,15 +9,20 @@ if [[ "${ENABLE_RAY_SERVE}" == "true" ]]; then
   uv run "${ENV_ARGS[@]}" -m api.main
 else
   echo "🚀 Starting with Uvicorn..."
-  # --reload is a development feature (watches/auto-imports source on change)
-  # and is incompatible with multiple workers. Enable it only with
-  # UVICORN_RELOAD=true for local dev; production runs without it.
+  # This path always runs a SINGLE uvicorn worker. The app initializes Ray and
+  # its named actors (Indexer, Vectordb, TaskStateManager, ...) at import time,
+  # so each extra worker would be a separate process starting its own isolated
+  # Ray cluster with duplicate actors — fragmenting task state and the vector
+  # DB. Concurrency comes from the async app + Ray, not from uvicorn workers.
+  # To scale the HTTP layer horizontally, use Ray Serve (ENABLE_RAY_SERVE=true,
+  # RAY_SERVE_NUM_REPLICAS=N), which runs N replicas inside one Ray cluster.
+  if [[ -n "${API_NUM_WORKERS}" && "${API_NUM_WORKERS}" != "1" ]]; then
+    echo "⚠️  API_NUM_WORKERS=${API_NUM_WORKERS} is ignored: this app runs a single uvicorn worker (Ray provides concurrency). To scale, set ENABLE_RAY_SERVE=true with RAY_SERVE_NUM_REPLICAS." >&2
+  fi
+  # --reload is dev-only (set UVICORN_RELOAD=true); it also forces a single worker.
   RELOAD_ARGS=()
-  WORKERS="${API_NUM_WORKERS:-1}"
   if [[ "${UVICORN_RELOAD}" == "true" ]]; then
     RELOAD_ARGS+=("--reload")
-    # uvicorn rejects --reload together with multiple workers; force single worker.
-    WORKERS="1"
   fi
-  uv run --no-dev "${ENV_ARGS[@]}" uvicorn api.main:app --host 0.0.0.0 --port "${APP_iPORT:-8080}" "${RELOAD_ARGS[@]}" --workers "${WORKERS}"
+  uv run --no-dev "${ENV_ARGS[@]}" uvicorn api.main:app --host 0.0.0.0 --port "${APP_iPORT:-8080}" "${RELOAD_ARGS[@]}" --workers 1
 fi

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
+
+# --- Writable-dir permission fix + privilege drop --------------------------
+# The app runs as a non-root user whose primary group is GID 0. Its writable
+# dirs (/app/data, /app/logs, /app/model_weights) are bind-mounted from the
+# host, so the image's group-0-writable perms (Dockerfile `chmod g=u`) don't
+# apply to them — the host directory's ownership does, and Docker creates a
+# missing bind source as root:root with no group-write. That makes the
+# non-root app fail with "Permission denied" on upload/logging/model download.
+#
+# To make bind mounts "just work" with no host-side chmod: when started as
+# root (compose sets `user: "0:0"` on the service), grant GID-0 write on those
+# dirs — mirroring the image's own `chmod g=u` — then drop to the non-root app
+# user and continue. When NOT root (OpenShift assigns an arbitrary non-root
+# UID in GID 0; or a plain non-root run), skip the fix: the platform's GID-0
+# membership plus the image's group-writable paths already cover it.
+APP_UID="${APP_UID:-10001}"
+if [ "$(id -u)" = "0" ]; then
+  for d in /app/data /app/logs /app/model_weights; do
+    mkdir -p "$d" 2>/dev/null || true
+    chgrp -R 0 "$d" 2>/dev/null || true
+    chmod -R g+rwX "$d" 2>/dev/null || true
+  done
+  # Re-exec this script as the non-root app user (UID in GID 0) to run the app.
+  exec setpriv --reuid "$APP_UID" --regid 0 --clear-groups /app/entrypoint.sh "$@"
+fi
+
 ENV_ARGS=()
 if [[ -n "${SHARED_ENV}" ]]; then
   ENV_ARGS+=("--env-file=${SHARED_ENV}")

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -6,7 +6,7 @@ fi
 
 if [[ "${ENABLE_RAY_SERVE}" == "true" ]]; then
   echo "🔁 Starting with Ray Serve..."
-  uv run "${ENV_ARGS[@]}" -m api.main
+  uv run --no-dev "${ENV_ARGS[@]}" -m api.main
 else
   echo "🚀 Starting with Uvicorn..."
   # This path always runs a SINGLE uvicorn worker. The app initializes Ray and

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
-ENV_ARG=""
+ENV_ARGS=()
 if [[ -n "${SHARED_ENV}" ]]; then
-  ENV_ARG="--env-file=${SHARED_ENV}"
+  ENV_ARGS+=("--env-file=${SHARED_ENV}")
 fi
 
 if [[ "${ENABLE_RAY_SERVE}" == "true" ]]; then
   echo "🔁 Starting with Ray Serve..."
-  uv run $ENV_ARG -m api.main
+  uv run "${ENV_ARGS[@]}" -m api.main
 else
   echo "🚀 Starting with Uvicorn..."
-  uv run --no-dev $ENV_ARG uvicorn api.main:app --host 0.0.0.0 --port ${APP_iPORT:-8080} --reload --workers ${API_NUM_WORKERS:-1}
+  # --reload is a development feature (watches/auto-imports source on change)
+  # and is incompatible with multiple workers. Enable it only with
+  # UVICORN_RELOAD=true for local dev; production runs without it.
+  RELOAD_ARGS=()
+  WORKERS="${API_NUM_WORKERS:-1}"
+  if [[ "${UVICORN_RELOAD}" == "true" ]]; then
+    RELOAD_ARGS+=("--reload")
+    # uvicorn rejects --reload together with multiple workers; force single worker.
+    WORKERS="1"
+  fi
+  uv run --no-dev "${ENV_ARGS[@]}" uvicorn api.main:app --host 0.0.0.0 --port "${APP_iPORT:-8080}" "${RELOAD_ARGS[@]}" --workers "${WORKERS}"
 fi

--- a/openrag/api/dependencies/auth.py
+++ b/openrag/api/dependencies/auth.py
@@ -72,7 +72,18 @@ async def ensure_partition_role(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Access to partition '{partition}' forbidden",
             )
-        return True
+        # Partition does not exist. The only legitimate reason a non-member may
+        # act on a missing partition is the create-on-write path (file upload),
+        # which is `editor` and which later creates the partition with the
+        # uploader as owner. Reading or owning a partition that does not exist
+        # must NOT silently succeed, or a non-member could pass an owner/viewer
+        # check by naming an unknown partition.
+        if required_role == "editor":
+            return True
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Partition '{partition}' not found",
+        )
 
     try:
         auth_service.check_partition_access(

--- a/openrag/api/dependencies/auth.py
+++ b/openrag/api/dependencies/auth.py
@@ -169,6 +169,11 @@ async def require_partitions_viewer(
     if SUPER_ADMIN_MODE and user.get("is_admin"):
         return user
     if isinstance(partitions, list) and len(partitions) == 1 and partitions[0] == "all":
+        if not user_partitions:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No accessible partitions",
+            )
         return user
     for partition in partitions:
         await ensure_partition_role(

--- a/openrag/api/dependencies/auth.py
+++ b/openrag/api/dependencies/auth.py
@@ -1,5 +1,6 @@
 import os
 
+from core.indexing.validators import validate_partition_name
 from core.utils.exceptions import OpenRAGError
 from core.utils.logging import get_logger
 from di.providers import get_auth_service, get_config, get_job_service, get_partition_service
@@ -62,6 +63,8 @@ async def ensure_partition_role(
     partition_service,
 ):
     """Ensure the user has at least `required_role` for the partition."""
+    # Reject crafted partition names before they reach any filter expression.
+    validate_partition_name(partition)
     if SUPER_ADMIN_MODE and user.get("is_admin"):
         return True
 

--- a/openrag/api/dependencies/llm.py
+++ b/openrag/api/dependencies/llm.py
@@ -101,6 +101,11 @@ async def get_partition_name(
             detail=f"Access to model `{model_name}` is forbidden for the current user",
         )
     if partition == "all" and not (is_admin and SUPER_ADMIN_MODE):
+        if not user_partitions:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No accessible partitions",
+            )
         return user_partitions
     return [partition]
 

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -150,14 +150,21 @@ async def lifespan(app: FastAPI):
     """
     if not ray.is_initialized():
         logger.info("Startup: initializing Ray")
-        # Bind the Ray dashboard to localhost by default; the dashboard / Jobs
-        # API is unauthenticated (CVE-2023-48022 "ShadowRay") so it must never
-        # listen on a routable interface. Operators that front it with an auth
-        # proxy can override via RAY_DASHBOARD_HOST.
-        ray.init(
-            dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
-            ignore_reinit_error=True,
-        )
+        _ray_address = os.environ.get("RAY_ADDRESS")
+        if _ray_address:
+            # Connect to an external Ray cluster (e.g. a dedicated ray-head
+            # container). No local dashboard is started — the head node owns it.
+            ray.init(address=_ray_address, ignore_reinit_error=True)
+        else:
+            # Embedded mode: start a local Ray cluster inside this process.
+            # Bind the Ray dashboard to localhost by default; the dashboard /
+            # Jobs API is unauthenticated (CVE-2023-48022 "ShadowRay") so it
+            # must never listen on a routable interface. Operators that front it
+            # with an auth proxy can override via RAY_DASHBOARD_HOST.
+            ray.init(
+                dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
+                ignore_reinit_error=True,
+            )
     logger.info("Startup: Ray is initialized")
 
     # ``ensure_worker_bootstrap`` imports ``services.workers.bootstrap``

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -299,6 +299,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.get("/", include_in_schema=False)
 def root_redirect():
     """Root handler — sends authenticated users to the indexer-ui (if

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -33,6 +33,7 @@ from api.error_handlers import register_error_handlers
 from api.middleware import (
     AuthMiddleware,
     InstrumentationMiddleware,
+    RateLimitMiddleware,
     RequestIdMiddleware,
     RequestTimeoutMiddleware,
 )
@@ -265,6 +266,10 @@ app.openapi = custom_openapi
 # and Instrumentation captures the full request duration including the
 # auth check. CORS is added later and ends up outside this stack so
 # preflights short-circuit before any instrumentation runs.
+# RateLimitMiddleware is registered BEFORE AuthMiddleware so it executes AFTER
+# it (registration is reverse of execution), letting it key limits on the
+# authenticated user id that AuthMiddleware just put on request.state.
+app.add_middleware(RateLimitMiddleware)
 app.add_middleware(
     AuthMiddleware,
     get_auth_service=lambda request: request.app.state.container.auth_service,

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -25,7 +25,6 @@ import warnings
 from contextlib import asynccontextmanager
 from enum import Enum
 from importlib.metadata import version as get_package_version
-from pathlib import Path
 
 import ray
 import uvicorn
@@ -50,6 +49,7 @@ from api.routers.admin.workspaces import router as workspaces_router
 from api.routers.auth.oidc import router as auth_router
 from api.routers.user.chat import prime_max_model_tokens
 from api.routers.user.chat import router as openai_router
+from api.routers.user.download import router as download_router
 from api.routers.user.extract import router as extract_router
 from api.routers.user.health import router as health_router
 from api.routers.user.search import router as search_router
@@ -63,7 +63,6 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.staticfiles import StaticFiles
 
 # pydub 0.25.1 ships invalid-escape regex literals; the warning is upstream.
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="pydub")
@@ -75,7 +74,6 @@ warnings.filterwarnings("ignore", category=SyntaxWarning, module="pydub")
 
 logger = get_logger()
 settings = load_config()
-DATA_DIR = Path(settings.paths.data_dir)
 CONTAINER_STARTUP_TIMEOUT = float(
     os.getenv("OPENRAG_CONTAINER_STARTUP_TIMEOUT", max(60, settings.rdb.command_timeout * 4))
 )
@@ -296,9 +294,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.mount("/static", StaticFiles(directory=DATA_DIR.resolve(), check_dir=True), name="static")
-
-
 @app.get("/", include_in_schema=False)
 def root_redirect():
     """Root handler — sends authenticated users to the indexer-ui (if
@@ -330,6 +325,8 @@ def get_config():
 app.include_router(health_router, tags=[Tags.MONITORING])
 app.include_router(indexer_router, prefix="/indexer", tags=[Tags.INDEXER])
 app.include_router(extract_router, prefix="/extract", tags=[Tags.EXTRACT])
+# Authorized, partition-checked source-file download (served under /static).
+app.include_router(download_router, tags=[Tags.EXTRACT])
 app.include_router(search_router, prefix="/search", tags=[Tags.SEARCH])
 app.include_router(partition_router, prefix="/partition", tags=[Tags.PARTITION])
 app.include_router(model_endpoints_router, prefix="/model-endpoints", tags=[Tags.MODEL_ENDPOINTS])

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -362,10 +362,25 @@ if __name__ == "__main__":
     if settings.ray.serve.enable:
         from ray import serve
 
+        # @serve.ingress cloudpickles `app` to ship it to replica processes.
+        # loguru's file sink isn't picklable (an open file handle, and with
+        # enqueue=True a multiprocessing.SimpleQueue that errors with "SimpleQueue
+        # objects should only be shared between processes through inheritance"),
+        # and the app graph (lifespan, exception handlers) captures the
+        # module-global logger by value. Strip the sinks before binding so the
+        # captured logger is handler-less (picklable), then restore them for this
+        # driver process below. Replica processes re-add their own sinks via the
+        # module-level get_logger() that runs on import — matching loguru's
+        # multiprocessing model, where handlers are per-process and never travel
+        # through a pickle.
+        logger.remove()
+
         @serve.deployment(num_replicas=settings.ray.serve.num_replicas)
         @serve.ingress(app)
         class OpenRagAPI:
             """Ray Serve deployment wrapper for the FastAPI app."""
+
+        get_logger()  # restore this driver's logging now that `app` is serialized
 
         serve.start(http_options={"host": settings.ray.serve.host, "port": settings.ray.serve.port})
         if WITH_CHAINLIT_UI:

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -150,7 +150,14 @@ async def lifespan(app: FastAPI):
     """
     if not ray.is_initialized():
         logger.info("Startup: initializing Ray")
-        ray.init(dashboard_host="0.0.0.0", ignore_reinit_error=True)
+        # Bind the Ray dashboard to localhost by default; the dashboard / Jobs
+        # API is unauthenticated (CVE-2023-48022 "ShadowRay") so it must never
+        # listen on a routable interface. Operators that front it with an auth
+        # proxy can override via RAY_DASHBOARD_HOST.
+        ray.init(
+            dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
+            ignore_reinit_error=True,
+        )
     logger.info("Startup: Ray is initialized")
 
     # ``ensure_worker_bootstrap`` imports ``services.workers.bootstrap``

--- a/openrag/api/mcp/server.py
+++ b/openrag/api/mcp/server.py
@@ -77,12 +77,18 @@ def _service():
 async def _startup() -> None:
     global _container
     if not ray.is_initialized():
-        # Bind the Ray dashboard to localhost by default; it is unauthenticated
-        # (CVE-2023-48022). Override via RAY_DASHBOARD_HOST behind an auth proxy.
-        ray.init(
-            dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
-            ignore_reinit_error=True,
-        )
+        _ray_address = os.environ.get("RAY_ADDRESS")
+        if _ray_address:
+            # Attach to an external Ray cluster; the head node owns the dashboard.
+            ray.init(address=_ray_address, ignore_reinit_error=True)
+        else:
+            # Bind the Ray dashboard to localhost by default; it is
+            # unauthenticated (CVE-2023-48022). Override via RAY_DASHBOARD_HOST
+            # behind an auth proxy.
+            ray.init(
+                dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
+                ignore_reinit_error=True,
+            )
     ensure_worker_bootstrap()
     container = ServiceContainer(config)
     try:

--- a/openrag/api/mcp/server.py
+++ b/openrag/api/mcp/server.py
@@ -77,7 +77,12 @@ def _service():
 async def _startup() -> None:
     global _container
     if not ray.is_initialized():
-        ray.init(dashboard_host="0.0.0.0", ignore_reinit_error=True)
+        # Bind the Ray dashboard to localhost by default; it is unauthenticated
+        # (CVE-2023-48022). Override via RAY_DASHBOARD_HOST behind an auth proxy.
+        ray.init(
+            dashboard_host=os.environ.get("RAY_DASHBOARD_HOST", "127.0.0.1"),
+            ignore_reinit_error=True,
+        )
     ensure_worker_bootstrap()
     container = ServiceContainer(config)
     try:

--- a/openrag/api/mcp/server.py
+++ b/openrag/api/mcp/server.py
@@ -119,10 +119,11 @@ class MCPAuthContextMiddleware(BaseHTTPMiddleware):
     """Resolve the bearer-token principal and set the MCP auth context.
 
     Mirrors the token-mode contract of ``api.middleware.AuthMiddleware``:
-    when ``AUTH_TOKEN`` is unset the server runs in dev mode and every call
-    acts as admin user 1; otherwise a valid ``Authorization: Bearer`` is
-    required. Allowed partitions follow ``current_user_or_admin_partitions_list``
-    (``["all"]`` for admins under ``SUPER_ADMIN_MODE``).
+    when ``AUTH_TOKEN`` is unset and ``ALLOW_NO_AUTH=true`` the server runs in
+    dev mode and every call acts as admin user 1; otherwise a valid
+    ``Authorization: Bearer`` is required. Allowed partitions follow
+    ``current_user_or_admin_partitions_list`` (``["all"]`` for admins under
+    ``SUPER_ADMIN_MODE``).
     """
 
     async def _resolve_principal(self, request: Request) -> tuple[int | None, bool, list[str] | None]:
@@ -135,7 +136,12 @@ class MCPAuthContextMiddleware(BaseHTTPMiddleware):
         # In OIDC mode AUTH_TOKEN is commonly unset; without this gate the MCP
         # endpoint would silently treat every caller as admin (auth bypass), so
         # a valid bearer (users.token) is always required there.
-        if auth_mode == "token" and auth_token is None:
+        allow_no_auth = os.getenv("ALLOW_NO_AUTH", "false").strip().lower() == "true"
+        if auth_mode == "token" and auth_token is None and allow_no_auth:
+            logger.warning(
+                "ALLOW_NO_AUTH=true and AUTH_TOKEN is unset: MCP authentication is DISABLED — "
+                "every request is treated as admin user 1. Never use this in production."
+            )
             user = await auth_service.get_user_for_request(1)
         else:
             header = request.headers.get("authorization", "")

--- a/openrag/api/mcp/server.py
+++ b/openrag/api/mcp/server.py
@@ -445,6 +445,7 @@ async def index_url(url: str, partition: str, file_id: str, extra_metadata: dict
         file_id=file_id,
         allowed_partitions=get_allowed_partitions(),
         user_id=get_user_id(),
+        is_admin=is_admin(),
         extra_metadata=extra_metadata,
     )
 

--- a/openrag/api/middleware/__init__.py
+++ b/openrag/api/middleware/__init__.py
@@ -6,12 +6,14 @@ without remembering each submodule.
 
 from api.middleware.auth import AuthMiddleware
 from api.middleware.instrumentation import InstrumentationMiddleware
+from api.middleware.rate_limit import RateLimitMiddleware
 from api.middleware.request_id import REQUEST_ID_HEADER, RequestIdMiddleware
 from api.middleware.request_timeout import RequestTimeoutMiddleware
 
 __all__ = [
     "AuthMiddleware",
     "InstrumentationMiddleware",
+    "RateLimitMiddleware",
     "RequestIdMiddleware",
     "REQUEST_ID_HEADER",
     "RequestTimeoutMiddleware",

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -108,15 +108,23 @@ class AuthFailureRateLimiter:
     def __init__(self) -> None:
         self.enabled = _env_flag("RATE_LIMIT_ENABLED", True)
         self._limiter = MovingWindowRateLimiter(MemoryStorage())
-        self._limit = parse(os.environ.get("RATE_LIMIT_AUTH_FAILURE", os.environ.get("RATE_LIMIT_AUTH", "20/minute")))
+        self._limit = (
+            parse(os.environ.get("RATE_LIMIT_AUTH_FAILURE", os.environ.get("RATE_LIMIT_AUTH", "20/minute")))
+            if self.enabled
+            else None
+        )
 
     @staticmethod
     def _identity(request: Request) -> str:
         client = request.client
         return f"ip:{client.host}" if client else "ip:unknown"
 
+    @staticmethod
+    def _safe_log_value(value: str, *, max_len: int = 200) -> str:
+        return value.replace("\r", "\\r").replace("\n", "\\n").replace("\x00", "\\0")[:max_len]
+
     async def response_if_limited(self, request: Request) -> JSONResponse | None:
-        if not self.enabled:
+        if not self.enabled or self._limit is None:
             return None
         identity = self._identity(request)
         tier = "auth-failure"
@@ -126,7 +134,7 @@ class AuthFailureRateLimiter:
         return await self._limited_response(request, identity)
 
     async def record_failure(self, request: Request) -> JSONResponse | None:
-        if not self.enabled:
+        if not self.enabled or self._limit is None:
             return None
         identity = self._identity(request)
         tier = "auth-failure"
@@ -136,10 +144,14 @@ class AuthFailureRateLimiter:
         return await self._limited_response(request, identity)
 
     async def _limited_response(self, request: Request, identity: str) -> JSONResponse:
+        assert self._limit is not None
         tier = "auth-failure"
         stats = await self._limiter.get_window_stats(self._limit, tier, identity)
         retry_after = max(1, int(stats.reset_time - time.time()))
-        logger.warning("Auth failure rate limit exceeded", path=request.url.path, identity=identity)
+        logger.bind(
+            path=self._safe_log_value(str(request.url.path)),
+            identity=self._safe_log_value(identity),
+        ).warning("Auth failure rate limit exceeded")
         return JSONResponse(
             status_code=429,
             content={"detail": "Rate limit exceeded. Please retry later.", "extra": {}},

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -83,6 +83,14 @@ def is_bypass_path(path: str, *, bypass_config: AuthBypassConfig | None = None) 
     return path in cfg.bypass_paths or path == "/chainlit" or path.startswith("/chainlit/")
 
 
+def _allow_no_auth() -> bool:
+    """Whether the no-auth dev bypass (AUTH_TOKEN unset → admin) is allowed.
+
+    Read lazily so it can be toggled per-test, mirroring the other env reads.
+    """
+    return os.getenv("ALLOW_NO_AUTH", "false").strip().lower() == "true"
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """FastAPI middleware enforcing authentication for both token and oidc modes.
 
@@ -110,7 +118,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
         enc_key = os.getenv("OIDC_TOKEN_ENCRYPTION_KEY") or ""
 
         # --- Dev mode: AUTH_MODE=token + AUTH_TOKEN unset → user 1 bypass.
-        if auth_mode == "token" and auth_token is None:
+        #     This disables authentication entirely (every request becomes the
+        #     admin user), so it is gated behind an explicit ALLOW_NO_AUTH=true
+        #     opt-in. Without that flag, an unset AUTH_TOKEN does not grant
+        #     access: requests fall through to normal Bearer auth and
+        #     unauthenticated callers get 401.
+        if auth_mode == "token" and auth_token is None and _allow_no_auth():
+            logger.warning(
+                "ALLOW_NO_AUTH=true and AUTH_TOKEN is unset: authentication is DISABLED — "
+                "every request is treated as admin user 1. Never use this in production."
+            )
             auth_service = self._get_auth_service(request)
             user = await auth_service.get_user_for_request(1)
             user_partitions = await auth_service.list_user_partitions_for_request(1)

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -120,9 +120,23 @@ class AuthFailureRateLimiter:
             return None
         identity = self._identity(request)
         tier = "auth-failure"
+        allowed = await self._limiter.test(self._limit, tier, identity)
+        if allowed:
+            return None
+        return await self._limited_response(request, identity)
+
+    async def record_failure(self, request: Request) -> JSONResponse | None:
+        if not self.enabled:
+            return None
+        identity = self._identity(request)
+        tier = "auth-failure"
         allowed = await self._limiter.hit(self._limit, tier, identity)
         if allowed:
             return None
+        return await self._limited_response(request, identity)
+
+    async def _limited_response(self, request: Request, identity: str) -> JSONResponse:
+        tier = "auth-failure"
         stats = await self._limiter.get_window_stats(self._limit, tier, identity)
         retry_after = max(1, int(stats.reset_time - time.time()))
         logger.warning("Auth failure rate limit exceeded", path=request.url.path, identity=identity)
@@ -155,7 +169,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         self._auth_failure_limiter = AuthFailureRateLimiter()
 
     async def _auth_failure(self, request: Request, *, status_code: int, detail: str) -> JSONResponse:
-        limited = await self._auth_failure_limiter.response_if_limited(request)
+        limited = await self._auth_failure_limiter.record_failure(request)
         if limited is not None:
             return limited
         return JSONResponse(status_code=status_code, content={"detail": detail})
@@ -216,6 +230,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                         status_code=302,
                     )
             return await call_next(request)
+
+        limited = await self._auth_failure_limiter.response_if_limited(request)
+        if limited is not None:
+            return limited
 
         user = None
         session = None

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -240,9 +240,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
                 session_valid = False
                 if cookie_token:
-                    auth_service = self._get_auth_service(request)
-                    session = await auth_service.get_oidc_session_by_token_for_request(cookie_token)
-                    session_valid = session is not None
+                    # Never let a session-lookup failure (e.g. a degraded boot
+                    # where the container's pool was never opened) surface as a
+                    # 500 on a plain page load — treat it as no session and let
+                    # the redirect below send the browser through /auth/login.
+                    try:
+                        auth_service = self._get_auth_service(request)
+                        session = await auth_service.get_oidc_session_by_token_for_request(cookie_token)
+                        session_valid = session is not None
+                    except Exception as e:
+                        logger.bind(error=str(e)).warning(
+                            "OIDC session check failed on chainlit bypass; redirecting to login"
+                        )
+                        session_valid = False
                 if not session_valid:
                     next_path = path
                     if request.url.query:

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -213,7 +213,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # --- Bypass list (docs, health, /auth/* callbacks, chainlit).
         path = request.url.path
-        if is_bypass_path(path, bypass_config=self._bypass_config):
+
+        # In oidc mode the interactive API docs are gated behind login rather
+        # than served anonymously: they expose the full route + schema surface,
+        # and an authenticated browser session still reaches them after the IdP
+        # redirect. In token mode they stay public — a browser has no login flow
+        # to bounce through — preserving the legacy bypass contract. ``oidc_gated``
+        # therefore suppresses the bypass for these paths only when AUTH_MODE=oidc,
+        # so they fall through to the normal auth + UI-redirect path below.
+        oidc_gated = auth_mode == "oidc" and path in self._bypass_config.oidc_gated_paths
+
+        if not oidc_gated and is_bypass_path(path, bypass_config=self._bypass_config):
             # Special case: browser HTML page-loads on /chainlit/* without an
             # active session can't be served usefully — Chainlit configures no
             # in-app auth provider when headerAuth is used, so the SPA shows
@@ -323,9 +333,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 # Token mode: no cookie + no bearer → legacy 403 "Missing token".
                 return await self._auth_failure(request, status_code=403, detail="Missing token")
 
-        # --- 3) Unauthenticated: redirect UI in oidc mode, else 401 JSON.
+        # --- 3) Unauthenticated: redirect UI (and the oidc-gated docs) in oidc
+        #        mode, else 401 JSON. ``oidc_gated`` is already mode-checked.
         if user is None:
-            if auth_mode == "oidc" and is_ui_path(path, bypass_config=self._bypass_config):
+            if oidc_gated or (auth_mode == "oidc" and is_ui_path(path, bypass_config=self._bypass_config)):
                 next_path = path
                 if request.url.query:
                     next_path = f"{path}?{request.url.query}"

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -30,6 +30,7 @@ and deleted the ``components/auth/middleware.py`` shim.
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote
@@ -38,6 +39,9 @@ from core.config.auth import AuthBypassConfig
 from core.utils.logging import get_logger
 from fastapi import Request
 from fastapi.responses import JSONResponse, RedirectResponse
+from limits import parse
+from limits.aio.storage import MemoryStorage
+from limits.aio.strategies import MovingWindowRateLimiter
 from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = get_logger()
@@ -91,6 +95,44 @@ def _allow_no_auth() -> bool:
     return os.getenv("ALLOW_NO_AUTH", "false").strip().lower() == "true"
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+class AuthFailureRateLimiter:
+    """Limit failed authentication attempts by client IP."""
+
+    def __init__(self) -> None:
+        self.enabled = _env_flag("RATE_LIMIT_ENABLED", True)
+        self._limiter = MovingWindowRateLimiter(MemoryStorage())
+        self._limit = parse(os.environ.get("RATE_LIMIT_AUTH_FAILURE", os.environ.get("RATE_LIMIT_AUTH", "20/minute")))
+
+    @staticmethod
+    def _identity(request: Request) -> str:
+        client = request.client
+        return f"ip:{client.host}" if client else "ip:unknown"
+
+    async def response_if_limited(self, request: Request) -> JSONResponse | None:
+        if not self.enabled:
+            return None
+        identity = self._identity(request)
+        tier = "auth-failure"
+        allowed = await self._limiter.hit(self._limit, tier, identity)
+        if allowed:
+            return None
+        stats = await self._limiter.get_window_stats(self._limit, tier, identity)
+        retry_after = max(1, int(stats.reset_time - time.time()))
+        logger.warning("Auth failure rate limit exceeded", path=request.url.path, identity=identity)
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Rate limit exceeded. Please retry later.", "extra": {}},
+            headers={"Retry-After": str(retry_after)},
+        )
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """FastAPI middleware enforcing authentication for both token and oidc modes.
 
@@ -110,6 +152,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._get_auth_service = get_auth_service
         self._bypass_config = bypass_config or AuthBypassConfig()
+        self._auth_failure_limiter = AuthFailureRateLimiter()
+
+    async def _auth_failure(self, request: Request, *, status_code: int, detail: str) -> JSONResponse:
+        limited = await self._auth_failure_limiter.response_if_limited(request)
+        if limited is not None:
+            return limited
+        return JSONResponse(status_code=status_code, content={"detail": detail})
 
     async def dispatch(self, request: Request, call_next):
         # Read env lazily so tests can flip AUTH_MODE per-test.
@@ -239,10 +288,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     user = await auth_service.get_user_by_token_for_request(token)
                     if not user and auth_mode == "token":
                         # Legacy test contract: robot suite asserts 403 + "Invalid token".
-                        return JSONResponse(status_code=403, content={"detail": "Invalid token"})
+                        return await self._auth_failure(request, status_code=403, detail="Invalid token")
             elif auth_mode == "token":
                 # Token mode: no cookie + no bearer → legacy 403 "Missing token".
-                return JSONResponse(status_code=403, content={"detail": "Missing token"})
+                return await self._auth_failure(request, status_code=403, detail="Missing token")
 
         # --- 3) Unauthenticated: redirect UI in oidc mode, else 401 JSON.
         if user is None:
@@ -254,7 +303,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     url=f"/auth/login?next={quote(next_path, safe='')}",
                     status_code=302,
                 )
-            return JSONResponse(status_code=401, content={"detail": "Unauthenticated"})
+            return await self._auth_failure(request, status_code=401, detail="Unauthenticated")
 
         # --- Happy path: user resolved.
         request.state.user = user

--- a/openrag/api/middleware/rate_limit.py
+++ b/openrag/api/middleware/rate_limit.py
@@ -1,0 +1,87 @@
+"""Per-identity request rate limiting, tiered by path.
+
+Keyed on the authenticated user, or the client IP for unauthenticated paths.
+Runs after AuthMiddleware (registered before it in ``api.main`` so it executes
+after auth populates ``request.state.user``). Limits are per-worker; use a Redis
+storage to share them across workers.
+
+Env: RATE_LIMIT_ENABLED (true), RATE_LIMIT_DEFAULT (300/minute),
+RATE_LIMIT_AUTH (20/minute, /auth/*), RATE_LIMIT_CHAT (60/minute, /v1/*).
+"""
+
+import os
+import time
+
+from core.utils.logging import get_logger
+from limits import parse
+from limits.aio.storage import MemoryStorage
+from limits.aio.strategies import MovingWindowRateLimiter
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = get_logger()
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Apply per-identity moving-window rate limits, tiered by path prefix."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.enabled = _env_flag("RATE_LIMIT_ENABLED", True)
+        self._limiter = MovingWindowRateLimiter(MemoryStorage())
+        self._default = parse(os.environ.get("RATE_LIMIT_DEFAULT", "300/minute"))
+        self._auth = parse(os.environ.get("RATE_LIMIT_AUTH", "20/minute"))
+        self._chat = parse(os.environ.get("RATE_LIMIT_CHAT", "60/minute"))
+        if self.enabled:
+            logger.info(
+                "Rate limiting enabled",
+                default=str(self._default),
+                auth=str(self._auth),
+                chat=str(self._chat),
+            )
+
+    def _limit_for(self, path: str):
+        if path.startswith("/auth/"):
+            return self._auth, "auth"
+        if path.startswith("/v1/"):
+            return self._chat, "chat"
+        return self._default, "default"
+
+    @staticmethod
+    def _identity(request: Request) -> str:
+        # user is a dict set by AuthMiddleware; fall back to client IP.
+        user = getattr(request.state, "user", None)
+        user_id = user.get("id") if isinstance(user, dict) else None
+        if user_id is not None:
+            return f"user:{user_id}"
+        client = request.client
+        return f"ip:{client.host}" if client else "ip:unknown"
+
+    async def dispatch(self, request: Request, call_next):
+        if not self.enabled:
+            return await call_next(request)
+
+        path = request.url.path
+        limit, tier = self._limit_for(path)
+        identity = self._identity(request)
+
+        # Key by tier so each tier has its own budget.
+        allowed = await self._limiter.hit(limit, tier, identity)
+        if not allowed:
+            stats = await self._limiter.get_window_stats(limit, tier, identity)
+            retry_after = max(1, int(stats.reset_time - time.time()))
+            logger.warning("Rate limit exceeded", path=path, tier=tier, identity=identity)
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded. Please retry later.", "extra": {}},
+                headers={"Retry-After": str(retry_after)},
+            )
+        return await call_next(request)

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -376,6 +376,10 @@ async def copy_file_between_partitions(
     auth_service=Depends(get_auth_service),
     partition_service=Depends(get_partition_service),
 ):
+    # source_file_id arrives as a form field (not a path param with the
+    # validate_file_id dependency), so validate it here against the same safe
+    # identifier allowlist before it reaches a Milvus filter expression.
+    await validate_file_id(source_file_id)
     # Make sure user has access to the source partition
     await ensure_partition_role(
         partition=source_partition,

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from api.dependencies.auth import (
     check_user_file_quota,
+    current_user,
     current_user_partitions,
     ensure_partition_role,
     require_partition_editor,
@@ -138,10 +139,12 @@ async def add_file(
     try:
         file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
     except Exception as e:
+        # Log the full error server-side; return a generic message so we don't
+        # leak filesystem paths or internals to the client.
         logger.exception("Failed to save file to disk.", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to save uploaded file.",
         )
 
     parsed_workspace_ids = None
@@ -462,6 +465,7 @@ async def get_task_error(
     task_id: str,
     task_details=Depends(require_task_owner),
     service=Depends(get_indexing_service),
+    user=Depends(current_user),
 ):
     error = await service.get_task_error(task_id)
     if error is None:
@@ -469,7 +473,11 @@ async def get_task_error(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No error found for task '{task_id}'.",
         )
-    return {"task_id": task_id, "traceback": error.splitlines()}
+    # The raw traceback exposes filesystem paths and internals; only return it
+    # to admins. Task owners get a generic failure indicator.
+    if user and user.get("is_admin", False):
+        return {"task_id": task_id, "traceback": error.splitlines()}
+    return {"task_id": task_id, "traceback": ["Task failed. Contact an administrator for details."]}
 
 
 @router.get(

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -47,6 +47,21 @@ def _require_service_method(service, method_name: str):
     return method
 
 
+def _max_partitions_for_user(user: dict) -> int | None:
+    """Return the non-admin owned-partition cap, or None when it is disabled."""
+    if user.get("is_admin", False):
+        return None
+    raw_limit = os.environ.get("MAX_PARTITIONS_PER_USER", "100")
+    try:
+        return int(raw_limit)
+    except (TypeError, ValueError) as exc:
+        logger.error("Invalid MAX_PARTITIONS_PER_USER value", value=raw_limit)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="MAX_PARTITIONS_PER_USER must be an integer.",
+        ) from exc
+
+
 @router.get(
     "/",
     description="""List all accessible partitions.
@@ -282,7 +297,7 @@ async def create_partition(
     # exhaust storage/metadata. None bypasses the cap (admins); a negative
     # MAX_PARTITIONS_PER_USER also disables it. The service raises a 403
     # (PARTITION_LIMIT_EXCEEDED) when the cap is reached.
-    max_owned = None if user.get("is_admin", False) else int(os.environ.get("MAX_PARTITIONS_PER_USER", "100"))
+    max_owned = _max_partitions_for_user(user)
     await service.create_partition(partition=partition, user_id=user_id, max_owned=max_owned)
     return Response(status_code=status.HTTP_201_CREATED)
 

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -9,6 +9,7 @@ whose exact non-bracketed ``{"detail": ...}`` body the endpoints return
 via ``HTTPException``.
 """
 
+import os
 from typing import Literal
 from urllib.parse import quote
 
@@ -286,7 +287,12 @@ async def create_partition(
     try:
         max_owned = max_partitions_for_user(user)
     except ConfigError as exc:
-        logger.error("Invalid MAX_PARTITIONS_PER_USER value")
+        logger.bind(
+            max_partitions_per_user=os.environ.get("MAX_PARTITIONS_PER_USER"),
+            user_id=user_id,
+            is_admin=bool(user.get("is_admin")),
+            partition=partition,
+        ).error("Invalid MAX_PARTITIONS_PER_USER value")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=exc.message,

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -9,7 +9,6 @@ whose exact non-bracketed ``{"detail": ...}`` body the endpoints return
 via ``HTTPException``.
 """
 
-import os
 from typing import Literal
 from urllib.parse import quote
 
@@ -20,7 +19,9 @@ from api.dependencies.auth import (
 )
 from api.dependencies.files import validate_file_id
 from api.schemas.admin.partition_schemas import PartitionDetailResponse, UpdatePartitionRequest
+from core.utils.exceptions import ConfigError
 from core.utils.logging import get_logger
+from core.utils.partition_limits import max_partitions_for_user
 from di.providers import get_partition_service
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
@@ -45,21 +46,6 @@ def _require_service_method(service, method_name: str):
             detail=f"{method_name} is not available.",
         )
     return method
-
-
-def _max_partitions_for_user(user: dict) -> int | None:
-    """Return the non-admin owned-partition cap, or None when it is disabled."""
-    if user.get("is_admin", False):
-        return None
-    raw_limit = os.environ.get("MAX_PARTITIONS_PER_USER", "100")
-    try:
-        return int(raw_limit)
-    except (TypeError, ValueError) as exc:
-        logger.error("Invalid MAX_PARTITIONS_PER_USER value", value=raw_limit)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="MAX_PARTITIONS_PER_USER must be an integer.",
-        ) from exc
 
 
 @router.get(
@@ -297,7 +283,14 @@ async def create_partition(
     # exhaust storage/metadata. None bypasses the cap (admins); a negative
     # MAX_PARTITIONS_PER_USER also disables it. The service raises a 403
     # (PARTITION_LIMIT_EXCEEDED) when the cap is reached.
-    max_owned = _max_partitions_for_user(user)
+    try:
+        max_owned = max_partitions_for_user(user)
+    except ConfigError as exc:
+        logger.error("Invalid MAX_PARTITIONS_PER_USER value")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=exc.message,
+        ) from exc
     await service.create_partition(partition=partition, user_id=user_id, max_owned=max_owned)
     return Response(status_code=status.HTTP_201_CREATED)
 

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -17,6 +17,7 @@ from api.dependencies.auth import (
     require_partition_owner,
     require_partition_viewer,
 )
+from api.dependencies.files import validate_file_id
 from api.schemas.admin.partition_schemas import PartitionDetailResponse, UpdatePartitionRequest
 from core.utils.logging import get_logger
 from di.providers import get_partition_service
@@ -172,8 +173,8 @@ Returns file information including:
 async def get_file(
     request: Request,
     partition: str,
-    file_id: str,
     limit: int = Query(default=2000, ge=0),
+    file_id: str = Depends(validate_file_id),
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_partition_service),
 ):
@@ -534,8 +535,8 @@ For email threads with parallel branches, each branch has its own ancestor path.
 )
 async def get_file_ancestors(
     partition: str,
-    file_id: str,
     max_ancestor_depth: int | None = None,
+    file_id: str = Depends(validate_file_id),
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_partition_service),
 ):

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -9,6 +9,7 @@ whose exact non-bracketed ``{"detail": ...}`` body the endpoints return
 via ``HTTPException``.
 """
 
+import os
 from typing import Literal
 from urllib.parse import quote
 
@@ -275,8 +276,14 @@ async def create_partition(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Partition '{partition}' already exists.",
         )
-    user_id = request.state.user["id"]
-    await service.create_partition(partition=partition, user_id=user_id)
+    user = request.state.user
+    user_id = user["id"]
+    # Cap how many partitions a non-admin may own so an authenticated user can't
+    # exhaust storage/metadata. None bypasses the cap (admins); a negative
+    # MAX_PARTITIONS_PER_USER also disables it. The service raises a 403
+    # (PARTITION_LIMIT_EXCEEDED) when the cap is reached.
+    max_owned = None if user.get("is_admin", False) else int(os.environ.get("MAX_PARTITIONS_PER_USER", "100"))
+    await service.create_partition(partition=partition, user_id=user_id, max_owned=max_owned)
     return Response(status_code=status.HTTP_201_CREATED)
 
 

--- a/openrag/api/routers/auth/oidc.py
+++ b/openrag/api/routers/auth/oidc.py
@@ -182,12 +182,37 @@ async def backchannel_logout(
 # ---------------------------------------------------------------------------
 
 
+def _is_csrf_safe_navigation(request: Request) -> bool:
+    """Reject the silent logout-CSRF vector while keeping the redirect-based UX.
+
+    Logout must remain reachable via top-level GET navigation (the OIDC
+    RP-initiated logout redirects the browser to the IdP), so we can't simply
+    require POST. Instead we use the Fetch Metadata headers: a forged request
+    from ``<img>``/``<script>``/cross-site ``fetch`` is a cross-site
+    *non-navigation* request and is blocked; genuine top-level navigations
+    (Sec-Fetch-Mode: navigate) and same-origin requests pass. Browsers that
+    don't send these headers (older) fall through as allowed.
+    """
+    site = request.headers.get("sec-fetch-site")
+    mode = request.headers.get("sec-fetch-mode")
+    if site == "cross-site" and mode not in (None, "navigate"):
+        return False
+    return True
+
+
 @router.get("/auth/logout", include_in_schema=False)
 async def logout(
     request: Request,
     _oidc: None = Depends(_require_oidc_mode),
     service=Depends(get_auth_service),
 ):
+    if not _is_csrf_safe_navigation(request):
+        logger.warning("Blocked cross-site non-navigation request to /auth/logout (CSRF)")
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"detail": "Cross-site logout requests are not allowed"},
+        )
+
     redirect_target = await service.logout(request.cookies.get(SESSION_COOKIE_NAME))
 
     if redirect_target:

--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -290,8 +290,11 @@ async def openai_chat_completion(
 
     log.debug("Received chat completion request with messages: {}", truncate(str(request.messages)))
 
+    # Bound the caller's input size in every mode. RAG-injected context is added
+    # server-side and separately capped (max_context_tokens), but the user's own
+    # messages must be limited regardless of direct-LLM vs RAG.
+    check_tokens_limit(request, log, config)
     if is_direct_llm_model(request, config):
-        check_tokens_limit(request, log, config)
         partitions = None
     else:
         partitions = await get_partition_name(
@@ -385,8 +388,9 @@ async def openai_completion(
             detail="Streaming is not supported for this endpoint",
         )
 
+    # Bound the caller's input size in every mode (RAG context is capped separately).
+    check_tokens_limit(request, log, config)
     if is_direct_llm_model(request, config):
-        check_tokens_limit(request, log, config)
         partitions = None
     else:
         partitions = await get_partition_name(

--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -113,8 +113,10 @@ async def list_models(
 
 
 def __prepare_sources(request: Request, docs: list, web_results: list | None = None):
-    def static_url(filename: str) -> str:
-        return str(request.url_for("static", path=filename))
+    def static_url(extract_id) -> str:
+        # Authorized, partition-checked download keyed by chunk id (replaces the
+        # open /static mount). The file is resolved server-side from the chunk.
+        return str(request.url_for("download_source", extract_id=extract_id))
 
     def chunk_url(extract_id) -> str:
         return str(request.url_for("get_extract", extract_id=extract_id))

--- a/openrag/api/routers/user/download.py
+++ b/openrag/api/routers/user/download.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 from api.dependencies.auth import current_user_or_admin_partitions_list
 from core.config import load_config
+from core.indexing.validators import validate_file_id
+from core.utils.exceptions import ValidationError
 from core.utils.logging import get_logger
 from di.providers import get_conversion_service
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -32,6 +34,10 @@ async def download_source(
 ):
     """Download the source document a chunk came from, authorized by partition."""
     log = logger.bind(extract_id=extract_id)
+    try:
+        extract_id = validate_file_id(extract_id)
+    except ValidationError as exc:
+        raise HTTPException(status_code=exc.status_code or status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     chunk = await service.get_chunk(extract_id)
     if chunk is None:

--- a/openrag/api/routers/user/download.py
+++ b/openrag/api/routers/user/download.py
@@ -1,0 +1,59 @@
+"""Authorized source-file download, keyed by chunk id.
+
+Serving ``DATA_DIR`` as a static mount would expose every tenant's source
+documents to any authenticated caller who learned a filename (from a source
+``file_url``, logs, or a since-revoked membership). Instead, this route mirrors
+``/extract``'s partition-membership check: it resolves the file from the chunk's
+stored ``source`` path and confines it to ``DATA_DIR``. The URL lives under
+``/static`` so the middleware's browser ``?token=`` access works the same way.
+"""
+
+from pathlib import Path
+
+from api.dependencies.auth import current_user_or_admin_partitions_list
+from core.config import load_config
+from core.utils.logging import get_logger
+from di.providers import get_conversion_service
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+
+logger = get_logger()
+
+_DATA_DIR = Path(load_config().paths.data_dir).resolve()
+
+router = APIRouter()
+
+
+@router.get("/static/{extract_id}", name="download_source")
+async def download_source(
+    extract_id: str,
+    user_partitions=Depends(current_user_or_admin_partitions_list),
+    service=Depends(get_conversion_service),
+):
+    """Download the source document a chunk came from, authorized by partition."""
+    log = logger.bind(extract_id=extract_id)
+
+    chunk = await service.get_chunk(extract_id)
+    if chunk is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    metadata = chunk.get("metadata", {})
+    chunk_partition = metadata.get("partition")
+    if chunk_partition not in user_partitions and user_partitions != ["all"]:
+        log.warning("User does not have access to this file.")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User does not have access to this file.",
+        )
+
+    source = metadata.get("source")
+    if not source:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    # Resolve and confine the path to DATA_DIR to defeat any traversal.
+    file_path = Path(source).resolve()
+    if not file_path.is_relative_to(_DATA_DIR) or not file_path.is_file():
+        log.warning("Resolved source path is outside DATA_DIR or missing.")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
+
+    return FileResponse(file_path, filename=file_path.name)

--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -16,6 +16,7 @@ from api.dependencies.auth import (
     require_partition_viewer,
     require_partitions_viewer,
 )
+from api.dependencies.files import validate_file_id
 from core.utils.logging import get_logger
 from di.providers import get_retrieval_service, get_workspace_service
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -305,8 +306,8 @@ Find specific information within a single document using semantic search.
 async def search_file(
     request: Request,
     partition: str,
-    file_id: str,
     search_params: Annotated[CommonSearchParams, Depends()],
+    file_id: str = Depends(validate_file_id),
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_retrieval_service),
 ):

--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -145,6 +145,8 @@ async def search_multiple_partitions(
 ):
     if partitions == ["all"]:
         partitions = user_partitions
+    if not partitions:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No accessible partitions")
 
     log = logger.bind(
         partitions=partitions,

--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -147,7 +147,7 @@ async def search_multiple_partitions(
 
     log = logger.bind(
         partitions=partitions,
-        query=search_params.text,
+        query_len=len(search_params.text),
         top_k=search_params.top_k,
         workspace=workspace,
         include_related=related_params.include_related,
@@ -233,7 +233,7 @@ async def search_one_partition(
 ):
     log = logger.bind(
         partition=partition,
-        query=search_params.text,
+        query_len=len(search_params.text),
         top_k=search_params.top_k,
         workspace=workspace,
         include_related=related_params.include_related,
@@ -310,7 +310,9 @@ async def search_file(
     partition_viewer=Depends(require_partition_viewer),
     service=Depends(get_retrieval_service),
 ):
-    log = logger.bind(partition=partition, file_id=file_id, query=search_params.text, top_k=search_params.top_k)
+    log = logger.bind(
+        partition=partition, file_id=file_id, query_len=len(search_params.text), top_k=search_params.top_k
+    )
 
     filter = "file_id == {_file_id}" + (f" AND {search_params.filter}" if search_params.filter else "")
     params = {"_file_id": file_id}

--- a/openrag/api/routers/user/source_links.py
+++ b/openrag/api/routers/user/source_links.py
@@ -17,20 +17,22 @@ def build_document_source_link(
 ) -> dict:
     """Build the response dict for one document source.
 
-    ``file_url`` is emitted only when the metadata yields a non-empty
-    filename, so a missing/empty ``source`` never produces a static URL with
-    an empty path. The static URL is percent-encoded.
+    ``file_url`` is emitted only when the chunk has a non-empty ``source``
+    filename, so a chunk with no source never produces a download URL. The URL
+    is keyed by the chunk id (``_id``): the download is authorized server-side
+    by partition membership, so it never exposes a raw, unguarded filesystem
+    path. The URL is percent-encoded.
 
     Args:
         doc_metadata: The chunk metadata (must contain ``_id``).
-        static_url_builder: Maps a filename to its static file URL.
+        static_url_builder: Maps an extract id to its authorized download URL.
         chunk_url_builder: Maps an extract id to its chunk URL.
     """
     source = doc_metadata.get("source") or ""
     filename = Path(source).name
     encoded_url = None
     if filename:
-        encoded_url = quote(static_url_builder(filename), safe=":/")
+        encoded_url = quote(static_url_builder(doc_metadata["_id"]), safe=":/")
     return {
         "source_type": "document",
         **({"file_url": encoded_url} if encoded_url else {}),

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -46,13 +46,15 @@ class OpenAIChatCompletionRequest(BaseModel):
 class OpenAICompletionRequest(BaseModel):
     model: str | None = Field(None, description="model name")
     prompt: str
-    best_of: int | None = Field(1)
+    # Bound n/best_of: each multiplies generation cost, so leaving them unbounded
+    # lets one request fan out into a resource-exhaustion amplifier.
+    best_of: int | None = Field(1, ge=1, le=8)
     echo: bool | None = Field(False)
     frequency_penalty: float | None = Field(0.0)
     logit_bias: dict | None = Field(None)
     logprobs: int | None = Field(None)
     max_tokens: int | None = Field(default_factory=default_max_tokens)
-    n: int | None = Field(1)
+    n: int | None = Field(1, ge=1, le=8)
     presence_penalty: float | None = Field(0.0)
     seed: int | None = Field(None)
     stop: list[str] | None = Field(None)

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -39,7 +39,7 @@ class OpenAIChatCompletionRequest(BaseModel):
             "websearch": False,
             "llm_override": None,
         },
-        description="Extra custom parameters. Supports 'llm_override' object with optional 'base_url', 'api_key', and 'model' to override the downstream LLM endpoint.",
+        description="Extra custom parameters. Supports 'llm_override' object with an optional 'model' to override the downstream model name. The LLM endpoint and credentials are fixed by server configuration and cannot be overridden by the client.",
     )
 
 

--- a/openrag/app_front.py
+++ b/openrag/app_front.py
@@ -262,7 +262,14 @@ async def _format_sources(metadata_sources, only_txt=False, api_key=None):
         filename = Path(s["filename"])
         file_url = s["file_url"]
         file_url = file_url.replace(INTERNAL_BASE_URL, external_url)  # put the correct base url
-        file_url = f"{file_url}?token={api_key}"  # add token for authentication
+        # Avoid leaking the credential in the URL (browser history, proxy logs,
+        # Referer headers). In OIDC mode the browser already sends the
+        # openrag_session cookie on same-origin file fetches, which the auth
+        # middleware accepts — so the token query param is unnecessary. In token
+        # mode there is no such cookie, so it remains the only way for the
+        # browser to authenticate the fetch.
+        if AUTH_MODE != "oidc":
+            file_url = f"{file_url}?token={api_key}"
         page = s["page"]
         source_name = f"{filename}" + (
             f" (page: {page})" if filename.suffix in [".pdf", ".pptx", ".docx", ".doc"] else ""

--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -1,21 +1,78 @@
+"""Standalone Chainlit ASGI app (Ray Serve mode).
+
+When ``ray.serve`` is enabled, ``api.main`` runs the API as a Ray Serve
+deployment and this app in a *separate* uvicorn process on its own port
+(``ray.serve.chainlit_port``). Because it is a distinct process, it cannot
+borrow the API replicas' asyncpg pool — it needs its own
+:class:`ServiceContainer`, initialized in a lifespan exactly like
+``api.main`` does.
+
+Without that initialization the OIDC ``AuthMiddleware`` session lookup
+(and the ``/static`` download route) reach an un-opened pool and raise
+``ConnectionManager.initialize() has not been called`` — a 500 on every
+``/chainlit/`` HTML load once a user holds an ``openrag_session`` cookie.
+In token mode the ``/chainlit`` bypass never touches the DB, which is why
+the crash only surfaced under ``AUTH_MODE=oidc``.
+"""
+
+from contextlib import asynccontextmanager
+
 from api.middleware.auth import AuthMiddleware
 from api.routers.user.download import router as download_router
 from chainlit.utils import mount_chainlit
+from core.config import load_config
+from core.utils.logging import get_logger
+from di.container import ServiceContainer
+from di.providers import set_container
 from fastapi import FastAPI
+
+logger = get_logger()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Own this process's ServiceContainer lifecycle.
+
+    Mirrors ``api.main.lifespan``'s container handling (minus the Ray /
+    worker bootstrap, which the API process owns): build the container and
+    open its asyncpg pool best-effort, so a Postgres/Milvus hiccup degrades
+    to 503 rather than blocking boot. ``container.initialize()`` is safe to
+    run here even though the API replicas already ran it — migrations and
+    seeds are idempotent, and Serve only starts this process after the API
+    deployment is healthy.
+    """
+    container: ServiceContainer | None
+    try:
+        container = ServiceContainer(load_config())
+        await container.initialize()
+    except Exception:
+        logger.exception("Chainlit ServiceContainer init failed; serving degraded (503)")
+        container = None
+    app.state.container = container
+    set_container(container)
+    try:
+        yield
+    finally:
+        if container is not None:
+            try:
+                await container.shutdown()
+            except Exception:  # pragma: no cover - defensive shutdown guard
+                logger.exception("Chainlit ServiceContainer shutdown skipped")
+        set_container(None)
 
 
 def _get_auth_service(request):
     container = getattr(request.app.state, "container", None)
     if container is None:
-        from core.config import load_config
-        from di.container import ServiceContainer
-
-        container = ServiceContainer(load_config())
-        request.app.state.container = container
+        # Degraded boot (container init failed). Surface as RuntimeError so
+        # AuthMiddleware maps it to a 503 on guarded routes; the /chainlit
+        # bypass treats the failed lookup as an invalid session and redirects
+        # to /auth/login instead of 500-ing.
+        raise RuntimeError("ServiceContainer is not available")
     return container.auth_service
 
 
-app = FastAPI()
+app = FastAPI(lifespan=lifespan)
 app.state.container = None
 app.add_middleware(
     AuthMiddleware,

--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -1,4 +1,5 @@
 from api.middleware.auth import AuthMiddleware
+from api.routers.user.download import router as download_router
 from chainlit.utils import mount_chainlit
 from fastapi import FastAPI
 
@@ -20,5 +21,13 @@ app.add_middleware(
     AuthMiddleware,
     get_auth_service=_get_auth_service,
 )
+
+# Ray Serve mode runs the API and Chainlit on separate ports. Source previews
+# rewrite their file download links to the browser origin (the Chainlit host),
+# so this standalone Chainlit app must also expose the authorized,
+# partition-checked source-download route (/static/{extract_id}) or those
+# links would 404. In the mounted (/chainlit) deployment the UI shares the
+# API's origin, which already serves this route.
+app.include_router(download_router)
 
 mount_chainlit(app=app, target="./app_front.py", path="/chainlit")

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -266,6 +266,14 @@ DEFAULT_API_PREFIXES: tuple[str, ...] = (
 # IdP flow instead of staring at a 401 JSON blob).
 DEFAULT_UI_PATH_PREFIXES: tuple[str, ...] = ("/static",)
 
+# Subset of the bypass paths that stay public in token mode but, under
+# AUTH_MODE=oidc, are gated behind login instead of served anonymously. The
+# interactive docs leak the full route + schema surface, so in an OIDC
+# deployment an unauthenticated browser is redirected to /auth/login; an
+# authenticated session still renders them. Must be a subset of
+# DEFAULT_BYPASS_PATHS (these are bypassed in token mode).
+DEFAULT_OIDC_GATED_PATHS: tuple[str, ...] = ("/docs", "/redoc", "/openapi.json")
+
 
 class AuthBypassConfig(BaseModel):
     """Path policy consulted by :class:`AuthMiddleware` per request.
@@ -279,3 +287,6 @@ class AuthBypassConfig(BaseModel):
     bypass_paths: tuple[str, ...] = DEFAULT_BYPASS_PATHS
     api_prefixes: tuple[str, ...] = DEFAULT_API_PREFIXES
     ui_path_prefixes: tuple[str, ...] = DEFAULT_UI_PATH_PREFIXES
+    # Public in token mode, login-gated under oidc (see constant above).
+    # Operators that want docs fully public under oidc can override to ().
+    oidc_gated_paths: tuple[str, ...] = DEFAULT_OIDC_GATED_PATHS

--- a/openrag/core/indexing/parsers/eml_parser.py
+++ b/openrag/core/indexing/parsers/eml_parser.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 
 _IMAGE_EXTS = {"png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"}
 
+# Parser-bomb cap: bound the attachments processed per email so a small message
+# with thousands of attachments can't exhaust CPU/memory during ingestion. (The
+# nested .eml-in-.eml recursion is bounded separately at parser-tree build time
+# via _MAX_EML_ATTACHMENT_DEPTH in the parser_dispatcher.)
+_MAX_EML_ATTACHMENTS = 50
+
 
 @parser_registry.register("eml")
 class EmlParser(DocumentParser):
@@ -131,6 +137,11 @@ class EmlParser(DocumentParser):
             disposition = part.get_content_disposition()
 
             if disposition in ("attachment", "inline"):
+                # Enforce the per-email cap BEFORE decoding the payload so a
+                # malicious message with thousands of attachments can't make us
+                # decode them all just to discard the overflow.
+                if len(attachments) >= _MAX_EML_ATTACHMENTS:
+                    continue
                 filename = part.get_filename()
                 payload = part.get_payload(decode=True)
                 if filename and payload:

--- a/openrag/core/indexing/parsers/eml_parser.py
+++ b/openrag/core/indexing/parsers/eml_parser.py
@@ -131,6 +131,7 @@ class EmlParser(DocumentParser):
     def _walk_parts(msg: email.message.Message) -> tuple[str, list[dict]]:
         body = ""
         attachments: list[dict] = []
+        attachment_candidates = 0
 
         for part in msg.walk():
             content_type = part.get_content_type()
@@ -140,8 +141,9 @@ class EmlParser(DocumentParser):
                 # Enforce the per-email cap BEFORE decoding the payload so a
                 # malicious message with thousands of attachments can't make us
                 # decode them all just to discard the overflow.
-                if len(attachments) >= _MAX_EML_ATTACHMENTS:
+                if attachment_candidates >= _MAX_EML_ATTACHMENTS:
                     continue
+                attachment_candidates += 1
                 filename = part.get_filename()
                 payload = part.get_payload(decode=True)
                 if filename and payload:

--- a/openrag/core/indexing/parsers/image_parser.py
+++ b/openrag/core/indexing/parsers/image_parser.py
@@ -95,7 +95,11 @@ class ImageParser(DocumentParser):
         try:
             import cairosvg
 
-            return cairosvg.svg2png(bytestring=raw)
+            # unsafe=False (cairosvg's default) routes resource loading through
+            # safe_fetch and sets forbid_external/forbid_entities, so an untrusted
+            # SVG cannot pull external URLs or expand XML entities (SSRF/XXE). Set
+            # it explicitly to document and lock in the guarantee.
+            return cairosvg.svg2png(bytestring=raw, unsafe=False)
         except Exception as exc:
             logger.warning("Failed to rasterize SVG: %s", exc)
             return None

--- a/openrag/core/indexing/validators.py
+++ b/openrag/core/indexing/validators.py
@@ -8,12 +8,19 @@ handler convert raised ``ValidationError`` instances into HTTP responses.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterable
 from typing import Any
 
 from ..utils.exceptions import ValidationError
 
 DEFAULT_FORBIDDEN_CHARS_IN_FILE_ID: frozenset[str] = frozenset("/")
+
+# Identifiers (file_id, partition name) are interpolated into Milvus filter
+# expression strings (e.g. ``file_id == "..."``). Even though the store escapes
+# values, restrict identifiers to a safe allowlist as defence-in-depth and input
+# hygiene so quotes / brackets / operators can never reach a filter literal.
+_VALID_IDENTIFIER_RE = re.compile(r"[A-Za-z0-9._:\-]+")
 
 
 def parse_metadata(raw: Any | None) -> dict:
@@ -45,13 +52,28 @@ def validate_file_id(
     file_id = file_id.strip()
     if not file_id:
         raise ValidationError("File ID cannot be empty.", status_code=400)
-    forbidden = frozenset(forbidden_chars)
-    if any(c in file_id for c in forbidden):
+    # ``forbidden_chars`` is retained for backward compatibility, but the safe
+    # identifier allowlist below is the primary (and stricter) gate.
+    if _VALID_IDENTIFIER_RE.fullmatch(file_id) is None:
         raise ValidationError(
-            f"File ID contains forbidden characters: {', '.join(sorted(forbidden))}",
+            "File ID may only contain letters, digits, '.', '_', ':' and '-'.",
             status_code=400,
         )
     return file_id
+
+
+def validate_partition_name(partition: str) -> str:
+    """Return ``partition`` if it is a safe identifier, else raise ``ValidationError``.
+
+    Used on partition creation and on every partition-scoped operation so a
+    crafted name can never reach a Milvus filter expression string.
+    """
+    if not isinstance(partition, str) or not partition or _VALID_IDENTIFIER_RE.fullmatch(partition) is None:
+        raise ValidationError(
+            "Partition name may only contain letters, digits, '.', '_', ':' and '-'.",
+            status_code=400,
+        )
+    return partition
 
 
 def validate_file_format(

--- a/openrag/core/indexing/validators.py
+++ b/openrag/core/indexing/validators.py
@@ -52,13 +52,13 @@ def validate_file_id(
     file_id = file_id.strip()
     if not file_id:
         raise ValidationError("File ID cannot be empty.", status_code=400)
-    # ``forbidden_chars`` is retained for backward compatibility, but the safe
-    # identifier allowlist below is the primary (and stricter) gate.
     if _VALID_IDENTIFIER_RE.fullmatch(file_id) is None:
         raise ValidationError(
             "File ID may only contain letters, digits, '.', '_', ':' and '-'.",
             status_code=400,
         )
+    if any(char in file_id for char in forbidden_chars):
+        raise ValidationError("File ID contains forbidden characters.", status_code=400)
     return file_id
 
 

--- a/openrag/core/models/user.py
+++ b/openrag/core/models/user.py
@@ -23,11 +23,13 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    model_config = ConfigDict(extra="allow")
+    # Reject unknown fields so callers cannot smuggle extra column names.
+    model_config = ConfigDict(extra="ignore")
 
 
 class UserUpdate(UserBase):
-    model_config = ConfigDict(extra="allow")
+    # Reject unknown fields; UserService additionally whitelists writable columns.
+    model_config = ConfigDict(extra="ignore")
 
 
 class UserPublic(UserBase):

--- a/openrag/core/models/user.py
+++ b/openrag/core/models/user.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import UTC, datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Request DTOs — shared between the API layer (request bodies) and the
@@ -20,6 +20,16 @@ class UserBase(BaseModel):
     email: str | None = Field(default=None, examples=[None])
     is_admin: bool = False
     file_quota: int | None = Field(default=None)
+
+    @field_validator("external_user_id", mode="before")
+    @classmethod
+    def _empty_external_id_to_none(cls, v):
+        # Coerce "" / whitespace to NULL so it can't collide on the unique index
+        # (Postgres allows many NULLs but only one empty string). This covers the
+        # update path too, which the repo-level create normalization does not.
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
 
 
 class UserCreate(UserBase):

--- a/openrag/core/ports/partition_repo.py
+++ b/openrag/core/ports/partition_repo.py
@@ -9,7 +9,9 @@ class PartitionRepository(ABC):
     """CRUD operations for partitions."""
 
     @abstractmethod
-    async def create_partition(self, name: str, user_id: int | None = None) -> dict: ...
+    async def create_partition(
+        self, name: str, user_id: int | None = None, *, max_owned: int | None = None
+    ) -> dict: ...
 
     @abstractmethod
     async def get_partition(self, name: str) -> dict | None: ...

--- a/openrag/core/prompts/chat_prompt_builder.py
+++ b/openrag/core/prompts/chat_prompt_builder.py
@@ -21,7 +21,7 @@ import copy
 from collections.abc import Callable
 from typing import Protocol
 
-from core.utils.text import sanitize_text
+from core.utils.text import neutralize_prompt_control_tokens, sanitize_text
 
 SOURCE_SEPARATOR = "-" * 10 + "\n\n"
 EMPTY_CONTEXT_MESSAGE = "No document found from the database"
@@ -65,12 +65,16 @@ def format_context(
 
     for i, text in enumerate(texts):
         prefix = f"[Source {len(reduced) + 1}]\n" if number_sources else ""
-        n_tokens = length_function(text)
+        # Neutralize control tokens so a poisoned document cannot forge a
+        # [Source N] block, inject a [Sources: ...] citation tag, or fake the
+        # inter-source separator. The [Source N] prefix is the only trusted marker.
+        content = neutralize_prompt_control_tokens(text)
+        n_tokens = length_function(content)
         if prefix:
             n_tokens += length_function(prefix)
         if total_tokens + n_tokens > max_context_tokens:
             break
-        reduced.append(f"{prefix}{text}")
+        reduced.append(f"{prefix}{content}")
         included.append(i)
         total_tokens += n_tokens
 
@@ -107,9 +111,9 @@ def format_web_context(
 
     for i, result in enumerate(web_results):
         n = start_index + i
-        title = sanitize_text(result.title)
+        title = neutralize_prompt_control_tokens(sanitize_text(result.title))
         body_raw = result.content if result.content else result.snippet
-        body = sanitize_text(body_raw) if body_raw else ""
+        body = neutralize_prompt_control_tokens(sanitize_text(body_raw)) if body_raw else ""
         block = f"[Source {n}]\n{title}\n{body}"
         block_tokens = length_function(block)
         if total_tokens + block_tokens > max_tokens:

--- a/openrag/core/utils/partition_limits.py
+++ b/openrag/core/utils/partition_limits.py
@@ -1,0 +1,24 @@
+"""Shared partition quota helpers."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from core.utils.exceptions import ConfigError
+
+
+def max_partitions_for_user(user: Mapping[str, Any] | None) -> int | None:
+    """Return the owned-partition cap for a caller.
+
+    Admin callers are exempt. Negative values disable the cap; zero means a
+    real limit of zero.
+    """
+    if user and user.get("is_admin", False):
+        return None
+    raw_limit = os.environ.get("MAX_PARTITIONS_PER_USER", "100")
+    try:
+        return int(raw_limit)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("MAX_PARTITIONS_PER_USER must be an integer.") from exc

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -106,6 +106,10 @@ async def stream_with_source_filtering(
             if chunk_template and len(final_clean) > emitted_len:
                 tail_chunk = copy.deepcopy(chunk_template)
                 tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
+                # Content chunk must not carry finish_reason (template may be the
+                # finish chunk); clients treat such a chunk as terminal and drop its
+                # delta. The separate finish chunk below emits it with an empty delta.
+                tail_chunk["choices"][0]["finish_reason"] = None
                 tail_chunk["extra"] = filtered_json
                 yield f"data: {json.dumps(tail_chunk)}\n\n"
 

--- a/openrag/core/utils/text.py
+++ b/openrag/core/utils/text.py
@@ -130,6 +130,45 @@ def sanitize_text(
     return text
 
 
+# Our RAG context uses a few control tokens that an attacker could embed in a
+# document to forge citations or fake source boundaries:
+#   - "[Source N]"        : the per-chunk block marker prepended in format_context
+#   - "[Sources: 1, 3]"   : the answer tag the LLM appends and we parse back
+#                           (the parser also accepts the unbracketed form
+#                            "Sources: 1, 3" at end-of-line)
+#   - "----------"        : the inter-source separator (SOURCE_SEPARATOR)
+# Neutralize them inside untrusted chunk/web text so they can only originate
+# from our own formatter, never from document content.
+# The block regex captures an optional trailing colon: the answer parser's
+# bracket is optional (\[?), so neutralizing only "[" would leave
+# "(Sources: 1, 2]" — still a parser match. Dropping the colon defangs the
+# keyword the parser keys on.
+_INJECT_SOURCE_BLOCK_RE = re.compile(r"\[\s*(sources?)\b(\s*:)?", re.IGNORECASE)
+_INJECT_SOURCES_TAG_RE = re.compile(r"(?im)^([ \t]*)(sources?)(\s*:\s*)(\[?[\d,\s]+\]?)[ \t]*$")
+_INJECT_SEPARATOR_RE = re.compile(r"-{4,}")
+
+
+def neutralize_prompt_control_tokens(text: str) -> str:
+    """Defang RAG control tokens that appear inside untrusted text.
+
+    Keeps the text human-readable while ensuring an embedded ``[Source 5]``,
+    ``[Sources: 1, 2]`` / ``Sources: 1, 2`` or ``----------`` separator can no
+    longer be mistaken for a marker our pipeline produced.
+    """
+    if not text:
+        return text
+    # "[Source...]" / "[Sources...]" -> open paren so it can't start a marker,
+    # and drop any "[Sources:" colon so the answer-tag parser can't match the
+    # remainder.
+    text = _INJECT_SOURCE_BLOCK_RE.sub(lambda m: "(" + m.group(1) + (" " if m.group(2) else ""), text)
+    # Break the unbracketed line-terminal "Sources: 1, 2" form the answer parser
+    # also matches, by replacing the colon.
+    text = _INJECT_SOURCES_TAG_RE.sub(r"\1\2 \4", text)
+    # Cap long hyphen runs so a chunk can't reproduce the source separator.
+    text = _INJECT_SEPARATOR_RE.sub("---", text)
+    return text
+
+
 def clean_markdown_table_spacing(markdown_table: str) -> str:
     """Normalize spacing inside a markdown table.
 

--- a/openrag/prompts/templates/sys_prompt_tmpl.txt
+++ b/openrag/prompts/templates/sys_prompt_tmpl.txt
@@ -11,6 +11,7 @@ Prioritize **clarity, accuracy, and completeness** in your responses.
    * Base your answer **exclusively** on the information contained in the `Context`.
    * **Never infer**, assume, or rely on any external knowledge.
    * If the context is **insufficient**, **invite the user** to clarify their query or provide additional keywords.
+   * **Always answer with at least one sentence of text.** Your response body must **never be empty**, even when no source is relevant — in that case briefly explain (in the user's language) that the documents do not cover the question, then end with `[Sources: none]`.
 
 2. Citations
    * Never place citations, source numbers, or references **inside** your answer text: citation is only at the end

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -54,7 +54,7 @@ class LogoutTokenClaims:
     sid: str | None
     iat: int
     jti: str | None
-    exp: int = 0
+    exp: int
 
 
 class OIDCClient:

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -27,6 +27,10 @@ import httpx
 from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.jose.errors import JoseError
 
+# Clock-skew tolerance (seconds) applied to time-based JWT claims (exp/nbf) so
+# small drift between the IdP and this host doesn't reject valid tokens.
+_CLOCK_SKEW_LEEWAY = 60
+
 
 @dataclass
 class TokenBundle:
@@ -298,8 +302,14 @@ class OIDCClient:
 
         if "exp" not in decoded:
             raise ValueError("ID token missing exp claim")
-        if int(decoded["exp"]) < now:
+        # Allow a small clock-skew leeway so a few seconds of drift between the
+        # IdP and this host doesn't spuriously reject otherwise-valid tokens.
+        if int(decoded["exp"]) < now - _CLOCK_SKEW_LEEWAY:
             raise ValueError("ID token has expired")
+
+        # Honour nbf (not-before) if present, with the same leeway.
+        if "nbf" in decoded and int(decoded["nbf"]) > now + _CLOCK_SKEW_LEEWAY:
+            raise ValueError("ID token not yet valid (nbf in the future)")
 
         if "iat" not in decoded:
             raise ValueError("ID token missing iat claim")
@@ -356,7 +366,7 @@ class OIDCClient:
         # it, or an absent exp would make the token never expire.
         if "exp" not in decoded:
             raise ValueError("logout_token missing exp claim")
-        if int(decoded["exp"]) < now:
+        if int(decoded["exp"]) < now - _CLOCK_SKEW_LEEWAY:
             raise ValueError("logout_token has expired")
         # jti is REQUIRED and is what enables replay detection by the caller.
         if not decoded.get("jti"):

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -50,6 +50,7 @@ class LogoutTokenClaims:
     sid: str | None
     iat: int
     jti: str | None
+    exp: int = 0
 
 
 class OIDCClient:
@@ -351,8 +352,15 @@ class OIDCClient:
 
         if "iat" not in decoded:
             raise ValueError("logout_token missing iat claim")
-        if int(decoded.get("exp", now + 1)) < now:
+        # exp is REQUIRED by the OIDC back-channel logout spec; do not default
+        # it, or an absent exp would make the token never expire.
+        if "exp" not in decoded:
+            raise ValueError("logout_token missing exp claim")
+        if int(decoded["exp"]) < now:
             raise ValueError("logout_token has expired")
+        # jti is REQUIRED and is what enables replay detection by the caller.
+        if not decoded.get("jti"):
+            raise ValueError("logout_token missing jti claim")
 
         events = decoded.get("events") or {}
         if "http://schemas.openid.net/event/backchannel-logout" not in events:
@@ -371,6 +379,7 @@ class OIDCClient:
             sid=decoded.get("sid"),
             iat=int(decoded["iat"]),
             jti=decoded.get("jti"),
+            exp=int(decoded["exp"]),
         )
 
     # ------------------------------------------------------------------

--- a/openrag/services/auth/oidc_client.py
+++ b/openrag/services/auth/oidc_client.py
@@ -30,6 +30,7 @@ from authlib.jose.errors import JoseError
 # Clock-skew tolerance (seconds) applied to time-based JWT claims (exp/nbf) so
 # small drift between the IdP and this host doesn't reject valid tokens.
 _CLOCK_SKEW_LEEWAY = 60
+_LOGOUT_TOKEN_MAX_AGE_WITHOUT_EXP = 300
 
 
 @dataclass
@@ -54,7 +55,7 @@ class LogoutTokenClaims:
     sid: str | None
     iat: int
     jti: str | None
-    exp: int
+    exp: int | None
 
 
 class OIDCClient:
@@ -362,12 +363,18 @@ class OIDCClient:
 
         if "iat" not in decoded:
             raise ValueError("logout_token missing iat claim")
-        # exp is REQUIRED by the OIDC back-channel logout spec; do not default
-        # it, or an absent exp would make the token never expire.
-        if "exp" not in decoded:
-            raise ValueError("logout_token missing exp claim")
-        if int(decoded["exp"]) < now - _CLOCK_SKEW_LEEWAY:
-            raise ValueError("logout_token has expired")
+        issued_at = int(decoded["iat"])
+        if issued_at > now + _CLOCK_SKEW_LEEWAY:
+            raise ValueError("logout_token not yet valid (iat in the future)")
+
+        exp: int | None = None
+        if "exp" in decoded:
+            exp = int(decoded["exp"])
+            if exp < now - _CLOCK_SKEW_LEEWAY:
+                raise ValueError("logout_token has expired")
+        elif issued_at < now - _LOGOUT_TOKEN_MAX_AGE_WITHOUT_EXP - _CLOCK_SKEW_LEEWAY:
+            raise ValueError("logout_token without exp is too old")
+
         # jti is REQUIRED and is what enables replay detection by the caller.
         if not decoded.get("jti"):
             raise ValueError("logout_token missing jti claim")
@@ -387,9 +394,9 @@ class OIDCClient:
             aud=decoded["aud"],
             sub=decoded.get("sub"),
             sid=decoded.get("sid"),
-            iat=int(decoded["iat"]),
+            iat=issued_at,
             jti=decoded.get("jti"),
-            exp=int(decoded["exp"]),
+            exp=exp,
         )
 
     # ------------------------------------------------------------------

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -87,17 +87,14 @@ class VLLMClient(LLM):
         model = self._model
         override_headers: dict[str, str] | None = None
 
+        # Only `model` may be overridden by the client. `base_url` / `api_key`
+        # are deliberately NOT read from the request: honoring a client-supplied
+        # endpoint enables SSRF (the server would issue requests to an arbitrary
+        # host, e.g. cloud metadata) and would leak the server's API key to that
+        # host. The endpoint and credentials always come from server config.
         llm_override = (kwargs.get("metadata") or {}).get("llm_override") or {}
-        if llm_override:
-            if llm_override.get("base_url"):
-                base_url = llm_override["base_url"].rstrip("/")
-            if llm_override.get("model"):
-                model = llm_override["model"]
-            if llm_override.get("api_key"):
-                override_headers = {
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {llm_override['api_key']}",
-                }
+        if llm_override.get("model"):
+            model = llm_override["model"]
 
         return base_url, model, override_headers
 

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -293,6 +293,14 @@ class AuthService:
         )
         return 0
 
+    async def revoke_user_oidc_sessions(self, user_id: int) -> int:
+        """Revoke all active OIDC sessions for a user.
+
+        Used when the user's API token is rotated so their browser sessions
+        can't outlive the rotation.
+        """
+        return await self._oidc_session_repo.revoke_by_user(user_id)
+
     async def logout(self, session_cookie_value: str | None) -> str | None:
         """Revoke the local session and build the IdP end-session redirect.
 

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -36,7 +36,7 @@ from services.auth import (
     hash_session_token,
     issue_session_token,
 )
-from services.auth.oidc_client import _CLOCK_SKEW_LEEWAY
+from services.auth.oidc_client import _CLOCK_SKEW_LEEWAY, _LOGOUT_TOKEN_MAX_AGE_WITHOUT_EXP
 from services.auth.oidc_groups import extract_partition_roles
 
 if TYPE_CHECKING:
@@ -71,17 +71,21 @@ class OIDCFlowError(OpenRAGError):
 
 
 # In-process replay cache for back-channel logout token jti values, mapping
-# jti -> token exp. A logout token may only be consumed once (OIDC spec). This
+# jti -> replay expiry. A logout token may only be consumed once (OIDC spec). This
 # is per-worker; with multiple workers a replay could still reach a different
 # worker, but back-channel logout is idempotent (re-revoking sessions is a
 # no-op), so this is a defence-in-depth guard, not the sole protection.
 _seen_logout_jti: dict[str, int] = {}
 
 
-def _logout_jti_is_replay(jti: str, exp: int) -> bool:
+def _logout_jti_is_replay(jti: str, exp: int | None, iat: int | None = None) -> bool:
     """Record a logout-token jti and report whether it was already seen."""
     now = int(time.time())
-    replay_expires_at = exp + _CLOCK_SKEW_LEEWAY
+    if exp is None:
+        issued_at = iat if iat is not None else now
+        replay_expires_at = max(issued_at + _LOGOUT_TOKEN_MAX_AGE_WITHOUT_EXP, now) + _CLOCK_SKEW_LEEWAY
+    else:
+        replay_expires_at = exp + _CLOCK_SKEW_LEEWAY
     # Prune expired entries to bound memory.
     for old_jti, old_exp in list(_seen_logout_jti.items()):
         if old_exp < now:
@@ -278,7 +282,7 @@ class AuthService:
             raise OIDCFlowError("invalid_request") from e
 
         # Reject replays: a given logout token (jti) must only be processed once.
-        if claims.jti and _logout_jti_is_replay(claims.jti, claims.exp):
+        if claims.jti and _logout_jti_is_replay(claims.jti, claims.exp, claims.iat):
             logger.warning(f"Replayed back-channel logout token ignored — jti={claims.jti!r}")
             raise OIDCFlowError("logout_token replayed", error_description="logout_token replayed")
 

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -18,6 +18,7 @@ come from ``services.auth`` — the infrastructure adapters for OIDC.
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -66,6 +67,27 @@ class OIDCFlowError(OpenRAGError):
     ) -> None:
         super().__init__(message, code="OIDC_FLOW_ERROR", status_code=status_code)
         self.error_description = error_description
+
+
+# In-process replay cache for back-channel logout token jti values, mapping
+# jti -> token exp. A logout token may only be consumed once (OIDC spec). This
+# is per-worker; with multiple workers a replay could still reach a different
+# worker, but back-channel logout is idempotent (re-revoking sessions is a
+# no-op), so this is a defence-in-depth guard, not the sole protection.
+_seen_logout_jti: dict[str, int] = {}
+
+
+def _logout_jti_is_replay(jti: str, exp: int) -> bool:
+    """Record a logout-token jti and report whether it was already seen."""
+    now = int(time.time())
+    # Prune expired entries to bound memory.
+    for old_jti, old_exp in list(_seen_logout_jti.items()):
+        if old_exp < now:
+            del _seen_logout_jti[old_jti]
+    if jti in _seen_logout_jti:
+        return True
+    _seen_logout_jti[jti] = exp
+    return False
 
 
 @dataclass
@@ -252,6 +274,11 @@ class AuthService:
         except Exception as e:
             logger.warning(f"Back-channel logout token verification failed: {e}")
             raise OIDCFlowError("invalid_request") from e
+
+        # Reject replays: a given logout token (jti) must only be processed once.
+        if claims.jti and _logout_jti_is_replay(claims.jti, claims.exp):
+            logger.warning(f"Replayed back-channel logout token ignored — jti={claims.jti!r}")
+            raise OIDCFlowError("logout_token replayed", error_description="logout_token replayed")
 
         if claims.sid:
             count = await self._oidc_session_repo.revoke_by_sid(claims.sid)

--- a/openrag/services/orchestrators/auth_service.py
+++ b/openrag/services/orchestrators/auth_service.py
@@ -36,6 +36,7 @@ from services.auth import (
     hash_session_token,
     issue_session_token,
 )
+from services.auth.oidc_client import _CLOCK_SKEW_LEEWAY
 from services.auth.oidc_groups import extract_partition_roles
 
 if TYPE_CHECKING:
@@ -80,13 +81,14 @@ _seen_logout_jti: dict[str, int] = {}
 def _logout_jti_is_replay(jti: str, exp: int) -> bool:
     """Record a logout-token jti and report whether it was already seen."""
     now = int(time.time())
+    replay_expires_at = exp + _CLOCK_SKEW_LEEWAY
     # Prune expired entries to bound memory.
     for old_jti, old_exp in list(_seen_logout_jti.items()):
         if old_exp < now:
             del _seen_logout_jti[old_jti]
     if jti in _seen_logout_jti:
         return True
-    _seen_logout_jti[jti] = exp
+    _seen_logout_jti[jti] = replay_expires_at
     return False
 
 

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from core.utils.exceptions import PartitionNotFoundError, ValidationError
+from core.utils.exceptions import AuthError, PartitionNotFoundError, ValidationError
 from core.utils.filename import extract_temporal_fields
 from core.utils.logging import get_logger
 from core.utils.partition_limits import max_partitions_for_user
@@ -123,7 +123,10 @@ class IndexingService:
         members = await self._partition_service.list_members(partition)
         membership = next((m for m in members if m.get("user_id") == user.get("id")), None)
         if membership is None or _ROLE_HIERARCHY.get(membership.get("role", ""), 0) < _ROLE_HIERARCHY["editor"]:
-            raise PermissionError(f"Editor role required for partition: {partition}")
+            # AuthError (status 403) so the global handler returns a clean
+            # Forbidden; a builtin PermissionError would fall through to the
+            # catch-all handler and surface as a 500.
+            raise AuthError(f"Editor role required for partition: {partition}")
 
     def _resolve_indexation_dispatch_config(self, partition: str) -> tuple[dict | None, str | None]:
         partitions = self._partition_configs()

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from core.utils.exceptions import PartitionNotFoundError
+from core.utils.exceptions import PartitionNotFoundError, ValidationError
 from core.utils.filename import extract_temporal_fields
 from core.utils.logging import get_logger
 from core.utils.partition_limits import max_partitions_for_user
@@ -32,6 +32,7 @@ logger = get_logger()
 
 # Client-supplied datetime fields lifted into queryable metadata.
 TEMPORAL_FIELDS = ["created_at"]
+_ROLE_HIERARCHY: dict[str, int] = {"viewer": 1, "editor": 2, "owner": 3}
 
 
 def _human_readable_size(size_bytes: int) -> str:
@@ -116,6 +117,14 @@ class IndexingService:
             return {}
         return getattr(self._config, "partitions", {}) or {}
 
+    async def _ensure_editor_access_after_create_race(self, partition: str, user: dict | None) -> None:
+        if user is None:
+            return
+        members = await self._partition_service.list_members(partition)
+        membership = next((m for m in members if m.get("user_id") == user.get("id")), None)
+        if membership is None or _ROLE_HIERARCHY.get(membership.get("role", ""), 0) < _ROLE_HIERARCHY["editor"]:
+            raise PermissionError(f"Editor role required for partition: {partition}")
+
     def _resolve_indexation_dispatch_config(self, partition: str) -> tuple[dict | None, str | None]:
         partitions = self._partition_configs()
         if not partitions:
@@ -145,12 +154,19 @@ class IndexingService:
             return
         user_id = (user or {}).get("id") or 1
         cap_user = user if user is not None else {"id": user_id, "is_admin": True}
-        await self._partition_service.create_partition(
-            partition,
-            user_id=user_id,
-            max_owned=max_partitions_for_user(cap_user),
-        )
-        logger.bind(partition=partition, user_id=user_id).info("Auto-created partition on index.")
+        try:
+            await self._partition_service.create_partition(
+                partition,
+                user_id=user_id,
+                max_owned=max_partitions_for_user(cap_user),
+            )
+        except ValidationError as exc:
+            if exc.code != "PARTITION_EXISTS":
+                raise
+            await self._partition_service.load_partitions()
+            await self._ensure_editor_access_after_create_race(partition, user)
+        else:
+            logger.bind(partition=partition, user_id=user_id).info("Auto-created partition on index.")
 
     async def add_file(
         self,

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from core.utils.exceptions import PartitionNotFoundError
 from core.utils.filename import extract_temporal_fields
 from core.utils.logging import get_logger
+from core.utils.partition_limits import max_partitions_for_user
 
 if TYPE_CHECKING:
     from core.config.root import Settings
@@ -143,7 +144,12 @@ class IndexingService:
             await self._partition_service.load_partitions()
             return
         user_id = (user or {}).get("id") or 1
-        await self._partition_service.create_partition(partition, user_id=user_id)
+        cap_user = user if user is not None else {"id": user_id, "is_admin": True}
+        await self._partition_service.create_partition(
+            partition,
+            user_id=user_id,
+            max_owned=max_partitions_for_user(cap_user),
+        )
         logger.bind(partition=partition, user_id=user_id).info("Auto-created partition on index.")
 
     async def add_file(

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -35,6 +35,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from core.utils.log_tail import collect_task_logs
 from core.utils.logging import get_logger
+from core.utils.partition_limits import max_partitions_for_user
 from core.utils.url_safety import is_blocked_address, is_safe_url
 
 if TYPE_CHECKING:
@@ -128,6 +129,8 @@ class MCPService:
             raise PermissionError("Authentication context is missing")
         if allowed_partitions == ["all"]:
             return ["all"] if requested_partitions == ["all"] else requested_partitions
+        if requested_partitions == ["all"] and not allowed_partitions:
+            raise PermissionError("No accessible partitions")
         if requested_partitions == ["all"]:
             return allowed_partitions
         denied = [p for p in requested_partitions if p not in allowed_partitions]
@@ -180,7 +183,8 @@ class MCPService:
             return allowed_partitions
         if await self._partitions.partition_exists(partition):
             return allowed_partitions  # exists but no membership → access check raises
-        await self._partitions.create_partition(partition, user_id)
+        cap_user = {"id": user_id, "is_admin": False} if user_id is not None else {"id": 1, "is_admin": True}
+        await self._partitions.create_partition(partition, user_id, max_owned=max_partitions_for_user(cap_user))
         return [*allowed_partitions, partition]
 
     # ------------------------------------------------------------------
@@ -405,7 +409,10 @@ class MCPService:
         state = await self._indexing.get_task_state(task_id)
         result: dict[str, Any] = {"task_id": task_id, "task_state": state, "details": details}
         if state == "FAILED":
-            result["error"] = await self._indexing.get_task_error(task_id)
+            if is_admin:
+                result["error"] = await self._indexing.get_task_error(task_id)
+            else:
+                result["error"] = "Task failed. Contact an administrator for details."
         return result
 
     async def list_my_tasks(
@@ -418,7 +425,10 @@ class MCPService:
         tasks = await self._jobs.list_tasks(is_admin=is_admin, user_id=user_id, task_status=task_status)
         for task in tasks:
             if task.get("state") == "FAILED":
-                task["error"] = await self._indexing.get_task_error(task["task_id"])
+                if is_admin:
+                    task["error"] = await self._indexing.get_task_error(task["task_id"])
+                else:
+                    task["error"] = "Task failed. Contact an administrator for details."
         return {"count": len(tasks), "tasks": tasks}
 
     async def get_task_logs(

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
+from core.utils.exceptions import ValidationError
 from core.utils.log_tail import collect_task_logs
 from core.utils.logging import get_logger
 from core.utils.partition_limits import max_partitions_for_user
@@ -186,7 +187,11 @@ class MCPService:
         if await self._partitions.partition_exists(partition):
             return allowed_partitions  # exists but no membership → access check raises
         cap_user = {"id": user_id, "is_admin": is_admin} if user_id is not None else {"id": 1, "is_admin": True}
-        await self._partitions.create_partition(partition, user_id, max_owned=max_partitions_for_user(cap_user))
+        try:
+            await self._partitions.create_partition(partition, user_id, max_owned=max_partitions_for_user(cap_user))
+        except ValidationError as exc:
+            if exc.code != "PARTITION_EXISTS":
+                raise
         return [*allowed_partitions, partition]
 
     # ------------------------------------------------------------------

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -169,6 +169,8 @@ class MCPService:
         partition: str,
         allowed_partitions: list[str] | None,
         user_id: int | None,
+        *,
+        is_admin: bool = False,
     ) -> list[str] | None:
         """Auto-create *partition* (owned by the caller) when it is missing.
 
@@ -183,7 +185,7 @@ class MCPService:
             return allowed_partitions
         if await self._partitions.partition_exists(partition):
             return allowed_partitions  # exists but no membership → access check raises
-        cap_user = {"id": user_id, "is_admin": False} if user_id is not None else {"id": 1, "is_admin": True}
+        cap_user = {"id": user_id, "is_admin": is_admin} if user_id is not None else {"id": 1, "is_admin": True}
         await self._partitions.create_partition(partition, user_id, max_owned=max_partitions_for_user(cap_user))
         return [*allowed_partitions, partition]
 
@@ -573,6 +575,7 @@ class MCPService:
         file_id: str,
         allowed_partitions: list[str] | None,
         user_id: int | None,
+        is_admin: bool = False,
         extra_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         # Validate cheap/safe inputs BEFORE any side effect (partition
@@ -585,7 +588,12 @@ class MCPService:
         if not is_safe_url(url):
             raise ValueError(f"URL is not allowed for server-side fetch: {url!r}")
 
-        allowed_partitions = await self._ensure_partition_exists(partition, allowed_partitions, user_id)
+        allowed_partitions = await self._ensure_partition_exists(
+            partition,
+            allowed_partitions,
+            user_id,
+            is_admin=is_admin,
+        )
         await self._enforce_editor_access(partition, allowed_partitions, user_id)
 
         if await self._partitions.file_exists(file_id, partition):
@@ -614,7 +622,7 @@ class MCPService:
             metadata=metadata,
             sanitized_filename=filename,
             original_filename=filename,
-            user={"id": user_id} if user_id is not None else None,
+            user={"id": user_id, "is_admin": is_admin} if user_id is not None else None,
         )
         return {
             "partition": partition,

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -32,6 +32,7 @@ from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.indexing.validators import validate_partition_name
 from core.models.preset import PartitionConfig
+from core.models.user import PartitionRole
 from core.utils.exceptions import (
     ConfigError,
     NotFoundError,
@@ -142,6 +143,7 @@ class PartitionService:
         partition: str,
         user_id: int,
         *,
+        max_owned: int | None = None,
         description: str = "",
         embedder: str = "default",
         indexation_preset: str = "default",
@@ -170,6 +172,23 @@ class PartitionService:
                 code="RESERVED_PARTITION_NAME",
             )
         validate_partition_name(partition)
+        # Cap how many partitions a non-admin may own so any authenticated user
+        # can't exhaust storage/metadata by creating partitions without bound.
+        # ``max_owned`` None (admins) or a negative value disables the cap. This
+        # is a check-then-create (small race window under heavy concurrency);
+        # acceptable for a DoS cap.
+        if max_owned is not None and max_owned >= 0:
+            owned = sum(
+                1
+                for up in await self._membership_repo.list_user_partitions(user_id)
+                if up.role == PartitionRole.OWNER
+            )
+            if owned >= max_owned:
+                raise ValidationError(
+                    f"Partition limit reached ({max_owned}). Contact an administrator.",
+                    status_code=403,
+                    code="PARTITION_LIMIT_EXCEEDED",
+                )
         if await self._partition_repo.partition_exists(name=partition):
             raise ValidationError(
                 f"Partition '{partition}' already exists.",

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
+from core.indexing.validators import validate_partition_name
 from core.models.preset import PartitionConfig
 from core.utils.exceptions import (
     ConfigError,
@@ -159,12 +160,16 @@ class PartitionService:
         fast and atomically), the non-default config columns are persisted,
         and the in-memory partition cache is re-resolved.
         """
+        # Reserved-name check first so a name that normalises to a reserved
+        # sentinel (e.g. "  all  ") returns the specific RESERVED_PARTITION_NAME
+        # error rather than the generic identifier-allowlist rejection.
         if partition.strip().lower() in _RESERVED_PARTITION_NAMES:
             raise ValidationError(
                 f"Partition name '{partition}' is reserved.",
                 status_code=400,
                 code="RESERVED_PARTITION_NAME",
             )
+        validate_partition_name(partition)
         if await self._partition_repo.partition_exists(name=partition):
             raise ValidationError(
                 f"Partition '{partition}' already exists.",

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -32,7 +32,6 @@ from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.indexing.validators import validate_partition_name
 from core.models.preset import PartitionConfig
-from core.models.user import PartitionRole
 from core.utils.exceptions import (
     ConfigError,
     NotFoundError,
@@ -172,21 +171,6 @@ class PartitionService:
                 code="RESERVED_PARTITION_NAME",
             )
         validate_partition_name(partition)
-        # Cap how many partitions a non-admin may own so any authenticated user
-        # can't exhaust storage/metadata by creating partitions without bound.
-        # ``max_owned`` None (admins) or a negative value disables the cap. This
-        # is a check-then-create (small race window under heavy concurrency);
-        # acceptable for a DoS cap.
-        if max_owned is not None and max_owned >= 0:
-            owned = sum(
-                1 for up in await self._membership_repo.list_user_partitions(user_id) if up.role == PartitionRole.OWNER
-            )
-            if owned >= max_owned:
-                raise ValidationError(
-                    f"Partition limit reached ({max_owned}). Contact an administrator.",
-                    status_code=403,
-                    code="PARTITION_LIMIT_EXCEEDED",
-                )
         if await self._partition_repo.partition_exists(name=partition):
             raise ValidationError(
                 f"Partition '{partition}' already exists.",
@@ -207,7 +191,7 @@ class PartitionService:
         if self._config is not None:
             self._validate_preset_refs({"partition": partition, **config_fields})
 
-        await self._partition_repo.create_partition(name=partition, user_id=user_id)
+        await self._partition_repo.create_partition(name=partition, user_id=user_id, max_owned=max_owned)
 
         # Persist the config columns (the insert only sets server defaults)
         # and re-resolve the in-memory cache. Only done in the Phase 14 flow

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -179,9 +179,7 @@ class PartitionService:
         # acceptable for a DoS cap.
         if max_owned is not None and max_owned >= 0:
             owned = sum(
-                1
-                for up in await self._membership_repo.list_user_partitions(user_id)
-                if up.role == PartitionRole.OWNER
+                1 for up in await self._membership_repo.list_user_partitions(user_id) if up.role == PartitionRole.OWNER
             )
             if owned >= max_owned:
                 raise ValidationError(

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -47,9 +47,7 @@ _MAX_DISPLAY_NAME = 255
 # never be overwritten through the user-update payload (mass assignment). The
 # repo's update_user accepts token/file_count for internal callers (token
 # rotation, quota tracking), so the boundary whitelist lives here.
-_UPDATABLE_USER_FIELDS = frozenset(
-    {"display_name", "external_user_id", "email", "is_admin", "file_quota"}
-)
+_UPDATABLE_USER_FIELDS = frozenset({"display_name", "external_user_id", "email", "is_admin", "file_quota"})
 
 
 class UserService:

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -42,6 +42,15 @@ logger = get_logger()
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _MAX_DISPLAY_NAME = 255
 
+# Fields a caller may set via update_user. Excludes identity/privilege and
+# security-sensitive columns (token, file_count, id, created_at) so they can
+# never be overwritten through the user-update payload (mass assignment). The
+# repo's update_user accepts token/file_count for internal callers (token
+# rotation, quota tracking), so the boundary whitelist lives here.
+_UPDATABLE_USER_FIELDS = frozenset(
+    {"display_name", "external_user_id", "email", "is_admin", "file_quota"}
+)
+
 
 class UserService:
     """User account CRUD — validation + repo delegation."""
@@ -193,6 +202,9 @@ class UserService:
     async def update_user(self, user_id: int, body: UserUpdate) -> dict:
         await self._ensure_exists(user_id)
         updates = body.model_dump(exclude_unset=True)
+        # Whitelist writable profile fields: never allow token, file_count or id
+        # to be set through the user-update payload (mass assignment).
+        updates = {k: v for k, v in updates.items() if k in _UPDATABLE_USER_FIELDS}
         self._validate_profile(updates.get("display_name"), updates.get("email"))
 
         user = await self._user_repo.update_user(user_id, **updates)

--- a/openrag/services/orchestrators/user_service.py
+++ b/openrag/services/orchestrators/user_service.py
@@ -194,6 +194,9 @@ class UserService:
         user = await self._user_repo.regenerate_user_token(user_id)
         if user is None:
             raise UserNotFoundError(f"User '{user_id}' not found")
+        # Rotating the API token also invalidates the user's active OIDC browser
+        # sessions so they can't outlive the rotation.
+        await self._auth_service.revoke_user_oidc_sessions(user_id)
         logger.info("Regenerated user token", user_id=user_id)
         return user
 

--- a/openrag/services/persistence/partition_repo.py
+++ b/openrag/services/persistence/partition_repo.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from core.ports.partition_repo import PartitionRepository
+from core.utils.exceptions import ValidationError
 
 if TYPE_CHECKING:
     import asyncpg
@@ -36,7 +37,7 @@ class PgPartitionRepository(PartitionRepository):
 
     # ── PartitionRepository port methods ─────────────────────────────
 
-    async def create_partition(self, name: str, user_id: int | None = None) -> dict:
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
         """Insert a partition row; idempotent on the unique constraint.
 
         When ``user_id`` is provided the caller is granted ``owner`` on
@@ -46,11 +47,27 @@ class PgPartitionRepository(PartitionRepository):
         """
         async with self.pool.acquire() as conn:
             async with conn.transaction():
+                if user_id is not None and max_owned is not None and max_owned >= 0:
+                    await conn.execute("SELECT pg_advisory_xact_lock($1::bigint)", user_id)
                 row = await conn.fetchrow(
                     "SELECT * FROM partitions WHERE partition = $1",
                     name,
                 )
                 if row is None:
+                    if user_id is not None and max_owned is not None and max_owned >= 0:
+                        owned = await conn.fetchval(
+                            """
+                            SELECT COUNT(*)::int FROM partition_memberships
+                            WHERE user_id = $1 AND role = 'owner'
+                            """,
+                            user_id,
+                        )
+                        if owned >= max_owned:
+                            raise ValidationError(
+                                f"Partition limit reached ({max_owned}). Contact an administrator.",
+                                status_code=403,
+                                code="PARTITION_LIMIT_EXCEEDED",
+                            )
                     row = await conn.fetchrow(
                         """
                         INSERT INTO partitions (partition, created_at)

--- a/openrag/services/persistence/partition_repo.py
+++ b/openrag/services/persistence/partition_repo.py
@@ -23,6 +23,8 @@ from core.utils.exceptions import ValidationError
 
 if TYPE_CHECKING:
     import asyncpg
+else:  # pragma: no cover - import shape only matters at runtime
+    import asyncpg
 
 
 class PgPartitionRepository(PartitionRepository):
@@ -38,12 +40,11 @@ class PgPartitionRepository(PartitionRepository):
     # ── PartitionRepository port methods ─────────────────────────────
 
     async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
-        """Insert a partition row; idempotent on the unique constraint.
+        """Insert a partition row and grant the creator owner membership.
 
-        When ``user_id`` is provided the caller is granted ``owner`` on
-        creation. Existing partitions are returned unchanged with no
-        membership churn — matches the legacy "already exists, log and
-        skip" behaviour.
+        Existing partitions are not treated as successful creates. The service
+        layer needs that distinction so it does not update preset/config fields
+        for a partition it did not create.
         """
         async with self.pool.acquire() as conn:
             async with conn.transaction():
@@ -53,21 +54,27 @@ class PgPartitionRepository(PartitionRepository):
                     "SELECT * FROM partitions WHERE partition = $1",
                     name,
                 )
-                if row is None:
-                    if user_id is not None and max_owned is not None and max_owned >= 0:
-                        owned = await conn.fetchval(
-                            """
-                            SELECT COUNT(*)::int FROM partition_memberships
-                            WHERE user_id = $1 AND role = 'owner'
-                            """,
-                            user_id,
+                if row is not None:
+                    raise ValidationError(
+                        f"Partition '{name}' already exists.",
+                        status_code=409,
+                        code="PARTITION_EXISTS",
+                    )
+                if user_id is not None and max_owned is not None and max_owned >= 0:
+                    owned = await conn.fetchval(
+                        """
+                        SELECT COUNT(*)::int FROM partition_memberships
+                        WHERE user_id = $1 AND role = 'owner'
+                        """,
+                        user_id,
+                    )
+                    if owned >= max_owned:
+                        raise ValidationError(
+                            f"Partition limit reached ({max_owned}). Contact an administrator.",
+                            status_code=403,
+                            code="PARTITION_LIMIT_EXCEEDED",
                         )
-                        if owned >= max_owned:
-                            raise ValidationError(
-                                f"Partition limit reached ({max_owned}). Contact an administrator.",
-                                status_code=403,
-                                code="PARTITION_LIMIT_EXCEEDED",
-                            )
+                try:
                     row = await conn.fetchrow(
                         """
                         INSERT INTO partitions (partition, created_at)
@@ -76,17 +83,23 @@ class PgPartitionRepository(PartitionRepository):
                         """,
                         name,
                     )
-                    if user_id is not None:
-                        await conn.execute(
-                            """
-                            INSERT INTO partition_memberships
-                                (partition_name, user_id, role, added_at)
-                            VALUES ($1, $2, 'owner', NOW())
-                            ON CONFLICT (partition_name, user_id) DO NOTHING
-                            """,
-                            name,
-                            user_id,
-                        )
+                except asyncpg.UniqueViolationError as exc:
+                    raise ValidationError(
+                        f"Partition '{name}' already exists.",
+                        status_code=409,
+                        code="PARTITION_EXISTS",
+                    ) from exc
+                if user_id is not None:
+                    await conn.execute(
+                        """
+                        INSERT INTO partition_memberships
+                            (partition_name, user_id, role, added_at)
+                        VALUES ($1, $2, 'owner', NOW())
+                        ON CONFLICT (partition_name, user_id) DO NOTHING
+                        """,
+                        name,
+                        user_id,
+                    )
         return self._row_to_dict(row)
 
     async def get_partition(self, name: str) -> dict | None:

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -498,7 +498,15 @@ class MilvusVectorStore(VectorStore):
         if raw_expr:
             parts.append(str(raw_expr))
 
-        return " and ".join(parts)
+        if len(parts) <= 1:
+            return parts[0] if parts else ""
+        # Multiple predicates: wrap each in parentheses when joining so a
+        # user-supplied filter (the ``expr`` escape hatch) cannot escape the
+        # partition scope via operator precedence — Milvus binds ``and`` tighter
+        # than ``or``, so an unparenthesised
+        # ``partition == 'p' and text != "" or partition == 'q'`` would leak
+        # another tenant's chunks.
+        return " and ".join(f"({part})" for part in parts)
 
     # ------------------------------------------------------------------
     # Sync paginated query helper (Milvus 2.6 query_iterator is sync-only)

--- a/openrag/services/storage/vector_store_searcher.py
+++ b/openrag/services/storage/vector_store_searcher.py
@@ -163,19 +163,28 @@ class VectorStoreSearcher(RetrievalSearcher):
         return [_dict_to_chunk(r) for r in rows[:limit]]
 
     async def _fetch_surrounding(self, chunks: list[Chunk]) -> list[Chunk]:
-        section_ids = [
-            sid
-            for c in chunks
-            for sid in (c.metadata.get("prev_section_id"), c.metadata.get("next_section_id"))
-            if sid is not None
-        ]
-        if not section_ids:
+        # section_id is only unique within a partition, so the lookup MUST be
+        # scoped to each source chunk's partition; otherwise a neighbouring
+        # section_id could resolve to another tenant's chunk (cross-tenant leak,
+        # N6). Group section_ids by partition and query each partition
+        # separately; drop refs whose source chunk has no partition.
+        by_partition: dict[str, list] = {}
+        for c in chunks:
+            if not c.partition:
+                continue
+            for sid in (c.metadata.get("prev_section_id"), c.metadata.get("next_section_id")):
+                if sid is not None:
+                    by_partition.setdefault(c.partition, []).append(sid)
+        if not by_partition:
             return []
-        rows = await self._store.query_chunks_by_filter(
-            self._collection,
-            {"section_id": section_ids},
-        )
-        return [_dict_to_chunk(r) for r in rows]
+        results: list[Chunk] = []
+        for partition, section_ids in by_partition.items():
+            rows = await self._store.query_chunks_by_filter(
+                self._collection,
+                {"section_id": section_ids, "partition": partition},
+            )
+            results.extend(_dict_to_chunk(r) for r in rows)
+        return results
 
 
 __all__ = ["VectorStoreSearcher"]

--- a/openrag/services/websearch/content_fetcher.py
+++ b/openrag/services/websearch/content_fetcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import socket
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -93,7 +94,7 @@ class ContentFetcher:
         max_results: int = 3,
         timeout: float = 1.0,
         max_tokens_per_page: int = 500,
-        verify_ssl: bool = False,
+        verify_ssl: bool = True,
     ):
         self.max_results = max_results
         self.timeout = timeout
@@ -111,6 +112,34 @@ class ContentFetcher:
         if last_space > max_chars * 0.8:
             truncated = truncated[:last_space]
         return truncated.rstrip() + " [...]"
+
+    @staticmethod
+    async def _guard_request(request: httpx.Request) -> None:
+        """httpx request hook: block requests whose host *resolves* to a
+        non-global IP.
+
+        ``_is_safe_url`` only inspects the literal host, so a public-looking
+        hostname that resolves to an internal address (DNS-rebinding-style
+        SSRF) would otherwise slip through. This hook resolves the host and
+        rejects any non-global resolved IP. It runs for the initial request
+        and every manually-followed redirect hop.
+        """
+        host = request.url.host
+        if not host:
+            raise httpx.RequestError("Blocked request with no host", request=request)
+        try:
+            infos = await asyncio.to_thread(socket.getaddrinfo, host, None)
+        except socket.gaierror as e:
+            raise httpx.RequestError(f"DNS resolution failed for {host}", request=request) from e
+        for info in infos:
+            ip = info[4][0]
+            try:
+                addr = ipaddress.ip_address(ip)
+            except ValueError as e:
+                raise httpx.RequestError(f"Unparseable address for {host}", request=request) from e
+            if _is_blocked_address(addr):
+                logger.warning("Blocked SSRF attempt to non-global address", host=host, ip=ip)
+                raise httpx.RequestError(f"Blocked non-global address {ip} for {host}", request=request)
 
     async def _fetch_single(self, client: httpx.AsyncClient, url: str) -> str | None:
         """Fetch a single URL and extract text. Returns None on any failure.
@@ -199,7 +228,10 @@ class ContentFetcher:
                 pool=self.timeout,
             )
             async with httpx.AsyncClient(
-                timeout=timeout, verify=self.verify_ssl, headers={"User-Agent": _USER_AGENT}
+                timeout=timeout,
+                verify=self.verify_ssl,
+                headers={"User-Agent": _USER_AGENT},
+                event_hooks={"request": [self._guard_request]},
             ) as client:
                 tasks = [self._fetch_single(client, r.url) for r in to_fetch]
                 contents = await asyncio.gather(*tasks)

--- a/openrag/services/workers/bootstrap.py
+++ b/openrag/services/workers/bootstrap.py
@@ -20,7 +20,6 @@ restart a named actor on-demand from the admin endpoint.
 from functools import wraps
 from typing import TYPE_CHECKING
 
-import ray
 from core.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -50,12 +49,13 @@ def _track_actor(func):
 
 @_track_actor
 def get_or_create_actor(name, cls, namespace="openrag", remote_args=(), **options):
-    try:
-        return ray.get_actor(name, namespace=namespace)
-    except ValueError:
-        return cls.options(name=name, namespace=namespace, **options).remote(*remote_args)
-    except Exception:
-        raise
+    # ``get_if_exists`` makes get-or-create atomic inside Ray: concurrent callers
+    # (e.g. the multiple Ray Serve replicas that all run worker bootstrap in their
+    # lifespan at once) either all attach to the same actor or exactly one creates
+    # it and the rest attach. The previous get_actor()-then-create pattern had a
+    # TOCTOU race — two replicas both saw "not found" and then collided on
+    # creation, crashing a replica's startup with "Failed to look up actor".
+    return cls.options(name=name, namespace=namespace, get_if_exists=True, **options).remote(*remote_args)
 
 
 def get_task_state_manager():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.12"
+version = "1.1.13"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.11"
+version = "1.1.12"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
     "authlib>=1.3",
     "itsdangerous>=2.2",
     "cryptography>=42",
+    # Moving-window rate limiter backing api.middleware.rate_limit.
+    "limits>=3.6",
     # Starlette < 0.47.2 is vulnerable to the multipart upload DoS CVE-2025-54121.
     # Constrain starlette and the coordinated fastapi line (fastapi 0.115.x pins
     # starlette<0.47). Both are otherwise pulled transitively (e.g. via chainlit).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ dependencies = [
     "authlib>=1.3",
     "itsdangerous>=2.2",
     "cryptography>=42",
+    # Starlette < 0.47.2 is vulnerable to the multipart upload DoS CVE-2025-54121.
+    # Constrain starlette and the coordinated fastapi line (fastapi 0.115.x pins
+    # starlette<0.47). Both are otherwise pulled transitively (e.g. via chainlit).
+    "starlette>=0.47.2,<0.48",
+    "fastapi>=0.116.1,<0.117",
     "tenacity>=8.2.0",
     "aiobreaker>=1.2.0",
     "mcp>=1.11.0",

--- a/tests/integration/api/api_run/docker-compose.yaml
+++ b/tests/integration/api/api_run/docker-compose.yaml
@@ -92,6 +92,8 @@ services:
       - VLM_API_KEY=EMPTY
       - VLM_MODEL=mock-vlm-model
       - RERANKER_ENABLED=false
+      # The API test suite issues request bursts; disable the rate limiter.
+      - RATE_LIMIT_ENABLED=false
       - WITH_CHAINLIT_UI=false
       - WITH_OPENAI_API=true
       - IMAGE_CAPTIONING=false

--- a/tests/unit/api/dependencies/test_auth.py
+++ b/tests/unit/api/dependencies/test_auth.py
@@ -107,6 +107,28 @@ async def test_ensure_partition_role_allows_unknown_partition_without_membership
     assert partition_service.checked == ["new-partition"]
 
 
+@pytest.mark.parametrize("role", ["viewer", "owner"])
+@pytest.mark.asyncio
+async def test_ensure_partition_role_404s_on_missing_partition_for_non_editor(role):
+    # A non-member must not pass a viewer/owner check by naming an unknown
+    # partition. Only `editor` (create-on-write) may proceed on a missing
+    # partition.
+    partition_service = FakePartitionService(existing=set())
+
+    with pytest.raises(HTTPException) as exc:
+        await ensure_partition_role(
+            partition="ghost",
+            user={"id": 1},
+            user_partitions=[],
+            required_role=role,
+            auth_service=FakeAuthService,
+            partition_service=partition_service,
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Partition 'ghost' not found"
+
+
 @pytest.mark.asyncio
 async def test_ensure_partition_role_forbids_existing_partition_without_membership():
     partition_service = FakePartitionService(existing={"existing"})

--- a/tests/unit/api/dependencies/test_auth.py
+++ b/tests/unit/api/dependencies/test_auth.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 
 import pytest
-from api.dependencies.auth import check_user_file_quota, ensure_partition_role, require_task_owner
+from api.dependencies.auth import (
+    check_user_file_quota,
+    ensure_partition_role,
+    require_partitions_viewer,
+    require_task_owner,
+)
 from core.utils.exceptions import AuthError
 from fastapi import HTTPException
 
@@ -145,6 +150,21 @@ async def test_ensure_partition_role_forbids_existing_partition_without_membersh
 
     assert exc.value.status_code == 403
     assert exc.value.detail == "Access to partition 'existing' forbidden"
+
+
+@pytest.mark.asyncio
+async def test_require_partitions_viewer_fails_closed_for_all_scope_without_memberships():
+    with pytest.raises(HTTPException) as exc:
+        await require_partitions_viewer(
+            partitions=["all"],
+            user={"id": 1, "is_admin": False},
+            user_partitions=[],
+            auth_service=FakeAuthService,
+            partition_service=FakePartitionService(existing=set()),
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "No accessible partitions"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/dependencies/test_llm.py
+++ b/tests/unit/api/dependencies/test_llm.py
@@ -1,0 +1,37 @@
+import pytest
+from api.dependencies.llm import get_partition_name
+from fastapi import HTTPException
+
+
+class FakePartitionService:
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing = existing or set()
+
+    async def partition_exists(self, partition: str) -> bool:
+        return partition in self.existing
+
+
+@pytest.mark.asyncio
+async def test_get_partition_name_all_fails_closed_for_user_without_partitions():
+    with pytest.raises(HTTPException) as exc:
+        await get_partition_name(
+            "openrag-all",
+            [],
+            partition_service=FakePartitionService(),
+            is_admin=False,
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "No accessible partitions"
+
+
+@pytest.mark.asyncio
+async def test_get_partition_name_all_uses_accessible_partitions():
+    partitions = await get_partition_name(
+        "openrag-all",
+        ["legal", "finance"],
+        partition_service=FakePartitionService(),
+        is_admin=False,
+    )
+
+    assert partitions == ["legal", "finance"]

--- a/tests/unit/api/mcp/test_server.py
+++ b/tests/unit/api/mcp/test_server.py
@@ -86,9 +86,23 @@ async def _dispatch(monkeypatch, request):
 
 
 @pytest.mark.asyncio
-async def test_dev_mode_resolves_user_one(monkeypatch):
+async def test_token_mode_missing_auth_token_fails_closed_without_allow_no_auth(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "token")
     monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ALLOW_NO_AUTH", raising=False)
+    _install_container(monkeypatch, FakeAuthService(user={"id": 1, "is_admin": True}))
+
+    response, captured = await _dispatch(monkeypatch, _request())
+
+    assert response.status_code == 403
+    assert captured == {}
+
+
+@pytest.mark.asyncio
+async def test_dev_mode_resolves_user_one_when_allow_no_auth_set(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ALLOW_NO_AUTH", "true")
     monkeypatch.delenv("SUPER_ADMIN_MODE", raising=False)
     _install_container(
         monkeypatch,
@@ -107,6 +121,7 @@ async def test_dev_mode_resolves_user_one(monkeypatch):
 async def test_super_admin_gets_wildcard(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "token")
     monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ALLOW_NO_AUTH", "true")
     monkeypatch.setenv("SUPER_ADMIN_MODE", "true")
     _install_container(monkeypatch, FakeAuthService(user={"id": 1, "is_admin": True}, partitions=[{"partition": "a"}]))
 

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 from api.middleware.auth import (
+    AuthFailureRateLimiter,
     AuthMiddleware,
     is_bypass_path,
     is_ui_path,
@@ -316,6 +317,31 @@ async def test_failed_bearer_limit_blocks_before_token_lookup(monkeypatch) -> No
     assert first.status_code == 403
     assert second.status_code == 429
     svc.get_user_by_token_for_request.assert_awaited_once_with("bad")
+
+
+@pytest.mark.asyncio
+async def test_disabled_auth_failure_limiter_ignores_malformed_limit(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+    monkeypatch.setenv("RATE_LIMIT_AUTH_FAILURE", "not-a-limit")
+
+    async def call_next(req):
+        return Response("ok")
+
+    middleware = AuthMiddleware(lambda scope, receive, send: None, get_auth_service=lambda _r: None)
+    response = await middleware.dispatch(_request(), call_next)
+
+    assert response.status_code == 403
+
+
+def test_auth_failure_log_value_is_single_line_and_bounded() -> None:
+    value = AuthFailureRateLimiter._safe_log_value("ip:1.2.3.4\nextra\rdata\x00" + ("x" * 300), max_len=40)
+
+    assert "\n" not in value
+    assert "\r" not in value
+    assert "\x00" not in value
+    assert len(value) == 40
 
 
 def test_request_object_is_unused_by_helpers() -> None:

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -273,6 +273,26 @@ async def test_dev_bypass_does_not_fail_open_without_flag(monkeypatch) -> None:
     svc.get_user_for_request.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_failed_token_auth_is_rate_limited_by_ip(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("RATE_LIMIT_AUTH_FAILURE", "1/minute")
+
+    async def call_next(req):
+        return Response("ok")
+
+    middleware = AuthMiddleware(lambda scope, receive, send: None, get_auth_service=lambda _r: None)
+
+    first = await middleware.dispatch(_request(), call_next)
+    second = await middleware.dispatch(_request(), call_next)
+
+    assert first.status_code == 403
+    assert second.status_code == 429
+    assert second.headers.get("Retry-After")
+
+
 def test_request_object_is_unused_by_helpers() -> None:
     """Sanity: ``is_ui_path`` / ``is_bypass_path`` are pure functions
     over the string path, so a FastAPI ``Request`` is never required

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -293,6 +293,31 @@ async def test_failed_token_auth_is_rate_limited_by_ip(monkeypatch) -> None:
     assert second.headers.get("Retry-After")
 
 
+@pytest.mark.asyncio
+async def test_failed_bearer_limit_blocks_before_token_lookup(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "true")
+    monkeypatch.setenv("RATE_LIMIT_AUTH_FAILURE", "1/minute")
+
+    svc = type("S", (), {})()
+    svc.get_user_by_token_for_request = AsyncMock(return_value=None)
+
+    async def call_next(req):
+        return Response("ok")
+
+    middleware = AuthMiddleware(lambda scope, receive, send: None, get_auth_service=lambda _r: svc)
+
+    first = await middleware.dispatch(_request(headers={"authorization": "Bearer bad"}), call_next)
+    second = await middleware.dispatch(_request(headers={"authorization": "Bearer bad"}), call_next)
+
+    assert first.status_code == 403
+    assert second.status_code == 429
+    svc.get_user_by_token_for_request.assert_awaited_once_with("bad")
+
+
 def test_request_object_is_unused_by_helpers() -> None:
     """Sanity: ``is_ui_path`` / ``is_bypass_path`` are pure functions
     over the string path, so a FastAPI ``Request`` is never required

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -240,9 +240,7 @@ async def test_dev_bypass_resolves_admin_when_allow_no_auth_set(monkeypatch) -> 
         captured["user"] = req.state.user
         return Response("ok")
 
-    middleware = AuthMiddleware(
-        lambda scope, receive, send: None, get_auth_service=lambda _r: svc
-    )
+    middleware = AuthMiddleware(lambda scope, receive, send: None, get_auth_service=lambda _r: svc)
     response = await middleware.dispatch(_request(), call_next)
 
     assert response.status_code == 200
@@ -267,9 +265,7 @@ async def test_dev_bypass_does_not_fail_open_without_flag(monkeypatch) -> None:
     async def call_next(req):
         return Response("ok")
 
-    middleware = AuthMiddleware(
-        lambda scope, receive, send: None, get_auth_service=lambda _r: svc
-    )
+    middleware = AuthMiddleware(lambda scope, receive, send: None, get_auth_service=lambda _r: svc)
     response = await middleware.dispatch(_request(), call_next)
 
     # No token + no opt-in → not authenticated, never resolves to admin.

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -216,6 +216,67 @@ def test_is_bypass_path_bypass_config_is_keyword_only() -> None:
         is_bypass_path("/docs", AuthBypassConfig())  # type: ignore[misc]
 
 
+# ---------------------------------------------------------------------------
+# Dev bypass (AUTH_MODE=token, AUTH_TOKEN unset) requires ALLOW_NO_AUTH=true
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_resolves_admin_when_allow_no_auth_set(monkeypatch) -> None:
+    """With ALLOW_NO_AUTH=true the no-token bypass resolves admin user 1."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ALLOW_NO_AUTH", "true")
+
+    svc = type("S", (), {})()
+    svc.get_user_for_request = AsyncMock(return_value={"id": 1, "display_name": "Admin"})
+    svc.list_user_partitions_for_request = AsyncMock(return_value=[])
+
+    captured = {}
+
+    async def call_next(req):
+        captured["user"] = req.state.user
+        return Response("ok")
+
+    middleware = AuthMiddleware(
+        lambda scope, receive, send: None, get_auth_service=lambda _r: svc
+    )
+    response = await middleware.dispatch(_request(), call_next)
+
+    assert response.status_code == 200
+    svc.get_user_for_request.assert_awaited_with(1)
+    assert captured["user"] == {"id": 1, "display_name": "Admin"}
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_does_not_fail_open_without_flag(monkeypatch) -> None:
+    """Without ALLOW_NO_AUTH a missing AUTH_TOKEN must NOT fail open to admin."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ALLOW_NO_AUTH", raising=False)
+
+    svc = type("S", (), {})()
+    svc.get_user_for_request = AsyncMock()
+    svc.list_user_partitions_for_request = AsyncMock()
+    svc.get_oidc_session_by_token_for_request = AsyncMock(return_value=None)
+
+    async def call_next(req):
+        return Response("ok")
+
+    middleware = AuthMiddleware(
+        lambda scope, receive, send: None, get_auth_service=lambda _r: svc
+    )
+    response = await middleware.dispatch(_request(), call_next)
+
+    # No token + no opt-in → not authenticated, never resolves to admin.
+    assert response.status_code in (401, 403)
+    svc.get_user_for_request.assert_not_awaited()
+
+
 def test_request_object_is_unused_by_helpers() -> None:
     """Sanity: ``is_ui_path`` / ``is_bypass_path`` are pure functions
     over the string path, so a FastAPI ``Request`` is never required

--- a/tests/unit/api/middleware/test_oidc_docs_gating.py
+++ b/tests/unit/api/middleware/test_oidc_docs_gating.py
@@ -1,0 +1,118 @@
+"""AuthMiddleware: interactive API docs are login-gated under AUTH_MODE=oidc.
+
+The OpenAPI docs (``/docs``, ``/redoc``, ``/openapi.json``) bypass auth in token
+mode (legacy contract) but expose the full route + schema surface, so serving
+them anonymously in an OIDC deployment is undesirable. Under ``AUTH_MODE=oidc``
+the middleware must instead treat them like any UI page: an unauthenticated
+browser is 302-redirected to ``/auth/login``, while a valid session still
+renders them. Health/version probes stay public in both modes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from api.middleware.auth import SESSION_COOKIE_NAME, AuthMiddleware
+from core.config.auth import AuthBypassConfig
+from fastapi import Request
+from starlette.responses import Response
+
+
+def _req(path: str, *, headers: dict[str, str] | None = None) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": raw,
+        "query_string": b"",
+        "client": ("1.2.3.4", 1234),
+    }
+    return Request(scope)
+
+
+async def _call_next(_request) -> Response:
+    return Response("ok")
+
+
+def _anon_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_oidc_session_by_token_for_request = AsyncMock(return_value=None)
+    svc.get_user_by_token_for_request = AsyncMock(return_value=None)
+    return svc
+
+
+def _authed_service() -> AsyncMock:
+    session = {"id": 7, "user_id": 1}
+    svc = AsyncMock()
+    svc.get_oidc_session_by_token_for_request = AsyncMock(return_value=session)
+    svc.refresh_session_if_needed = AsyncMock(return_value=session)
+    svc.get_user_for_request = AsyncMock(return_value={"id": 1, "is_admin": True})
+    svc.list_user_partitions_for_request = AsyncMock(return_value=[])
+    return svc
+
+
+def _middleware(svc, *, bypass_config: AuthBypassConfig | None = None) -> AuthMiddleware:
+    return AuthMiddleware(
+        lambda scope, receive, send: None,
+        get_auth_service=lambda _r: svc,
+        bypass_config=bypass_config,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _oidc_env(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", "x")
+    # Keep the auth-failure limiter out of the way of these dispatch assertions.
+    monkeypatch.setenv("RATE_LIMIT_ENABLED", "false")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+async def test_oidc_anonymous_docs_redirect_to_login(path) -> None:
+    mw = _middleware(_anon_service())
+    resp = await mw.dispatch(_req(path), _call_next)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"/auth/login?next={path.replace('/', '%2F')}"
+
+
+@pytest.mark.asyncio
+async def test_oidc_authenticated_session_reaches_docs() -> None:
+    captured: dict = {}
+
+    async def call_next(req):
+        captured["user"] = req.state.user
+        return Response("ok")
+
+    mw = _middleware(_authed_service())
+    resp = await mw.dispatch(_req("/docs", headers={"cookie": f"{SESSION_COOKIE_NAME}=tok"}), call_next)
+    assert resp.status_code == 200
+    assert captured["user"] == {"id": 1, "is_admin": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/health_check", "/version", "/auth/login"])
+async def test_oidc_non_docs_bypass_paths_stay_public(path) -> None:
+    """Only the docs are gated — health/version/auth callbacks still bypass."""
+    mw = _middleware(_anon_service())
+    resp = await mw.dispatch(_req(path), _call_next)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_token_mode_docs_stay_public(monkeypatch) -> None:
+    monkeypatch.setenv("AUTH_MODE", "token")
+    monkeypatch.setenv("AUTH_TOKEN", "secret")
+    mw = _middleware(_anon_service())
+    resp = await mw.dispatch(_req("/docs"), _call_next)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_empty_oidc_gated_paths_restores_public_docs() -> None:
+    """Operators can opt back into anonymous docs under oidc by clearing the set."""
+    mw = _middleware(_anon_service(), bypass_config=AuthBypassConfig(oidc_gated_paths=()))
+    resp = await mw.dispatch(_req("/docs"), _call_next)
+    assert resp.status_code == 200

--- a/tests/unit/api/middleware/test_rate_limit.py
+++ b/tests/unit/api/middleware/test_rate_limit.py
@@ -1,0 +1,82 @@
+"""Tests for the path-tiered rate limiting middleware."""
+
+import pytest
+from api.middleware.rate_limit import RateLimitMiddleware
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _make_request(user=None, host="1.2.3.4") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "client": (host, 1234),
+    }
+    req = Request(scope)
+    if user is not None:
+        req.state.user = user
+    return req
+
+
+def test_identity_keys_on_authenticated_user_dict():
+    # request.state.user is a dict (set by AuthMiddleware); identity must key on
+    # its "id", not fall through to the client IP.
+    assert RateLimitMiddleware._identity(_make_request(user={"id": 7})) == "user:7"
+
+
+def test_identity_falls_back_to_ip_when_unauthenticated():
+    assert RateLimitMiddleware._identity(_make_request(user=None, host="9.9.9.9")) == "ip:9.9.9.9"
+
+
+def _build_app(monkeypatch, **env):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    async def ok(request: Request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/v1/chat", ok), Route("/auth/login", ok), Route("/other", ok)])
+    app.add_middleware(RateLimitMiddleware)
+    return app
+
+
+def test_allows_under_limit(monkeypatch):
+    app = _build_app(monkeypatch, RATE_LIMIT_CHAT="5/minute")
+    client = TestClient(app)
+    for _ in range(5):
+        assert client.get("/v1/chat").status_code == 200
+
+
+def test_blocks_over_limit_with_retry_after(monkeypatch):
+    app = _build_app(monkeypatch, RATE_LIMIT_CHAT="2/minute")
+    client = TestClient(app)
+    assert client.get("/v1/chat").status_code == 200
+    assert client.get("/v1/chat").status_code == 200
+    resp = client.get("/v1/chat")
+    assert resp.status_code == 429
+    assert "Retry-After" in resp.headers
+
+
+def test_tiers_have_independent_budgets(monkeypatch):
+    # Exhausting the chat tier must not affect the auth tier.
+    app = _build_app(monkeypatch, RATE_LIMIT_CHAT="1/minute", RATE_LIMIT_AUTH="1/minute")
+    client = TestClient(app)
+    assert client.get("/v1/chat").status_code == 200
+    assert client.get("/v1/chat").status_code == 429
+    assert client.get("/auth/login").status_code == 200
+
+
+def test_disabled_passes_through(monkeypatch):
+    app = _build_app(monkeypatch, RATE_LIMIT_ENABLED="false", RATE_LIMIT_CHAT="1/minute")
+    client = TestClient(app)
+    for _ in range(5):
+        assert client.get("/v1/chat").status_code == 200
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -70,6 +70,19 @@ class FakeListService:
         return [{"partition": "p1"}, {"partition": "p2"}]
 
 
+class FakeCreatePartitionService:
+    """Service double for create-partition route tests."""
+
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    async def partition_exists(self, partition: str) -> bool:
+        return False
+
+    async def create_partition(self, **kwargs: Any) -> None:
+        self.created.append(kwargs)
+
+
 def _build_list_app(*, is_admin: bool) -> FastAPI:
     """App for the list route, with a regular user whose sole membership is ``all``."""
     app = FastAPI()
@@ -82,6 +95,20 @@ def _build_list_app(*, is_admin: bool) -> FastAPI:
     app.include_router(partitions.router, prefix="/partition")
     app.dependency_overrides[partitions_with_details] = lambda: [{"partition": "all"}]
     app.dependency_overrides[get_partition_service] = lambda: FakeListService()
+    return app
+
+
+def _build_create_app(service, *, is_admin: bool = False) -> FastAPI:
+    """App for create route tests with a current user in request state."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _set_user(request, call_next):
+        request.state.user = {"id": 1, "is_admin": is_admin}
+        return await call_next(request)
+
+    app.include_router(partitions.router, prefix="/partition")
+    app.dependency_overrides[get_partition_service] = lambda: service
     return app
 
 
@@ -166,3 +193,18 @@ async def test_partition_config_routes_return_501_until_service_methods_exist(as
     assert patch_response.json()["detail"] == "update_partition_config is not available."
     assert get_response.status_code == 501
     assert get_response.json()["detail"] == "get_partition_config is not available."
+
+
+@pytest.mark.asyncio
+async def test_create_partition_rejects_malformed_limit_before_writing(async_client_factory, monkeypatch):
+    """A bad deployment env value should fail cleanly before creating a partition."""
+    monkeypatch.setenv("MAX_PARTITIONS_PER_USER", "not-an-int")
+    service = FakeCreatePartitionService()
+    app = _build_create_app(service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post("/partition/legal")
+
+    assert response.status_code == 500
+    assert "MAX_PARTITIONS_PER_USER" in response.json()["detail"]
+    assert service.created == []

--- a/tests/unit/api/routers/user/test_download.py
+++ b/tests/unit/api/routers/user/test_download.py
@@ -1,0 +1,51 @@
+"""Tests for the authorized source-file download route under /static.
+
+Covers the partition-membership check and DATA_DIR confinement.
+"""
+
+from __future__ import annotations
+
+from api.dependencies.auth import current_user_or_admin_partitions_list
+from api.routers.user.download import router as download_router
+from di.providers import get_conversion_service
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client(chunk, partitions):
+    app = FastAPI()
+    app.include_router(download_router)
+    app.dependency_overrides[current_user_or_admin_partitions_list] = lambda: partitions
+
+    class _FakeConversionService:
+        async def get_chunk(self, chunk_id):
+            return chunk
+
+    app.dependency_overrides[get_conversion_service] = lambda: _FakeConversionService()
+    return TestClient(app)
+
+
+def test_download_404_when_chunk_missing():
+    client = _client(None, ["p1"])
+    assert client.get("/static/123").status_code == 404
+
+
+def test_download_403_when_user_lacks_partition_access():
+    chunk = {"metadata": {"partition": "other-tenant", "source": "/data/secret.pdf"}}
+    client = _client(chunk, ["p1"])
+    r = client.get("/static/123")
+    assert r.status_code == 403
+
+
+def test_download_404_when_source_path_escapes_data_dir():
+    # Partition access is granted, but the source path resolves outside DATA_DIR
+    # (path-traversal attempt) → 404, never served.
+    chunk = {"metadata": {"partition": "p1", "source": "/etc/passwd"}}
+    client = _client(chunk, ["p1"])
+    assert client.get("/static/123").status_code == 404
+
+
+def test_download_404_when_source_missing():
+    chunk = {"metadata": {"partition": "p1"}}
+    client = _client(chunk, ["p1"])
+    assert client.get("/static/123").status_code == 404

--- a/tests/unit/api/routers/user/test_download.py
+++ b/tests/unit/api/routers/user/test_download.py
@@ -12,17 +12,32 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
+class _FakeConversionService:
+    def __init__(self, chunk):
+        self.chunk = chunk
+        self.calls: list[str] = []
+
+    async def get_chunk(self, chunk_id):
+        self.calls.append(chunk_id)
+        return self.chunk
+
+
 def _client(chunk, partitions):
     app = FastAPI()
     app.include_router(download_router)
     app.dependency_overrides[current_user_or_admin_partitions_list] = lambda: partitions
 
-    class _FakeConversionService:
-        async def get_chunk(self, chunk_id):
-            return chunk
-
-    app.dependency_overrides[get_conversion_service] = lambda: _FakeConversionService()
+    app.dependency_overrides[get_conversion_service] = lambda: _FakeConversionService(chunk)
     return TestClient(app)
+
+
+def _client_with_service(chunk, partitions):
+    app = FastAPI()
+    service = _FakeConversionService(chunk)
+    app.include_router(download_router)
+    app.dependency_overrides[current_user_or_admin_partitions_list] = lambda: partitions
+    app.dependency_overrides[get_conversion_service] = lambda: service
+    return TestClient(app), service
 
 
 def test_download_404_when_chunk_missing():
@@ -49,3 +64,12 @@ def test_download_404_when_source_missing():
     chunk = {"metadata": {"partition": "p1"}}
     client = _client(chunk, ["p1"])
     assert client.get("/static/123").status_code == 404
+
+
+def test_download_rejects_invalid_extract_id_before_storage_lookup():
+    client, service = _client_with_service(None, ["p1"])
+
+    response = client.get("/static/bad%20id")
+
+    assert response.status_code == 400
+    assert service.calls == []

--- a/tests/unit/api/routers/user/test_search.py
+++ b/tests/unit/api/routers/user/test_search.py
@@ -1,0 +1,47 @@
+from api.dependencies.auth import (
+    current_user,
+    current_user_or_admin_partitions_list,
+    current_user_partitions,
+)
+from api.routers.user.search import router as search_router
+from di.providers import get_auth_service, get_partition_service, get_retrieval_service, get_workspace_service
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _AuthService:
+    @staticmethod
+    def check_partition_access(**_kwargs):
+        return True
+
+
+class _PartitionService:
+    async def partition_exists(self, _partition):
+        return False
+
+
+class _RetrievalService:
+    async def search(self, **_kwargs):
+        raise AssertionError("search must not run without an authorized partition scope")
+
+
+def _client(*, user_partitions):
+    app = FastAPI()
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[current_user] = lambda: {"id": 7, "is_admin": False}
+    app.dependency_overrides[current_user_partitions] = lambda: user_partitions
+    app.dependency_overrides[current_user_or_admin_partitions_list] = lambda: [
+        row["partition"] for row in user_partitions
+    ]
+    app.dependency_overrides[get_auth_service] = lambda: _AuthService
+    app.dependency_overrides[get_partition_service] = lambda: _PartitionService()
+    app.dependency_overrides[get_retrieval_service] = lambda: _RetrievalService()
+    app.dependency_overrides[get_workspace_service] = lambda: object()
+    return TestClient(app)
+
+
+def test_search_default_all_fails_closed_when_user_has_no_partitions():
+    response = _client(user_partitions=[]).get("/search", params={"text": "hello"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "No accessible partitions"

--- a/tests/unit/api/routers/user/test_source_links.py
+++ b/tests/unit/api/routers/user/test_source_links.py
@@ -15,8 +15,9 @@ Covered:
 from api.routers.user.source_links import build_document_source_link
 
 
-def _static(filename: str) -> str:
-    return f"https://host/static/{filename}"
+def _static(extract_id) -> str:
+    # Authorized download is keyed by chunk id, not a raw filename.
+    return f"https://host/static/{extract_id}"
 
 
 def _chunk(extract_id) -> str:
@@ -44,15 +45,16 @@ def test_empty_source_value_omits_file_url():
     assert "file_url" not in link
 
 
-def test_file_url_emitted_and_encoded_when_source_present():
-    link = _build({"_id": "x", "source": "/srv/data/my doc.pdf"})
-    # basename only, with spaces percent-encoded by quote()
-    assert link["file_url"] == "https://host/static/my%20doc.pdf"
+def test_file_url_keyed_by_chunk_id_when_source_present():
+    # A chunk with a source gets a download URL keyed by its id (not the raw
+    # filename), so the URL never leaks an unguarded filesystem path.
+    link = _build({"_id": "42", "source": "/srv/data/my doc.pdf"})
+    assert link["file_url"] == "https://host/static/42"
 
 
-def test_basename_extracted_from_path():
-    link = _build({"_id": "x", "source": "/srv/data/doc.pdf"})
-    assert link["file_url"] == "https://host/static/doc.pdf"
+def test_file_url_independent_of_source_basename():
+    link = _build({"_id": "7", "source": "/srv/data/doc.pdf"})
+    assert link["file_url"] == "https://host/static/7"
 
 
 def test_metadata_is_passed_through():

--- a/tests/unit/api/schemas/test_api_schema_imports.py
+++ b/tests/unit/api/schemas/test_api_schema_imports.py
@@ -116,3 +116,11 @@ def test_add_files_request_accepts_id_list():
 def test_tool_info_schema():
     info = ToolInfo(name="extractText", description="Extract text from a file")
     assert info.name == "extractText"
+
+
+def test_completion_request_bounds_n_and_best_of():
+    # M12: n / best_of each multiply generation cost — reject out-of-range values.
+    assert OpenAICompletionRequest(prompt="x", n=8, best_of=8).n == 8
+    for bad in ({"n": 0}, {"n": 9}, {"best_of": 0}, {"best_of": 9}):
+        with pytest.raises(ValidationError):
+            OpenAICompletionRequest(prompt="x", **bad)

--- a/tests/unit/core/indexing/parsers/test_eml_parser.py
+++ b/tests/unit/core/indexing/parsers/test_eml_parser.py
@@ -1,0 +1,42 @@
+"""Tests for EmlParser — focused on the parser-bomb fan-out cap."""
+
+from __future__ import annotations
+
+import email.message
+
+import pytest
+from core.indexing.parsers.eml_parser import _MAX_EML_ATTACHMENTS, EmlParser
+from core.models.document import Document, DocumentType
+
+
+def _eml_with_attachments(n: int) -> bytes:
+    msg = email.message.EmailMessage()
+    msg["Subject"] = "bomb"
+    msg["From"] = "a@b.com"
+    msg["To"] = "c@d.com"
+    msg.set_content("body text")
+    for i in range(n):
+        msg.add_attachment(
+            b"x" * 8,
+            maintype="application",
+            subtype="octet-stream",
+            filename=f"file{i}.bin",
+        )
+    return msg.as_bytes()
+
+
+@pytest.mark.asyncio
+async def test_eml_caps_attachment_fanout():
+    # A malicious email with far more than the cap must process at most the cap.
+    raw = _eml_with_attachments(_MAX_EML_ATTACHMENTS + 25)
+    doc = Document(filename="bomb.eml", content_type=DocumentType.EML, raw_bytes=raw)
+    processed = await EmlParser().parse(doc)
+    assert processed.metadata["email_attachment_count"] == _MAX_EML_ATTACHMENTS
+
+
+@pytest.mark.asyncio
+async def test_eml_under_cap_processes_all():
+    raw = _eml_with_attachments(3)
+    doc = Document(filename="ok.eml", content_type=DocumentType.EML, raw_bytes=raw)
+    processed = await EmlParser().parse(doc)
+    assert processed.metadata["email_attachment_count"] == 3

--- a/tests/unit/core/indexing/parsers/test_eml_parser.py
+++ b/tests/unit/core/indexing/parsers/test_eml_parser.py
@@ -25,6 +25,22 @@ def _eml_with_attachments(n: int) -> bytes:
     return msg.as_bytes()
 
 
+def _eml_with_unnamed_attachments(n: int) -> email.message.EmailMessage:
+    msg = email.message.EmailMessage()
+    msg["Subject"] = "malformed bomb"
+    msg["From"] = "a@b.com"
+    msg["To"] = "c@d.com"
+    msg.set_content("body text")
+    msg.make_mixed()
+    for _ in range(n):
+        part = email.message.EmailMessage()
+        part.set_content("payload")
+        part.replace_header("Content-Type", "application/octet-stream")
+        part["Content-Disposition"] = "attachment"
+        msg.attach(part)
+    return msg
+
+
 @pytest.mark.asyncio
 async def test_eml_caps_attachment_fanout():
     # A malicious email with far more than the cap must process at most the cap.
@@ -40,3 +56,22 @@ async def test_eml_under_cap_processes_all():
     doc = Document(filename="ok.eml", content_type=DocumentType.EML, raw_bytes=raw)
     processed = await EmlParser().parse(doc)
     assert processed.metadata["email_attachment_count"] == 3
+
+
+def test_eml_caps_attachment_candidates_before_decoding(monkeypatch):
+    msg = _eml_with_unnamed_attachments(_MAX_EML_ATTACHMENTS + 25)
+    original_get_payload = email.message.Message.get_payload
+    attachment_decodes = 0
+
+    def counting_get_payload(self, *args, **kwargs):
+        nonlocal attachment_decodes
+        if kwargs.get("decode") and self.get_content_disposition() in ("attachment", "inline"):
+            attachment_decodes += 1
+        return original_get_payload(self, *args, **kwargs)
+
+    monkeypatch.setattr(email.message.Message, "get_payload", counting_get_payload)
+
+    _, attachments = EmlParser._walk_parts(msg)
+
+    assert attachments == []
+    assert attachment_decodes == _MAX_EML_ATTACHMENTS

--- a/tests/unit/core/indexing/test_validators.py
+++ b/tests/unit/core/indexing/test_validators.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import pytest
-from core.indexing.validators import parse_metadata, validate_file_format, validate_file_id
+from core.indexing.validators import (
+    parse_metadata,
+    validate_file_format,
+    validate_file_id,
+    validate_partition_name,
+)
 from core.utils.exceptions import ValidationError
 
 
@@ -46,10 +51,25 @@ class TestValidateFileId:
             with pytest.raises(ValidationError):
                 validate_file_id(bad)
 
-    def test_custom_forbidden_chars(self):
-        with pytest.raises(ValidationError):
-            validate_file_id("hello?world", forbidden_chars="?")
-        assert validate_file_id("hello/world", forbidden_chars="?") == "hello/world"
+    def test_allowlist_rejects_injection_characters(self):
+        # Quotes / brackets / operators / spaces could break out of a Milvus
+        # filter literal — the safe-identifier allowlist rejects them.
+        for bad in ('x" or partition=="other', "a b", "a[b]", "a'b", "a/b"):
+            with pytest.raises(ValidationError):
+                validate_file_id(bad)
+
+    def test_allowlist_allows_safe_identifier_chars(self):
+        assert validate_file_id("File.1_2:3-4") == "File.1_2:3-4"
+
+
+class TestValidatePartitionName:
+    def test_valid(self):
+        assert validate_partition_name("my-partition.1") == "my-partition.1"
+
+    def test_rejects_empty_and_injection(self):
+        for bad in ("", '"', "a b", 'p" or partition=="other'):
+            with pytest.raises(ValidationError):
+                validate_partition_name(bad)
 
 
 class TestValidateFileFormat:

--- a/tests/unit/core/indexing/test_validators.py
+++ b/tests/unit/core/indexing/test_validators.py
@@ -61,6 +61,10 @@ class TestValidateFileId:
     def test_allowlist_allows_safe_identifier_chars(self):
         assert validate_file_id("File.1_2:3-4") == "File.1_2:3-4"
 
+    def test_custom_forbidden_chars_are_still_enforced(self):
+        with pytest.raises(ValidationError):
+            validate_file_id("File:1", forbidden_chars={":"})
+
 
 class TestValidatePartitionName:
     def test_valid(self):

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -252,6 +252,29 @@ class TestStreamWithSourceFiltering:
         assert _parse_finish_sources(result) == [{"file": "a.pdf"}, {"file": "c.pdf"}]
 
     @pytest.mark.asyncio
+    async def test_content_tail_chunk_has_null_finish_reason(self):
+        """The content-bearing tail chunk must not carry finish_reason — the
+        upstream finish chunk becomes the template, and a spec-compliant client
+        treats a finish_reason!=null chunk as terminal and drops its delta."""
+        lines = [
+            _make_chunk("Here is the answer."),
+            _make_chunk("\n[Sources: 1, 3]"),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        tail = None
+        for line in result:
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            data = json.loads(line[len("data: ") :])
+            choice = data.get("choices", [{}])[0]
+            if choice.get("delta", {}).get("content") and data.get("extra"):
+                tail = choice
+        assert tail is not None, "no content-bearing tail chunk with sources was emitted"
+        assert tail["finish_reason"] is None
+
+    @pytest.mark.asyncio
     async def test_case2_llm_says_sources_none(self):
         """Case 2: LLM says [Sources: none] → no sources returned."""
         lines = [

--- a/tests/unit/core/utils/test_text.py
+++ b/tests/unit/core/utils/test_text.py
@@ -1,0 +1,41 @@
+"""Tests for core.utils.text sanitization helpers."""
+
+from __future__ import annotations
+
+from core.utils.text import neutralize_prompt_control_tokens
+
+
+class TestNeutralizePromptControlTokens:
+    """Defang RAG control tokens embedded in untrusted document/web text."""
+
+    def test_source_block_marker_defanged(self):
+        out = neutralize_prompt_control_tokens("real text\n[Source 99]\nfake source body")
+        assert "[Source 99]" not in out
+        assert "(Source 99]" in out  # opening bracket neutralized
+
+    def test_bracketed_sources_tag_defanged(self):
+        out = neutralize_prompt_control_tokens("answer [Sources: 1, 2]")
+        assert "[Sources: 1, 2]" not in out
+
+    def test_bracketed_sources_tag_colon_dropped(self):
+        # #487: dropping the colon defangs the keyword the answer parser keys on,
+        # even though only the opening bracket is turned into a paren.
+        out = neutralize_prompt_control_tokens("answer [Sources: 1, 2]")
+        assert "Sources: 1, 2" not in out
+
+    def test_unbracketed_sources_tag_line_defanged(self):
+        # The answer parser also strips an unbracketed "Sources: 1, 2" at line end.
+        out = neutralize_prompt_control_tokens("blah\nSources: 1, 2")
+        assert "Sources: 1, 2" not in out
+
+    def test_separator_run_capped(self):
+        out = neutralize_prompt_control_tokens("a\n----------\n\nb")
+        assert "----------" not in out
+        assert "---" in out
+
+    def test_benign_text_preserved(self):
+        text = "The function returns a list. See the table below."
+        assert neutralize_prompt_control_tokens(text) == text
+
+    def test_empty_text(self):
+        assert neutralize_prompt_control_tokens("") == ""

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -54,8 +54,12 @@ def test_milvus_compose_defaults_preserve_existing_host_paths() -> None:
 
 
 def test_named_volume_profile_is_opt_in() -> None:
+    default_env_values = _load_env_example(COMPOSE_DIR / ".env.example")
     env_values = _load_env_example(COMPOSE_DIR / ".env.named-volumes.example")
     named_milvus = _load_yaml(COMPOSE_DIR / "milvus" / "milvus.named-volumes.yaml")
+
+    assert "MINIO_ACCESS_KEY" in default_env_values
+    assert "MINIO_SECRET_KEY" in default_env_values
 
     assert env_values["DATA_VOLUME"] == "appdata"
     assert env_values["LOG_VOLUME"] == "logs"
@@ -71,11 +75,13 @@ def test_named_volume_profile_is_opt_in() -> None:
 
     minio_env = named_milvus["services"]["minio"]["environment"]
     milvus_env = named_milvus["services"]["milvus"]["environment"]
-    assert minio_env["MINIO_ROOT_USER"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
-    assert minio_env["MINIO_ROOT_PASSWORD"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+    assert "MINIO_ROOT_USER" not in minio_env
+    assert "MINIO_ROOT_PASSWORD" not in minio_env
+    assert minio_env["MINIO_ACCESS_KEY"] == "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}"
+    assert minio_env["MINIO_SECRET_KEY"] == "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}"
     assert "minioadmin" not in str(minio_env)
-    assert milvus_env["MINIO_ACCESS_KEY_ID"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
-    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+    assert milvus_env["MINIO_ACCESS_KEY_ID"] == "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}"
+    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}"
 
 
 def test_quick_start_milvus_uses_current_minio_root_env_names() -> None:

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -69,6 +69,28 @@ def test_named_volume_profile_is_opt_in() -> None:
     assert named_milvus["services"]["milvus"]["volumes"] == ["${MILVUS_VOLUME:-milvus}:/var/lib/milvus"]
     assert {"etcd", "minio", "milvus"} <= set(named_milvus["volumes"])
 
+    minio_env = named_milvus["services"]["minio"]["environment"]
+    milvus_env = named_milvus["services"]["milvus"]["environment"]
+    assert minio_env["MINIO_ROOT_USER"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
+    assert minio_env["MINIO_ROOT_PASSWORD"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+    assert "minioadmin" not in str(minio_env)
+    assert milvus_env["MINIO_ACCESS_KEY_ID"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
+    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+
+
+def test_quick_start_milvus_uses_current_minio_root_env_names() -> None:
+    quickstart = _load_yaml(ROOT / "infra" / "quick_start" / "vdb" / "milvus.yaml")
+
+    minio_env = quickstart["services"]["minio"]["environment"]
+    milvus_env = quickstart["services"]["milvus"]["environment"]
+
+    assert "MINIO_ACCESS_KEY" not in minio_env
+    assert "MINIO_SECRET_KEY" not in minio_env
+    assert minio_env["MINIO_ROOT_USER"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
+    assert minio_env["MINIO_ROOT_PASSWORD"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+    assert milvus_env["MINIO_ACCESS_KEY_ID"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
+    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+
 
 def test_model_serving_cache_preserves_host_path_default_with_named_volume_opt_in() -> None:
     compose = _load_yaml(COMPOSE_DIR / "docker-compose.yaml")

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -35,6 +35,7 @@ def test_compose_defaults_preserve_existing_host_paths() -> None:
     assert "${DATA_VOLUME:-../../data}:/app/data" in openrag_volumes
     assert "${LOG_VOLUME:-../../logs}:/app/logs" in openrag_volumes
     assert "${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights" in openrag_volumes
+    assert compose["x-openrag"]["build"]["args"]["APP_UID"] == "${APP_UID:-1000}"
     # N8: the ../../openrag source bind-mount is commented out by default
     # (dev-only) so production never lets host changes override the running code.
     assert "../../openrag:/app/openrag" not in openrag_volumes

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -92,6 +92,16 @@ def test_quick_start_milvus_uses_current_minio_root_env_names() -> None:
     assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
 
 
+def test_ollama_cpu_milvus_uses_matching_minio_credentials() -> None:
+    compose = _load_yaml(ROOT / "docs" / "assets" / "compose_ollama_cpu.yaml")
+
+    minio_env = compose["services"]["minio"]["environment"]
+    milvus_env = compose["services"]["milvus"]["environment"]
+
+    assert milvus_env["MINIO_ACCESS_KEY_ID"] == minio_env["MINIO_ACCESS_KEY"]
+    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == minio_env["MINIO_SECRET_KEY"]
+
+
 def test_model_serving_cache_preserves_host_path_default_with_named_volume_opt_in() -> None:
     compose = _load_yaml(COMPOSE_DIR / "docker-compose.yaml")
     infinity = _load_yaml(EXTERN_DIR / "reranker" / "infinity.yaml")

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -35,7 +35,9 @@ def test_compose_defaults_preserve_existing_host_paths() -> None:
     assert "${DATA_VOLUME:-../../data}:/app/data" in openrag_volumes
     assert "${LOG_VOLUME:-../../logs}:/app/logs" in openrag_volumes
     assert "${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights" in openrag_volumes
-    assert "../../openrag:/app/openrag" in openrag_volumes
+    # N8: the ../../openrag source bind-mount is commented out by default
+    # (dev-only) so production never lets host changes override the running code.
+    assert "../../openrag:/app/openrag" not in openrag_volumes
     assert "${DB_VOLUME:-../../db}:/var/lib/postgresql/data" in rdb_volumes
 
     assert {"appdata", "logs", "modelweights", "pgdata"} <= top_level_volumes

--- a/tests/unit/infra/test_helm_security_hardening.py
+++ b/tests/unit/infra/test_helm_security_hardening.py
@@ -79,6 +79,15 @@ def test_chart_workloads_apply_restricted_security_contexts() -> None:
     assert "image: {{ $.Values.ray.image.repository }}:{{ $.Values.ray.image.tag }}" in raycluster
 
 
+def test_ray_dashboard_defaults_to_loopback_in_helm_cluster() -> None:
+    values = _values()
+    raycluster = _template("raycluster.yaml")
+
+    assert values["ray"]["dashboardHost"] == "127.0.0.1"
+    assert "--dashboard-host=0.0.0.0" not in raycluster
+    assert "--dashboard-host={{ .Values.ray.dashboardHost }}" in raycluster
+
+
 def test_ingress_is_not_exposed_by_default_and_supports_tls() -> None:
     values = _values()
     template = _template("ingress.yaml")

--- a/tests/unit/services/auth/test_oidc_client.py
+++ b/tests/unit/services/auth/test_oidc_client.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+pytest.importorskip("authlib")
+
+from authlib.jose import JsonWebKey, JsonWebToken  # noqa: E402
+from services.auth import oidc_client as oidc_module  # noqa: E402
+from services.auth.oidc_client import OIDCClient  # noqa: E402
+
+ISSUER = "https://idp.example.com/realms/openrag"
+CLIENT_ID = "openrag-client"
+
+_RSA_PRIVATE = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+_RSA_PUBLIC_JWK = _RSA_PRIVATE.as_dict()
+_RSA_PUBLIC_JWK["use"] = "sig"
+_RSA_PUBLIC_JWK["alg"] = "RS256"
+_RSA_PUBLIC_JWK["kid"] = "test-key-1"
+JWKS_RESPONSE = {"keys": [_RSA_PUBLIC_JWK]}
+
+
+def _sign_jwt(payload: dict[str, Any]) -> str:
+    token = JsonWebToken(["RS256"]).encode({"alg": "RS256", "kid": "test-key-1"}, payload, _RSA_PRIVATE)
+    return token.decode() if isinstance(token, bytes) else token
+
+
+def _logout_token(*, iat: int, exp: int | None = None) -> str:
+    payload: dict[str, Any] = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "iat": iat,
+        "jti": "logout-jti-1",
+        "events": {"http://schemas.openid.net/event/backchannel-logout": {}},
+        "sid": "sid-1",
+        "sub": "sub-1",
+    }
+    if exp is not None:
+        payload["exp"] = exp
+    return _sign_jwt(payload)
+
+
+def _client() -> OIDCClient:
+    client = OIDCClient(
+        issuer=ISSUER,
+        client_id=CLIENT_ID,
+        client_secret="secret",
+        redirect_uri="https://openrag.example.com/auth/callback",
+        scopes="openid",
+    )
+    client._metadata = {"issuer": ISSUER, "jwks_uri": f"{ISSUER}/certs"}
+    client._metadata_fetched_at = time.time()
+    client._jwks = JsonWebKey.import_key_set(JWKS_RESPONSE)
+    client._jwks_fetched_at = time.time()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_verify_logout_token_accepts_current_token_without_exp(monkeypatch) -> None:
+    now = 1_700_000_000
+    monkeypatch.setattr(oidc_module.time, "time", lambda: now)
+
+    claims = await _client().verify_logout_token(_logout_token(iat=now))
+
+    assert claims.jti == "logout-jti-1"
+    assert claims.exp is None
+
+
+@pytest.mark.asyncio
+async def test_verify_logout_token_rejects_stale_token_without_exp(monkeypatch) -> None:
+    now = 1_700_000_000
+    monkeypatch.setattr(oidc_module.time, "time", lambda: now)
+
+    token = _logout_token(iat=now - 10_000)
+
+    with pytest.raises(ValueError, match="too old"):
+        await _client().verify_logout_token(token)
+
+
+@pytest.mark.asyncio
+async def test_verify_logout_token_rejects_future_iat_without_exp(monkeypatch) -> None:
+    now = 1_700_000_000
+    monkeypatch.setattr(oidc_module.time, "time", lambda: now)
+
+    token = _logout_token(iat=now + 120)
+
+    with pytest.raises(ValueError, match="not yet valid"):
+        await _client().verify_logout_token(token)

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -189,7 +189,7 @@ class TestVLLMClientOverrides:
         assert model == "default-model"
         assert headers is None
 
-    def test_llm_override_in_metadata(self):
+    def test_llm_override_model_applied_endpoint_and_key_ignored(self):
         client = self._make_client()
         original_metadata = {
             "llm_override": {
@@ -200,10 +200,10 @@ class TestVLLMClientOverrides:
         }
         kwargs: dict = {"metadata": original_metadata}
         base_url, model, headers = client._resolve_overrides(kwargs)
-        assert base_url == "http://custom:9000/v1"
+        # Only `model` is honored; endpoint and credentials stay server-side.
         assert model == "custom-model"
-        assert headers is not None
-        assert headers["Authorization"] == "Bearer custom-key"
+        assert base_url == "http://default:8000/v1"
+        assert headers is None
         # kwargs must not be mutated — retries depend on llm_override surviving.
         assert kwargs["metadata"] is original_metadata
         assert "llm_override" in kwargs["metadata"]
@@ -225,11 +225,23 @@ class TestVLLMClientOverrides:
             "use_map_reduce": True,
         }
 
-    def test_trailing_slash_stripped(self):
+    def test_client_base_url_and_api_key_override_ignored(self):
+        # SSRF / key-exfiltration guard: a client-supplied base_url/api_key
+        # must never be honored.
         client = self._make_client()
-        kwargs: dict = {"metadata": {"llm_override": {"base_url": "http://custom:9000/v1///"}}}
-        base_url, _, _ = client._resolve_overrides(kwargs)
-        assert base_url == "http://custom:9000/v1"
+        kwargs: dict = {
+            "metadata": {
+                "llm_override": {
+                    "base_url": "http://169.254.169.254/latest/meta-data",
+                    "api_key": "attacker-key",
+                    "model": "custom-model",
+                }
+            }
+        }
+        base_url, model, headers = client._resolve_overrides(kwargs)
+        assert model == "custom-model"
+        assert base_url == "http://default:8000/v1"
+        assert headers is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -14,7 +14,7 @@ from core.models.user import PartitionRole, User, UserPartition
 from core.utils.exceptions import OpenRAGError
 from cryptography.fernet import Fernet
 from services.auth import StateCookieSerializer, hash_session_token
-from services.auth.oidc_client import LogoutTokenClaims, TokenBundle
+from services.auth.oidc_client import _CLOCK_SKEW_LEEWAY, LogoutTokenClaims, TokenBundle
 from services.orchestrators.auth_service import AuthService, OIDCFlowError
 
 KEY = Fernet.generate_key().decode()
@@ -424,7 +424,7 @@ async def test_claim_mapping_rejects_userinfo_sub_mismatch():
 @pytest.mark.asyncio
 async def test_backchannel_logout_revokes_by_sid():
     srepo = FakeSessionRepo()
-    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid="sess-9", iat=0, jti=None)
+    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid="sess-9", iat=0, jti=None, exp=1)
     svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
     count = await svc.handle_backchannel_logout("tok")
     assert count == 3
@@ -442,7 +442,7 @@ async def test_backchannel_logout_invalid_token_carries_description():
 @pytest.mark.asyncio
 async def test_backchannel_logout_sidless_is_noop_200():
     srepo = FakeSessionRepo()
-    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid=None, iat=0, jti=None)
+    claims = LogoutTokenClaims(iss="i", aud="openrag", sub="s", sid=None, iat=0, jti=None, exp=1)
     svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
     assert await svc.handle_backchannel_logout("tok") == 0
     assert srepo.revoked_sids == []
@@ -472,6 +472,22 @@ async def test_backchannel_logout_rejects_replayed_jti():
     with pytest.raises(OIDCFlowError) as ei:
         await svc.handle_backchannel_logout("tok")
     assert ei.value.error_description == "logout_token replayed"
+
+
+def test_logout_replay_cache_keeps_jti_for_clock_skew(monkeypatch):
+    """Replay protection must last through the same leeway accepted by token verification."""
+    from services.orchestrators import auth_service as _as
+
+    now = 1_000_000
+    _as._seen_logout_jti.clear()
+    monkeypatch.setattr(_as.time, "time", lambda: now)
+
+    assert _as._logout_jti_is_replay("skew-jti", now - 1) is False
+    assert _as._logout_jti_is_replay("skew-jti", now - 1) is True
+
+    monkeypatch.setattr(_as.time, "time", lambda: now + _CLOCK_SKEW_LEEWAY + 1)
+    assert _as._logout_jti_is_replay("skew-jti", now - 1) is False
+    _as._seen_logout_jti.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -444,6 +444,32 @@ async def test_backchannel_logout_sidless_is_noop_200():
 
 
 @pytest.mark.asyncio
+async def test_backchannel_logout_rejects_replayed_jti():
+    import time as _time
+
+    from services.orchestrators import auth_service as _as
+
+    _as._seen_logout_jti.clear()
+    srepo = FakeSessionRepo()
+    claims = LogoutTokenClaims(
+        iss="i",
+        aud="openrag",
+        sub="s",
+        sid="sess-9",
+        iat=0,
+        jti="jti-replay-1",
+        exp=int(_time.time()) + 120,
+    )
+    svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
+    # First processing succeeds and revokes the session(s).
+    assert await svc.handle_backchannel_logout("tok") == 3
+    # Re-processing the same jti is rejected as a replay.
+    with pytest.raises(OIDCFlowError) as ei:
+        await svc.handle_backchannel_logout("tok")
+    assert ei.value.error_description == "logout_token replayed"
+
+
+@pytest.mark.asyncio
 async def test_logout_revokes_and_builds_end_session_url():
     # Seed a real session via the callback path so the stored id_token is
     # encrypted with the configured key.

--- a/tests/unit/services/orchestrators/test_auth_service.py
+++ b/tests/unit/services/orchestrators/test_auth_service.py
@@ -474,6 +474,32 @@ async def test_backchannel_logout_rejects_replayed_jti():
     assert ei.value.error_description == "logout_token replayed"
 
 
+@pytest.mark.asyncio
+async def test_backchannel_logout_rejects_replayed_jti_without_exp(monkeypatch):
+    from services.orchestrators import auth_service as _as
+
+    now = 1_000_000
+    _as._seen_logout_jti.clear()
+    monkeypatch.setattr(_as.time, "time", lambda: now)
+
+    srepo = FakeSessionRepo()
+    claims = LogoutTokenClaims(
+        iss="i",
+        aud="openrag",
+        sub="s",
+        sid="sess-9",
+        iat=now,
+        jti="jti-without-exp",
+        exp=None,
+    )
+    svc = _service(session_repo=srepo, client=FakeOIDCClient(logout_claims=claims))
+
+    assert await svc.handle_backchannel_logout("tok") == 3
+    with pytest.raises(OIDCFlowError) as ei:
+        await svc.handle_backchannel_logout("tok")
+    assert ei.value.error_description == "logout_token replayed"
+
+
 def test_logout_replay_cache_keeps_jti_for_clock_skew(monkeypatch):
     """Replay protection must last through the same leeway accepted by token verification."""
     from services.orchestrators import auth_service as _as

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -6,7 +6,7 @@ import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.models.preset import PartitionConfig
-from core.utils.exceptions import PartitionNotFoundError
+from core.utils.exceptions import PartitionNotFoundError, ValidationError
 from services.orchestrators.indexing_service import IndexingService
 
 
@@ -112,6 +112,7 @@ class FakePartitionService:
     def __init__(self, config, *, db_partitions: set[str] | None = None):
         self._config = config
         self._db = db_partitions or set()
+        self._members: dict[str, list[dict]] = {}
         self.created: list[tuple[str, int]] = []
         self.create_kwargs: list[dict] = []
         self.loaded = 0
@@ -131,6 +132,7 @@ class FakePartitionService:
         self.created.append((partition, user_id))
         self.create_kwargs.append(dict(_))
         self._db.add(partition)
+        self._members.setdefault(partition, []).append({"user_id": user_id, "role": "owner"})
         # Mimic create_partition + load_partitions populating the cache.
         self._config.partitions[partition] = self._cfg(partition)
 
@@ -139,6 +141,27 @@ class FakePartitionService:
         # Mimic the cache being rebuilt from all DB rows.
         for name in self._db:
             self._config.partitions.setdefault(name, self._cfg(name))
+
+    async def list_members(self, partition: str) -> list[dict]:
+        return list(self._members.get(partition, []))
+
+
+class RaceLostPartitionService(FakePartitionService):
+    def __init__(self, config, *, grant_owner: bool = True):
+        super().__init__(config)
+        self.grant_owner = grant_owner
+
+    async def create_partition(self, partition: str, *, user_id: int, **_) -> None:
+        self.created.append((partition, user_id))
+        self.create_kwargs.append(dict(_))
+        self._db.add(partition)
+        if self.grant_owner:
+            self._members.setdefault(partition, []).append({"user_id": user_id, "role": "owner"})
+        raise ValidationError(
+            f"Partition '{partition}' already exists.",
+            status_code=409,
+            code="PARTITION_EXISTS",
+        )
 
 
 def _service(*, doc=None, ws=None, disp=None, config=None, partition_service=None):
@@ -359,6 +382,54 @@ async def test_add_file_refreshes_cache_when_partition_row_exists(tmp_path):
     assert psvc.created == []
     assert psvc.loaded == 1
     assert disp.dispatched[0]["partition"] == "tenant-new"
+
+
+@pytest.mark.asyncio
+async def test_add_file_treats_partition_exists_race_as_success(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    disp = FakeDispatcher()
+    config = _config_with_partition("tenant-a")
+    psvc = RaceLostPartitionService(config)
+    svc = _service(disp=disp, config=config, partition_service=psvc)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="tenant-new",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+    )
+
+    assert psvc.created == [("tenant-new", 7)]
+    assert psvc.create_kwargs == [{"max_owned": 100}]
+    assert psvc.loaded == 1
+    assert disp.dispatched[0]["partition"] == "tenant-new"
+
+
+@pytest.mark.asyncio
+async def test_add_file_rejects_partition_exists_race_without_membership(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    disp = FakeDispatcher()
+    config = _config_with_partition("tenant-a")
+    psvc = RaceLostPartitionService(config, grant_owner=False)
+    svc = _service(disp=disp, config=config, partition_service=psvc)
+
+    with pytest.raises(PermissionError, match="Editor role required"):
+        await svc.add_file(
+            file_path=str(f),
+            file_id="f1",
+            partition="tenant-new",
+            metadata={},
+            sanitized_filename="doc.txt",
+            original_filename="doc.txt",
+            user={"id": 7},
+        )
+
+    assert disp.dispatched == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -314,6 +314,28 @@ async def test_add_file_auto_create_defaults_to_admin_when_user_missing(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_add_file_auto_create_preserves_admin_cap_bypass(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    config = _config_with_partition("tenant-a")
+    psvc = FakePartitionService(config)
+    svc = _service(config=config, partition_service=psvc)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="tenant-new",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7, "is_admin": True},
+    )
+
+    assert psvc.created == [("tenant-new", 7)]
+    assert psvc.create_kwargs == [{"max_owned": None}]
+
+
+@pytest.mark.asyncio
 async def test_add_file_refreshes_cache_when_partition_row_exists(tmp_path):
     f = tmp_path / "doc.txt"
     f.write_text("x")

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -6,7 +6,7 @@ import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.models.preset import PartitionConfig
-from core.utils.exceptions import PartitionNotFoundError, ValidationError
+from core.utils.exceptions import AuthError, PartitionNotFoundError, ValidationError
 from services.orchestrators.indexing_service import IndexingService
 
 
@@ -418,7 +418,7 @@ async def test_add_file_rejects_partition_exists_race_without_membership(tmp_pat
     psvc = RaceLostPartitionService(config, grant_owner=False)
     svc = _service(disp=disp, config=config, partition_service=psvc)
 
-    with pytest.raises(PermissionError, match="Editor role required"):
+    with pytest.raises(AuthError, match="Editor role required") as exc_info:
         await svc.add_file(
             file_path=str(f),
             file_id="f1",
@@ -429,6 +429,8 @@ async def test_add_file_rejects_partition_exists_race_without_membership(tmp_pat
             user={"id": 7},
         )
 
+    # Maps to a clean 403 Forbidden, not the catch-all 500.
+    assert exc_info.value.status_code == 403
     assert disp.dispatched == []
 
 

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -113,6 +113,7 @@ class FakePartitionService:
         self._config = config
         self._db = db_partitions or set()
         self.created: list[tuple[str, int]] = []
+        self.create_kwargs: list[dict] = []
         self.loaded = 0
 
     def _cfg(self, partition: str) -> PartitionConfig:
@@ -128,6 +129,7 @@ class FakePartitionService:
 
     async def create_partition(self, partition: str, *, user_id: int, **_) -> None:
         self.created.append((partition, user_id))
+        self.create_kwargs.append(dict(_))
         self._db.add(partition)
         # Mimic create_partition + load_partitions populating the cache.
         self._config.partitions[partition] = self._cfg(partition)
@@ -285,6 +287,7 @@ async def test_add_file_auto_creates_unknown_partition_when_service_wired(tmp_pa
 
     # Partition was created with the uploader as owner, then the file dispatched.
     assert psvc.created == [("tenant-new", 7)]
+    assert psvc.create_kwargs == [{"max_owned": 100}]
     assert disp.dispatched[0]["partition"] == "tenant-new"
 
 
@@ -307,6 +310,7 @@ async def test_add_file_auto_create_defaults_to_admin_when_user_missing(tmp_path
     )
 
     assert psvc.created == [("tenant-new", 1)]
+    assert psvc.create_kwargs == [{"max_owned": None}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from core.utils.exceptions import ValidationError
 from services.orchestrators.mcp_service import MCPService
 
 # ---------------------------------------------------------------------------
@@ -72,6 +73,17 @@ class FakePartitions:
         # Mirror PgPartitionRepository: the creator is granted owner.
         self.created.append((partition, user_id, max_owned))
         self._members.append({"user_id": user_id, "role": "owner"})
+
+
+class RaceLostPartitions(FakePartitions):
+    async def create_partition(self, partition, user_id, *, max_owned=None):
+        self.created.append((partition, user_id, max_owned))
+        self._members.append({"user_id": user_id, "role": "owner"})
+        raise ValidationError(
+            f"Partition '{partition}' already exists.",
+            status_code=409,
+            code="PARTITION_EXISTS",
+        )
 
 
 class FakeIndexing:
@@ -695,6 +707,30 @@ async def test_index_url_admin_auto_create_bypasses_partition_cap(monkeypatch):
 
     assert parts.created == [("adminpart", 1, None)]
     assert indexing.added[0]["user"] == {"id": 1, "is_admin": True}
+
+
+@pytest.mark.asyncio
+async def test_index_url_treats_partition_exists_race_as_success(monkeypatch):
+    parts = RaceLostPartitions(exists=False, partition_exists=False)
+    indexing = FakeIndexing()
+    svc = _service(partitions=parts, indexing=indexing)
+
+    async def fake_download(url, dest):
+        dest.write_bytes(b"data")
+
+    monkeypatch.setattr(svc, "_safe_download", fake_download)
+
+    out = await svc.index_url(
+        url="https://example.com/report.pdf",
+        partition="newpart",
+        file_id="f1",
+        allowed_partitions=["other"],
+        user_id=7,
+    )
+
+    assert parts.created == [("newpart", 7, 100)]
+    assert indexing.added[0]["partition"] == "newpart"
+    assert out["task_id"] == "task-123"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -674,6 +674,30 @@ async def test_index_url_auto_creates_partition_and_indexes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_index_url_admin_auto_create_bypasses_partition_cap(monkeypatch):
+    parts = FakePartitions(exists=False, partition_exists=False)
+    indexing = FakeIndexing()
+    svc = _service(partitions=parts, indexing=indexing)
+
+    async def fake_download(url, dest):
+        dest.write_bytes(b"data")
+
+    monkeypatch.setattr(svc, "_safe_download", fake_download)
+
+    await svc.index_url(
+        url="https://example.com/report.pdf",
+        partition="adminpart",
+        file_id="f1",
+        allowed_partitions=["other"],
+        user_id=1,
+        is_admin=True,
+    )
+
+    assert parts.created == [("adminpart", 1, None)]
+    assert indexing.added[0]["user"] == {"id": 1, "is_admin": True}
+
+
+@pytest.mark.asyncio
 async def test_safe_download_rejects_redirect_to_private(monkeypatch, tmp_path):
     # A public host that 302-redirects to a loopback target must be rejected on
     # the re-validated hop, not followed.

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -47,7 +47,7 @@ class FakePartitions:
         self._chunks = chunks if chunks is not None else []
         self._members = members if members is not None else []
         self._partition_exists = partition_exists
-        self.created: list[tuple[str, int | None]] = []
+        self.created: list[tuple[str, int | None, int | None]] = []
 
     async def list_partitions(self):
         return list(self._partitions)
@@ -68,9 +68,9 @@ class FakePartitions:
     async def partition_exists(self, partition):
         return self._partition_exists
 
-    async def create_partition(self, partition, user_id):
+    async def create_partition(self, partition, user_id, *, max_owned=None):
         # Mirror PgPartitionRepository: the creator is granted owner.
-        self.created.append((partition, user_id))
+        self.created.append((partition, user_id, max_owned))
         self._members.append({"user_id": user_id, "role": "owner"})
 
 
@@ -193,6 +193,12 @@ async def test_search_all_request_resolves_to_allowed():
         query="hi", partitions=["all"], top_k=None, allowed_partitions=["a", "b"]
     )
     assert retrieval.calls[0]["partitions"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_search_all_with_empty_allowed_partitions_fails_closed():
+    with pytest.raises(PermissionError, match="No accessible partitions"):
+        await _service().search_documents(query="hi", partitions=["all"], top_k=None, allowed_partitions=[])
 
 
 @pytest.mark.asyncio
@@ -378,17 +384,26 @@ async def test_task_status_admin_bypasses_owner():
 
 
 @pytest.mark.asyncio
-async def test_task_status_failed_includes_error():
+async def test_task_status_failed_redacts_error_for_non_admin():
     jobs = FakeJobs(details={"user_id": 1})
     out = await _service(jobs=jobs, indexing=FakeIndexing(state="FAILED", error="kaboom")).get_task_status(
         task_id="t1", user_id=1, is_admin=False
     )
     assert out["task_state"] == "FAILED"
+    assert out["error"] == "Task failed. Contact an administrator for details."
+
+
+@pytest.mark.asyncio
+async def test_task_status_failed_includes_raw_error_for_admin():
+    jobs = FakeJobs(details={"user_id": 1})
+    out = await _service(jobs=jobs, indexing=FakeIndexing(state="FAILED", error="kaboom")).get_task_status(
+        task_id="t1", user_id=1, is_admin=True
+    )
     assert out["error"] == "kaboom"
 
 
 @pytest.mark.asyncio
-async def test_list_my_tasks_forwards_scope_and_decorates_failed():
+async def test_list_my_tasks_forwards_scope_and_redacts_failed_for_non_admin():
     jobs = FakeJobs(
         tasks=[
             {"task_id": "t1", "state": "FAILED", "details": {}},
@@ -400,9 +415,18 @@ async def test_list_my_tasks_forwards_scope_and_decorates_failed():
     )
     assert jobs.last == {"is_admin": False, "user_id": 5, "task_status": "failed"}
     failed = next(t for t in out["tasks"] if t["task_id"] == "t1")
-    assert failed["error"] == "why"
+    assert failed["error"] == "Task failed. Contact an administrator for details."
     completed = next(t for t in out["tasks"] if t["task_id"] == "t2")
     assert "error" not in completed
+
+
+@pytest.mark.asyncio
+async def test_list_my_tasks_keeps_raw_failed_error_for_admin():
+    jobs = FakeJobs(tasks=[{"task_id": "t1", "state": "FAILED", "details": {}}])
+    out = await _service(jobs=jobs, indexing=FakeIndexing(error="why")).list_my_tasks(
+        user_id=5, is_admin=True, task_status="failed"
+    )
+    assert out["tasks"][0]["error"] == "why"
 
 
 @pytest.mark.asyncio
@@ -638,7 +662,7 @@ async def test_index_url_auto_creates_partition_and_indexes(monkeypatch):
         extra_metadata={"author": "me", "created_by": 999},  # created_by must be stripped
     )
     # auto-created the missing partition, owned by the caller
-    assert parts.created == [("newpart", 7)]
+    assert parts.created == [("newpart", 7, 100)]
     added = indexing.added[0]
     assert added["file_id"] == "f1"
     assert added["partition"] == "newpart"

--- a/tests/unit/services/orchestrators/test_partition_preset_resolution.py
+++ b/tests/unit/services/orchestrators/test_partition_preset_resolution.py
@@ -41,8 +41,8 @@ class _FakePartitionRepo:
     async def partition_exists(self, name: str) -> bool:
         return name in self._store
 
-    async def create_partition(self, name: str, user_id: int | None = None) -> dict:
-        self.calls.append(("create_partition", (name, user_id)))
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
+        self.calls.append(("create_partition", (name, user_id, max_owned)))
         self._store.setdefault(name, _full_row(name))
         return self._store[name]
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -161,6 +161,24 @@ async def test_create_partition_enforces_owned_cap():
 
 
 @pytest.mark.asyncio
+async def test_create_partition_zero_cap_blocks_regular_user():
+    prepo = FakePartitionRepo(existing=set())
+    mrepo = FakeMembershipRepo(owned={7: 0})
+    with pytest.raises(ValidationError) as exc:
+        await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=0)
+    assert exc.value.status_code == 403
+    assert prepo.created == []
+
+
+@pytest.mark.asyncio
+async def test_create_partition_negative_cap_disables_limit():
+    prepo = FakePartitionRepo(existing=set())
+    mrepo = FakeMembershipRepo(owned={7: 999})
+    await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=-1)
+    assert "new" in prepo._existing
+
+
+@pytest.mark.asyncio
 async def test_create_partition_under_cap_succeeds():
     prepo = FakePartitionRepo(existing=set())
     mrepo = FakeMembershipRepo(owned={7: 1})

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -8,8 +8,9 @@ from services.orchestrators.partition_service import PartitionService
 
 
 class FakePartitionRepo:
-    def __init__(self, existing: set[str] | None = None):
+    def __init__(self, existing: set[str] | None = None, *, owned_count: int = 0):
         self._existing = existing if existing is not None else set()
+        self._owned_count = owned_count
         self.created: list[tuple[str, int]] = []
         self.deleted: list[str] = []
 
@@ -19,7 +20,13 @@ class FakePartitionRepo:
     async def list_partitions(self) -> list[dict]:
         return [{"partition": p} for p in sorted(self._existing)]
 
-    async def create_partition(self, name: str, user_id: int | None = None) -> dict:
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
+        if max_owned is not None and max_owned >= 0 and self._owned_count >= max_owned:
+            raise ValidationError(
+                f"Partition limit reached ({max_owned}). Contact an administrator.",
+                status_code=403,
+                code="PARTITION_LIMIT_EXCEEDED",
+            )
         self._existing.add(name)
         self.created.append((name, user_id))
         return {"partition": name}
@@ -152,7 +159,7 @@ async def test_create_partition_conflict_raises_409():
 
 @pytest.mark.asyncio
 async def test_create_partition_enforces_owned_cap():
-    prepo = FakePartitionRepo(existing=set())
+    prepo = FakePartitionRepo(existing=set(), owned_count=2)
     mrepo = FakeMembershipRepo(owned={7: 2})
     with pytest.raises(ValidationError) as exc:
         await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=2)
@@ -162,7 +169,7 @@ async def test_create_partition_enforces_owned_cap():
 
 @pytest.mark.asyncio
 async def test_create_partition_zero_cap_blocks_regular_user():
-    prepo = FakePartitionRepo(existing=set())
+    prepo = FakePartitionRepo(existing=set(), owned_count=0)
     mrepo = FakeMembershipRepo(owned={7: 0})
     with pytest.raises(ValidationError) as exc:
         await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=0)
@@ -172,7 +179,7 @@ async def test_create_partition_zero_cap_blocks_regular_user():
 
 @pytest.mark.asyncio
 async def test_create_partition_negative_cap_disables_limit():
-    prepo = FakePartitionRepo(existing=set())
+    prepo = FakePartitionRepo(existing=set(), owned_count=999)
     mrepo = FakeMembershipRepo(owned={7: 999})
     await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=-1)
     assert "new" in prepo._existing
@@ -180,7 +187,7 @@ async def test_create_partition_negative_cap_disables_limit():
 
 @pytest.mark.asyncio
 async def test_create_partition_under_cap_succeeds():
-    prepo = FakePartitionRepo(existing=set())
+    prepo = FakePartitionRepo(existing=set(), owned_count=1)
     mrepo = FakeMembershipRepo(owned={7: 1})
     await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=5)
     assert "new" in prepo._existing
@@ -188,7 +195,7 @@ async def test_create_partition_under_cap_succeeds():
 
 @pytest.mark.asyncio
 async def test_create_partition_admin_bypass_cap_when_max_owned_none():
-    prepo = FakePartitionRepo(existing=set())
+    prepo = FakePartitionRepo(existing=set(), owned_count=999)
     mrepo = FakeMembershipRepo(owned={7: 999})
     # max_owned=None (admin) → cap skipped even with many owned partitions.
     await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=None)

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -31,11 +31,24 @@ class FakePartitionRepo:
 
 
 class FakeMembershipRepo:
-    def __init__(self, members: set[tuple[int, str]] | None = None):
+    def __init__(
+        self,
+        members: set[tuple[int, str]] | None = None,
+        owned: dict[int, int] | None = None,
+    ):
         self._members = members or set()
+        self._owned = owned or {}  # user_id -> number of partitions owned
         self.added: list[tuple[str, int, str]] = []
         self.removed: list[tuple[str, int]] = []
         self.role_updates: list[tuple[str, int, str]] = []
+
+    async def list_user_partitions(self, user_id: int):
+        from core.models.user import PartitionRole, UserPartition
+
+        return [
+            UserPartition(user_id=user_id, partition=f"owned-{i}", role=PartitionRole.OWNER)
+            for i in range(self._owned.get(user_id, 0))
+        ]
 
     async def user_is_partition_member(self, user_id: int, partition: str) -> bool:
         return (user_id, partition) in self._members
@@ -135,6 +148,33 @@ async def test_create_partition_conflict_raises_409():
     with pytest.raises(ValidationError) as ei:
         await _svc(prepo=prepo).create_partition("p1", 1)
     assert ei.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_partition_enforces_owned_cap():
+    prepo = FakePartitionRepo(existing=set())
+    mrepo = FakeMembershipRepo(owned={7: 2})
+    with pytest.raises(ValidationError) as exc:
+        await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=2)
+    assert exc.value.status_code == 403
+    assert exc.value.code == "PARTITION_LIMIT_EXCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_create_partition_under_cap_succeeds():
+    prepo = FakePartitionRepo(existing=set())
+    mrepo = FakeMembershipRepo(owned={7: 1})
+    await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=5)
+    assert "new" in prepo._existing
+
+
+@pytest.mark.asyncio
+async def test_create_partition_admin_bypass_cap_when_max_owned_none():
+    prepo = FakePartitionRepo(existing=set())
+    mrepo = FakeMembershipRepo(owned={7: 999})
+    # max_owned=None (admin) → cap skipped even with many owned partitions.
+    await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=None)
+    assert "new" in prepo._existing
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -182,7 +182,7 @@ async def test_create_partition_negative_cap_disables_limit():
     prepo = FakePartitionRepo(existing=set(), owned_count=999)
     mrepo = FakeMembershipRepo(owned={7: 999})
     await _svc(prepo=prepo, mrepo=mrepo).create_partition("new", 7, max_owned=-1)
-    assert "new" in prepo._existing
+    assert prepo.created == [("new", 7)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_user_service.py
+++ b/tests/unit/services/orchestrators/test_user_service.py
@@ -257,6 +257,28 @@ async def test_update_user_validates_email():
         await _svc(repo).update_user(2, UserUpdate(email="bogus"))
 
 
+@pytest.mark.asyncio
+async def test_update_user_drops_mass_assignment_fields():
+    """token / file_count / other non-profile columns must never reach the repo
+    through the update payload (mass assignment)."""
+    repo = FakeUserRepo(existing={2})
+    repo._users[2] = User(id=2, display_name="X", is_admin=False, file_quota=5, file_count=4)
+    # extra="ignore" drops unknown fields at parse; the service whitelist is the
+    # second line of defence. Both are exercised here.
+    body = UserUpdate.model_validate(
+        {"display_name": "X", "is_admin": True, "token": "evil", "file_count": 999, "id": 7}
+    )
+    await _svc(repo).update_user(2, body)
+    assert repo.updated, "repo.update_user was not called"
+    _, fields = repo.updated[-1]
+    assert "token" not in fields
+    assert "file_count" not in fields
+    assert "id" not in fields
+    # whitelisted profile fields still pass through
+    assert fields.get("display_name") == "X"
+    assert fields.get("is_admin") is True
+
+
 # --------------------------------------------------------------------------- #
 # get_current_user_info — quota-usage block (8F: moved out of the router)
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_user_service.py
+++ b/tests/unit/services/orchestrators/test_user_service.py
@@ -80,6 +80,15 @@ class FakeJobService:
         return self._pending
 
 
+class FakeAuthService:
+    def __init__(self):
+        self.revoked_user_sessions: list[int] = []
+
+    async def revoke_user_oidc_sessions(self, user_id: int) -> int:
+        self.revoked_user_sessions.append(user_id)
+        return 0
+
+
 def _svc(
     repo: FakeUserRepo,
     *,
@@ -87,10 +96,11 @@ def _svc(
     partition_service: FakePartitionService | None = None,
     membership_repo: FakeMembershipRepo | None = None,
     job_service: FakeJobService | None = None,
+    auth_service: FakeAuthService | None = None,
 ) -> UserService:
     return UserService(
         user_repo=repo,
-        auth_service=object(),
+        auth_service=auth_service or FakeAuthService(),
         default_file_quota=default_quota,
         partition_service=partition_service or FakePartitionService(),
         membership_repo=membership_repo or FakeMembershipRepo(),
@@ -219,9 +229,12 @@ async def test_regenerate_token_repo_returns_none_404():
 async def test_regenerate_token_success():
     repo = FakeUserRepo(existing={3})
     repo.regen_results[3] = {"id": 3, "token": "or-new"}
-    out = await _svc(repo).regenerate_token(3)
+    auth = FakeAuthService()
+    out = await _svc(repo, auth_service=auth).regenerate_token(3)
     assert out == {"id": 3, "token": "or-new"}
     assert repo.regenerated == [3]
+    # Rotating the token must revoke the user's active OIDC sessions.
+    assert auth.revoked_user_sessions == [3]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_partition_repo.py
+++ b/tests/unit/services/persistence/test_partition_repo.py
@@ -18,8 +18,9 @@ class _AsyncContext:
 
 
 class _FakeConn:
-    def __init__(self, *, owned_count: int = 0):
+    def __init__(self, *, owned_count: int = 0, existing_partition: bool = False):
         self.owned_count = owned_count
+        self.existing_partition = existing_partition
         self.operations: list[tuple[str, tuple]] = []
         self.inserted_partition = False
 
@@ -30,6 +31,8 @@ class _FakeConn:
     async def fetchrow(self, query: str, *params):
         self.operations.append((query, params))
         if "SELECT * FROM partitions" in query:
+            if self.existing_partition:
+                return {"partition": params[0], "created_at": datetime(2026, 1, 1, tzinfo=UTC)}
             return None
         if "INSERT INTO partitions" in query:
             self.inserted_partition = True
@@ -87,3 +90,18 @@ async def test_create_partition_locks_user_before_counting_owned_partitions():
     count_index = next(i for i, query in enumerate(operations) if "COUNT(*)::int FROM partition_memberships" in query)
     insert_index = next(i for i, query in enumerate(operations) if "INSERT INTO partitions" in query)
     assert lock_index < count_index < insert_index
+
+
+@pytest.mark.asyncio
+async def test_create_partition_existing_row_raises_conflict():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _FakeConn(existing_partition=True)
+    repo = PgPartitionRepository(pool_getter=lambda: _FakePool(conn))
+
+    with pytest.raises(ValidationError) as exc:
+        await repo.create_partition("existing", user_id=7, max_owned=2)
+
+    assert exc.value.status_code == 409
+    assert exc.value.code == "PARTITION_EXISTS"
+    assert conn.inserted_partition is False

--- a/tests/unit/services/persistence/test_partition_repo.py
+++ b/tests/unit/services/persistence/test_partition_repo.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from core.utils.exceptions import ValidationError
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, *, owned_count: int = 0):
+        self.owned_count = owned_count
+        self.operations: list[tuple[str, tuple]] = []
+        self.inserted_partition = False
+
+    def transaction(self):
+        self.operations.append(("BEGIN", ()))
+        return _AsyncContext(self)
+
+    async def fetchrow(self, query: str, *params):
+        self.operations.append((query, params))
+        if "SELECT * FROM partitions" in query:
+            return None
+        if "INSERT INTO partitions" in query:
+            self.inserted_partition = True
+            return {"partition": params[0], "created_at": datetime(2026, 1, 1, tzinfo=UTC)}
+        return None
+
+    async def fetchval(self, query: str, *params):
+        self.operations.append((query, params))
+        if "COUNT(*)::int FROM partition_memberships" in query:
+            return self.owned_count
+        return None
+
+    async def execute(self, query: str, *params):
+        self.operations.append((query, params))
+        return "INSERT 0 1"
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConn):
+        self.conn = conn
+
+    def acquire(self):
+        return _AsyncContext(self.conn)
+
+
+@pytest.mark.asyncio
+async def test_create_partition_enforces_owner_cap_inside_transaction():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _FakeConn(owned_count=2)
+    repo = PgPartitionRepository(pool_getter=lambda: _FakePool(conn))
+
+    with pytest.raises(ValidationError) as exc:
+        await repo.create_partition("new", user_id=7, max_owned=2)
+
+    assert exc.value.code == "PARTITION_LIMIT_EXCEEDED"
+    assert conn.inserted_partition is False
+    operations = [query for query, _params in conn.operations]
+    assert any("pg_advisory_xact_lock" in query for query in operations)
+    assert any("COUNT(*)::int FROM partition_memberships" in query for query in operations)
+    assert not any("INSERT INTO partitions" in query for query in operations)
+
+
+@pytest.mark.asyncio
+async def test_create_partition_locks_user_before_counting_owned_partitions():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _FakeConn(owned_count=1)
+    repo = PgPartitionRepository(pool_getter=lambda: _FakePool(conn))
+
+    await repo.create_partition("new", user_id=7, max_owned=2)
+
+    operations = [query for query, _params in conn.operations]
+    lock_index = next(i for i, query in enumerate(operations) if "pg_advisory_xact_lock" in query)
+    count_index = next(i for i, query in enumerate(operations) if "COUNT(*)::int FROM partition_memberships" in query)
+    insert_index = next(i for i, query in enumerate(operations) if "INSERT INTO partitions" in query)
+    assert lock_index < count_index < insert_index

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -152,15 +152,26 @@ class TestBuildFilterExpr:
         assert expr == "created_at > ISO '2025-01-01'"
 
     def test_raw_expr_combined_with_partition(self, store: MilvusVectorStore) -> None:
+        # Multiple predicates are each parenthesised so the raw user expr cannot
+        # escape the partition scope via operator precedence.
         expr = store._build_filter_expr({"partition": "p1", "expr": "page > 5"})
-        assert expr == 'partition == "p1" and page > 5'
+        assert expr == '(partition == "p1") and (page > 5)'
 
     def test_partition_and_field_joined_with_and(self, store: MilvusVectorStore) -> None:
         expr = store._build_filter_expr({"partition": "p1", "file_id": "f1"})
-        assert expr == 'partition == "p1" and file_id == "f1"'
+        assert expr == '(partition == "p1") and (file_id == "f1")'
 
     def test_int_value_passes_through(self, store: MilvusVectorStore) -> None:
         assert store._build_filter_expr({"page": 7}) == "page == 7"
+
+    def test_user_expr_with_or_cannot_escape_partition_scope(self, store: MilvusVectorStore) -> None:
+        # A viewer-supplied filter with `or` must stay contained within the
+        # partition predicate: `and` binds tighter than `or` in Milvus, so
+        # without parentheses this would read another tenant's chunks.
+        expr = store._build_filter_expr(
+            {"partition": "p1", "expr": 'text != "" or partition == "other"'}
+        )
+        assert expr == '(partition == "p1") and (text != "" or partition == "other")'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -168,9 +168,7 @@ class TestBuildFilterExpr:
         # A viewer-supplied filter with `or` must stay contained within the
         # partition predicate: `and` binds tighter than `or` in Milvus, so
         # without parentheses this would read another tenant's chunks.
-        expr = store._build_filter_expr(
-            {"partition": "p1", "expr": 'text != "" or partition == "other"'}
-        )
+        expr = store._build_filter_expr({"partition": "p1", "expr": 'text != "" or partition == "other"'})
         assert expr == '(partition == "p1") and (text != "" or partition == "other")'
 
 

--- a/tests/unit/services/storage/test_vector_store_searcher.py
+++ b/tests/unit/services/storage/test_vector_store_searcher.py
@@ -248,3 +248,29 @@ async def test_get_ancestor_chunks_passes_max_depth():
     searcher, _, _, doc_repo = _make_searcher(ancestor_ids=[])
     await searcher.get_ancestor_chunks(partition="p1", file_id="f1", limit=5, max_ancestor_depth=2)
     doc_repo.get_ancestor_file_ids.assert_awaited_once_with(partition="p1", file_id="f1", max_ancestor_depth=2)
+
+
+@pytest.mark.asyncio
+async def test_fetch_surrounding_scopes_section_lookup_to_partition():
+    """N6: section_id is only unique within a partition, so neighbour lookups
+    must be scoped to each source chunk's partition (no cross-tenant leak)."""
+    searcher, store, _, _ = _make_searcher()
+    chunks = [
+        _dict_to_chunk(_make_row("1", partition="p1", prev_section_id="s0")),
+        _dict_to_chunk(_make_row("2", partition="p2", next_section_id="s9")),
+    ]
+    await searcher._fetch_surrounding(chunks)
+    calls = store.query_chunks_by_filter.call_args_list
+    # One scoped query per partition; section_id is never queried unscoped.
+    by_part = {c.args[1]["partition"]: set(c.args[1]["section_id"]) for c in calls}
+    assert by_part == {"p1": {"s0"}, "p2": {"s9"}}
+    assert all("partition" in c.args[1] for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_fetch_surrounding_drops_refs_without_partition():
+    searcher, store, _, _ = _make_searcher()
+    c = _dict_to_chunk(_make_row("1", partition="p1", prev_section_id="s0"))
+    c.partition = ""  # source chunk with no partition → dropped, not queried unscoped
+    assert await searcher._fetch_surrounding([c]) == []
+    store.query_chunks_by_filter.assert_not_awaited()

--- a/tests/unit/services/websearch/test_content_fetcher.py
+++ b/tests/unit/services/websearch/test_content_fetcher.py
@@ -319,9 +319,7 @@ class TestGuardRequest:
         def fake_getaddrinfo(host, port, *args, **kwargs):
             return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
 
-        monkeypatch.setattr(
-            "services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo
-        )
+        monkeypatch.setattr("services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo)
         req = httpx.Request("GET", "http://internal.example.com/")
         with pytest.raises(httpx.RequestError):
             await fetcher._guard_request(req)
@@ -331,9 +329,7 @@ class TestGuardRequest:
         def fake_getaddrinfo(host, port, *args, **kwargs):
             return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
 
-        monkeypatch.setattr(
-            "services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo
-        )
+        monkeypatch.setattr("services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo)
         req = httpx.Request("GET", "http://example.com/")
         await fetcher._guard_request(req)  # must not raise
 

--- a/tests/unit/services/websearch/test_content_fetcher.py
+++ b/tests/unit/services/websearch/test_content_fetcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 
 import httpx
 import pytest
@@ -304,3 +305,39 @@ def test_fetch_verify_ssl_default_is_true():
 
     cfg = StaanWebSearchConfig()
     assert cfg.fetch_verify_ssl is True
+
+
+# ---------------------------------------------------------------------------
+# _guard_request — DNS-resolution-time SSRF guard + verify_ssl default
+# ---------------------------------------------------------------------------
+
+
+class TestGuardRequest:
+    @pytest.mark.asyncio
+    async def test_blocks_host_resolving_to_private_ip(self, fetcher, monkeypatch):
+        # A public-looking hostname that resolves to an internal IP must be blocked.
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+
+        monkeypatch.setattr(
+            "services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo
+        )
+        req = httpx.Request("GET", "http://internal.example.com/")
+        with pytest.raises(httpx.RequestError):
+            await fetcher._guard_request(req)
+
+    @pytest.mark.asyncio
+    async def test_allows_host_resolving_to_public_ip(self, fetcher, monkeypatch):
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr(
+            "services.websearch.content_fetcher.socket.getaddrinfo", fake_getaddrinfo
+        )
+        req = httpx.Request("GET", "http://example.com/")
+        await fetcher._guard_request(req)  # must not raise
+
+
+def test_verify_ssl_defaults_to_true():
+    # Fetched content feeds the LLM; default to verifying TLS to prevent MITM.
+    assert ContentFetcher().verify_ssl is True

--- a/tests/unit/test_auth_router.py
+++ b/tests/unit/test_auth_router.py
@@ -286,3 +286,27 @@ def test_logout_without_idp_target_confirms_in_place(oidc_env, client, stub):
     assert r.status_code == 200
     assert r.json()["detail"] == "Logged out"
     assert any(SESSION_COOKIE_NAME in c for c in _set_cookies(r))
+
+
+def test_logout_blocks_cross_site_non_navigation_csrf(oidc_env, client, stub):
+    # A forged <img>/fetch request is cross-site and not a top-level navigation.
+    r = client.get(
+        "/auth/logout",
+        headers={"sec-fetch-site": "cross-site", "sec-fetch-mode": "no-cors"},
+        cookies={SESSION_COOKIE_NAME: "sess"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 403
+    assert stub.calls == []  # session never revoked
+
+
+def test_logout_allows_cross_site_top_level_navigation(oidc_env, client, stub):
+    # The IdP RP-initiated logout redirect is a genuine top-level navigation.
+    r = client.get(
+        "/auth/logout",
+        headers={"sec-fetch-site": "cross-site", "sec-fetch-mode": "navigate"},
+        cookies={SESSION_COOKIE_NAME: "sess"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert stub.calls == [("logout", "sess")]

--- a/tests/unit/test_chainlit_api_auth.py
+++ b/tests/unit/test_chainlit_api_auth.py
@@ -43,3 +43,61 @@ def test_standalone_chainlit_redirects_unauthenticated_oidc_html(monkeypatch):
 
     assert response.status_code == 302
     assert response.headers["location"] == "/auth/login?next=%2Fchainlit%2F"
+
+
+def _stub_chainlit(monkeypatch):
+    chainlit = types.ModuleType("chainlit")
+    chainlit_utils = types.ModuleType("chainlit.utils")
+
+    def mount_chainlit(app: FastAPI, target: str, path: str):
+        @app.get(f"{path}/")
+        async def chainlit_page():
+            return PlainTextResponse("chainlit")
+
+    chainlit_utils.mount_chainlit = mount_chainlit
+    chainlit.utils = chainlit_utils
+    monkeypatch.setitem(sys.modules, "chainlit", chainlit)
+    monkeypatch.setitem(sys.modules, "chainlit.utils", chainlit_utils)
+
+
+def test_standalone_chainlit_oidc_cookie_uses_initialized_container(monkeypatch):
+    """A session cookie must be looked up against an *initialized* container.
+
+    Regression: in Ray Serve mode the standalone Chainlit app ran in its own
+    process and never called ``ServiceContainer.initialize()``, so a logged-in
+    user revisiting ``/chainlit/`` (cookie present) hit
+    ``ConnectionManager.initialize() has not been called`` → 500. The lifespan
+    now opens the container's pool; here we assert the cookie lookup reaches
+    the auth service (rather than crashing) and redirects when the session is
+    unknown.
+    """
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    monkeypatch.setenv("OIDC_TOKEN_ENCRYPTION_KEY", "dummy")
+
+    auth_service = MagicMock()
+    auth_service.get_oidc_session_by_token_for_request = AsyncMock(return_value=None)
+
+    container = MagicMock()
+    container.auth_service = auth_service
+    container.initialize = AsyncMock()
+    container.shutdown = AsyncMock()
+
+    _stub_chainlit(monkeypatch)
+    sys.modules.pop("chainlit_api", None)
+    module = importlib.import_module("chainlit_api")
+    # The lifespan builds the container from this symbol — swap in a fake whose
+    # pool is already "open" so no real Postgres/Milvus is required.
+    monkeypatch.setattr(module, "ServiceContainer", lambda *a, **k: container)
+
+    with TestClient(module.app) as client:
+        client.cookies.set("openrag_session", "opaque-session-token")
+        response = client.get(
+            "/chainlit/",
+            headers={"accept": "text/html"},
+            follow_redirects=False,
+        )
+
+    container.initialize.assert_awaited_once()
+    auth_service.get_oidc_session_by_token_for_request.assert_awaited_once_with("opaque-session-token")
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/login?next=%2Fchainlit%2F"

--- a/tests/unit/test_chainlit_api_download.py
+++ b/tests/unit/test_chainlit_api_download.py
@@ -1,0 +1,45 @@
+"""Regression test for the standalone Chainlit app's source-download route.
+
+In Ray Serve mode the API and Chainlit run on separate ports. Source previews
+rewrite their file download links to the browser origin (the Chainlit host),
+so the standalone Chainlit app (``chainlit_api.app``) must expose the
+authorized ``/static/{extract_id}`` download route — otherwise PDFs/images/audio
+from search sources would 404 against the Chainlit service.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+
+def _import_chainlit_api(monkeypatch):
+    """Import ``chainlit_api`` with ``chainlit`` stubbed out."""
+    chainlit = types.ModuleType("chainlit")
+    chainlit_utils = types.ModuleType("chainlit.utils")
+
+    def mount_chainlit(app: FastAPI, target: str, path: str):
+        @app.get(f"{path}/")
+        async def chainlit_page():
+            return PlainTextResponse("chainlit")
+
+    chainlit_utils.mount_chainlit = mount_chainlit
+    chainlit.utils = chainlit_utils
+    monkeypatch.setitem(sys.modules, "chainlit", chainlit)
+    monkeypatch.setitem(sys.modules, "chainlit.utils", chainlit_utils)
+
+    sys.modules.pop("chainlit_api", None)
+    return importlib.import_module("chainlit_api")
+
+
+def test_standalone_chainlit_exposes_source_download_route(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "token")
+
+    module = _import_chainlit_api(monkeypatch)
+
+    routes = {getattr(r, "name", None): getattr(r, "path", None) for r in module.app.routes}
+    assert routes.get("download_source") == "/static/{extract_id}"

--- a/uv.lock
+++ b/uv.lock
@@ -1895,6 +1895,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
 name = "literalai"
 version = "0.1.201"
 source = { registry = "https://pypi.org/simple" }
@@ -2728,6 +2742,7 @@ dependencies = [
     { name = "langchain-huggingface" },
     { name = "langchain-openai" },
     { name = "langchain-qdrant" },
+    { name = "limits" },
     { name = "llvmlite" },
     { name = "loguru" },
     { name = "lxml" },
@@ -2797,6 +2812,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=0.1.2" },
     { name = "langchain-openai", specifier = ">=0.3.7" },
     { name = "langchain-qdrant", specifier = ">=0.2.0" },
+    { name = "limits", specifier = ">=3.6" },
     { name = "llvmlite", specifier = ">=0.44.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=5.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,62 @@ wheels = [
 ]
 
 [[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
+]
+
+[[package]]
 name = "authlib"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -477,11 +533,12 @@ wheels = [
 
 [[package]]
 name = "chainlit"
-version = "2.6.2"
+version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "asyncer" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "click" },
     { name = "dataclasses-json" },
     { name = "fastapi" },
@@ -493,6 +550,7 @@ dependencies = [
     { name = "nest-asyncio" },
     { name = "packaging" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -503,9 +561,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/80/c519168d27b3f226b75348ba37c2b01e07ec2dd67b0d0dcb37634d5c777d/chainlit-2.6.2.tar.gz", hash = "sha256:4dd3568c83ee301ab7db0d08521b7cc22b739da76549d55cb271a66dd1233d93", size = 9523061, upload-time = "2025-07-16T04:29:41.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/87/080352b58401851f4bc9d595fc222103d431eb3e4bb2df2e9659028d3203/chainlit-2.11.1.tar.gz", hash = "sha256:74b7f801c63f39e7b4d99fd1fa9654df4a97ce01a07c739558566d750b5de3b6", size = 11205431, upload-time = "2026-04-22T00:56:31.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/5f/1c6e479dcb5af41a3e4094932a9b633610c81add27a4f47b783b9f00e5de/chainlit-2.6.2-py3-none-any.whl", hash = "sha256:f630c2e8dc45a8dc02539de192d27f6d51d9a7da2e6c029c875abc8eb1cc297f", size = 9674525, upload-time = "2025-07-16T04:29:39.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a2/3bbabfdb6bcbb9b0f952eac62ff277464d6359d126ce8f254ba513c1d4c8/chainlit-2.11.1-py3-none-any.whl", hash = "sha256:7cbd341a6cb2b7788845713dc41f86a44c6b36073dcd0fedb0fc7f230b542ec7", size = 11314614, upload-time = "2026-04-22T00:56:26.413Z" },
 ]
 
 [[package]]
@@ -968,16 +1026,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.14"
+version = "0.116.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/64/1296f46d6b9e3b23fb22e5d01af3f104ef411425531376212f1eefa2794d/fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529", size = 298595, upload-time = "2025-09-16T18:29:23.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e4/c543271a8018874b7f682bf6156863c416e1334b8ed3e51a69495c5d4360/fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db", size = 95670, upload-time = "2025-09-16T18:29:21.329Z" },
 ]
 
 [[package]]
@@ -2658,6 +2716,7 @@ dependencies = [
     { name = "einops" },
     { name = "eml-parser" },
     { name = "fast-langdetect" },
+    { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "hdbscan" },
     { name = "html-to-markdown" },
@@ -2694,6 +2753,7 @@ dependencies = [
     { name = "ruff" },
     { name = "spire-doc" },
     { name = "sqlalchemy-utils" },
+    { name = "starlette" },
     { name = "tenacity" },
     { name = "torch" },
     { name = "umap-learn" },
@@ -2725,6 +2785,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8.1" },
     { name = "eml-parser", specifier = ">=2.0.0" },
     { name = "fast-langdetect", specifier = ">=1.0.0" },
+    { name = "fastapi", specifier = ">=0.116.1,<0.117" },
     { name = "faster-whisper", specifier = ">=1.1.0" },
     { name = "hdbscan", specifier = ">=0.8.40" },
     { name = "html-to-markdown", specifier = ">=2.4.0" },
@@ -2761,6 +2822,7 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.14.1" },
     { name = "spire-doc", specifier = ">=13.1.0" },
     { name = "sqlalchemy-utils" },
+    { name = "starlette", specifier = ">=0.47.2,<0.48" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "torch", specifier = ">=2.4.1" },
     { name = "umap-learn", specifier = ">=0.5.9.post2" },
@@ -4901,14 +4963,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "0.47.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51", size = 72991, upload-time = "2025-08-24T13:36:40.887Z" },
 ]
 
 [[package]]
@@ -5364,26 +5427,88 @@ wheels = [
 
 [[package]]
 name = "watchfiles"
-version = "0.20.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/48/02d2d2cbf54e134810b2cb40ac79fdb8ce08476184536a4764717a7bc9f4/watchfiles-0.20.0.tar.gz", hash = "sha256:728575b6b94c90dd531514677201e8851708e6e4b5fe7028ac506a200b622019", size = 37041, upload-time = "2023-08-24T12:49:17.616Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/db/899832e11fef2d468bf8b3c1c13289b1db4cb7c3410bb2a9612a52fc8b22/watchfiles-0.20.0-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:3796312bd3587e14926013612b23066912cf45a14af71cf2b20db1c12dadf4e9", size = 417357, upload-time = "2023-08-24T12:48:43.687Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/1a/85c914e4db62a3f8197daa98a271ea380a5d200a8d3058bd9f417752bc26/watchfiles-0.20.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:d0002d81c89a662b595645fb684a371b98ff90a9c7d8f8630c82f0fde8310458", size = 407258, upload-time = "2023-08-24T12:48:45.7Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ae/b7bddad421af5e33079a2ce639aa58837b715a2da98df16e25ecd310af52/watchfiles-0.20.0-cp37-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:570848706440373b4cd8017f3e850ae17f76dbdf1e9045fc79023b11e1afe490", size = 1331327, upload-time = "2023-08-24T12:48:47.005Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e5/b080cec4e841b1cf338ccbd958cf3232ad1691a590653b2d124b5c79cf6b/watchfiles-0.20.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a0351d20d03c6f7ad6b2e8a226a5efafb924c7755ee1e34f04c77c3682417fa", size = 1301371, upload-time = "2023-08-24T12:48:48.338Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a0/2fb2c36730995a6b3f060187195dc08ad9ceee67426bdca8a4296024071c/watchfiles-0.20.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:007dcc4a401093010b389c044e81172c8a2520dba257c88f8828b3d460c6bb38", size = 1302438, upload-time = "2023-08-24T12:48:49.816Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ea/d11971958ae703cfe443b21f672169cb8bc12dbec5781b910633fa2186ec/watchfiles-0.20.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0d82dbc1832da83e441d112069833eedd4cf583d983fb8dd666fbefbea9d99c0", size = 1410655, upload-time = "2023-08-24T12:48:51.758Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/81/3f922f3ede53ca9c0b4095f63688ffeea19a49592d0ac62db1eb9632b1e3/watchfiles-0.20.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99f4c65fd2fce61a571b2a6fcf747d6868db0bef8a934e8ca235cc8533944d95", size = 1494222, upload-time = "2023-08-24T12:48:54.331Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/46/c9d5ee4871b187d291d62e61c41f9a4d67d4866a89704b0ad16b6949e9bd/watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5392dd327a05f538c56edb1c6ebba6af91afc81b40822452342f6da54907bbdf", size = 1294171, upload-time = "2023-08-24T12:48:56.288Z" },
-    { url = "https://files.pythonhosted.org/packages/59/5e/6b64e3bf9fd4422250f3c716d992dd76dbe55e6fa1e7ebaf2bf88f389707/watchfiles-0.20.0-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:08dc702529bb06a2b23859110c214db245455532da5eaea602921687cfcd23db", size = 1462256, upload-time = "2023-08-24T12:48:57.638Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c0/75f5a71ac24118ab11bd898e0114cedc72b25924ff2d960d473bddb4ec6e/watchfiles-0.20.0-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:7d4e66a857621584869cfbad87039e65dadd7119f0d9bb9dbc957e089e32c164", size = 1461725, upload-time = "2023-08-24T12:48:59.713Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d4/0c0fdcc4293ad1b73db54896fa0de4b37439ae4f25971b5eb1708dd04f9a/watchfiles-0.20.0-cp37-abi3-win32.whl", hash = "sha256:a03d1e6feb7966b417f43c3e3783188167fd69c2063e86bad31e62c4ea794cc5", size = 268193, upload-time = "2023-08-24T12:49:01.101Z" },
-    { url = "https://files.pythonhosted.org/packages/87/79/098b1b1fcb6de16149d23283a2ab5dadce6a06b864e7a182d231f57a1f9e/watchfiles-0.20.0-cp37-abi3-win_amd64.whl", hash = "sha256:eccc8942bcdc7d638a01435d915b913255bbd66f018f1af051cd8afddb339ea3", size = 276723, upload-time = "2023-08-24T12:49:02.351Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/45dddf4f5bf8b73ba27382cebb2bb3c0ee922c7ef77d936b86276aa39dca/watchfiles-0.20.0-cp37-abi3-win_arm64.whl", hash = "sha256:b17d4176c49d207865630da5b59a91779468dd3e08692fe943064da260de2c7c", size = 265344, upload-time = "2023-08-24T12:49:04.107Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2641,7 +2641,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "1.1.11"
+version = "1.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
## What

Forward-ports the changes that landed on **`main`** after the refactor branch point onto the new **hexagonal** layout (`core/ services/ api/ di/` + `infra/`). A literal `git rebase` was the wrong tool (it would replay the refactor's ~465 commits onto main); instead each `main` commit is re-expressed against the new file structure, skipping anything already fixed and obviating anything the new architecture no longer needs.

Of the **68 non-merge commits** on `main` since the merge-base, this branch lands **59 commits**: every source commit is **ported**, **obviated (with analysis)**, **already-present**, or **(one) deliberately deferred**. Each commit is 1:1 with its `main` source and carries a `Forward-ported from <hash>` trailer. Full per-commit accounting (including new-vs-old file mapping and skip reasons) is in **`FORWARD_PORT_LOG.md`**.

## By area

- **Infra / deploy hardening** — Ray dashboard → localhost everywhere (+ external `RAY_ADDRESS`), non-root OpenShift Dockerfiles, no prod bind-mount / `--reload`, MinIO/DB/AUTH default removal, Helm DB-password→Secret + default-deny NetworkPolicy, seccomp drop, metrics lockdown, image-tag pins, Ansible hardening, version → 1.1.13.
- **Auth / OIDC** — `ALLOW_NO_AUTH` gate on the no-token admin bypass, `update_user` mass-assignment whitelist, `external_user_id`→NULL, no session-token in UI file URLs, back-channel-logout **exp/jti + replay cache**, **clock-skew/nbf**, **logout CSRF** (Fetch-Metadata), OIDC-session revocation on token regen.
- **RAG / retrieval / loaders** — **Milvus filter-injection** guards (paren-wrap + identifier allowlist), `llm_override` credential/SSRF strip, **control-token neutralizer**, surrounding-chunk partition scoping (cross-tenant leak), token-limit + `n`/`best_of` bounds, stack-trace leak, **partition-scoped source-download authz** (the open `/static` mount was still live), EML attachment-fan-out cap, web/SVG SSRF hardening, cap-partitions-per-user, copy-endpoint validation, streaming `finish_reason` fix, non-empty-answer prompt rule.
- **Dependencies** — Starlette/FastAPI **CVE-2025-54121** pin (lockfile regenerated) + a path-tiered **rate-limit middleware** (`limits`).
- **Docs** — Chainlit-on-`CHAINLIT_PORT` note, OIDC/SSO quick-start frontmatter + pointer fixes.

## Obviated (verified, with analysis — not a live problem on this branch)

- `199424bf` empty-stream 502 → non-streaming uses materialized `chat()`/`generate()` + `InferenceError(502)`; no `__anext__` path.
- `70a2db36` doc-loader page bug → `CustomDocLoader` removed by the parser-shim cleanup.
- `63a857af` image-URL SSRF → the refactor captions extracted **bytes**; a document's remote image URL is never fetched nor forwarded to the VLM.

Several ports involved real judgment where the refactor differed (output-escaping vs. input-allowlist for Milvus, repo-abstraction vs. atomic-session for the partition cap, the source-download rekeyed to chunk-id, and **not** re-loosening the refactor's stricter `CHAINLIT_AUTH_SECRET` policy). See the log for rationale.

## Not included — one item, by deliberate choice

`4bbefd41` **compose non-root rework** (init-perms bootstrap container + per-service `user:` mappings). It's all-or-nothing, **runtime-only** (no CI/unit feedback — compose isn't exercised in tests), depends on fragile path-mapping onto `infra/compose/`, and is the least security-critical item (the images already *build* non-root via the Dockerfiles ported here). Committing it on faith risks a silently broken stack, so it's left for a follow-up that can `docker compose up` to verify. Target files + notes are in `FORWARD_PORT_LOG.md`.

## Verification

- `tests/unit/` — **1355 passed**. (One failure, `test_seed_defaults_preserves_endpoint_api_keys`, is an environmental artifact of the local nested-worktree `.env`, not a code defect — passes in a non-nested checkout / CI.)
- Integration repos vs. a real Postgres — **82 passed**; the lone failure (`create_legacy_user` signature) is a **pre-existing base-branch** bug untouched by this PR.
- Live ASGI checks (real HTTP via TestClient) — rate-limit `429`/per-tier budgets, logout CSRF `403`/`302`, download authz `403`/`404`.
- App boots cleanly under the new deps; middleware stack correct (`… Auth → RateLimit → route`), `download_source` route present, open `/static` mount removed.
- `ruff check` + `ruff format --check` clean; layer-import guard OK.

> ⚠️ The base `refactor/hexagonal` advanced after this branch was cut, so a rebase / conflict check may be needed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request rate limiting for authentication and chat traffic.
  * Added secure source-document downloads and improved source-link URL generation.
* **Bug Fixes**
  * Fixed streaming so terminal SSE chunks don’t prematurely end client handling.
  * Enforced stricter validation for partitions, file IDs, and chat token limits across modes.
* **Security**
  * Restricted Ray dashboard/monitoring exposure to localhost; added default-deny ingress NetworkPolicy.
  * Removed unsafe credential defaults; require secrets via environment variables.
  * Added OIDC logout CSRF protection, SSRF blocking, prompt-injection defenses, and logout replay prevention.
* **Documentation**
  * Updated OIDC/SSO and Ray/environment guidance (including Ray Serve/port behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->