### PR TITLE
fix(indexing): return 403 (not 500) when a create-race loser lacks access

### DIFF
--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from core.utils.exceptions import PartitionNotFoundError, ValidationError
+from core.utils.exceptions import AuthError, PartitionNotFoundError, ValidationError
 from core.utils.filename import extract_temporal_fields
 from core.utils.logging import get_logger
 from core.utils.partition_limits import max_partitions_for_user
@@ -123,7 +123,10 @@ class IndexingService:
         members = await self._partition_service.list_members(partition)
         membership = next((m for m in members if m.get("user_id") == user.get("id")), None)
         if membership is None or _ROLE_HIERARCHY.get(membership.get("role", ""), 0) < _ROLE_HIERARCHY["editor"]:
-            raise PermissionError(f"Editor role required for partition: {partition}")
+            # AuthError (status 403) so the global handler returns a clean
+            # Forbidden; a builtin PermissionError would fall through to the
+            # catch-all handler and surface as a 500.
+            raise AuthError(f"Editor role required for partition: {partition}")
 
     def _resolve_indexation_dispatch_config(self, partition: str) -> tuple[dict | None, str | None]:
         partitions = self._partition_configs()

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -6,7 +6,7 @@ import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.models.preset import PartitionConfig
-from core.utils.exceptions import PartitionNotFoundError, ValidationError
+from core.utils.exceptions import AuthError, PartitionNotFoundError, ValidationError
 from services.orchestrators.indexing_service import IndexingService
 
 
@@ -418,7 +418,7 @@ async def test_add_file_rejects_partition_exists_race_without_membership(tmp_pat
     psvc = RaceLostPartitionService(config, grant_owner=False)
     svc = _service(disp=disp, config=config, partition_service=psvc)
 
-    with pytest.raises(PermissionError, match="Editor role required"):
+    with pytest.raises(AuthError, match="Editor role required") as exc_info:
         await svc.add_file(
             file_path=str(f),
             file_id="f1",
@@ -429,6 +429,8 @@ async def test_add_file_rejects_partition_exists_race_without_membership(tmp_pat
             user={"id": 7},
         )
 
+    # Maps to a clean 403 Forbidden, not the catch-all 500.
+    assert exc_info.value.status_code == 403
     assert disp.dispatched == []
 
 


### PR DESCRIPTION
## What

Follow-up to a review finding on #568 (F11). The partition auto-create race guard (`_ensure_editor_access_after_create_race` in `indexing_service.py`) correctly **fails closed** when a concurrent create lost the race and the loser turns out not to be a member of the partition — but it raised a builtin `PermissionError`.

## Why it matters

The global exception handlers (`api/error_handlers.py`) map `OpenRAGError` subclasses to their declared status and everything else to the catch-all **500**. So a builtin `PermissionError` from this guard surfaced a legitimate authorization denial as an *Internal Server Error* instead of a `403 Forbidden`.

This only triggers on the narrow cross-user race (two different users creating the same brand-new partition name simultaneously, where the loser has no membership). It already fails closed — this just corrects the status code. The common case (same user, concurrent uploads — the scenario the race guard was added for) is unaffected: the user owns the partition and the upload continues.

## Change

- `indexing_service.py`: raise `AuthError` (status 403) instead of `PermissionError`.
- `test_indexing_service.py`: the cross-user race test now expects `AuthError` and asserts `status_code == 403`.

## Verification

- `uv run pytest tests/unit/services/orchestrators/test_indexing_service.py` → 18 passed
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)