### PR TITLE
fix(quick_start): align MinIO credential vars with documented .env

### DIFF
--- a/infra/quick_start/vdb/milvus.yaml
+++ b/infra/quick_start/vdb/milvus.yaml
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
@@ -37,8 +37,8 @@ services:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
       # Keep Milvus's MinIO credentials in sync with the minio service above.
-      MINIO_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}
-      MINIO_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus
     healthcheck:

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -84,18 +84,25 @@ def test_named_volume_profile_is_opt_in() -> None:
     assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}"
 
 
-def test_quick_start_milvus_uses_current_minio_root_env_names() -> None:
+def test_quick_start_milvus_uses_matching_minio_credentials() -> None:
+    # The quickstart docs tell users to ``cp .env.example .env`` (which defines
+    # MINIO_ACCESS_KEY / MINIO_SECRET_KEY) and drop it in quick_start/. The
+    # quick_start compose must therefore read the same variable names, both so
+    # interpolation succeeds and so Milvus's object-storage creds match minio's.
     quickstart = _load_yaml(ROOT / "infra" / "quick_start" / "vdb" / "milvus.yaml")
+    default_env_values = _load_env_example(COMPOSE_DIR / ".env.example")
 
     minio_env = quickstart["services"]["minio"]["environment"]
     milvus_env = quickstart["services"]["milvus"]["environment"]
 
-    assert "MINIO_ACCESS_KEY" not in minio_env
-    assert "MINIO_SECRET_KEY" not in minio_env
-    assert minio_env["MINIO_ROOT_USER"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
-    assert minio_env["MINIO_ROOT_PASSWORD"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
-    assert milvus_env["MINIO_ACCESS_KEY_ID"] == "${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in your .env}"
-    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == "${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in your .env}"
+    assert "MINIO_ROOT_USER" not in minio_env
+    assert "MINIO_ROOT_PASSWORD" not in minio_env
+    assert "MINIO_ACCESS_KEY" in default_env_values
+    assert "MINIO_SECRET_KEY" in default_env_values
+    assert minio_env["MINIO_ACCESS_KEY"] == "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in your .env}"
+    assert minio_env["MINIO_SECRET_KEY"] == "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}"
+    assert milvus_env["MINIO_ACCESS_KEY_ID"] == minio_env["MINIO_ACCESS_KEY"]
+    assert milvus_env["MINIO_SECRET_ACCESS_KEY"] == minio_env["MINIO_SECRET_KEY"]
 
 
 def test_ollama_cpu_milvus_uses_matching_minio_credentials() -> None:


### PR DESCRIPTION
## What

Follow-up to a review finding on #568 (F12). The named-volume Milvus profile was reconciled to `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` there, but the **quick_start** stack was left requiring `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`.

## Why it's broken

The quickstart guide (`docs/.../getting_started/quickstart.mdx`) tells users to:
1. `cp .env.example .env` — which defines `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` (blank to fill in),
2. drop that `.env` in the `quick_start/` folder,
3. bring the stack up.

But `infra/quick_start/vdb/milvus.yaml` used fail-fast interpolation on `${MINIO_ROOT_USER:?…}` / `${MINIO_ROOT_PASSWORD:?…}` — variable names **no `.env.example` anywhere defines**. So the documented flow aborts during compose interpolation (`Set MINIO_ROOT_USER in your .env`) before the stack even starts.

## Change

- `infra/quick_start/vdb/milvus.yaml`: minio + milvus services now read `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` — the same variables used by the main compose stack (`infra/compose/milvus/milvus.yaml`), the named-volume profile, and the Ollama CPU asset. One documented `.env` now works everywhere, and Milvus's object-storage creds stay in sync with minio's.
- `tests/unit/infra/test_compose_storage.py`: the test previously locked in the `MINIO_ROOT_*` names; it now asserts the quick_start uses the documented vars and that they exist in `.env.example`.

## Verification

- `uv run pytest tests/unit/infra/test_compose_storage.py` → 7 passed
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quick-start storage setup to use the current MinIO credential variable names, improving compatibility with the latest environment configuration.
  * Ensured the Milvus service picks up the matching MinIO access credentials correctly.
* **Tests**
  * Updated coverage to verify the new credential mapping and confirm the older credential names are no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->