### PR TITLE
ci: add build_rc.yml on main so the RC workflow is dispatchable

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -9,6 +9,11 @@
 # pipeline) builds only api + ray — it needs the admin-ui job added before GA.
 # Never tags `latest`.
 #
+# Publishing is ATOMIC: the three image jobs build and push a run-scoped staging
+# tag; the final `v2.0.0-rc.N` tags are created only by the `promote` job, which
+# runs after all three succeed — so a partial failure never leaves a half-
+# published RC. (Run-scoped `rc-staging-<run_id>` tags are left in ghcr.)
+#
 # DELETE this whole file once `refactor/hexagonal` is merged to `main` and
 # releases build from `main` again.
 name: Build RC (refactor/hexagonal)
@@ -17,13 +22,20 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Image tag to publish (e.g. v2.0.0-rc.1). Must NOT be 'latest'."
+        description: "Image tag to publish (e.g. v2.0.0-rc.1). Must match v2.0.0-rc.N."
         required: true
         default: "v2.0.0-rc.1"
+
+# Serialize runs that target the same version so two dispatches can't race to
+# publish the same tags.
+concurrency:
+  group: build-rc-${{ inputs.version }}
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  STAGING_TAG: rc-staging-${{ github.run_id }}
 
 jobs:
   guard:
@@ -56,45 +68,24 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            linagoraai/openrag
-          tags: |
-            type=raw,value=${{ inputs.version }}
-
-      - name: Build and push Docker image
+      - name: Build and push api (staging)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: infra/docker/api.Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.STAGING_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -106,44 +97,27 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray
-          tags: |
-            type=raw,value=${{ inputs.version }}
-
-      - name: Build and push Docker image
+      - name: Build and push ray (staging)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: infra/docker/ray.Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray:${{ env.STAGING_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # The admin UI is a separate image (nginx serving the vendored ui/ Vite build).
-  # build.yml does NOT build it today — this RC workflow covers it so the v2.0
-  # compose/Helm `linagoraai/openrag-admin-ui` reference resolves. The GA pipeline
-  # (build.yml) needs the same job added before v2.0.0 final.
   build-and-push-image-admin-ui:
     needs: guard
     runs-on: ubuntu-latest
@@ -152,44 +126,70 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-ui
-            linagoraai/openrag-admin-ui
-          tags: |
-            type=raw,value=${{ inputs.version }}
-
-      - name: Build and push Docker image
+      - name: Build and push admin-ui (staging)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: infra/docker/ui.Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-ui:${{ env.STAGING_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  promote:
+    # Atomic publish: only after all three image builds succeed, retag the
+    # run-scoped staging images to the final v2.0.0-rc.N tags (registry-side via
+    # imagetools, no rebuild) so a partial failure never leaves a half-published RC.
+    needs:
+      - build-and-push-image
+      - build-and-push-image-ray
+      - build-and-push-image-admin-ui
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Promote staging images to the final RC tags
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          GHCR="$REGISTRY/$IMAGE_NAME"
+          # api -> ghcr + Docker Hub
+          docker buildx imagetools create \
+            -t "${GHCR}:${VERSION}" \
+            -t "linagoraai/openrag:${VERSION}" \
+            "${GHCR}:${STAGING_TAG}"
+          # ray -> ghcr only
+          docker buildx imagetools create \
+            -t "${GHCR}-ray:${VERSION}" \
+            "${GHCR}-ray:${STAGING_TAG}"
+          # admin-ui -> ghcr + Docker Hub
+          docker buildx imagetools create \
+            -t "${GHCR}-admin-ui:${VERSION}" \
+            -t "linagoraai/openrag-admin-ui:${VERSION}" \
+            "${GHCR}-admin-ui:${STAGING_TAG}"

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -1,12 +1,13 @@
 # TEMPORARY (v2.0 release-candidate only).
 #
-# Builds and pushes the OpenRag api + ray images from `refactor/hexagonal` so
-# v2.0.0-rc.* can be published before the GA cutover, WITHOUT touching the
-# production release pipeline (`build.yml`, which only builds from `main`).
+# Builds and pushes the OpenRag api, ray, and admin-ui images from
+# `refactor/hexagonal` so v2.0.0-rc.* can be published before the GA cutover,
+# WITHOUT touching the production release pipeline (`build.yml`).
 #
-# Runs entirely on GitHub-hosted runners — no local/L4 builds. Same two images
-# and Dockerfiles as `build.yml`; the api image goes to ghcr + Docker Hub, the
-# ray image to ghcr only (matching `build.yml`). Never tags `latest`.
+# Runs entirely on GitHub-hosted runners — no local/L4 builds. api and admin-ui
+# go to ghcr + Docker Hub; ray goes to ghcr only. NOTE: `build.yml` (the GA
+# pipeline) builds only api + ray — it needs the admin-ui job added before GA.
+# Never tags `latest`.
 #
 # DELETE this whole file once `refactor/hexagonal` is merged to `main` and
 # releases build from `main` again.

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -1,0 +1,194 @@
+# TEMPORARY (v2.0 release-candidate only).
+#
+# Builds and pushes the OpenRag api + ray images from `refactor/hexagonal` so
+# v2.0.0-rc.* can be published before the GA cutover, WITHOUT touching the
+# production release pipeline (`build.yml`, which only builds from `main`).
+#
+# Runs entirely on GitHub-hosted runners — no local/L4 builds. Same two images
+# and Dockerfiles as `build.yml`; the api image goes to ghcr + Docker Hub, the
+# ray image to ghcr only (matching `build.yml`). Never tags `latest`.
+#
+# DELETE this whole file once `refactor/hexagonal` is merged to `main` and
+# releases build from `main` again.
+name: Build RC (refactor/hexagonal)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag to publish (e.g. v2.0.0-rc.1). Must NOT be 'latest'."
+        required: true
+        default: "v2.0.0-rc.1"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      # Safety rails for a hand-dispatched release build. Context/input are read
+      # via env (not inlined into the shell) to avoid expression injection.
+      - name: Validate ref and version
+        env:
+          REF: ${{ github.ref }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$REF" != "refs/heads/refactor/hexagonal" ]; then
+            echo "::error::build_rc.yml may only be dispatched from refactor/hexagonal (got $REF)."
+            exit 1
+          fi
+          # Only the 2.0.0 RC line — the tree's pyproject is 2.0.0, so a tag from
+          # another line (e.g. v3.0.0-rc.1) would mislabel the built images.
+          if ! printf '%s\n' "$VERSION" | grep -Eq '^v2\.0\.0-rc\.[0-9]+$'; then
+            echo "::error::Version must match v2.0.0-rc.N (got '$VERSION')."
+            exit 1
+          fi
+
+  build-and-push-image:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            linagoraai/openrag
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/api.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-push-image-ray:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/ray.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # The admin UI is a separate image (nginx serving the vendored ui/ Vite build).
+  # build.yml does NOT build it today — this RC workflow covers it so the v2.0
+  # compose/Helm `linagoraai/openrag-admin-ui` reference resolves. The GA pipeline
+  # (build.yml) needs the same job added before v2.0.0 final.
+  build-and-push-image-admin-ui:
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-ui
+            linagoraai/openrag-admin-ui
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/ui.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -9,10 +9,13 @@
 # pipeline) builds only api + ray — it needs the admin-ui job added before GA.
 # Never tags `latest`.
 #
-# Publishing is ATOMIC: the three image jobs build and push a run-scoped staging
-# tag; the final `v2.0.0-rc.N` tags are created only by the `promote` job, which
-# runs after all three succeed — so a partial failure never leaves a half-
-# published RC. (Run-scoped `rc-staging-<run_id>` tags are left in ghcr.)
+# Publish safety (NOT fully atomic): the three image jobs build and push a run-
+# scoped staging tag; the final `v2.0.0-rc.N` tags are created only by the
+# `promote` job, after all three builds pass — so a build failure never leaves a
+# half-BUILT RC. The promote step then retags the three images sequentially and
+# is NOT transactional across them: if a later retag fails, an earlier image's
+# final tag can already be published. Recovery is to re-dispatch the same version
+# with `force: true`. (Run-scoped `rc-staging-<run_id>` tags are left in ghcr.)
 #
 # DELETE this whole file once `refactor/hexagonal` is merged to `main` and
 # releases build from `main` again.
@@ -25,6 +28,11 @@ on:
         description: "Image tag to publish (e.g. v2.0.0-rc.1). Must match v2.0.0-rc.N."
         required: true
         default: "v2.0.0-rc.1"
+      force:
+        description: "Overwrite tags if this version was already published (re-cut, or recover a partial promote)."
+        type: boolean
+        required: false
+        default: false
 
 # Serialize runs that target the same version so two dispatches can't race to
 # publish the same tags.
@@ -40,7 +48,8 @@ env:
 jobs:
   guard:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      packages: read
     steps:
       # Safety rails for a hand-dispatched release build. Context/input are read
       # via env (not inlined into the shell) to avoid expression injection.
@@ -57,6 +66,32 @@ jobs:
           # another line (e.g. v3.0.0-rc.1) would mislabel the built images.
           if ! printf '%s\n' "$VERSION" | grep -Eq '^v2\.0\.0-rc\.[0-9]+$'; then
             echo "::error::Version must match v2.0.0-rc.N (got '$VERSION')."
+            exit 1
+          fi
+      # Refuse to silently overwrite an already-published RC. The concurrency
+      # group only stops CONCURRENT same-version runs; a later re-dispatch of an
+      # already-published version would otherwise rebuild and overwrite its final
+      # tags. The api tag is the sentinel — `promote` publishes it first, so its
+      # presence means this version was already (at least partially) published.
+      # Bypass with force=true to deliberately re-cut or recover a partial promote.
+      - name: Set up Docker Buildx
+        if: ${{ !inputs.force }}
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        if: ${{ !inputs.force }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Refuse to overwrite an already-published version
+        if: ${{ !inputs.force }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:${VERSION}" >/dev/null 2>&1; then
+            echo "::error::${REGISTRY}/${IMAGE_NAME}:${VERSION} already exists. Re-dispatch with force=true to overwrite (re-cut, or recover a partial promote)."
             exit 1
           fi
 
@@ -148,9 +183,12 @@ jobs:
           cache-to: type=gha,mode=max
 
   promote:
-    # Atomic publish: only after all three image builds succeed, retag the
-    # run-scoped staging images to the final v2.0.0-rc.N tags (registry-side via
-    # imagetools, no rebuild) so a partial failure never leaves a half-published RC.
+    # After all three image builds pass, retag the run-scoped staging images to
+    # the final v2.0.0-rc.N tags (registry-side via imagetools, no rebuild). This
+    # gates the final tags on a fully-built image set, but the three retags below
+    # run sequentially and are NOT atomic across images: a mid-promote failure can
+    # leave an earlier image's final tag published. Re-dispatch the same version
+    # with force:true to recover.
     needs:
       - build-and-push-image
       - build-and-push-image-ray


### PR DESCRIPTION
`workflow_dispatch` workflows are only runnable when the file exists on the **default branch** (`main`). The temporary RC image build (PR #592) targets `refactor/hexagonal`, so without this it would not be dispatchable at all.

This adds the **identical** `build_rc.yml` to `main` so the workflow is exposed/dispatchable. Its in-workflow `guard` restricts actual runs to `github.ref == refs/heads/refactor/hexagonal` (and to `v2.0.0-rc.N` tags), so the file is **inert on `main`** — dispatching it against `main` is refused.

Flow: merge #592 (adds it to `refactor/hexagonal`) + this PR (adds it to `main`) → dispatch `Build RC` selecting the `refactor/hexagonal` ref → builds api/ray/admin-ui RC images.

**Temporary** — delete alongside the `refactor/hexagonal` copy after the v2.0 cutover to `main`.

Found via codex review on #592 (P1: workflow not reachable from the default branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow to publish v2.0.0 RC container images in two phases: build/push run-scoped staging tags first, then promote to the final RC tags only after all images succeed.
  * Added workflow guardrails: runs only on the intended branch, validates `version` format, and prevents overwriting already-published RC images unless forced.
  * Promotion retags images without rebuilding and updates both GHCR and Docker Hub for the API, Ray, and Admin UI images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->