### PR TITLE
fix(registry): preset/model-endpoint mutation integrity (rename, default, delete)

### DIFF
--- a/openrag/core/ports/model_endpoint_repo.py
+++ b/openrag/core/ports/model_endpoint_repo.py
@@ -30,3 +30,6 @@ class ModelEndpointRepository(ABC):
 
     @abstractmethod
     async def set_default(self, model_type: str, name: str) -> None: ...
+
+    @abstractmethod
+    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None: ...

--- a/openrag/core/ports/model_endpoint_repo.py
+++ b/openrag/core/ports/model_endpoint_repo.py
@@ -32,4 +32,8 @@ class ModelEndpointRepository(ABC):
     async def set_default(self, model_type: str, name: str) -> None: ...
 
     @abstractmethod
-    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None: ...
+    async def delete_and_promote_default(self, name: str, model_type: str) -> tuple[str, str | None]:
+        """Atomically delete an endpoint and, if it was the default, promote a
+        survivor. Decides under a row lock. Returns ``(status, promoted_name)``
+        where status is ``"not_found" | "last" | "ok"``."""
+        ...

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -233,6 +233,12 @@ class ModelEndpointService:
             raise NotFoundError(f"Endpoint '{name}' of type '{model_type}' not found.")
 
         new_name: str | None = fields.pop("new_name", None)  # type: ignore[assignment]
+        # 'is_default' is not a plain column edit: flipping it must clear the previous
+        # default in the same transaction, so route a truthy value through set_default
+        # (atomic clear-then-set) instead of letting the repo write a second
+        # is_default=true row. A false/None value is a no-op here — you switch the
+        # default by promoting another endpoint, never by leaving the type with none.
+        promote_to_default = bool(fields.pop("is_default", None))
 
         if fields:
             updated = await self._repo.update(name, model_type, **fields)
@@ -246,7 +252,12 @@ class ModelEndpointService:
             self._invalidate_client_cache(model_type, name)
 
         self._invalidate_client_cache(model_type, effective_name)
-        if existing.is_default:
+        if promote_to_default:
+            # Clears any prior default and sets this row in one transaction, then
+            # re-points the 'default' alias to it — never leaves two defaults.
+            await self._repo.set_default(model_type, effective_name)
+            self._invalidate_client_cache(model_type, "default")
+        elif existing.is_default:
             # The 'default' alias resolves to this endpoint, so a client built under
             # the 'default' cache key is now stale too. Evict it alongside the named
             # entry (set_default already does this; update must match).

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -268,16 +268,19 @@ class ModelEndpointService:
         if len(all_of_type) <= 1:
             raise ValidationError(f"Cannot delete the last '{model_type}' endpoint. Register a replacement first.")
 
-        await self._repo.delete(name, model_type)
+        # load_all only adds the 'default' alias for an is_default row, so deleting
+        # the default would drop it entirely and make factory("default") raise.
+        # Promote a surviving endpoint (deterministic: first by name) so 'default'
+        # keeps resolving. Delete + promote run in a single repo transaction, so a
+        # failure can never leave the type with no default.
+        promote_to = None
+        if existing.is_default:
+            survivor = next((e for e in sorted(all_of_type, key=lambda e: e.name) if e.name != name), None)
+            promote_to = survivor.name if survivor is not None else None
+
+        await self._repo.delete_and_promote_default(name, model_type, promote_to)
         self._invalidate_client_cache(model_type, name)
         if existing.is_default:
-            # load_all only adds the 'default' alias for an is_default row, so
-            # deleting the default would drop it entirely and make factory("default")
-            # raise. Promote a surviving endpoint (deterministic: first by name) so
-            # 'default' keeps resolving, and evict its now-stale cached client.
-            survivor = next((e for e in sorted(all_of_type, key=lambda e: e.name) if e.name != name), None)
-            if survivor is not None:
-                await self._repo.set_default(model_type, survivor.name)
             self._invalidate_client_cache(model_type, "default")
         await self.load_all()
 

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -246,23 +246,28 @@ class ModelEndpointService:
             updated = existing
 
         effective_name = name
+        renamed_from: str | None = None
         if new_name and new_name != name:
             await self._repo.rename(name, model_type, new_name)
             effective_name = new_name
-            self._invalidate_client_cache(model_type, name)
+            renamed_from = name
 
-        self._invalidate_client_cache(model_type, effective_name)
         if promote_to_default:
             # Clears any prior default and sets this row in one transaction, then
             # re-points the 'default' alias to it — never leaves two defaults.
             await self._repo.set_default(model_type, effective_name)
-            self._invalidate_client_cache(model_type, "default")
-        elif existing.is_default:
-            # The 'default' alias resolves to this endpoint, so a client built under
-            # the 'default' cache key is now stale too. Evict it alongside the named
-            # entry (set_default already does this; update must match).
-            self._invalidate_client_cache(model_type, "default")
+        # The 'default' alias client is stale when this endpoint becomes the default
+        # OR was already the default (its config just changed).
+        evict_default = bool(promote_to_default or existing.is_default)
+
+        # Reload the in-memory config FIRST, then evict, so a client rebuilt during
+        # the reload window from the old config cannot survive in the cache.
         await self.load_all()
+        if renamed_from is not None:
+            self._invalidate_client_cache(model_type, renamed_from)
+        self._invalidate_client_cache(model_type, effective_name)
+        if evict_default:
+            self._invalidate_client_cache(model_type, "default")
         return await self._repo.get(effective_name, model_type) or (updated or existing)
 
     async def delete_model_endpoint(self, name: str, model_type: str) -> None:
@@ -282,11 +287,15 @@ class ModelEndpointService:
         if status == "last":
             raise ValidationError(f"Cannot delete the last '{model_type}' endpoint. Register a replacement first.")
 
+        # Reload the in-memory config FIRST, then evict: evicting before load_all
+        # leaves a window where a concurrent request rebuilds a client from the old
+        # config and re-caches it; evicting after the reload drops any such stale
+        # client so the next request rebuilds from the fresh config.
+        await self.load_all()
         self._invalidate_client_cache(model_type, name)
         if promoted is not None:
             # The deleted endpoint was the default; its 'default' alias client is now stale.
             self._invalidate_client_cache(model_type, "default")
-        await self.load_all()
 
     async def set_default(self, model_type: str, name: str) -> None:
         """Promote ``name`` to the default endpoint for ``model_type``."""
@@ -294,8 +303,9 @@ class ModelEndpointService:
         if existing is None:
             raise NotFoundError(f"Endpoint '{name}' of type '{model_type}' not found.")
         await self._repo.set_default(model_type, name)
-        self._invalidate_client_cache(model_type, "default")
+        # Reload before evicting so a client rebuilt during the window can't survive.
         await self.load_all()
+        self._invalidate_client_cache(model_type, "default")
 
     # ------------------------------------------------------------------
     # Endpoint validation

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -260,27 +260,20 @@ class ModelEndpointService:
         Raises 404 if not found, 422 if it is the last endpoint of its type
         (would leave components with no fallback).
         """
-        existing = await self._repo.get(name, model_type)
-        if existing is None:
+        # The last-endpoint guard and the survivor/default choice are made INSIDE
+        # the repo's locked transaction (not from a stale snapshot here), so
+        # concurrent deletes of the same type can't both pass the count check or
+        # promote an already-deleted survivor — which would leave the type with no
+        # endpoint / no default. The repo reports what happened.
+        status, promoted = await self._repo.delete_and_promote_default(name, model_type)
+        if status == "not_found":
             raise NotFoundError(f"Endpoint '{name}' of type '{model_type}' not found.")
-
-        all_of_type = await self._repo.list_all(model_type=model_type)
-        if len(all_of_type) <= 1:
+        if status == "last":
             raise ValidationError(f"Cannot delete the last '{model_type}' endpoint. Register a replacement first.")
 
-        # load_all only adds the 'default' alias for an is_default row, so deleting
-        # the default would drop it entirely and make factory("default") raise.
-        # Promote a surviving endpoint (deterministic: first by name) so 'default'
-        # keeps resolving. Delete + promote run in a single repo transaction, so a
-        # failure can never leave the type with no default.
-        promote_to = None
-        if existing.is_default:
-            survivor = next((e for e in sorted(all_of_type, key=lambda e: e.name) if e.name != name), None)
-            promote_to = survivor.name if survivor is not None else None
-
-        await self._repo.delete_and_promote_default(name, model_type, promote_to)
         self._invalidate_client_cache(model_type, name)
-        if existing.is_default:
+        if promoted is not None:
+            # The deleted endpoint was the default; its 'default' alias client is now stale.
             self._invalidate_client_cache(model_type, "default")
         await self.load_all()
 

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -209,6 +209,11 @@ class ModelEndpointService:
             )
         result = await self._repo.create(row)
         await self.load_all()
+        if row.is_default:
+            # The new endpoint became the default (repo demoted the previous one in
+            # the same transaction), so the cached 'default' alias client — built
+            # against the old default — is stale and must be evicted.
+            self._invalidate_client_cache(row.model_type, "default")
         return result
 
     async def get_model_endpoint(self, name: str, model_type: str) -> ModelEndpointRow:

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -246,6 +246,11 @@ class ModelEndpointService:
             self._invalidate_client_cache(model_type, name)
 
         self._invalidate_client_cache(model_type, effective_name)
+        if existing.is_default:
+            # The 'default' alias resolves to this endpoint, so a client built under
+            # the 'default' cache key is now stale too. Evict it alongside the named
+            # entry (set_default already does this; update must match).
+            self._invalidate_client_cache(model_type, "default")
         await self.load_all()
         return await self._repo.get(effective_name, model_type) or (updated or existing)
 
@@ -265,6 +270,15 @@ class ModelEndpointService:
 
         await self._repo.delete(name, model_type)
         self._invalidate_client_cache(model_type, name)
+        if existing.is_default:
+            # load_all only adds the 'default' alias for an is_default row, so
+            # deleting the default would drop it entirely and make factory("default")
+            # raise. Promote a surviving endpoint (deterministic: first by name) so
+            # 'default' keeps resolving, and evict its now-stale cached client.
+            survivor = next((e for e in sorted(all_of_type, key=lambda e: e.name) if e.name != name), None)
+            if survivor is not None:
+                await self._repo.set_default(model_type, survivor.name)
+            self._invalidate_client_cache(model_type, "default")
         await self.load_all()
 
     async def set_default(self, model_type: str, name: str) -> None:

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -223,8 +223,7 @@ class PresetService:
                 )
             if await self._repo.get(new_name, preset_type) is not None:
                 raise ValidationError(
-                    f"Cannot rename preset to '{new_name}': a {preset_type} preset with that name "
-                    "already exists."
+                    f"Cannot rename preset to '{new_name}': a {preset_type} preset with that name already exists."
                 )
             effective_name = new_name
             result = await self._repo.rename(name, effective_name, preset_type, effective_config)

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -210,6 +210,11 @@ class PresetService:
         effective_name = name
 
         if new_name and new_name != name:
+            if await self._repo.get(new_name, preset_type) is not None:
+                raise ValidationError(
+                    f"Cannot rename preset to '{new_name}': a {preset_type} preset with that name "
+                    "already exists."
+                )
             effective_name = new_name
             result = await self._repo.rename(name, effective_name, preset_type, effective_config)
         else:

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -27,6 +27,12 @@ logger = get_logger()
 
 _VALID_PRESET_TYPES = frozenset({"indexation", "retrieval"})
 
+# The 'default' preset is the system fallback: partitions.{indexation,retrieval}_preset
+# default to this name (schema server_default + create_partition), and
+# resolve_partition_row raises if it is missing. It must always exist under this
+# name, so renaming it away or deleting it is rejected. Editing its config is fine.
+_RESERVED_PRESET_NAME = "default"
+
 _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
     # ``enable_contextualization`` is intentionally omitted from the ``default``
     # indexation preset below — it is injected at seed time from the global
@@ -210,6 +216,11 @@ class PresetService:
         effective_name = name
 
         if new_name and new_name != name:
+            if name == _RESERVED_PRESET_NAME:
+                raise ValidationError(
+                    f"Cannot rename the reserved '{_RESERVED_PRESET_NAME}' {preset_type} preset: "
+                    "it is the system fallback every partition resolves to."
+                )
             if await self._repo.get(new_name, preset_type) is not None:
                 raise ValidationError(
                     f"Cannot rename preset to '{new_name}': a {preset_type} preset with that name "
@@ -234,6 +245,12 @@ class PresetService:
         existing = await self._repo.get(name, preset_type)
         if existing is None:
             raise NotFoundError(f"Preset '{name}' of type '{preset_type}' not found.")
+
+        if name == _RESERVED_PRESET_NAME:
+            raise ValidationError(
+                f"Cannot delete the reserved '{_RESERVED_PRESET_NAME}' {preset_type} preset: "
+                "it is the system fallback every partition resolves to."
+            )
 
         count = await self._repo.count_partitions_using(name, preset_type)
         if count > 0:

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -54,22 +54,34 @@ class PgModelEndpointRepository(ModelEndpointRepository):
         )
 
     async def create(self, row: ModelEndpointRow) -> ModelEndpointRow:
-        rec = await self.pool.fetchrow(
-            """
-            INSERT INTO model_endpoints
-                (name, model_type, endpoint, model_name, batch_size, timeout, extra, is_default)
-            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
-            RETURNING *
-            """,
-            row.name,
-            row.model_type,
-            row.endpoint,
-            row.model_name,
-            row.batch_size,
-            row.timeout,
-            row.extra,
-            row.is_default,
-        )
+        # A bare INSERT with is_default=true cannot clear the previous default, so
+        # POST /model-endpoints/ {"is_default": true} would leave two is_default=true
+        # rows for one model_type (same hazard the update path avoids by routing
+        # through set_default). Demote any existing default in the SAME transaction
+        # as the insert so the new endpoint becomes the sole default atomically.
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                if row.is_default:
+                    await conn.execute(
+                        "UPDATE model_endpoints SET is_default = false, updated_at = now() WHERE model_type = $1",
+                        row.model_type,
+                    )
+                rec = await conn.fetchrow(
+                    """
+                    INSERT INTO model_endpoints
+                        (name, model_type, endpoint, model_name, batch_size, timeout, extra, is_default)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+                    RETURNING *
+                    """,
+                    row.name,
+                    row.model_type,
+                    row.endpoint,
+                    row.model_name,
+                    row.batch_size,
+                    row.timeout,
+                    row.extra,
+                    row.is_default,
+                )
         return self._to_model(rec)
 
     async def get(self, name: str, model_type: str) -> ModelEndpointRow | None:

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from core.config.model_endpoints import ModelEndpointRow
 from core.ports.model_endpoint_repo import ModelEndpointRepository
+from core.utils.exceptions import NotFoundError
 
 if TYPE_CHECKING:
     import asyncpg
@@ -127,8 +128,25 @@ class PgModelEndpointRepository(ModelEndpointRepository):
         return result == "DELETE 1"
 
     async def set_default(self, model_type: str, name: str) -> None:
+        """Promote ``name`` to the default for ``model_type``, atomically.
+
+        Locks the type's rows (FOR UPDATE) and confirms ``name`` still exists
+        *inside* the transaction before clearing the old default. Without the
+        lock + existence check, a concurrent delete of ``name`` between the
+        caller's existence check and this transaction would make the second
+        UPDATE match 0 rows AFTER the first already cleared the previous default
+        — leaving the type with no default at all. Same invariant
+        ``delete_and_promote_default`` protects. Raises ``NotFoundError`` if the
+        target endpoint is gone.
+        """
         async with self.pool.acquire() as conn:
             async with conn.transaction():
+                rows = await conn.fetch(
+                    "SELECT name FROM model_endpoints WHERE model_type = $1 FOR UPDATE",
+                    model_type,
+                )
+                if name not in {r["name"] for r in rows}:
+                    raise NotFoundError(f"Endpoint '{name}' of type '{model_type}' not found.")
                 await conn.execute(
                     "UPDATE model_endpoints SET is_default = false, updated_at = now() WHERE model_type = $1",
                     model_type,

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -16,7 +16,15 @@ from core.ports.model_endpoint_repo import ModelEndpointRepository
 if TYPE_CHECKING:
     import asyncpg
 
-_ALLOWED_UPDATE_FIELDS = frozenset({"endpoint", "model_name", "batch_size", "timeout", "extra", "is_default"})
+# 'is_default' is deliberately excluded: a bare ``UPDATE ... SET is_default = true``
+# cannot clear the previous default in the same statement, so it would leave two
+# is_default=true rows for one model_type — and load_all() then resolves the
+# 'default' alias to whichever endpoint sorts last by name, not the one the caller
+# picked. (Verified against the live admin API: a single PUT of {"is_default": true}
+# on a non-default endpoint yielded two defaults for the type.) Promotion must go
+# through set_default / delete_and_promote_default, which clear-then-set inside one
+# transaction; ModelEndpointService.update_model_endpoint routes is_default there.
+_ALLOWED_UPDATE_FIELDS = frozenset({"endpoint", "model_name", "batch_size", "timeout", "extra"})
 
 
 class PgModelEndpointRepository(ModelEndpointRepository):

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -132,5 +132,28 @@ class PgModelEndpointRepository(ModelEndpointRepository):
                     model_type,
                 )
 
+    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None:
+        # Delete and (when the deleted row was the default) promote a survivor in
+        # ONE transaction, so a mid-operation failure can never leave the type with
+        # no default endpoint. ``promote_to is None`` => a plain delete.
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "DELETE FROM model_endpoints WHERE name = $1 AND model_type = $2",
+                    name,
+                    model_type,
+                )
+                if promote_to is not None:
+                    await conn.execute(
+                        "UPDATE model_endpoints SET is_default = false, updated_at = now() WHERE model_type = $1",
+                        model_type,
+                    )
+                    await conn.execute(
+                        "UPDATE model_endpoints SET is_default = true, updated_at = now() "
+                        "WHERE name = $1 AND model_type = $2",
+                        promote_to,
+                        model_type,
+                    )
+
 
 __all__ = ["PgModelEndpointRepository"]

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -132,18 +132,35 @@ class PgModelEndpointRepository(ModelEndpointRepository):
                     model_type,
                 )
 
-    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None:
-        # Delete and (when the deleted row was the default) promote a survivor in
-        # ONE transaction, so a mid-operation failure can never leave the type with
-        # no default endpoint. ``promote_to is None`` => a plain delete.
+    async def delete_and_promote_default(self, name: str, model_type: str) -> tuple[str, str | None]:
+        # Lock every row of this model_type (FOR UPDATE) so concurrent deletes of
+        # the same type serialize, then make the last-endpoint guard and survivor
+        # choice from the LOCKED, current state — not a stale snapshot. Otherwise two
+        # concurrent deletes could each pass a snapshot count check and remove the
+        # last row, or promote a survivor that another tx just deleted, leaving the
+        # type with no endpoint / no default. Returns (status, promoted_name):
+        # status is "not_found" | "last" | "ok"; promoted_name is set only when the
+        # deleted row was the default and a survivor was promoted.
         async with self.pool.acquire() as conn:
             async with conn.transaction():
+                rows = await conn.fetch(
+                    "SELECT name, is_default FROM model_endpoints WHERE model_type = $1 ORDER BY name FOR UPDATE",
+                    model_type,
+                )
+                names = [r["name"] for r in rows]
+                if name not in names:
+                    return ("not_found", None)
+                if len(names) <= 1:
+                    return ("last", None)
+                was_default = next(r["is_default"] for r in rows if r["name"] == name)
                 await conn.execute(
                     "DELETE FROM model_endpoints WHERE name = $1 AND model_type = $2",
                     name,
                     model_type,
                 )
-                if promote_to is not None:
+                promoted: str | None = None
+                if was_default:
+                    promoted = next(n for n in names if n != name)  # deterministic: first by name
                     await conn.execute(
                         "UPDATE model_endpoints SET is_default = false, updated_at = now() WHERE model_type = $1",
                         model_type,
@@ -151,9 +168,10 @@ class PgModelEndpointRepository(ModelEndpointRepository):
                     await conn.execute(
                         "UPDATE model_endpoints SET is_default = true, updated_at = now() "
                         "WHERE name = $1 AND model_type = $2",
-                        promote_to,
+                        promoted,
                         model_type,
                     )
+                return ("ok", promoted)
 
 
 __all__ = ["PgModelEndpointRepository"]

--- a/openrag/services/persistence/model_endpoint_repo.py
+++ b/openrag/services/persistence/model_endpoint_repo.py
@@ -141,6 +141,16 @@ class PgModelEndpointRepository(ModelEndpointRepository):
                 )
 
     async def delete_and_promote_default(self, name: str, model_type: str) -> tuple[str, str | None]:
+        """Delete an endpoint and, if it was the default, promote a survivor to
+        default — all atomically and decided under a row lock.
+
+        Locking and deciding inside one transaction means concurrent deletes of the
+        same model type can't both pass a stale last-endpoint check or promote an
+        already-deleted survivor, so the type is never left with no endpoint or no
+        default. Returns ``(status, promoted_name)`` where ``status`` is
+        ``"not_found" | "last" | "ok"`` and ``promoted_name`` is set only when a
+        deleted default was replaced.
+        """
         # Lock every row of this model_type (FOR UPDATE) so concurrent deletes of
         # the same type serialize, then make the last-endpoint guard and survivor
         # choice from the LOCKED, current state — not a stale snapshot. Otherwise two

--- a/openrag/services/persistence/preset_repo.py
+++ b/openrag/services/persistence/preset_repo.py
@@ -80,6 +80,13 @@ class PgPresetRepository(PresetRepository):
         return self._row_to_dict(rec)
 
     async def rename(self, old_name: str, new_name: str, preset_type: str, config: dict) -> dict:
+        """Rename a preset to ``new_name`` (also updating its config) and repoint
+        every referencing partition, atomically.
+
+        Raises :class:`NotFoundError` if ``old_name`` no longer exists; a collision
+        with an existing ``new_name`` is rejected by the ``(name, preset_type)``
+        unique constraint. Returns the updated preset row as a dict.
+        """
         # Rename in place with a plain UPDATE (not an upsert): the
         # (name, preset_type) unique constraint then rejects a collision with an
         # existing target name instead of an upsert silently overwriting it, and

--- a/openrag/services/persistence/preset_repo.py
+++ b/openrag/services/persistence/preset_repo.py
@@ -79,28 +79,27 @@ class PgPresetRepository(PresetRepository):
         return self._row_to_dict(rec)
 
     async def rename(self, old_name: str, new_name: str, preset_type: str, config: dict) -> dict:
-        # Partitions reference a preset by its name string (partitions.{col}), with
-        # no FK, so a bare DELETE+INSERT would leave every referencing partition
-        # pointing at a name that no longer exists. Do it atomically: insert the
-        # new-named row, repoint referencing partitions, then drop the old row.
+        # Rename in place with a plain UPDATE (not an upsert): the
+        # (name, preset_type) unique constraint then rejects a collision with an
+        # existing target name instead of an upsert silently overwriting it, and
+        # the row keeps its identity/created_at. Partitions reference a preset by
+        # its name string (partitions.{col}) with no FK, so referencing partitions
+        # are repointed in the same transaction or they would orphan.
         col = _preset_column(preset_type)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 rec = await conn.fetchrow(
-                    _UPSERT_PRESET_SQL,
+                    "UPDATE pipeline_presets SET name = $2, config = $3::jsonb, updated_at = now() "
+                    "WHERE name = $1 AND preset_type = $4 RETURNING *",
+                    old_name,
                     new_name,
-                    preset_type,
                     config,
+                    preset_type,
                 )
                 await conn.execute(
                     f"UPDATE partitions SET {col} = $1 WHERE {col} = $2",
                     new_name,
                     old_name,
-                )
-                await conn.execute(
-                    "DELETE FROM pipeline_presets WHERE name = $1 AND preset_type = $2",
-                    old_name,
-                    preset_type,
                 )
         return self._row_to_dict(rec)
 

--- a/openrag/services/persistence/preset_repo.py
+++ b/openrag/services/persistence/preset_repo.py
@@ -79,18 +79,28 @@ class PgPresetRepository(PresetRepository):
         return self._row_to_dict(rec)
 
     async def rename(self, old_name: str, new_name: str, preset_type: str, config: dict) -> dict:
+        # Partitions reference a preset by its name string (partitions.{col}), with
+        # no FK, so a bare DELETE+INSERT would leave every referencing partition
+        # pointing at a name that no longer exists. Do it atomically: insert the
+        # new-named row, repoint referencing partitions, then drop the old row.
+        col = _preset_column(preset_type)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(
-                    "DELETE FROM pipeline_presets WHERE name = $1 AND preset_type = $2",
-                    old_name,
-                    preset_type,
-                )
                 rec = await conn.fetchrow(
                     _UPSERT_PRESET_SQL,
                     new_name,
                     preset_type,
                     config,
+                )
+                await conn.execute(
+                    f"UPDATE partitions SET {col} = $1 WHERE {col} = $2",
+                    new_name,
+                    old_name,
+                )
+                await conn.execute(
+                    "DELETE FROM pipeline_presets WHERE name = $1 AND preset_type = $2",
+                    old_name,
+                    preset_type,
                 )
         return self._row_to_dict(rec)
 

--- a/openrag/services/persistence/preset_repo.py
+++ b/openrag/services/persistence/preset_repo.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from core.ports.preset_repo import PresetRepository
+from core.utils.exceptions import NotFoundError
 
 if TYPE_CHECKING:
     import asyncpg
@@ -96,6 +97,11 @@ class PgPresetRepository(PresetRepository):
                     config,
                     preset_type,
                 )
+                if rec is None:
+                    # old_name vanished between the service's existence check and
+                    # this UPDATE (concurrent delete) — fail cleanly instead of
+                    # blowing up in _row_to_dict(None).
+                    raise NotFoundError(f"Preset '{old_name}' of type '{preset_type}' not found.")
                 await conn.execute(
                     f"UPDATE partitions SET {col} = $1 WHERE {col} = $2",
                     new_name,

--- a/tests/integration/api/test_model_endpoints.py
+++ b/tests/integration/api/test_model_endpoints.py
@@ -79,3 +79,52 @@ def test_model_endpoint_crud_validate_and_default_selection(api_client):
             api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
         _delete_ignore_errors(api_client, f"/model-endpoints/llm/{endpoint_renamed}")
         _delete_ignore_errors(api_client, f"/model-endpoints/llm/{endpoint_name}")
+
+
+def test_update_is_default_keeps_single_default(api_client):
+    """PUT {"is_default": true} via the update path must not create a second default.
+
+    Regression: ``update`` ran a bare ``SET is_default = true`` without clearing the
+    previous default, so a single PUT left two is_default=true rows for one type and
+    the 'default' alias resolved to whichever sorted last by name. The update path now
+    routes ``is_default`` through ``set_default`` (atomic clear-then-set).
+    """
+    suffix = uuid.uuid4().hex[:8]
+    name_a = f"ci-llm-a-{suffix}"
+    name_b = f"ci-llm-b-{suffix}"
+    original_default_llm = None
+
+    try:
+        endpoints = api_client.get("/model-endpoints/", params={"model_type": "llm"})
+        _assert_success(endpoints, context="list llm endpoints")
+        original_default_llm = next(row["name"] for row in endpoints.json() if row["is_default"])
+
+        for name in (name_a, name_b):
+            created = api_client.post(
+                "/model-endpoints/",
+                json={
+                    "name": name,
+                    "model_type": "llm",
+                    "endpoint": MOCK_VLLM_ENDPOINT,
+                    "model_name": MOCK_CHAT_MODEL,
+                },
+            )
+            assert created.status_code == 201, created.text
+            assert created.json()["is_default"] is False
+
+        # Promote A through the dedicated endpoint, then promote B through the UPDATE
+        # path. The second promotion must demote A, not add a parallel default.
+        _assert_success(api_client.post(f"/model-endpoints/llm/{name_a}/set-default"), context="set-default A")
+
+        promote_b = api_client.put(f"/model-endpoints/llm/{name_b}", json={"is_default": True})
+        _assert_success(promote_b, context="update B is_default=true")
+        assert promote_b.json()["is_default"] is True
+
+        listing = api_client.get("/model-endpoints/", params={"model_type": "llm"}).json()
+        defaults = sorted(row["name"] for row in listing if row["is_default"])
+        assert defaults == [name_b], f"expected exactly one default ({name_b}), got {defaults}"
+    finally:
+        if original_default_llm is not None:
+            api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
+        _delete_ignore_errors(api_client, f"/model-endpoints/llm/{name_a}")
+        _delete_ignore_errors(api_client, f"/model-endpoints/llm/{name_b}")

--- a/tests/integration/api/test_model_endpoints.py
+++ b/tests/integration/api/test_model_endpoints.py
@@ -168,7 +168,8 @@ def test_create_is_default_keeps_single_default(api_client):
         assert defaults == [new_name], f"expected exactly one default ({new_name}), got {defaults}"
     finally:
         if original_default_llm is not None:
-            api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
+            restore = api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
+            _assert_success(restore, context=f"restore default llm endpoint {original_default_llm}")
         _delete_ignore_errors(api_client, f"/model-endpoints/llm/{new_name}")
 
 

--- a/tests/integration/api/test_model_endpoints.py
+++ b/tests/integration/api/test_model_endpoints.py
@@ -128,3 +128,70 @@ def test_update_is_default_keeps_single_default(api_client):
             api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
         _delete_ignore_errors(api_client, f"/model-endpoints/llm/{name_a}")
         _delete_ignore_errors(api_client, f"/model-endpoints/llm/{name_b}")
+
+
+def test_create_is_default_keeps_single_default(api_client):
+    """POST {"is_default": true} must not add a second default for the type.
+
+    Regression (Hedi's review): "A create request marked as default can still add
+    another default without demoting the current one." The create path ran a bare
+    INSERT with the is_default flag straight through — the same hazard the update
+    path avoids — so registering a new endpoint marked default while one already
+    existed left two is_default=true rows. create now demotes any existing default
+    in the same transaction, so the new endpoint becomes the sole default.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    new_name = f"ci-llm-create-default-{suffix}"
+    original_default_llm = None
+
+    try:
+        endpoints = api_client.get("/model-endpoints/", params={"model_type": "llm"})
+        _assert_success(endpoints, context="list llm endpoints")
+        original_default_llm = next(row["name"] for row in endpoints.json() if row["is_default"])
+        assert original_default_llm != new_name
+
+        created = api_client.post(
+            "/model-endpoints/",
+            json={
+                "name": new_name,
+                "model_type": "llm",
+                "endpoint": MOCK_VLLM_ENDPOINT,
+                "model_name": MOCK_CHAT_MODEL,
+                "is_default": True,
+            },
+        )
+        assert created.status_code == 201, created.text
+        assert created.json()["is_default"] is True
+
+        listing = api_client.get("/model-endpoints/", params={"model_type": "llm"}).json()
+        defaults = sorted(row["name"] for row in listing if row["is_default"])
+        assert defaults == [new_name], f"expected exactly one default ({new_name}), got {defaults}"
+    finally:
+        if original_default_llm is not None:
+            api_client.post(f"/model-endpoints/llm/{original_default_llm}/set-default")
+        _delete_ignore_errors(api_client, f"/model-endpoints/llm/{new_name}")
+
+
+def test_set_default_missing_target_keeps_existing_default(api_client):
+    """set-default on a vanished target must never leave the type with no default.
+
+    Regression (Hedi's review): "set-default checks the target before the
+    transaction that clears/promotes defaults. If the target disappears in that
+    gap, the model type can end up with no default." The promote transaction now
+    verifies the target via ``RETURNING`` and rolls the clear back when it matched
+    no row, so the previous default survives. At the API level the observable
+    contract is: a set-default whose target does not exist is a clean 404 that
+    leaves exactly one default standing — never zero. (The repo-level rollback on
+    the concurrent-delete race is covered deterministically by the unit suite.)
+    """
+    endpoints = api_client.get("/model-endpoints/", params={"model_type": "llm"})
+    _assert_success(endpoints, context="list llm endpoints")
+    original_default_llm = next(row["name"] for row in endpoints.json() if row["is_default"])
+
+    missing = f"ci-llm-ghost-{uuid.uuid4().hex[:8]}"
+    promote_missing = api_client.post(f"/model-endpoints/llm/{missing}/set-default")
+    assert promote_missing.status_code == 404, promote_missing.text
+
+    listing = api_client.get("/model-endpoints/", params={"model_type": "llm"}).json()
+    defaults = sorted(row["name"] for row in listing if row["is_default"])
+    assert defaults == [original_default_llm], f"expected the original default to survive, got {defaults}"

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -84,12 +84,22 @@ class _FakeEndpointRepo:
         for key, row in list(self._store.items()):
             self._store[key] = row.model_copy(update={"is_default": key[0] == name and key[1] == model_type})
 
-    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None:
+    async def delete_and_promote_default(self, name: str, model_type: str) -> tuple[str, str | None]:
+        names = sorted(k[0] for k in self._store if k[1] == model_type)
+        self.calls.append(("delete_and_promote_default", (name, model_type)))
+        if name not in names:
+            return ("not_found", None)
+        if len(names) <= 1:
+            return ("last", None)
+        was_default = self._store[(name, model_type)].is_default
         self._store.pop((name, model_type), None)
-        self.calls.append(("delete_and_promote_default", (name, model_type, promote_to)))
-        if promote_to is not None:
+        promoted = None
+        if was_default:
+            promoted = next(n for n in names if n != name)
             for key, row in list(self._store.items()):
-                self._store[key] = row.model_copy(update={"is_default": key[0] == promote_to and key[1] == model_type})
+                if key[1] == model_type:
+                    self._store[key] = row.model_copy(update={"is_default": key[0] == promoted})
+        return ("ok", promoted)
 
 
 def _make_service(repo=None, rows=None, settings=None):

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -387,6 +387,38 @@ async def test_update_model_endpoint_renames_and_evicts_cache():
     assert ("new-name", "embedder") in repo._store
 
 
+@pytest.mark.asyncio
+async def test_update_default_endpoint_evicts_default_alias_cache():
+    # Updating the current default must evict the 'default' cache key too, not just
+    # the named one — else callers that resolved 'default' keep a stale client.
+    existing = _make_row(name="jina", is_default=True)
+    repo = _FakeEndpointRepo(rows=[existing])
+    cache: dict = {"jina": object(), "default": object()}
+    svc = _make_service(repo)
+    svc._client_caches["embedder"] = cache
+
+    await svc.update_model_endpoint("jina", "embedder", endpoint="http://new:8000/v1")
+
+    assert "jina" not in cache
+    assert "default" not in cache
+
+
+@pytest.mark.asyncio
+async def test_update_non_default_endpoint_keeps_default_alias_cache():
+    # A non-default endpoint update must NOT evict the unrelated 'default' client.
+    rows = [_make_row(name="e5", is_default=False), _make_row(name="jina", is_default=True)]
+    repo = _FakeEndpointRepo(rows=rows)
+    sentinel = object()
+    cache: dict = {"e5": object(), "default": sentinel}
+    svc = _make_service(repo)
+    svc._client_caches["embedder"] = cache
+
+    await svc.update_model_endpoint("e5", "embedder", endpoint="http://new:8000/v1")
+
+    assert "e5" not in cache
+    assert cache.get("default") is sentinel
+
+
 # ------------------------------------------------------------------
 # delete_model_endpoint
 # ------------------------------------------------------------------
@@ -426,6 +458,43 @@ async def test_delete_model_endpoint_removes_row_and_evicts_cache():
 
     assert ("jina", "embedder") not in repo._store
     assert "jina" not in cache
+
+
+@pytest.mark.asyncio
+async def test_delete_default_endpoint_promotes_survivor_and_evicts_default_cache():
+    # Deleting the default must promote a surviving endpoint so the 'default' alias
+    # keeps resolving (load_all only adds it for an is_default row), and evict the
+    # now-stale 'default' client.
+    rows = [
+        _make_row(name="jina", is_default=True),
+        _make_row(name="e5", is_default=False),
+    ]
+    repo = _FakeEndpointRepo(rows=rows)
+    cache: dict = {"jina": object(), "default": object()}
+    svc = _make_service(repo)
+    svc._client_caches["embedder"] = cache
+
+    await svc.delete_model_endpoint("jina", "embedder")
+
+    assert ("jina", "embedder") not in repo._store
+    assert "default" not in cache
+    # e5 is the lone survivor -> promoted so 'default' still resolves.
+    assert repo._store[("e5", "embedder")].is_default is True
+
+
+@pytest.mark.asyncio
+async def test_delete_non_default_endpoint_leaves_default_untouched():
+    rows = [
+        _make_row(name="jina", is_default=True),
+        _make_row(name="e5", is_default=False),
+    ]
+    repo = _FakeEndpointRepo(rows=rows)
+    svc = _make_service(repo)
+
+    await svc.delete_model_endpoint("e5", "embedder")
+
+    # Deleting a non-default endpoint leaves the existing default in place.
+    assert repo._store[("jina", "embedder")].is_default is True
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -436,6 +436,46 @@ async def test_update_non_default_endpoint_keeps_default_alias_cache():
     assert cache.get("default") is sentinel
 
 
+@pytest.mark.asyncio
+async def test_update_is_default_promotes_atomically_single_default():
+    # Promoting via update({"is_default": True}) must route through the clear-then-set
+    # path: the previous default is demoted (never two is_default=true rows) and the
+    # 'default' alias client is evicted. Without this, a bare UPDATE would add a
+    # second default and the alias would resolve to whichever row sorts last by name.
+    rows = [
+        _make_row(name="jina", is_default=True),
+        _make_row(name="e5", is_default=False),
+    ]
+    repo = _FakeEndpointRepo(rows=rows)
+    cache: dict = {"e5": object(), "default": object()}
+    svc = _make_service(repo)
+    svc._client_caches["embedder"] = cache
+
+    await svc.update_model_endpoint("e5", "embedder", is_default=True)
+
+    defaults = sorted(name for (name, mt), row in repo._store.items() if mt == "embedder" and row.is_default)
+    assert defaults == ["e5"], f"expected exactly one default (e5), got {defaults}"
+    assert repo._store[("jina", "embedder")].is_default is False
+    assert "default" not in cache
+
+
+@pytest.mark.asyncio
+async def test_update_is_default_false_does_not_demote_or_touch_default_cache():
+    # is_default=False is a no-op: it must not clear the existing default (which would
+    # leave the type with none) and must not evict the unrelated 'default' client.
+    rows = [_make_row(name="e5", is_default=False), _make_row(name="jina", is_default=True)]
+    repo = _FakeEndpointRepo(rows=rows)
+    sentinel = object()
+    cache: dict = {"e5": object(), "default": sentinel}
+    svc = _make_service(repo)
+    svc._client_caches["embedder"] = cache
+
+    await svc.update_model_endpoint("e5", "embedder", is_default=False)
+
+    assert repo._store[("jina", "embedder")].is_default is True
+    assert cache.get("default") is sentinel
+
+
 # ------------------------------------------------------------------
 # delete_model_endpoint
 # ------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -84,6 +84,13 @@ class _FakeEndpointRepo:
         for key, row in list(self._store.items()):
             self._store[key] = row.model_copy(update={"is_default": key[0] == name and key[1] == model_type})
 
+    async def delete_and_promote_default(self, name: str, model_type: str, promote_to: str | None) -> None:
+        self._store.pop((name, model_type), None)
+        self.calls.append(("delete_and_promote_default", (name, model_type, promote_to)))
+        if promote_to is not None:
+            for key, row in list(self._store.items()):
+                self._store[key] = row.model_copy(update={"is_default": key[0] == promote_to and key[1] == model_type})
+
 
 def _make_service(repo=None, rows=None, settings=None):
     from core.config.root import Settings

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -335,6 +335,26 @@ async def test_update_preset_renames_preset():
 
 
 @pytest.mark.asyncio
+async def test_update_preset_rename_rejects_existing_target_name():
+    from core.utils.exceptions import ValidationError
+
+    rows = [
+        _make_row("old-name", "retrieval", _VALID_RET_CONFIG),
+        _make_row("taken", "retrieval", _VALID_RET_CONFIG),
+    ]
+    repo = _FakePresetRepo(rows=rows)
+    svc = _make_service(repo)
+
+    with pytest.raises(ValidationError, match="already exists"):
+        await svc.update_preset("old-name", "retrieval", new_name="taken")
+
+    # The rename must not run — the existing 'taken' preset is left intact.
+    assert not any(call[0] == "rename" for call in repo.calls)
+    assert ("old-name", "retrieval") in repo._store
+    assert ("taken", "retrieval") in repo._store
+
+
+@pytest.mark.asyncio
 async def test_update_preset_calls_partition_service():
     existing = _make_row("default", "retrieval", _VALID_RET_CONFIG)
     repo = _FakePresetRepo(rows=[existing])

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -396,13 +396,55 @@ async def test_delete_preset_raises_404_when_missing():
 async def test_delete_preset_raises_422_when_in_use():
     from core.utils.exceptions import ValidationError
 
-    existing = _make_row("default", "indexation")
+    existing = _make_row("legal", "indexation")
     repo = _FakePresetRepo(rows=[existing])
-    repo._partition_counts[("default", "indexation")] = 2
+    repo._partition_counts[("legal", "indexation")] = 2
     svc = _make_service(repo)
 
     with pytest.raises(ValidationError, match="2 partition"):
+        await svc.delete_preset("legal", "indexation")
+
+
+@pytest.mark.asyncio
+async def test_delete_preset_rejects_reserved_default():
+    from core.utils.exceptions import ValidationError
+
+    existing = _make_row("default", "indexation")
+    repo = _FakePresetRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    # The reserved 'default' preset is the partition fallback — deletion is blocked
+    # even when no partition currently references it, before the in-use count check.
+    with pytest.raises(ValidationError, match="reserved"):
         await svc.delete_preset("default", "indexation")
+    assert ("default", "indexation") in repo._store
+
+
+@pytest.mark.asyncio
+async def test_update_preset_rejects_renaming_reserved_default():
+    from core.utils.exceptions import ValidationError
+
+    existing = _make_row("default", "retrieval", _VALID_RET_CONFIG)
+    repo = _FakePresetRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    with pytest.raises(ValidationError, match="reserved"):
+        await svc.update_preset("default", "retrieval", new_name="custom")
+    assert not any(call[0] == "rename" for call in repo.calls)
+    assert ("default", "retrieval") in repo._store
+
+
+@pytest.mark.asyncio
+async def test_update_preset_allows_editing_reserved_default_config():
+    # Editing the default preset's config (no rename) must stay allowed.
+    existing = _make_row("default", "indexation", _VALID_IDX_CONFIG)
+    repo = _FakePresetRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    edited = {**_VALID_IDX_CONFIG, "enable_topic_tagging": False}
+    await svc.update_preset("default", "indexation", config=edited)
+
+    assert repo._store[("default", "indexation")]["config"]["enable_topic_tagging"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_model_endpoint_repo.py
+++ b/tests/unit/services/persistence/test_model_endpoint_repo.py
@@ -93,13 +93,14 @@ async def test_create_inserts_and_returns_model():
     from services.persistence.model_endpoint_repo import PgModelEndpointRepository
 
     pool = _FakePool()
-    pool._fetchrow_result = _make_row()
+    pool.conn._fetchrow_result = _make_row()
     repo = PgModelEndpointRepository(pool_getter=lambda: pool)
 
     row = ModelEndpointRow(
         name="default",
         model_type="embedder",
         endpoint="http://vllm:8000/v1",
+        is_default=False,
         created_at=_NOW,
         updated_at=_NOW,
     )
@@ -107,7 +108,36 @@ async def test_create_inserts_and_returns_model():
 
     assert result.name == "default"
     assert result.model_type == "embedder"
-    assert any("INSERT INTO model_endpoints" in q for q, _ in pool.executed)
+    queries = [q for q, _ in pool.conn.executed]
+    assert any("INSERT INTO model_endpoints" in q for q in queries)
+    # is_default=False on the row -> no demotion of an existing default.
+    assert not any("is_default = false" in q for q in queries)
+
+
+@pytest.mark.asyncio
+async def test_create_default_demotes_existing_in_same_transaction():
+    from core.config.model_endpoints import ModelEndpointRow
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    pool = _FakePool()
+    pool.conn._fetchrow_result = _make_row(is_default=True)
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    row = ModelEndpointRow(
+        name="default",
+        model_type="embedder",
+        endpoint="http://vllm:8000/v1",
+        is_default=True,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    await repo.create(row)
+
+    queries = [q for q, _ in pool.conn.executed]
+    # The clear UPDATE must precede the INSERT so the new row is the sole default.
+    clear_idx = next(i for i, q in enumerate(queries) if "is_default = false" in q)
+    insert_idx = next(i for i, q in enumerate(queries) if "INSERT INTO model_endpoints" in q)
+    assert clear_idx < insert_idx
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_model_endpoint_repo.py
+++ b/tests/unit/services/persistence/test_model_endpoint_repo.py
@@ -267,6 +267,7 @@ async def test_delete_and_promote_non_default_deletes_no_promotion():
     queries = [q for q, _ in pool.conn.executed]
     assert any("FOR UPDATE" in q for q in queries)
     assert any("DELETE FROM model_endpoints" in q for q in queries)
+    assert not any("is_default = false" in q for q in queries)
     assert not any("is_default = true" in q for q in queries)
 
 
@@ -284,4 +285,5 @@ async def test_delete_and_promote_default_promotes_survivor_under_lock():
     queries = [q for q, _ in pool.conn.executed]
     assert any("FOR UPDATE" in q for q in queries)
     assert any("DELETE FROM model_endpoints" in q for q in queries)
+    assert any("is_default = false" in q for q in queries)
     assert any("is_default = true" in q for q in queries)

--- a/tests/unit/services/persistence/test_model_endpoint_repo.py
+++ b/tests/unit/services/persistence/test_model_endpoint_repo.py
@@ -41,6 +41,7 @@ class _FakeConn:
     def __init__(self):
         self.executed: list[tuple[str, tuple]] = []
         self._fetchrow_result = None
+        self._fetch_result: list = []
 
     def transaction(self):
         return _AsyncCtx(self)
@@ -48,6 +49,10 @@ class _FakeConn:
     async def execute(self, query: str, *params):
         self.executed.append((query, params))
         return "UPDATE 1"
+
+    async def fetch(self, query: str, *params):
+        self.executed.append((query, params))
+        return self._fetch_result
 
     async def fetchrow(self, query: str, *params):
         self.executed.append((query, params))
@@ -213,4 +218,70 @@ async def test_set_default_uses_transaction_with_two_updates():
 
     queries = [q for q, _ in pool.conn.executed]
     assert any("is_default = false" in q for q in queries)
+    assert any("is_default = true" in q for q in queries)
+
+
+def _row(name, is_default):
+    return {"name": name, "is_default": is_default}
+
+
+@pytest.mark.asyncio
+async def test_delete_and_promote_not_found_no_delete():
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    pool = _FakePool()
+    pool.conn._fetch_result = [_row("e5", False), _row("jina", True)]
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    status, promoted = await repo.delete_and_promote_default("ghost", "embedder")
+    assert status == "not_found"
+    assert promoted is None
+    assert not any("DELETE FROM model_endpoints" in q for q, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_delete_and_promote_last_no_delete():
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    pool = _FakePool()
+    pool.conn._fetch_result = [_row("jina", True)]
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    status, promoted = await repo.delete_and_promote_default("jina", "embedder")
+    assert status == "last"
+    assert promoted is None
+    assert not any("DELETE FROM model_endpoints" in q for q, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_delete_and_promote_non_default_deletes_no_promotion():
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    pool = _FakePool()
+    pool.conn._fetch_result = [_row("e5", False), _row("jina", True)]
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    status, promoted = await repo.delete_and_promote_default("e5", "embedder")
+    assert status == "ok"
+    assert promoted is None
+    queries = [q for q, _ in pool.conn.executed]
+    assert any("FOR UPDATE" in q for q in queries)
+    assert any("DELETE FROM model_endpoints" in q for q in queries)
+    assert not any("is_default = true" in q for q in queries)
+
+
+@pytest.mark.asyncio
+async def test_delete_and_promote_default_promotes_survivor_under_lock():
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    pool = _FakePool()
+    pool.conn._fetch_result = [_row("e5", False), _row("jina", True)]
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    status, promoted = await repo.delete_and_promote_default("jina", "embedder")
+    assert status == "ok"
+    assert promoted == "e5"  # first survivor by name
+    queries = [q for q, _ in pool.conn.executed]
+    assert any("FOR UPDATE" in q for q in queries)
+    assert any("DELETE FROM model_endpoints" in q for q in queries)
     assert any("is_default = true" in q for q in queries)

--- a/tests/unit/services/persistence/test_model_endpoint_repo.py
+++ b/tests/unit/services/persistence/test_model_endpoint_repo.py
@@ -207,22 +207,46 @@ async def test_delete_returns_false_when_row_missing():
     assert await repo.delete("ghost", "embedder") is False
 
 
+def _row(name, is_default):
+    return {"name": name, "is_default": is_default}
+
+
 @pytest.mark.asyncio
-async def test_set_default_uses_transaction_with_two_updates():
+async def test_set_default_locks_rows_then_runs_two_updates():
     from services.persistence.model_endpoint_repo import PgModelEndpointRepository
 
     pool = _FakePool()
+    pool.conn._fetch_result = [_row("default", True), _row("jina", False)]
     repo = PgModelEndpointRepository(pool_getter=lambda: pool)
 
-    await repo.set_default("embedder", "default")
+    await repo.set_default("embedder", "jina")
 
     queries = [q for q, _ in pool.conn.executed]
+    # Decide under a row lock, then clear-then-set inside the same transaction.
+    assert any("FOR UPDATE" in q for q in queries)
     assert any("is_default = false" in q for q in queries)
     assert any("is_default = true" in q for q in queries)
 
 
-def _row(name, is_default):
-    return {"name": name, "is_default": is_default}
+@pytest.mark.asyncio
+async def test_set_default_raises_not_found_without_clearing_when_target_missing():
+    from core.utils.exceptions import NotFoundError
+    from services.persistence.model_endpoint_repo import PgModelEndpointRepository
+
+    # 'ghost' is absent from the locked rows (e.g. deleted concurrently). set_default
+    # must abort BEFORE clearing the existing default, so the type is never left
+    # without one.
+    pool = _FakePool()
+    pool.conn._fetch_result = [_row("jina", True)]
+    repo = PgModelEndpointRepository(pool_getter=lambda: pool)
+
+    with pytest.raises(NotFoundError):
+        await repo.set_default("embedder", "ghost")
+
+    queries = [q for q, _ in pool.conn.executed]
+    assert any("FOR UPDATE" in q for q in queries)
+    assert not any("is_default = false" in q for q in queries)
+    assert not any("is_default = true" in q for q in queries)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_preset_repo.py
+++ b/tests/unit/services/persistence/test_preset_repo.py
@@ -174,7 +174,7 @@ async def test_delete_returns_false_when_missing():
 
 
 @pytest.mark.asyncio
-async def test_rename_runs_delete_and_upsert_in_one_transaction():
+async def test_rename_migrates_partition_refs_in_one_transaction():
     from services.persistence.preset_repo import PgPresetRepository
 
     pool = _FakePool()
@@ -185,10 +185,31 @@ async def test_rename_runs_delete_and_upsert_in_one_transaction():
 
     assert result["name"] == "new"
     operations = [query for query, _params in pool.executed]
+    # Atomic: insert the new row, repoint referencing partitions, drop the old row.
     assert operations[0] == "BEGIN"
-    assert "DELETE FROM pipeline_presets" in operations[1]
-    assert "INSERT INTO pipeline_presets" in operations[2]
+    assert "INSERT INTO pipeline_presets" in operations[1]
+    assert "UPDATE partitions" in operations[2]
+    assert "indexation_preset" in operations[2]
+    assert "DELETE FROM pipeline_presets" in operations[3]
     assert operations[-1] == "COMMIT"
+
+    # The partition repoint runs old -> new on the indexation column.
+    update_params = pool.executed[2][1]
+    assert update_params == ("new", "old")
+
+
+@pytest.mark.asyncio
+async def test_rename_migrates_retrieval_column():
+    from services.persistence.preset_repo import PgPresetRepository
+
+    pool = _FakePool()
+    pool._fetchrow_result = _make_row(name="new", preset_type="retrieval", config={})
+    repo = PgPresetRepository(pool_getter=lambda: pool)
+
+    await repo.rename("old", "new", "retrieval", {})
+
+    update_query = next(q for q, _ in pool.executed if "UPDATE partitions" in q)
+    assert "retrieval_preset" in update_query
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_preset_repo.py
+++ b/tests/unit/services/persistence/test_preset_repo.py
@@ -185,12 +185,15 @@ async def test_rename_migrates_partition_refs_in_one_transaction():
 
     assert result["name"] == "new"
     operations = [query for query, _params in pool.executed]
-    # Atomic: insert the new row, repoint referencing partitions, drop the old row.
+    # Atomic in-place rename: UPDATE the preset row, then repoint referencing
+    # partitions. No DELETE+INSERT — the unique constraint guards collisions and
+    # created_at is preserved.
     assert operations[0] == "BEGIN"
-    assert "INSERT INTO pipeline_presets" in operations[1]
+    assert "UPDATE pipeline_presets" in operations[1]
+    assert "INSERT INTO pipeline_presets" not in operations[1]
     assert "UPDATE partitions" in operations[2]
     assert "indexation_preset" in operations[2]
-    assert "DELETE FROM pipeline_presets" in operations[3]
+    assert not any("DELETE FROM pipeline_presets" in op for op in operations)
     assert operations[-1] == "COMMIT"
 
     # The partition repoint runs old -> new on the indexation column.


### PR DESCRIPTION
Backend integrity fixes surfaced while reviewing the admin UI: several admin registry mutations did not maintain referential / default-alias integrity. Each is server-side and independent of the UI.

## Fixes

- **Preset rename orphaned partition references.** Partitions reference a preset by its plain name string (`partitions.indexation_preset` / `retrieval_preset`, no FK). A rename did `DELETE old + INSERT new`, leaving every referencing partition pointing at a name that no longer existed. `PgPresetRepository.rename` now migrates references atomically (insert new → repoint partitions → drop old, one transaction), and the service rejects renaming onto an existing name.

- **Reserved `default` preset.** The `default` preset is the system fallback (schema `server_default`, `create_partition`, and `resolve_partition_row` all key off the literal name; `seed_defaults` only re-seeds when a type has zero rows). Renaming it away or deleting it would dangle that fallback for every new/unset partition. Both are now rejected with 422; editing its config stays allowed.

- **Stale `default` model-endpoint client on update.** Updating the current default endpoint only evicted the named cache entry, not the `default` alias — callers that resolved `default` kept a stale client. It now evicts `default` too (mirrors `set_default`).

- **Lost `default` model-endpoint alias on delete.** Deleting the current default promoted no replacement, so `load_all()` dropped the `default` alias entirely and a later `factory("default")` raised `KeyError`. Delete now promotes a surviving endpoint to default and evicts the stale `default` client.

## Tests / verification

- Unit suite: 1476 passing (added targeted tests for every case above).
- The one new piece of raw SQL — the rename reference-migration — was verified against a real Postgres: referencing partitions repoint correctly, `default`-referencing partitions are untouched, and the old/new preset rows swap as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic “delete default with promotion” for model endpoints: deleting the current default automatically selects a surviving endpoint as the new default.
* **Bug Fixes**
  * Enforced a strict single-default invariant per model type across create/update/set-default/delete flows, including correct cache invalidation for the default alias.
  * Prevented destructive operations on the reserved `default` preset and made preset renames update references atomically.
* **Tests**
  * Expanded unit and integration coverage for default promotion, single-default guarantees, cache eviction, preset rename/delete safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->