### PR TITLE
chore(release): v2.0.0 version bump + temporary RC build workflow

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -1,0 +1,189 @@
+# TEMPORARY (v2.0 release-candidate only).
+#
+# Builds and pushes the OpenRag api + ray images from `refactor/hexagonal` so
+# v2.0.0-rc.* can be published before the GA cutover, WITHOUT touching the
+# production release pipeline (`build.yml`, which only builds from `main`).
+#
+# Runs entirely on GitHub-hosted runners — no local/L4 builds. Same two images
+# and Dockerfiles as `build.yml`; the api image goes to ghcr + Docker Hub, the
+# ray image to ghcr only (matching `build.yml`). Never tags `latest`.
+#
+# DELETE this whole file once `refactor/hexagonal` is merged to `main` and
+# releases build from `main` again.
+name: Build RC (refactor/hexagonal)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag to publish (e.g. v2.0.0-rc.1). Must NOT be 'latest'."
+        required: true
+        default: "v2.0.0-rc.1"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      # Safety rails for a hand-dispatched release build.
+      - name: Validate ref and version
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/refactor/hexagonal" ]; then
+            echo "::error::build_rc.yml may only be dispatched from refactor/hexagonal (got ${{ github.ref }})."
+            exit 1
+          fi
+          case "${{ inputs.version }}" in
+            latest|"")
+              echo "::error::Refusing to publish an RC under the '${{ inputs.version }}' tag."
+              exit 1
+              ;;
+          esac
+
+  build-and-push-image:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            linagoraai/openrag
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/api.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-push-image-ray:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/ray.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # The admin UI is a separate image (nginx serving the vendored ui/ Vite build).
+  # build.yml does NOT build it today — this RC workflow covers it so the v2.0
+  # compose/Helm `linagoraai/openrag-admin-ui` reference resolves. The GA pipeline
+  # (build.yml) needs the same job added before v2.0.0 final.
+  build-and-push-image-admin-ui:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-ui
+            linagoraai/openrag-admin-ui
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/ui.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -1,12 +1,13 @@
 # TEMPORARY (v2.0 release-candidate only).
 #
-# Builds and pushes the OpenRag api + ray images from `refactor/hexagonal` so
-# v2.0.0-rc.* can be published before the GA cutover, WITHOUT touching the
-# production release pipeline (`build.yml`, which only builds from `main`).
+# Builds and pushes the OpenRag api, ray, and admin-ui images from
+# `refactor/hexagonal` so v2.0.0-rc.* can be published before the GA cutover,
+# WITHOUT touching the production release pipeline (`build.yml`).
 #
-# Runs entirely on GitHub-hosted runners — no local/L4 builds. Same two images
-# and Dockerfiles as `build.yml`; the api image goes to ghcr + Docker Hub, the
-# ray image to ghcr only (matching `build.yml`). Never tags `latest`.
+# Runs entirely on GitHub-hosted runners — no local/L4 builds. api and admin-ui
+# go to ghcr + Docker Hub; ray goes to ghcr only. NOTE: `build.yml` (the GA
+# pipeline) builds only api + ray — it needs the admin-ui job added before GA.
+# Never tags `latest`.
 #
 # DELETE this whole file once `refactor/hexagonal` is merged to `main` and
 # releases build from `main` again.

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -27,20 +27,25 @@ env:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      # Safety rails for a hand-dispatched release build.
+      # Safety rails for a hand-dispatched release build. Context/input are read
+      # via env (not inlined into the shell) to avoid expression injection.
       - name: Validate ref and version
+        env:
+          REF: ${{ github.ref }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/refactor/hexagonal" ]; then
-            echo "::error::build_rc.yml may only be dispatched from refactor/hexagonal (got ${{ github.ref }})."
+          if [ "$REF" != "refs/heads/refactor/hexagonal" ]; then
+            echo "::error::build_rc.yml may only be dispatched from refactor/hexagonal (got $REF)."
             exit 1
           fi
-          case "${{ inputs.version }}" in
-            latest|"")
-              echo "::error::Refusing to publish an RC under the '${{ inputs.version }}' tag."
-              exit 1
-              ;;
-          esac
+          # Only the 2.0.0 RC line — the tree's pyproject is 2.0.0, so a tag from
+          # another line (e.g. v3.0.0-rc.1) would mislabel the built images.
+          if ! printf '%s\n' "$VERSION" | grep -Eq '^v2\.0\.0-rc\.[0-9]+$'; then
+            echo "::error::Version must match v2.0.0-rc.N (got '$VERSION')."
+            exit 1
+          fi
 
   build-and-push-image:
     needs: guard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "1.1.13"
+version = "2.0.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2713,7 +2713,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "1.1.13"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
Prep to publish `v2.0.0-rc.1` images off `refactor/hexagonal` so the chart work can start against real v2.0 artifacts.

- `pyproject` + `uv.lock`: 1.1.13 → 2.0.0
- `build_rc.yml` (NEW, temporary): `workflow_dispatch` builds + pushes **api, ray, admin-ui** images tagged from a version input, guarded to `refactor/hexagonal`, never `latest`. Leaves the GA `build.yml` untouched. **Delete after the merge to main.**

Notably, `admin-ui` (`linagoraai/openrag-admin-ui`) is built by no existing workflow — `build.yml` needs the same job before v2.0.0 GA.

**Not included:** Helm chart changes (admin-ui template, image tags, routing topology) — tracked separately for the devops + app teams. RC images are unverified handoff artifacts, not a tested build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release-candidate build workflow to publish container images only from the intended branch.
  * Supports manual runs with a required version input and validates the release-candidate version format before building.
  * Builds and publishes API, Ray, and admin UI images to container registries (amd64), with improved build caching.
* **Chores**
  * Bumped the project version to **2.0.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->