### PR TITLE
fix(chunking): stop cutting chunks mid-sentence on PDF line-wraps (#579)

### DIFF
--- a/openrag/core/chunking/recursive.py
+++ b/openrag/core/chunking/recursive.py
@@ -12,6 +12,7 @@ separate stage by the orchestrator — not from inside the chunker.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -35,6 +36,56 @@ _IMAGE_PLACEHOLDER_MARKER = "[image placeholder]"
 # Tables/images smaller than this token count are inlined with surrounding
 # text rather than emitted as standalone chunks.
 _INLINE_ELEMENT_TOKEN_THRESHOLD = 100
+
+# A line that begins a markdown block (heading, list item, blockquote, table
+# row, code fence, horizontal rule, or a synthetic [PAGE_N] marker). Such lines
+# must keep their own line — they are NOT prose to be joined into a paragraph.
+_BLOCK_LINE_RE = re.compile(
+    r"^\s*(?:"
+    r"#{1,6}\s"  # heading
+    r"|[-*+]\s"  # bullet list
+    r"|\d+[.)]\s"  # ordered list
+    r"|>\s?"  # blockquote
+    r"|\|"  # table row
+    r"|```|~~~"  # code fence
+    r"|(?:-{3,}|\*{3,}|_{3,})\s*$"  # horizontal rule (---, ***, ___)
+    r"|\[PAGE_\d+\]\s*$"  # synthetic page marker
+    r")"
+)
+
+
+def dewrap_paragraphs(text: str) -> str:
+    """Reflow PDF visual line-wraps so prose paragraphs sit on a single line.
+
+    Backends like ``pymupdf4llm`` keep the PDF's line breaks inside a
+    paragraph (e.g. ``"…assisted by the\\nexternal auditors…"``). Those
+    mid-sentence ``\\n`` make the splitter break mid-sentence and read poorly
+    once stored. We join consecutive prose lines with a space while preserving
+    paragraph breaks (blank lines) and any markdown block line (heading, list
+    item, table row, code fence, blockquote, rule, page marker), which keep
+    their own line. See #579.
+    """
+    out: list[str] = []
+    paragraph: list[str] = []
+
+    def flush() -> None:
+        if paragraph:
+            out.append(" ".join(line.strip() for line in paragraph))
+            paragraph.clear()
+
+    for line in text.split("\n"):
+        if line.strip() == "":
+            flush()
+            out.append("")
+        elif _BLOCK_LINE_RE.match(line):
+            flush()
+            out.append(line)
+        else:
+            paragraph.append(line)
+    flush()
+
+    # Collapse any 3+ newline runs the flushing may have produced.
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip()
 
 
 class BaseChunker(ChunkingStrategy):
@@ -181,7 +232,10 @@ class BaseChunker(ChunkingStrategy):
         objects without leaking domain types into the lower-level helpers.
         """
         texts, tables_and_images = self._prepare_md_elements(content=content)
-        combined_texts = "\n".join(e.content for e in texts)
+        # Reflow PDF line-wraps within each element, then join elements as
+        # paragraphs (blank line) so the splitter cuts on paragraph/sentence
+        # boundaries rather than mid-sentence line-wraps (#579).
+        combined_texts = "\n\n".join(dewrap_paragraphs(e.content) for e in texts)
 
         sanitized = sanitize_text(
             combined_texts,
@@ -276,5 +330,8 @@ class RecursiveSplitter(BaseChunker):
             chunk_overlap=self.chunk_overlap,
             length_function=self.length_function,
             is_separator_regex=True,
-            separators=["\n", r"(?<=[\.\?\!])"],
+            # Paragraph → sentence → line → word. A single "\n" is a last
+            # resort (only when a sentence itself exceeds chunk_size), so the
+            # splitter no longer breaks mid-sentence on a line-wrap (#579).
+            separators=["\n\n", r"(?<=[\.\?\!])", "\n", " "],
         )

--- a/openrag/core/chunking/recursive.py
+++ b/openrag/core/chunking/recursive.py
@@ -53,6 +53,9 @@ _BLOCK_LINE_RE = re.compile(
     r")"
 )
 
+# A ``` / ~~~ fenced-code-block delimiter line (open or close).
+_CODE_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+
 
 def dewrap_paragraphs(text: str) -> str:
     """Reflow PDF visual line-wraps so prose paragraphs sit on a single line.
@@ -67,6 +70,7 @@ def dewrap_paragraphs(text: str) -> str:
     """
     out: list[str] = []
     paragraph: list[str] = []
+    in_fence = False
 
     def flush() -> None:
         if paragraph:
@@ -74,6 +78,16 @@ def dewrap_paragraphs(text: str) -> str:
             paragraph.clear()
 
     for line in text.split("\n"):
+        # Inside a ``` / ~~~ code fence, emit lines verbatim — never reflow, or
+        # we'd destroy code indentation and line breaks.
+        if _CODE_FENCE_RE.match(line):
+            flush()
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
         if line.strip() == "":
             flush()
             out.append("")

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -292,3 +292,24 @@ def test_recursive_splitter_does_not_cut_mid_sentence_on_line_wraps():
     assert not any(c.text.strip().endswith("gamma") for c in chunks)
     # ...and every text chunk ends on a sentence terminator.
     assert all(c.text.strip()[-1] in ".?!" for c in chunks if c.chunk_type == ChunkType.TEXT)
+
+
+def test_dewrap_preserves_code_fence_verbatim():
+    """Lines inside a ``` fence must keep their indentation/line breaks (not be
+    space-joined as prose), while surrounding prose still reflows (#583)."""
+    from core.chunking.recursive import dewrap_paragraphs
+
+    text = (
+        "Intro wrapped\nacross two lines.\n"
+        "```python\n"
+        "def f():\n"
+        "    return 1\n"
+        "```\n"
+        "Outro wrapped\nacross two.\n"
+    )
+    lines = dewrap_paragraphs(text).splitlines()
+
+    assert "def f():" in lines  # code line on its own, not joined to the fence
+    assert "    return 1" in lines  # indentation preserved
+    assert "Intro wrapped across two lines." in lines  # prose still reflowed
+    assert "Outro wrapped across two." in lines

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -249,3 +249,46 @@ def test_recursive_splitter_skips_pages_get_correct_marker():
     pages = sorted({c.page_number for c in chunks if c.page_number is not None})
     assert 1 in pages
     assert 5 in pages, f"page 5 missing despite second block on page 5: {pages}"
+
+
+def test_dewrap_paragraphs_collapses_line_wraps_but_keeps_structure():
+    from core.chunking.recursive import dewrap_paragraphs
+
+    text = (
+        "# Heading\n"
+        "The committee reviewed the report\n"
+        "and was assisted by the auditors.\n"
+        "\n"
+        "- first item\n"
+        "- second item\n"
+        "[PAGE_2]\n"
+    )
+    lines = dewrap_paragraphs(text).splitlines()
+
+    # Wrapped prose is joined onto one line.
+    assert "The committee reviewed the report and was assisted by the auditors." in lines
+    # Markdown block lines keep their own line.
+    assert "# Heading" in lines
+    assert "- first item" in lines
+    assert "- second item" in lines
+    assert "[PAGE_2]" in lines
+
+
+def test_recursive_splitter_does_not_cut_mid_sentence_on_line_wraps():
+    """A mid-paragraph line-wrap (as pymupdf4llm emits) must not become a chunk
+    boundary; chunks should break on sentence/paragraph boundaries (#579)."""
+    # "Alpha beta gamma\ndelta epsilon zeta." carries a wrap inside one sentence.
+    text = "Alpha beta gamma\ndelta epsilon zeta. Eta theta iota kappa lambda mu. Nu xi omicron pi rho sigma."
+    splitter = RecursiveSplitter(chunk_size=12, chunk_overlap_rate=0.0, length_function=_word_tokens)
+    doc = ProcessedDocument(
+        document_id="d1",
+        text_blocks=[TextBlock(text=text, page_number=1)],
+        metadata={"source": "wrapped.md"},
+    )
+    chunks = splitter.chunk(doc, partition="p1")
+
+    assert len(chunks) >= 2
+    # The wrap word must never end a chunk...
+    assert not any(c.text.strip().endswith("gamma") for c in chunks)
+    # ...and every text chunk ends on a sentence terminator.
+    assert all(c.text.strip()[-1] in ".?!" for c in chunks if c.chunk_type == ChunkType.TEXT)

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -299,14 +299,7 @@ def test_dewrap_preserves_code_fence_verbatim():
     space-joined as prose), while surrounding prose still reflows (#583)."""
     from core.chunking.recursive import dewrap_paragraphs
 
-    text = (
-        "Intro wrapped\nacross two lines.\n"
-        "```python\n"
-        "def f():\n"
-        "    return 1\n"
-        "```\n"
-        "Outro wrapped\nacross two.\n"
-    )
+    text = "Intro wrapped\nacross two lines.\n```python\ndef f():\n    return 1\n```\nOutro wrapped\nacross two.\n"
     lines = dewrap_paragraphs(text).splitlines()
 
     assert "def f():" in lines  # code line on its own, not joined to the fence


### PR DESCRIPTION
The `recursive_splitter` could end a chunk mid-sentence by breaking on a single line-wrap newline (pymupdf4llm preserves PDF visual line breaks inside paragraphs) before considering sentence boundaries — the separators didn't match the class's own 'paragraph, then sentence' docstring.

- `dewrap_paragraphs()` reflows intra-paragraph line-wraps into spaces while preserving markdown block lines (headings, lists, tables, code fences, blockquotes, rules, `[PAGE_N]`) and paragraph breaks.
- Join text elements as paragraphs and reorder separators to paragraph → sentence → line → word, so a lone `\n` is only a last resort.
- Tests: dewrap structure preservation + no chunk ends mid-sentence.

First iteration of chunk-quality work. Refs #579.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive markdown-aware chunking to reflow PDF line-wrapped prose into full paragraphs.
  * Reduced mid-sentence chunk breaks by rebalancing chunk boundaries toward paragraph and sentence endings.
  * Preserves key formatting and structure, including headings, lists, quotes, tables, code fences, horizontal rules, and `[PAGE_N]` markers.
* **Tests**
  * Added unit coverage for paragraph dewrapping behavior, mid-sentence wrap avoidance, and verbatim code-fence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->