### PR TITLE
fix(llm): default logprobs off and make it client-controlled

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -13,7 +13,9 @@ _llm_params: &llm_params
   temperature: 0.1
   timeout: 60
   max_retries: 2
-  logprobs: true
+  # Default off — API clients opt in per request. Requesting logprobs
+  # unsolicited can break streaming on some OpenAI-compatible backends.
+  logprobs: false
   # null omits chat_template_kwargs; set false for Qwen-style models when
   # reasoning traces should be disabled. Leave unset for Mistral tokenizers.
   enable_thinking: null

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -24,7 +24,12 @@ class OpenAIChatCompletionRequest(BaseModel):
     top_p: float | None = Field(1.0)
     stream: bool | None = Field(False)
     max_tokens: int | None = Field(default_factory=default_max_tokens)
-    logprobs: int | None = Field(None)
+    # Client-controlled and forwarded as-is to the downstream model; the server
+    # default is off (see LLMParamsConfig.logprobs). For chat completions
+    # `logprobs` is a boolean — `top_logprobs` carries the count — unlike the
+    # legacy /completions endpoint where `logprobs` is an integer.
+    logprobs: bool | None = Field(None)
+    top_logprobs: int | None = Field(None)
     response_format: dict[str, Any] | None = Field(
         None,
         description="OpenAI response_format, e.g. {'type': 'json_object'} or "

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 def default_max_tokens():
@@ -46,6 +46,18 @@ class OpenAIChatCompletionRequest(BaseModel):
         },
         description="Extra custom parameters. Supports 'llm_override' object with optional 'base_url', 'api_key', and 'model' to override the downstream LLM endpoint.",
     )
+
+    @model_validator(mode="after")
+    def _ignore_top_logprobs_without_logprobs(self) -> "OpenAIChatCompletionRequest":
+        # OpenAI semantics: `top_logprobs` only applies when `logprobs` is
+        # enabled. Mirror that by silently dropping it otherwise (rather than
+        # raising) — stays OpenAI-compatible while never forwarding an invalid
+        # pair to strict downstream providers that reject `top_logprobs` unless
+        # `logprobs` is true. Dropped to None so model_dump(exclude_none=True)
+        # omits it entirely.
+        if self.top_logprobs is not None and not self.logprobs:
+            self.top_logprobs = None
+        return self
 
 
 class OpenAICompletionRequest(BaseModel):

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -13,7 +13,11 @@ class LLMParamsConfig(ConfigMixin):
     temperature: float = 0.1
     timeout: int = 60
     max_retries: int = 2
-    logprobs: bool = True
+    # Default OFF: OpenRAG doesn't consume logprobs, and requesting them
+    # unsolicited breaks streaming on some OpenAI-compatible backends (e.g. a
+    # LiteLLM proxy crashes serializing the final chunk's ChoiceLogprobs). API
+    # clients that want logprobs opt in per request (see OpenAIChatCompletionRequest).
+    logprobs: bool = False
     enable_thinking: bool | None = None
 
 

--- a/tests/unit/api/schemas/test_api_schema_imports.py
+++ b/tests/unit/api/schemas/test_api_schema_imports.py
@@ -54,6 +54,31 @@ def test_chat_request_omits_response_format_when_unset():
     assert "response_format" not in dump
 
 
+def test_chat_request_logprobs_opt_in_is_boolean_and_forwarded():
+    """logprobs is off by default (server) but a client can opt in. For chat
+    completions it's a boolean and must reach the LLM as `true`, not coerced int.
+    """
+    request = OpenAIChatCompletionRequest.model_validate(
+        {"messages": [{"role": "user", "content": "hi"}], "logprobs": True, "top_logprobs": 5}
+    )
+    dump = request.model_dump(exclude_none=True)
+
+    assert dump["logprobs"] is True
+    assert dump["top_logprobs"] == 5
+
+
+def test_chat_request_omits_logprobs_when_unset():
+    """An unset logprobs must not be emitted — the server never requests it on the
+    client's behalf (sending it unsolicited can break streaming on some backends).
+    """
+    request = OpenAIChatCompletionRequest(messages=[OpenAIMessage(role="user", content="hi")])
+    dump = request.model_dump(exclude_none=True)
+
+    assert request.logprobs is None
+    assert "logprobs" not in dump
+    assert "top_logprobs" not in dump
+
+
 def test_chat_request_passes_through_extra_openai_params():
     """extra='allow' keeps vendor params (tools, seed, ...) that are not declared
     on the model, so any OpenAI-compatible field reaches the downstream LLM

--- a/tests/unit/api/schemas/test_api_schema_imports.py
+++ b/tests/unit/api/schemas/test_api_schema_imports.py
@@ -67,6 +67,24 @@ def test_chat_request_logprobs_opt_in_is_boolean_and_forwarded():
     assert dump["top_logprobs"] == 5
 
 
+def test_chat_request_drops_top_logprobs_when_logprobs_not_enabled():
+    """top_logprobs only applies when logprobs is enabled. Mirroring OpenAI, an
+    unsolicited top_logprobs (logprobs false/omitted) is silently dropped — not
+    rejected — so it never reaches strict downstream providers that would error.
+    """
+    omitted = OpenAIChatCompletionRequest.model_validate(
+        {"messages": [{"role": "user", "content": "hi"}], "top_logprobs": 5}
+    )
+    explicit_false = OpenAIChatCompletionRequest.model_validate(
+        {"messages": [{"role": "user", "content": "hi"}], "logprobs": False, "top_logprobs": 5}
+    )
+
+    for request in (omitted, explicit_false):
+        dump = request.model_dump(exclude_none=True)
+        assert request.top_logprobs is None
+        assert "top_logprobs" not in dump
+
+
 def test_chat_request_omits_logprobs_when_unset():
     """An unset logprobs must not be emitted — the server never requests it on the
     client's behalf (sending it unsolicited can break streaming on some backends).

--- a/tests/unit/core/config/test_endpoints.py
+++ b/tests/unit/core/config/test_endpoints.py
@@ -1,0 +1,22 @@
+"""Tests for LLM/VLM endpoint config (core.config.endpoints)."""
+
+from __future__ import annotations
+
+from core.config.endpoints import LLMConfig, LLMParamsConfig, VLMConfig
+
+
+def test_logprobs_is_a_configurable_knob():
+    """logprobs stays a server-side knob operators can flip, shared by LLM/VLM."""
+    assert "logprobs" in LLMParamsConfig.model_fields
+    assert "logprobs" in LLMConfig.model_fields
+    assert "logprobs" in VLMConfig.model_fields
+
+
+def test_logprobs_defaults_off():
+    """Default OFF: OpenRAG must not request logprobs on its own — sending them
+    unsolicited breaks streaming on some OpenAI-compatible backends
+    (linagora/openrag#563). Clients opt in per request.
+    """
+    assert LLMConfig().logprobs is False
+    assert VLMConfig().logprobs is False
+    assert LLMConfig().model_dump()["logprobs"] is False


### PR DESCRIPTION
## What

`logprobs` was force-injected server-side (`logprobs: true` in the shared `_llm_params` default, used by the LLM and VLM endpoints) on every request, even though OpenRAG never consumes it. This makes logprobs **client-controlled**:

- Default it **off** — `LLMParamsConfig.logprobs` and the `_llm_params` anchor in `conf/config.yaml`.
- Chat request `logprobs: int → bool` (OpenAI chat spec) + add `top_logprobs`, so a client's `logprobs: true` is forwarded as a boolean rather than coerced to an int.

Clients opt in per request; operators can still enable it globally via config.

## Root cause is the proxy server, not OpenRAG

Reproduced directly against the LiteLLM proxy, outside OpenRAG. **`logprobs: true` on a streamed request is what triggers the error** — content chunks stream fine, then the proxy crashes serializing the final chunk:

```
File ".../litellm/proxy/proxy_server.py", line 4632, in async_data_generator
    chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
pydantic_core._pydantic_core.PydanticSerializationError:
  ... 'MockValSer' object cannot be converted to 'SchemaSerializer'
```

| Request | Result |
|---|---|
| Streaming, no logprobs | ✅ OK |
| Streaming, `logprobs: true` | ❌ 500 `MockValSer` |
| Non-streaming, `logprobs: true` | ✅ OK |

The defect lives in the **LiteLLM proxy** (final streaming-chunk serialization), before anything reaches OpenRAG.

## Scope — no further fix needed on the OpenRAG side

This is the complete OpenRAG-side change: it stops sending the unsolicited `logprobs` that was tripping the proxy on the default chat path, and makes logprobs an explicit client opt-in. The `MockValSer` serialization bug itself is **a LiteLLM issue and must be fixed there** (upgrade/fix the proxy) — a client that explicitly opts into streaming + logprobs against an affected proxy will still hit it. Nothing more to change in OpenRAG.

Tests: config defaults-off guard; chat schema forwards `logprobs: true` as a bool (+ `top_logprobs`) and omits when unset. Lint/format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate `logprobs` and `top_logprobs` settings in chat requests, with safer request handling when `top_logprobs` is used alone.
* **Bug Fixes**
  * Prevented invalid parameter forwarding that could affect streaming on some compatible backends.
  * Default `logprobs` behavior is now off in configuration, reducing unexpected request payloads.
* **Tests**
  * Added coverage for request serialization and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->