### PR TITLE
feat: colored startup banner + fix logger coloring/dropped records

### DIFF
--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -55,6 +55,7 @@ from api.routers.user.extract import router as extract_router
 from api.routers.user.health import router as health_router
 from api.routers.user.search import router as search_router
 from core.config import load_config
+from core.utils.banner import print_startup_banner
 from core.utils.logging import get_logger
 from di.container import ServiceContainer
 from di.providers import set_container
@@ -217,6 +218,7 @@ async def lifespan(app: FastAPI):
     logger.info("Startup: registering process container", available=getattr(app.state, "container", None) is not None)
     set_container(getattr(app.state, "container", None))
     logger.info("Startup: complete")
+    print_startup_banner(app_version)
 
     try:
         yield

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -47,6 +47,11 @@ _DIM = "\033[2m"
 
 
 def _status_box(version: str, docs_url: str, *, color: bool) -> str:
+    """Render the boxed version / docs-URL / status panel shown under the logo.
+
+    ``color`` toggles the brand-red border + bold labels; the plain branch is a
+    byte-for-byte ASCII box so widths still line up when color is disabled.
+    """
     plain_lines = [
         f"OpenRAG v{version}",
         f"API docs: {docs_url}",
@@ -88,10 +93,12 @@ def _supports_color() -> bool:
 
 
 def _disabled() -> bool:
+    """Whether the banner is suppressed via a falsy ``OPENRAG_BANNER`` value."""
     return os.environ.get("OPENRAG_BANNER", "true").strip().lower() in {"0", "false", "no", "off"}
 
 
 def _fg(rgb: tuple[int, int, int]) -> str:
+    """Build a 24-bit (true-color) ANSI foreground escape for an RGB triple."""
     return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m"
 
 

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -68,10 +68,7 @@ def _status_box(version: str, docs_url: str, *, color: bool) -> str:
         f"{_BOLD}API docs{_NORMAL}: {docs_url}",
         f"{_BOLD}Status{_NORMAL}: ready",
     ]
-    body = [
-        f"│ {visible}{' ' * (width - 2 - len(plain))} │"
-        for visible, plain in zip(visible_lines, plain_lines)
-    ]
+    body = [f"│ {visible}{' ' * (width - 2 - len(plain))} │" for visible, plain in zip(visible_lines, plain_lines)]
     return "\n".join(f"{red}{line}{_RESET}" for line in [top, *body, bottom])
 
 

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -42,7 +42,37 @@ _GRAD_END = (0x83, 0x13, 0x2D)  # linagora-800 — deep crimson
 
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
+_NORMAL = "\033[22m"
 _DIM = "\033[2m"
+
+
+def _status_box(version: str, docs_url: str, *, color: bool) -> str:
+    plain_lines = [
+        f"OpenRAG v{version}",
+        f"API docs: {docs_url}",
+        "Status: ready",
+    ]
+    width = max(len(line) for line in plain_lines) + 2
+
+    if not color:
+        top = "╭" + ("─" * width) + "╮"
+        bottom = "╰" + ("─" * width) + "╯"
+        body = [f"│ {line.ljust(width - 2)} │" for line in plain_lines]
+        return "\n".join([top, *body, bottom])
+
+    red = _fg(_GRAD_START)
+    top = "╭" + ("─" * width) + "╮"
+    bottom = "╰" + ("─" * width) + "╯"
+    visible_lines = [
+        f"{_BOLD}OpenRAG v{version}{_NORMAL}",
+        f"{_BOLD}API docs{_NORMAL}: {docs_url}",
+        f"{_BOLD}Status{_NORMAL}: ready",
+    ]
+    body = [
+        f"│ {visible}{' ' * (width - 2 - len(plain))} │"
+        for visible, plain in zip(visible_lines, plain_lines)
+    ]
+    return "\n".join(f"{red}{line}{_RESET}" for line in [top, *body, bottom])
 
 
 def _supports_color() -> bool:
@@ -98,13 +128,10 @@ def print_startup_banner(version: str | None = None, *, stream=None) -> None:
     if _supports_color():
         n = len(_LOGO_LINES)
         logo = "\n".join(f"{_BOLD}{_gradient(i, n)}{line}{_RESET}" for i, line in enumerate(_LOGO_LINES))
-        meta = (
-            f"  {_BOLD}{_fg(_GRAD_START)}OpenRAG{_RESET} {_DIM}v{version}{_RESET}"
-            f"   {_DIM}API docs:{_RESET} {_fg(_GRAD_START)}{docs_url}{_RESET}"
-        )
+        meta = _status_box(version, docs_url, color=True)
     else:
         logo = "\n".join(_LOGO_LINES)
-        meta = f"  OpenRAG v{version}   API docs: {docs_url}"
+        meta = _status_box(version, docs_url, color=False)
 
     try:
         stream.write(f"\n{logo}\n\n{meta}\n\n")

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -1,0 +1,113 @@
+"""Startup banner.
+
+Renders the OpenRAG ASCII logo + version once the FastAPI lifespan has
+finished booting — the vLLM-style "the server is up" splash.
+
+Printed straight to the stream (default ``sys.stderr``) rather than through
+loguru: the structured log formatter (:mod:`core.utils.logging`) wraps each
+record with its own level/location markup and would mangle the figlet art.
+
+Color (a per-line true-color gradient) is on by default and suppressed only by
+``NO_COLOR`` / ``TERM=dumb`` — matching the logger sink, which now forces ANSI
+on even when stderr isn't a TTY (``docker compose up``). Set
+``OPENRAG_BANNER=false`` to suppress the banner entirely.
+
+The art is the ``speed`` figlet font, hardcoded so there is no runtime
+``pyfiglet`` dependency. It is pure ASCII, so it renders identically on any
+terminal — the plain fallback (no gradient) is only taken when color is
+disabled.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib.metadata import version as _pkg_version
+
+# "OpenRAG" in the speed figlet font (pure ASCII, bold slanted strokes).
+_LOGO_LINES = (
+    r"_______                    ________________________",
+    r"__  __ \______________________  __ \__    |_  ____/",
+    r"_  / / /__  __ \  _ \_  __ \_  /_/ /_  /| |  / __",
+    r"/ /_/ /__  /_/ /  __/  / / /  _, _/_  ___ / /_/ /",
+    r"\____/ _  .___/\___//_/ /_//_/ |_| /_/  |_\____/",
+    r"       /_/",
+)
+
+# Gradient endpoints (R, G, B): the OpenRAG brand crimson, swept top to bottom.
+# Sourced from the indexer-ui's ``--color-linagora-*`` scale (src/app.css); 500
+# (#c71f45) is the logo circle fill in src/lib/icons/OpenRAG.svelte.
+_GRAD_START = (0xC7, 0x1F, 0x45)  # linagora-500 — brand red (logo fill)
+_GRAD_END = (0x83, 0x13, 0x2D)  # linagora-800 — deep crimson
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+
+
+def _supports_color() -> bool:
+    """Color on by default, opted out only via ``NO_COLOR`` / ``TERM=dumb``.
+
+    Deliberately not gated on ``isatty()``: OpenRAG usually runs with its
+    stderr piped (``docker compose up``, log capture), and the logger sink
+    already forces ANSI there — the banner matches so the splash isn't the one
+    colorless thing in an otherwise colored boot log.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return True
+
+
+def _disabled() -> bool:
+    return os.environ.get("OPENRAG_BANNER", "true").strip().lower() in {"0", "false", "no", "off"}
+
+
+def _fg(rgb: tuple[int, int, int]) -> str:
+    return f"\033[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m"
+
+
+def _gradient(i: int, n: int) -> str:
+    """24-bit foreground escape for row ``i`` of ``n``, interpolated start->end."""
+    t = i / (n - 1) if n > 1 else 0.0
+    rgb = tuple(round(a + (b - a) * t) for a, b in zip(_GRAD_START, _GRAD_END))
+    return _fg(rgb)  # type: ignore[arg-type]
+
+
+def print_startup_banner(version: str | None = None, *, stream=None) -> None:
+    """Print the OpenRAG logo, version, and the local API docs URL.
+
+    Safe to call unconditionally from the lifespan: it no-ops when
+    ``OPENRAG_BANNER`` is falsy and never raises (a banner must not be able
+    to break boot).
+    """
+    if _disabled():
+        return
+    stream = stream or sys.stderr
+
+    if version is None:
+        try:
+            version = _pkg_version("openrag")
+        except Exception:
+            version = "unknown"
+
+    port = os.environ.get("APP_PORT", "8080")
+    docs_url = f"http://localhost:{port}/docs"
+
+    if _supports_color():
+        n = len(_LOGO_LINES)
+        logo = "\n".join(f"{_BOLD}{_gradient(i, n)}{line}{_RESET}" for i, line in enumerate(_LOGO_LINES))
+        meta = (
+            f"  {_BOLD}{_fg(_GRAD_START)}OpenRAG{_RESET} {_DIM}v{version}{_RESET}"
+            f"   {_DIM}API docs:{_RESET} {_fg(_GRAD_START)}{docs_url}{_RESET}"
+        )
+    else:
+        logo = "\n".join(_LOGO_LINES)
+        meta = f"  OpenRAG v{version}   API docs: {docs_url}"
+
+    try:
+        stream.write(f"\n{logo}\n\n{meta}\n\n")
+        stream.flush()
+    except Exception:  # pragma: no cover - a banner must never break boot
+        pass

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -43,7 +43,6 @@ _GRAD_END = (0x83, 0x13, 0x2D)  # linagora-800 — deep crimson
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _NORMAL = "\033[22m"
-_DIM = "\033[2m"
 
 
 def _status_box(version: str, docs_url: str, *, color: bool) -> str:

--- a/openrag/core/utils/logging.py
+++ b/openrag/core/utils/logging.py
@@ -26,30 +26,32 @@ def mask_email(email: str | None) -> str:
     return f"{masked_local}@{domain}"
 
 
+def terminal_formatter(record) -> str:
+    """Build the loguru template for the colorized stderr sink.
+
+    ``format`` is a callable, so loguru parses the *returned string* as a
+    template — for color markup (``<...>``) AND field placeholders (``{...}``).
+    Keep the record fields as placeholders ({level}, {name}, …): loguru
+    substitutes those values after parsing, so a function named ``<module>`` /
+    ``<lambda>`` or a message containing ``{}`` is inserted safely. (Splicing
+    them in raw is what raised "Tag <module> does not correspond to any known
+    color directive" and dropped those records.) Only the bound ``extra``
+    values are literal template text, so they must escape both markup
+    (escape_markup) and braces.
+
+    A callable ``format`` also means loguru does NOT auto-append its usual
+    ``"\\n{exception}"`` — that convenience only applies to string formats — so
+    the trailing ``{exception}`` placeholder is required here, otherwise
+    ``logger.exception()`` / ``opt(exception=True)`` records lose their
+    traceback. It renders to an empty string when no exception is attached.
+    """
+    extra = " | ".join(f"{escape_markup(k)}={escape_markup(str(v))}" for k, v in record["extra"].items())
+    suffix = f" [{extra}]".replace("{", "{{").replace("}", "}}") if extra else ""
+    return "<level>{level: <8}</level> | <cyan>{name}:{function}:{line}</cyan> - {message}" + suffix + "\n{exception}"
+
+
 def get_logger(config=None):
     config = config or load_config()
-
-    def formatter(record):
-        # ``format`` is a callable, so loguru parses the *returned string* as a
-        # template — for color markup (``<...>``) AND field placeholders
-        # (``{...}``). Keep the record fields as placeholders ({level}, {name},
-        # …): loguru substitutes those values after parsing, so a function named
-        # ``<module>`` / ``<lambda>`` or a message containing ``{}`` is inserted
-        # safely. (Splicing them in raw is what raised "Tag <module> does not
-        # correspond to any known color directive" and dropped those records.)
-        # Only the bound ``extra`` values are literal template text, so they
-        # must escape both markup (escape_markup) and braces.
-        #
-        # A callable ``format`` also means loguru does NOT auto-append its usual
-        # ``"\n{exception}"`` — that convenience only applies to string formats —
-        # so the trailing ``{exception}`` placeholder is required here, otherwise
-        # ``logger.exception()`` / ``opt(exception=True)`` records lose their
-        # traceback. It renders to an empty string when no exception is attached.
-        extra = " | ".join(f"{escape_markup(k)}={escape_markup(str(v))}" for k, v in record["extra"].items())
-        suffix = f" [{extra}]".replace("{", "{{").replace("}", "}}") if extra else ""
-        return (
-            "<level>{level: <8}</level> | <cyan>{name}:{function}:{line}</cyan> - {message}" + suffix + "\n{exception}"
-        )
 
     logger.remove()
 
@@ -58,7 +60,7 @@ def get_logger(config=None):
     # colorize=True forces ANSI on even when stderr isn't a TTY (e.g. under
     # ``docker compose up``); the JSON file sink below stays uncolored for
     # machine ingestion.
-    logger.add(sys.stderr, format=formatter, level=config.verbose.level, colorize=True)
+    logger.add(sys.stderr, format=terminal_formatter, level=config.verbose.level, colorize=True)
 
     # JSON logs to file for later use (e.g. Grafana ingestion)
     log_path = app_log_file(getattr(config.paths, "log_dir", None))

--- a/openrag/core/utils/logging.py
+++ b/openrag/core/utils/logging.py
@@ -30,19 +30,27 @@ def get_logger(config=None):
     config = config or load_config()
 
     def formatter(record):
-        level = record["level"].name
-        mod = record["name"]
-        func = record["function"]
-        line = record["line"]
-
-        msg = escape_markup(record["message"])
-        extra = " | ".join(f"{k}={escape_markup(str(v))}" for k, v in record["extra"].items())
-        return f"{level:<8} | {mod}:{func}:{line} - {msg}" + (f" [{extra}]" if extra else "") + "\n"
+        # ``format`` is a callable, so loguru parses the *returned string* as a
+        # template — for color markup (``<...>``) AND field placeholders
+        # (``{...}``). Keep the record fields as placeholders ({level}, {name},
+        # …): loguru substitutes those values after parsing, so a function named
+        # ``<module>`` / ``<lambda>`` or a message containing ``{}`` is inserted
+        # safely. (Splicing them in raw is what raised "Tag <module> does not
+        # correspond to any known color directive" and dropped those records.)
+        # Only the bound ``extra`` values are literal template text, so they
+        # must escape both markup (escape_markup) and braces.
+        extra = " | ".join(f"{escape_markup(k)}={escape_markup(str(v))}" for k, v in record["extra"].items())
+        suffix = f" [{extra}]".replace("{", "{{").replace("}", "}}") if extra else ""
+        return "<level>{level: <8}</level> | <cyan>{name}:{function}:{line}</cyan> - {message}" + suffix + "\n"
 
     logger.remove()
 
-    # Pretty logs to stdout (terminal)
-    logger.add(sys.stderr, format=formatter, level=config.verbose.level, colorize=False)
+    # Pretty, colorized logs to the terminal (stderr): the level label is
+    # colored by severity via loguru's <level> tag and the call site is cyan.
+    # colorize=True forces ANSI on even when stderr isn't a TTY (e.g. under
+    # ``docker compose up``); the JSON file sink below stays uncolored for
+    # machine ingestion.
+    logger.add(sys.stderr, format=formatter, level=config.verbose.level, colorize=True)
 
     # JSON logs to file for later use (e.g. Grafana ingestion)
     log_path = app_log_file(getattr(config.paths, "log_dir", None))

--- a/openrag/core/utils/logging.py
+++ b/openrag/core/utils/logging.py
@@ -39,9 +39,17 @@ def get_logger(config=None):
         # correspond to any known color directive" and dropped those records.)
         # Only the bound ``extra`` values are literal template text, so they
         # must escape both markup (escape_markup) and braces.
+        #
+        # A callable ``format`` also means loguru does NOT auto-append its usual
+        # ``"\n{exception}"`` — that convenience only applies to string formats —
+        # so the trailing ``{exception}`` placeholder is required here, otherwise
+        # ``logger.exception()`` / ``opt(exception=True)`` records lose their
+        # traceback. It renders to an empty string when no exception is attached.
         extra = " | ".join(f"{escape_markup(k)}={escape_markup(str(v))}" for k, v in record["extra"].items())
         suffix = f" [{extra}]".replace("{", "{{").replace("}", "}}") if extra else ""
-        return "<level>{level: <8}</level> | <cyan>{name}:{function}:{line}</cyan> - {message}" + suffix + "\n"
+        return (
+            "<level>{level: <8}</level> | <cyan>{name}:{function}:{line}</cyan> - {message}" + suffix + "\n{exception}"
+        )
 
     logger.remove()
 

--- a/tests/unit/core/utils/test_logging.py
+++ b/tests/unit/core/utils/test_logging.py
@@ -1,4 +1,4 @@
-from core.utils.logging import escape_markup, mask_email
+from core.utils.logging import escape_markup, mask_email, terminal_formatter
 
 
 def test_mask_email_keeps_first_char_and_domain():
@@ -28,3 +28,22 @@ def test_escape_markup_escapes_backslashes_first():
     out = escape_markup(s)
     # backslashes doubled + angle brackets escaped
     assert out == r"path\\to\\file \<tag\>"
+
+
+def test_terminal_formatter_appends_exception_placeholder():
+    # Regression guard: a callable ``format`` means loguru does NOT auto-append
+    # "\n{exception}", so the template must carry it or tracebacks are dropped.
+    template = terminal_formatter({"extra": {}})
+    assert template.endswith("\n{exception}")
+    # Record fields stay as placeholders so loguru substitutes them safely.
+    assert "{level: <8}" in template
+    assert "{message}" in template
+
+
+def test_terminal_formatter_escapes_and_brace_guards_extra():
+    template = terminal_formatter({"extra": {"file_id": "a<b>", "n": "{x}"}})
+    # markup escaped (angle brackets) and braces doubled so extra values are
+    # never reparsed as loguru placeholders.
+    assert r"file_id=a\<b\>" in template
+    assert "n={{x}}" in template
+    assert template.endswith("\n{exception}")


### PR DESCRIPTION
## Summary

Adds a vLLM-style startup banner and fixes the stderr logger, which was both **uncolored** and **silently dropping log records**.

### `fix(logging)` — colorize stderr + stop dropping records
The stderr sink used a *callable* formatter that spliced raw record values (`name`/`function`/`message`) into the returned string. loguru parses a callable's return as a color-markup + placeholder **template**, so:
- a `function` of `<module>` / `<lambda>` / `<listcomp>`, or a message containing `{...}`, raised inside loguru's colorizer (`Tag "<module>" does not correspond to any known color directive`) → the record was **dropped** with a `Logging error in Loguru Handler #1`.
- logs were never colored (`colorize=False` + no color tags in the template).

Fix: use loguru **placeholders** for the record fields (substituted *after* markup parsing, so they can't break it), wrap the level in `<level>` (severity color) and the call site in `<cyan>`, escape only the literal bound-`extra` suffix (markup + braces), and set `colorize=True`. The JSON file sink stays uncolored for machine ingestion.

### `feat(banner)` — startup banner
Prints a `speed`-figlet `OpenRAG` logo + version + local docs URL once the lifespan finishes, in a brand-crimson true-color gradient (`#c71f45 → #83132d`, sourced from the indexer-ui `--color-linagora-*` scale / logo fill).
- Written straight to `stderr` (not through loguru, which would wrap it).
- Color on by default (matching the logger sink), suppressed by `NO_COLOR` / `TERM=dumb`.
- `OPENRAG_BANNER=false` disables it; never raises (can't break boot).
- No runtime `pyfiglet` dependency — the art is hardcoded.

## Notes
- `colorize=True` forces ANSI even when stderr isn't a TTY (so colors show under `docker compose up`). The JSON sink is unaffected.
- Targets `refactor/hexagonal` (these files only exist in this post-refactor layout).

## Test plan
- [x] `escape_markup` / `mask_email` unit tests pass (5)
- [x] Repro'd the old crash (`<module>` fn, `{...}` message, `<tag>`/`{x}` in bound extra) — all now emit, with color
- [x] Verified JSON file sink contains no ANSI
- [x] `ruff check` + `ruff format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-launch startup banner with version info and a link to the local API docs.
* **Bug Fixes**
  * Made banner output resilient (won’t interrupt startup) and added auto color/NO_COLOR handling for improved terminal compatibility.
  * Enhanced terminal logging with richer, colorized formatting and safer template/markup handling to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->