### PR TITLE
feat(indexer): per-stage indexing timings

### DIFF
--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -65,6 +65,7 @@ class IndexerWorker:
             # One indexation timestamp for this file, shared by the Milvus chunks
             # (via the store stage) and the Postgres catalog row, so they agree.
             row: dict[str, Any] = {
+                "task_id": task_id,
                 "document": document,
                 "partition": partition,
                 "filename": document.filename,

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 from typing import Any
@@ -67,8 +68,14 @@ class IndexingPipeline:
     topic_tagger_factory: Callable[[str], TopicTagger] | None = None
 
     async def run(self, row: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        """Run a single row through parse, optional enrichments, embed, and store."""
+        """Run a single row through parse, optional enrichments, embed, and store.
 
+        Each stage is timed and a single structured line is logged per file
+        (``ms_parse``, ``ms_chunk``, ``ms_embed``, …), so a slow backend or
+        stage is easy to spot — e.g. comparing docling vs marker parse cost.
+        Timings are emitted even when a stage fails, so a failure shows how far
+        indexing got before erroring.
+        """
         config = self._effective_indexation_config(row)
         parser = self._select_parser(config)
         chunker = self._select_chunker(config)
@@ -76,45 +83,77 @@ class IndexingPipeline:
         contextualizer = self._select_contextualizer(config)
         topic_tagger = self._select_topic_tagger(config)
 
-        await parse_stage(row, parser, timeout=self.timeouts.parse)
-        if self._should_caption(row, config):
-            vlm = self._select_vlm(config)
-            if vlm is not None:
-                await caption_stage(
-                    row,
-                    vlm,
-                    timeout=self.timeouts.caption,
-                    per_image_timeout=self.timeouts.caption_per_image,
+        timings: dict[str, float] = {}
+
+        async def _timed(name: str, coro: Any) -> None:
+            start = time.perf_counter()
+            try:
+                await coro
+            finally:
+                timings[name] = (time.perf_counter() - start) * 1000.0
+
+        try:
+            await _timed("parse", parse_stage(row, parser, timeout=self.timeouts.parse))
+            if self._should_caption(row, config):
+                vlm = self._select_vlm(config)
+                if vlm is not None:
+                    await _timed(
+                        "caption",
+                        caption_stage(
+                            row,
+                            vlm,
+                            timeout=self.timeouts.caption,
+                            per_image_timeout=self.timeouts.caption_per_image,
+                        ),
+                    )
+            await _timed("chunk", chunk_stage(row, chunker, timeout=self.timeouts.chunk))
+            if contextualizer is not None:
+                await _timed(
+                    "contextualize",
+                    contextualize_stage(
+                        row,
+                        contextualizer,
+                        timeout=self.timeouts.contextualize,
+                        per_chunk_timeout=self.timeouts.contextualize_per_chunk,
+                    ),
                 )
-        await chunk_stage(row, chunker, timeout=self.timeouts.chunk)
-        if contextualizer is not None:
-            await contextualize_stage(
-                row,
-                contextualizer,
-                timeout=self.timeouts.contextualize,
-                per_chunk_timeout=self.timeouts.contextualize_per_chunk,
+            if topic_tagger is not None:
+                max_tags = config.max_topic_tags if config is not None else 7
+                await _timed(
+                    "topic_tag",
+                    topic_tag_stage(
+                        row,
+                        topic_tagger,
+                        max_tags=max_tags,
+                        timeout=self.timeouts.topic_tag,
+                    ),
+                )
+            await _timed(
+                "embed",
+                embed_stage(
+                    row,
+                    embedder,
+                    timeout=self.timeouts.embed,
+                    per_chunk_timeout=self.timeouts.embed_per_chunk,
+                ),
             )
-        if topic_tagger is not None:
-            max_tags = config.max_topic_tags if config is not None else 7
-            await topic_tag_stage(
-                row,
-                topic_tagger,
-                max_tags=max_tags,
-                timeout=self.timeouts.topic_tag,
+            await _timed(
+                "store",
+                store_stage(
+                    row,
+                    self.vector_store,
+                    timeout=self.timeouts.store,
+                    per_chunk_timeout=self.timeouts.store_per_chunk,
+                ),
             )
-        await embed_stage(
-            row,
-            embedder,
-            timeout=self.timeouts.embed,
-            per_chunk_timeout=self.timeouts.embed_per_chunk,
-        )
-        await store_stage(
-            row,
-            self.vector_store,
-            timeout=self.timeouts.store,
-            per_chunk_timeout=self.timeouts.store_per_chunk,
-        )
-        return row
+            return row
+        finally:
+            logger.bind(
+                filename=row.get("filename", ""),
+                n_chunks=len(row.get("chunks") or []),
+                **{f"ms_{name}": round(value) for name, value in timings.items()},
+                ms_total=round(sum(timings.values())),
+            ).info("indexing stage timings (ms)")
 
     def _effective_indexation_config(self, row: MutableMapping[str, Any]) -> IndexationPipelineConfig | None:
         raw_config = row.get("indexation_config", self.indexation_config)

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -159,6 +159,7 @@ class IndexingPipeline:
             return row
         finally:
             logger.bind(
+                task_id=row.get("task_id"),
                 filename=row.get("filename", ""),
                 n_chunks=len(row.get("chunks") or []),
                 **{f"ms_{name}": round(value) for name, value in timings.items()},

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -75,6 +75,16 @@ class IndexingPipeline:
         stage is easy to spot — e.g. comparing docling vs marker parse cost.
         Timings are emitted even when a stage fails, so a failure shows how far
         indexing got before erroring.
+
+        CAVEAT — these are **wall-clock**, not CPU time. Files in a batch index
+        concurrently and stages share resources (the parser pools, the
+        ``asyncio.to_thread`` chunk executor + the GIL, async LLM calls), so a
+        stage's value includes time spent **queued/contending** for a slot, not
+        just its own work. Under concurrency a value can balloon far past the
+        real cost (e.g. the same file chunking in 0.3 s in one run and 67 s in a
+        busy batch). They are only a clean per-stage cost at **low concurrency**
+        — index one file at a time for accurate numbers; for a batch, read the
+        first-finishing (least-contended) file.
         """
         config = self._effective_indexation_config(row)
         parser = self._select_parser(config)

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -196,6 +196,32 @@ async def test_process_file_success_sets_state_and_returns_count(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_process_file_passes_task_id_to_pipeline_row(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    captured: dict[str, Any] = {}
+
+    class RecordingPipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            captured.update(row)
+            row["stored_count"] = 1
+            row["stage"] = "stored"
+            return row
+
+    tsm = _fake_tsm()
+    worker = IndexerWorker(pipeline=RecordingPipeline(), task_state_manager=tsm)
+
+    await worker.process_file(
+        task_id="t1",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="p",
+    )
+
+    assert captured["task_id"] == "t1"
+
+
+@pytest.mark.asyncio
 async def test_process_file_pipeline_failure_sets_failed_and_reraises(tmp_path: Path) -> None:
     path = tmp_path / "bad.txt"
     path.write_bytes(b"x")

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -548,3 +548,45 @@ async def test_pipeline_indexation_config_disables_topic_tagging():
 
     assert topic_tagger.calls == []
     assert row.get("topic_tags") is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_logs_per_stage_timings(monkeypatch):
+    """run() emits one structured line per file with per-stage durations so a
+    slow backend/stage (e.g. docling vs marker parse) is visible in the logs."""
+    import services.workers.pipeline_builder as pb
+
+    class _RecordingLogger:
+        def __init__(self) -> None:
+            self.bound: dict | None = None
+            self.message: str | None = None
+
+        def bind(self, **kwargs):
+            self.bound = kwargs
+            return self
+
+        def info(self, message: str) -> None:
+            self.message = message
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(pb, "logger", recorder)
+
+    document = Document(filename="note.txt", text="hello", partition="tenant-a")
+    processed = ProcessedDocument(document_id=document.id, text_blocks=[TextBlock(text="hello")])
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([Chunk(id="c1", text="hello", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0, 0.0]]),
+        vector_store=FakeVectorStore(),
+    )
+
+    await pipeline.run({"document": document, "partition": "tenant-a", "filename": "note.txt"})
+
+    assert recorder.message == "indexing stage timings (ms)"
+    assert recorder.bound is not None
+    for key in ("ms_parse", "ms_chunk", "ms_embed", "ms_store", "ms_total"):
+        assert key in recorder.bound
+    # Optional stages weren't configured, so they aren't timed.
+    assert "ms_caption" not in recorder.bound
+    assert recorder.bound["n_chunks"] == 1
+    assert recorder.bound["filename"] == "note.txt"

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -580,7 +580,7 @@ async def test_pipeline_logs_per_stage_timings(monkeypatch):
         vector_store=FakeVectorStore(),
     )
 
-    await pipeline.run({"document": document, "partition": "tenant-a", "filename": "note.txt"})
+    await pipeline.run({"task_id": "t1", "document": document, "partition": "tenant-a", "filename": "note.txt"})
 
     assert recorder.message == "indexing stage timings (ms)"
     assert recorder.bound is not None
@@ -588,5 +588,6 @@ async def test_pipeline_logs_per_stage_timings(monkeypatch):
         assert key in recorder.bound
     # Optional stages weren't configured, so they aren't timed.
     assert "ms_caption" not in recorder.bound
+    assert recorder.bound["task_id"] == "t1"
     assert recorder.bound["n_chunks"] == 1
     assert recorder.bound["filename"] == "note.txt"


### PR DESCRIPTION
Times each pipeline stage and logs one structured line per file (`ms_parse`, `ms_chunk`, `ms_embed`, `ms_store`, …, `ms_total`) so a slow backend or stage is easy to spot (e.g. quantifying docling vs marker parse cost). Fields are bound via `logger.bind()` so they render, and emitted from a `finally` block so a failed stage still reports how far it got.

Docstring notes the timings are **wall-clock** (include scheduling/queue contention under concurrent batch indexing) — clean per-stage numbers need low concurrency. Test asserts the line is logged with per-stage keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Indexing now carries the job/task identifier through the processing flow, improving traceability of file processing.

- **Bug Fixes**
  - Added more reliable timing and logging for indexing stages, so performance data is recorded even if a step fails.
  - Logging now includes clearer per-stage and total duration details to help diagnose slow or incomplete indexing runs.

- **Tests**
  - Added coverage for task identifier propagation and indexing timing logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->