### PR TITLE
fix(embedder): plumb max_model_len into model-endpoint embedders (default 2047)

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -50,7 +50,7 @@ embedder:
   model_name: jinaai/jina-embeddings-v3
   base_url: http://vllm:8000/v1
   api_key: EMPTY
-  max_model_len: 8192
+  max_model_len: 2047 # truncate_prompt_tokens = this - 1; keep below the model's context boundary (vllm#29496)
   timeout: 120.0       # per-request HTTP timeout (s); raise for slow remote endpoints
   batch_size: 32       # chunks per embedding request (big docs are split into batches)
   embed_concurrency: 4 # max embedding requests in flight at once

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -44,7 +44,10 @@ class EmbedderConfig(ConfigMixin):
     model_name: str = "jinaai/jina-embeddings-v3"
     base_url: str = "http://vllm:8000/v1"
     api_key: str = Field(default="EMPTY", repr=False)
-    max_model_len: int = 8192
+    # 2047 (just below the 2048 boundary): the embedder sends
+    # truncate_prompt_tokens = max_model_len - 1, avoiding the Qwen3-Embedding
+    # context-boundary hang (vllm-project/vllm#29496).
+    max_model_len: int = Field(default=2047, gt=0)
     # Constrained > 0: a bad env var should fail at config load, not silently
     # degrade into surprising runtime behavior (VLLMEmbedder rewrites a
     # non-positive batch_size/embed_concurrency to 1 and would pass a <= 0

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -147,11 +147,24 @@ class ServiceContainer:
     def _wire_named_component_factories(self, settings: Settings) -> None:
         """Wire Phase 14 named inference factories from ``settings.models``."""
         models = settings.models
+        embed_defaults = settings.embedder
+
+        def _embedder_extra_kwargs(cfg: Any) -> dict[str, Any]:
+            """Backfill max_model_len/embed_concurrency from static settings when the
+            endpoint's ``extra`` omits them (an explicit ``extra`` value wins)."""
+            defaults: dict[str, Any] = {}
+            if "max_model_len" not in cfg.extra:
+                defaults["max_model_len"] = embed_defaults.max_model_len
+            if "embed_concurrency" not in cfg.extra:
+                defaults["embed_concurrency"] = embed_defaults.embed_concurrency
+            return defaults
+
         self.embedder_factory, self._embedder_cache = make_component_factory(
             registry=embedder_registry,
             config_section=models.embedder,
             default_impl="vllm",
             client_caches=self._client_caches,
+            extra_kwargs_fn=_embedder_extra_kwargs,
         )
         self.reranker_factory, self._reranker_cache = make_component_factory(
             registry=reranker_registry,

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -212,6 +212,17 @@ class VLLMEmbedder(Embedder):
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         self._client = httpx.AsyncClient(timeout=timeout, headers=headers)
+        logger.bind(
+            model=self._model,
+            max_model_len=self._max_model_len,
+            batch_size=self._batch_size,
+            embed_concurrency=self._embed_concurrency,
+        ).debug("VLLMEmbedder ready")
+        if self._max_model_len is None:
+            logger.bind(model=self._model).warning(
+                "VLLMEmbedder built without max_model_len — truncate_prompt_tokens disabled; "
+                "pooling models can hang/400 on context-boundary inputs (vllm#29496)."
+            )
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed *texts*, splitting large inputs into bounded-concurrent batches.
@@ -243,7 +254,11 @@ class VLLMEmbedder(Embedder):
                 *tasks,
                 desc=f"Embedding {len(texts)} chunks ({len(batches)} batches of {self._batch_size})",
             )
-        except BaseException:
+        except BaseException as exc:
+            done = sum(1 for task in tasks if task.done() and not task.cancelled() and task.exception() is None)
+            logger.bind(batches_done=done, n_batches=len(batches), error=repr(exc)).warning(
+                "Embedding failed after {d}/{b} batches", d=done, b=len(batches)
+            )
             for task in tasks:
                 if not task.done():
                     task.cancel()

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -454,6 +454,15 @@ def _build_embedder_factory(cfg: Settings) -> Any:
                 return entry[1]
             impl_kwargs = {key: value for key, value in model_cfg.extra.items() if key != "implementation"}
             impl = model_cfg.extra.get("implementation", "vllm")
+            # Backfill max_model_len/embed_concurrency from static settings when the
+            # endpoint's `extra` omits them — otherwise truncate_prompt_tokens is off
+            # and pooling models hang/400 on boundary inputs (vllm#29496). Explicit
+            # `extra` wins. Mirrors the API container's _embedder_extra_kwargs.
+            embed_defaults = getattr(cfg, "embedder", None)
+            for default_key in ("max_model_len", "embed_concurrency"):
+                default = getattr(embed_defaults, default_key, None)
+                if default is not None:
+                    impl_kwargs.setdefault(default_key, default)
             instance = embedder_registry.create(
                 impl,
                 endpoint=model_cfg.endpoint,

--- a/tests/unit/di/test_container.py
+++ b/tests/unit/di/test_container.py
@@ -548,6 +548,8 @@ class TestPhase14NamedComponentFactories:
         llm = c.llm_factory("chat-a")
         vlm = c.vlm_factory("vision-a")
 
+        # max_model_len / embed_concurrency aren't carried by the endpoint config,
+        # so the embedder factory backfills them from the static ``embedder`` settings.
         assert embedder.kwargs == {
             "endpoint": "http://embedder:8000/v1",
             "model_name": "embed-model",
@@ -555,6 +557,8 @@ class TestPhase14NamedComponentFactories:
             "timeout": 12.5,
             "api_key": "embed-key",
             "dimension": 384,
+            "max_model_len": 2047,
+            "embed_concurrency": 4,
         }
         assert reranker.kwargs["endpoint"] == "http://reranker:8000"
         assert reranker.kwargs["model_name"] == "rank-model"
@@ -563,6 +567,14 @@ class TestPhase14NamedComponentFactories:
         assert llm.kwargs["temperature"] == 0.2
         assert vlm.kwargs["endpoint"] == "http://vlm:8000/v1"
         assert vlm.kwargs["max_tokens"] == 256
+
+    def test_embedder_extra_overrides_backfilled_max_model_len(self):
+        """A per-endpoint ``extra.max_model_len`` wins over the settings default."""
+        settings = _settings_with_named_models()
+        settings.models.embedder["embed-a"].extra["max_model_len"] = 4096
+        c = ServiceContainer(settings)
+
+        assert c.embedder_factory("embed-a").kwargs["max_model_len"] == 4096
 
     def test_named_factories_cache_by_endpoint_name(self):
         """Repeated factory calls for the same endpoint return one client."""

--- a/tests/unit/di/test_container.py
+++ b/tests/unit/di/test_container.py
@@ -568,13 +568,16 @@ class TestPhase14NamedComponentFactories:
         assert vlm.kwargs["endpoint"] == "http://vlm:8000/v1"
         assert vlm.kwargs["max_tokens"] == 256
 
-    def test_embedder_extra_overrides_backfilled_max_model_len(self):
-        """A per-endpoint ``extra.max_model_len`` wins over the settings default."""
+    def test_embedder_extra_overrides_backfilled_embedder_defaults(self):
+        """Per-endpoint embedder extras win over the settings defaults."""
         settings = _settings_with_named_models()
         settings.models.embedder["embed-a"].extra["max_model_len"] = 4096
+        settings.models.embedder["embed-a"].extra["embed_concurrency"] = 9
         c = ServiceContainer(settings)
 
-        assert c.embedder_factory("embed-a").kwargs["max_model_len"] == 4096
+        embedder = c.embedder_factory("embed-a")
+        assert embedder.kwargs["max_model_len"] == 4096
+        assert embedder.kwargs["embed_concurrency"] == 9
 
     def test_named_factories_cache_by_endpoint_name(self):
         """Repeated factory calls for the same endpoint return one client."""

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -290,6 +290,44 @@ def test_embedder_factory_reads_live_registry() -> None:
         embedder_registry._registry.pop("live-probe-embedder", None)
 
 
+def test_embedder_factory_backfills_max_model_len_from_settings() -> None:
+    """A named endpoint whose `extra` omits max_model_len inherits it from the
+    static embedder settings (an explicit per-endpoint value still wins)."""
+    from core.embeddings import embedder_registry
+    from services.workers.indexer_pool import _build_embedder_factory
+
+    class ProbeEmbedder:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    embedder_registry.register("backfill-probe-embedder")(ProbeEmbedder)
+    try:
+        registry: dict = {
+            "no-extra": ModelEndpointConfig(
+                endpoint="http://embed.example/v1",
+                model_name="embed-model",
+                extra={"implementation": "backfill-probe-embedder", "api_key": "k"},
+            ),
+            "explicit": ModelEndpointConfig(
+                endpoint="http://embed.example/v1",
+                model_name="embed-model",
+                extra={"implementation": "backfill-probe-embedder", "max_model_len": 4096},
+            ),
+        }
+        cfg = SimpleNamespace(
+            models=SimpleNamespace(embedder=registry),
+            embedder=SimpleNamespace(max_model_len=2047, embed_concurrency=4),
+        )
+
+        factory = _build_embedder_factory(cfg)
+        backfilled = factory("no-extra")
+        assert backfilled.kwargs["max_model_len"] == 2047
+        assert backfilled.kwargs["embed_concurrency"] == 4
+        assert factory("explicit").kwargs["max_model_len"] == 4096  # per-endpoint extra wins
+    finally:
+        embedder_registry._registry.pop("backfill-probe-embedder", None)
+
+
 def test_embedder_factory_rebuilds_on_api_key_rotation() -> None:
     from core.embeddings import embedder_registry
     from services.workers.indexer_pool import _build_embedder_factory


### PR DESCRIPTION
## Problem

The indexer (and API) embedders are built from the DB-backed **model-endpoint** config, whose `extra` carries only `implementation` + `api_key`. `max_model_len` is dropped, so `VLLMEmbedder` is constructed with `max_model_len=None`. That disables the `truncate_prompt_tokens` guard, and pooling models such as **Qwen3-Embedding** then **400 / hang** on context-boundary inputs ([vllm-project/vllm#29496](https://github.com/vllm-project/vllm/issues/29496)).

Setting `MAX_MODEL_LEN` did **not** help: that env var only feeds the *static* `embedder` settings, not the named model-endpoint embedders the indexer/API actually use. The indexer also has its **own** factory (`_build_embedder_factory`), separate from the API container's `make_component_factory`, so each path dropped the value independently.

Observed in the wild: a litellm-proxied endpoint returned `ContextWindowExceededError: This model's maximum context length is 2048 tokens. However, you requested 1000003 tokens`. Sending `truncate_prompt_tokens` fixes it.

## Changes

- **Backfill** `max_model_len` / `embed_concurrency` from the static `embedder` settings in **both** factories — `di/container.py` (`_embedder_extra_kwargs`) and `services/workers/indexer_pool.py` (`_build_embedder_factory`). An explicit per-endpoint `extra` value still wins, so it stays **presetable per endpoint**.
- **Default** `max_model_len` `8192 → 2047` (one below the common 2048 boundary) so a fresh deployment is safe out of the box.
- **Minimal logging**: one DEBUG line at embedder construction (shows `max_model_len`), a WARNING when `max_model_len` is unset, and a WARNING when a batched embed fails (with how many batches completed). No per-batch / INFO noise.

## Tests

- `test_container.py`: factory backfills the two kwargs; new `test_embedder_extra_overrides_backfilled_max_model_len` (explicit `extra` wins).
- `test_indexer_pool.py`: new `test_embedder_factory_backfills_max_model_len_from_settings` (backfill + explicit-wins).
- Verified end-to-end: a partition pointed at an embedder endpoint with `extra.max_model_len=1000` indexes with `truncate_prompt_tokens=999`.

Base branch: `refactor/hexagonal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated embedder default `max_model_len` to better align with prompt truncation behavior.
  * When endpoint embedder settings omit `max_model_len` or `embed_concurrency`, the service now backfills safe defaults from global embedder settings (endpoint overrides still take precedence).
  * Improved embedder logging on startup readiness and on embedding failures, including batch completion progress to aid diagnosis.

* **Tests**
  * Expanded unit tests to verify default backfilling and that per-endpoint overrides override global values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->