### PR TITLE
fix(chainlit): serve source downloads from standalone Chainlit app (Ray Serve mode)

### DIFF
--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -1,4 +1,5 @@
 from api.middleware.auth import AuthMiddleware
+from api.routers.user.download import router as download_router
 from chainlit.utils import mount_chainlit
 from fastapi import FastAPI
 
@@ -20,5 +21,13 @@ app.add_middleware(
     AuthMiddleware,
     get_auth_service=_get_auth_service,
 )
+
+# Ray Serve mode runs the API and Chainlit on separate ports. Source previews
+# rewrite their file download links to the browser origin (the Chainlit host),
+# so this standalone Chainlit app must also expose the authorized,
+# partition-checked source-download route (/static/{extract_id}) or those
+# links would 404. In the mounted (/chainlit) deployment the UI shares the
+# API's origin, which already serves this route.
+app.include_router(download_router)
 
 mount_chainlit(app=app, target="./app_front.py", path="/chainlit")

--- a/tests/unit/test_chainlit_api_download.py
+++ b/tests/unit/test_chainlit_api_download.py
@@ -1,0 +1,45 @@
+"""Regression test for the standalone Chainlit app's source-download route.
+
+In Ray Serve mode the API and Chainlit run on separate ports. Source previews
+rewrite their file download links to the browser origin (the Chainlit host),
+so the standalone Chainlit app (``chainlit_api.app``) must expose the
+authorized ``/static/{extract_id}`` download route — otherwise PDFs/images/audio
+from search sources would 404 against the Chainlit service.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+
+def _import_chainlit_api(monkeypatch):
+    """Import ``chainlit_api`` with ``chainlit`` stubbed out."""
+    chainlit = types.ModuleType("chainlit")
+    chainlit_utils = types.ModuleType("chainlit.utils")
+
+    def mount_chainlit(app: FastAPI, target: str, path: str):
+        @app.get(f"{path}/")
+        async def chainlit_page():
+            return PlainTextResponse("chainlit")
+
+    chainlit_utils.mount_chainlit = mount_chainlit
+    chainlit.utils = chainlit_utils
+    monkeypatch.setitem(sys.modules, "chainlit", chainlit)
+    monkeypatch.setitem(sys.modules, "chainlit.utils", chainlit_utils)
+
+    sys.modules.pop("chainlit_api", None)
+    return importlib.import_module("chainlit_api")
+
+
+def test_standalone_chainlit_exposes_source_download_route(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "token")
+
+    module = _import_chainlit_api(monkeypatch)
+
+    routes = {getattr(r, "name", None): getattr(r, "path", None) for r in module.app.routes}
+    assert routes.get("download_source") == "/static/{extract_id}"


### PR DESCRIPTION
## What

Follow-up to a review finding on #568 (F9). In **Ray Serve mode**, source-document previews (PDFs/images/audio) fail to load in the Chainlit chat UI.

## Why it's broken

In Ray Serve mode the API and Chainlit run on **separate ports**:
- the API (with `download_router` mounted) via `serve.run(OpenRagAPI.bind(), route_prefix="/")` on `ray.serve.port`,
- Chainlit via its own `uvicorn.run(chainlit_app, port=ray.serve.chainlit_port)` — where `chainlit_app` is `chainlit_api.app`.

`_format_sources` (`app_front.py`) rewrites each file URL from the internal base URL to the **browser origin** (`get_external_url()`, derived from the `Referer`). In separate-port mode that origin is the **Chainlit host**, but `chainlit_api.py` only mounted the Chainlit UI — so `/static/{extract_id}` didn't exist there and every source preview 404'd.

The default mounted `/chainlit` deployment is fine because the UI and API share one origin (the API already serves the route).

## Change

- `openrag/chainlit_api.py`: mount `download_router` on the standalone Chainlit FastAPI app.
  - Auth is unchanged: the same `AuthMiddleware` runs here. In OIDC mode the `openrag_session` cookie is sent to the Chainlit port too (cookies aren't port-scoped), and in token mode the preview link carries `?token=`. The route resolves its services from the container the middleware initializes on `app.state.container`.
- `tests/unit/test_chainlit_api_download.py`: regression test asserting the standalone app exposes `download_source` at `/static/{extract_id}` (would fail before this change).

## Verification

- `uv run pytest tests/unit/test_chainlit_api_download.py tests/unit/test_chainlit_api_auth.py tests/unit/api/routers/user/test_download.py` → all pass
- `ruff check` clean; layer-import guard OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)