### PR TITLE
fix(milvus): cap query_iterator page size for vector-inclusive reads

### DIFF
--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -162,6 +162,11 @@ class MilvusVectorStore(VectorStore):
             ) from e
 
         self._embedding_dimension: int | None = None
+        # Real dense-vector dimension read from the live collection schema,
+        # cached for page sizing. Distinct from ``_embedding_dimension`` (the
+        # configured value passed to ``initialize``), which is ignored when the
+        # collection already exists and so may not match what Milvus stores.
+        self._schema_vector_dim: int | None = None
         self._loaded = False
         self._load_lock = asyncio.Lock()
         # Connection healing: pymilvus 2.6 exposes no documented client-level
@@ -519,21 +524,26 @@ class MilvusVectorStore(VectorStore):
     # ------------------------------------------------------------------
 
     def _vector_dim(self) -> int:
-        """Dense-vector dimension for page sizing.
+        """Best-effort dense-vector dimension for page sizing.
 
-        Prefers the value recorded at :meth:`initialize`. A read-only process
-        never indexes, so that may be ``None``; fall back to the live collection
-        schema (cached on success) and finally to :data:`_UNKNOWN_VECTOR_DIM` so
-        the page stays safe even when the schema can't be read. Reading too
-        small a dimension here would re-introduce the oversized-page failure
-        this guard exists to prevent.
+        Prefers the *real* dimension from the live collection schema, because
+        the value recorded at :meth:`initialize` is only the dimension this
+        process was configured with — it is ignored when the collection already
+        exists, so it can disagree with what Milvus actually stores. Page sizing
+        cares about on-the-wire bytes, so the schema wins. The schema read is
+        cached (the dimension can't change without a drop + recreate). Falls
+        back to the :meth:`initialize` value when the schema can't be read, then
+        to :data:`_UNKNOWN_VECTOR_DIM`. Reading too small a dimension here would
+        re-introduce the oversized-page failure this guard exists to prevent.
         """
-        if self._embedding_dimension is not None:
-            return self._embedding_dimension
+        if self._schema_vector_dim is not None:
+            return self._schema_vector_dim
         dim = self._describe_vector_dim()
         if dim is not None:
-            self._embedding_dimension = dim
+            self._schema_vector_dim = dim
             return dim
+        if self._embedding_dimension is not None:
+            return self._embedding_dimension
         return _UNKNOWN_VECTOR_DIM
 
     def _describe_vector_dim(self) -> int | None:
@@ -580,7 +590,7 @@ class MilvusVectorStore(VectorStore):
         """Drain a Milvus 2.6 ``query_iterator`` into a list.
 
         ``batch_size`` defaults to :meth:`_safe_batch_size`, which shrinks the
-        page when the dense vector is requested so one page stays under Milvus's
+        page for vector-inclusive projections so one page stays under Milvus's
         result-size limit. Total result-set size is unaffected — the iterator
         paginates until the filter is drained.
 
@@ -1070,6 +1080,9 @@ class MilvusVectorStore(VectorStore):
             ) from e
         self._loaded = False
         self._embedding_dimension = None
+        # A recreated collection may have a different dimension — drop the
+        # cached schema read so the next query re-probes.
+        self._schema_vector_dim = None
 
     # ------------------------------------------------------------------
     # Milvus-specific (not on the VectorStore ABC)
@@ -1152,9 +1165,10 @@ class MilvusVectorStore(VectorStore):
     ) -> list[dict[str, Any]]:
         """Return full row data for every chunk matching ``filters``.
 
-        ``output_fields`` defaults to ``["*"]``. Milvus 2.6 quirk: ``"*"``
-        does NOT include the dense vector — callers that need the vector
-        must pass ``output_fields=["*", "vector"]`` explicitly.
+        ``output_fields`` defaults to ``["*"]``, which in Milvus 2.6 includes
+        the dense ``vector`` field (unlike :meth:`search`, which strips it via
+        ``_SEARCH_RESULT_DROPPED_KEYS``). Callers that don't want the vector
+        should pass an explicit scalar projection instead of ``["*"]``.
         """
         self._resolve_collection(collection)
         expr = self._build_filter_expr(filters)

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -515,10 +515,14 @@ class MilvusVectorStore(VectorStore):
     def _safe_batch_size(self, output_fields: list[str]) -> int:
         """Cap the batch so one page stays under Milvus's ~64MB result limit.
 
-        Only matters when the dense ``vector`` is requested (~dim*4 bytes/row);
-        scalar-only pages are small, so they keep the large default.
+        Only matters when the dense ``vector`` rides along (~dim*4 bytes/row);
+        explicit scalar projections are small, so they keep the large default.
+        Milvus 2.6 returns the vector for the ``"*"`` wildcard too — the search
+        path strips it post-hoc via ``_SEARCH_RESULT_DROPPED_KEYS`` and
+        ``query_chunks_by_filter(["*"])`` leaks it — so ``"*"`` counts as
+        vector-inclusive here.
         """
-        if "vector" not in output_fields:
+        if "vector" not in output_fields and "*" not in output_fields:
             return 16_000
         dim = self._embedding_dimension or 1024
         budget = 32 * 1024 * 1024  # ~half of Milvus's ~64MB cap

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -107,6 +107,12 @@ RRF_K = 100
 #: noisy and large; ``text`` stays in the payload (callers need it).
 _SEARCH_RESULT_DROPPED_KEYS = frozenset({"vector"})
 
+#: Fallback dense-vector dimension for page sizing when the real one is
+#: unknown — i.e. a read-only process that never ran ``initialize`` AND the
+#: collection-schema probe also failed. Conservatively large so a vector page
+#: stays under Milvus's result-size cap for any realistic embedder.
+_UNKNOWN_VECTOR_DIM = 4096
+
 #: BM25 analyzer params for the ``text`` field — standard tokenizer plus
 #: OpenRAG-specific stop words so chunk-boundary / image-placeholder markers
 #: don't pollute lexical scores.
@@ -512,6 +518,40 @@ class MilvusVectorStore(VectorStore):
     # Sync paginated query helper (Milvus 2.6 query_iterator is sync-only)
     # ------------------------------------------------------------------
 
+    def _vector_dim(self) -> int:
+        """ dense-vector dimension for page sizing.
+
+        Prefers the value recorded at :meth:`initialize`. A read-only process
+        never indexes, so that may be ``None``; fall back to the live collection
+        schema (cached on success) and finally to :data:`_UNKNOWN_VECTOR_DIM` so
+        the page stays safe even when the schema can't be read. Reading too
+        small a dimension here would re-introduce the oversized-page failure
+        this guard exists to prevent.
+        """
+        if self._embedding_dimension is not None:
+            return self._embedding_dimension
+        dim = self._describe_vector_dim()
+        if dim is not None:
+            self._embedding_dimension = dim
+            return dim
+        return _UNKNOWN_VECTOR_DIM
+
+    def _describe_vector_dim(self) -> int | None:
+        """Read the ``vector`` field's ``dim`` from the live collection schema.
+
+        Returns ``None`` if the collection or field can't be inspected (e.g. the
+        collection does not exist yet), leaving the caller to pick a fallback.
+        """
+        try:
+            desc = self._client.describe_collection(self._collection_name)
+            for field in desc.get("fields", []):
+                if field.get("name") == "vector":
+                    dim = field.get("params", {}).get("dim")
+                    return int(dim) if dim else None
+        except Exception:
+            return None
+        return None
+
     def _safe_batch_size(self, output_fields: list[str]) -> int:
         """Cap the batch so one page stays under Milvus's ~64MB result limit.
 
@@ -520,11 +560,13 @@ class MilvusVectorStore(VectorStore):
         Milvus 2.6 returns the vector for the ``"*"`` wildcard too — the search
         path strips it post-hoc via ``_SEARCH_RESULT_DROPPED_KEYS`` and
         ``query_chunks_by_filter(["*"])`` leaks it — so ``"*"`` counts as
-        vector-inclusive here.
+        vector-inclusive here. The dimension comes from :meth:`_vector_dim`, not
+        a fixed guess, so a read-only process still sizes pages to the real
+        collection.
         """
         if "vector" not in output_fields and "*" not in output_fields:
             return 16_000
-        dim = self._embedding_dimension or 1024
+        dim = self._vector_dim()
         budget = 32 * 1024 * 1024  # ~half of Milvus's ~64MB cap
         per_row = dim * 4 + 6_144  # float32 vector + text/metadata headroom
         return max(1, min(16_000, budget // per_row))

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -512,16 +512,36 @@ class MilvusVectorStore(VectorStore):
     # Sync paginated query helper (Milvus 2.6 query_iterator is sync-only)
     # ------------------------------------------------------------------
 
+    def _safe_batch_size(self, output_fields: list[str]) -> int:
+        """Cap the batch so one page stays under Milvus's ~64MB result limit.
+
+        Only matters when the dense ``vector`` is requested (~dim*4 bytes/row);
+        scalar-only pages are small, so they keep the large default.
+        """
+        if "vector" not in output_fields:
+            return 16_000
+        dim = self._embedding_dimension or 1024
+        budget = 32 * 1024 * 1024  # ~half of Milvus's ~64MB cap
+        per_row = dim * 4 + 6_144  # float32 vector + text/metadata headroom
+        return max(1, min(16_000, budget // per_row))
+
     def _iter_query(
         self,
         expr: str,
         output_fields: list[str],
-        batch_size: int = 16_000,
+        batch_size: int | None = None,
     ) -> list[dict[str, Any]]:
         """Drain a Milvus 2.6 ``query_iterator`` into a list.
 
+        ``batch_size`` defaults to :meth:`_safe_batch_size`, which shrinks the
+        page when the dense vector is requested so one page stays under Milvus's
+        result-size limit. Total result-set size is unaffected — the iterator
+        paginates until the filter is drained.
+
         Synchronous; call via :func:`asyncio.to_thread` from async methods.
         """
+        if batch_size is None:
+            batch_size = self._safe_batch_size(output_fields)
         iterator = self._client.query_iterator(
             collection_name=self._collection_name,
             filter=expr,

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -519,7 +519,7 @@ class MilvusVectorStore(VectorStore):
     # ------------------------------------------------------------------
 
     def _vector_dim(self) -> int:
-        """ dense-vector dimension for page sizing.
+        """Dense-vector dimension for page sizing.
 
         Prefers the value recorded at :meth:`initialize`. A read-only process
         never indexes, so that may be ``None``; fall back to the live collection

--- a/tests/integration/repos/test_milvus_store_integration.py
+++ b/tests/integration/repos/test_milvus_store_integration.py
@@ -333,13 +333,12 @@ class TestQueryByFilter:
         assert rows
         assert rows[0]["partition"] == "p1"
         assert rows[0]["text"] == "only"
-        # NOTE: ``_iter_query`` does NOT strip the vector field, unlike the
-        # search path (which filters via ``_SEARCH_RESULT_DROPPED_KEYS``).
-        # ``query_chunks_by_filter`` therefore leaks the dense vector when
-        # called with the default ``["*"]`` output_fields — asymmetric with
-        # ``search()`` and contradicts the method docstring. Tracked as a
-        # follow-up; this test documents current behaviour so the next change
-        # is intentional.
+        # Milvus 2.6 returns the dense ``vector`` for the default ``["*"]``
+        # projection (unlike the search path, which strips it via
+        # ``_SEARCH_RESULT_DROPPED_KEYS``). ``_safe_batch_size`` relies on this
+        # to shrink the query_iterator page for wildcard reads, so assert the
+        # behaviour explicitly rather than only documenting it in prose.
+        assert "vector" in rows[0]
 
 
 class TestDropAndDelete:

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -276,10 +276,16 @@ class TestChunkOrderMetadata:
 
 
 class TestSafeBatchSize:
-    def test_scalar_only_keeps_large_default(self, store: MilvusVectorStore) -> None:
-        # No vector requested → tiny rows → keep the large default page.
-        assert store._safe_batch_size(["*"]) == 16_000
+    def test_explicit_scalar_projection_keeps_large_default(self, store: MilvusVectorStore) -> None:
+        # No vector and no wildcard → tiny rows → keep the large default page.
         assert store._safe_batch_size(["_id"]) == 16_000
+        assert store._safe_batch_size(["partition", "file_id"]) == 16_000
+
+    def test_wildcard_is_treated_as_vector_inclusive(self, store: MilvusVectorStore) -> None:
+        # Milvus 2.6 returns the dense vector for ``["*"]`` too, so a wildcard
+        # page must shrink even without an explicit ``"vector"`` field.
+        store._embedding_dimension = 1024
+        assert store._safe_batch_size(["*"]) == 3_276
 
     def test_vector_request_shrinks_page(self, store: MilvusVectorStore) -> None:
         store._embedding_dimension = 1024

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -298,10 +298,30 @@ class TestSafeBatchSize:
         assert page == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
         assert page < 3_276  # bigger vectors → fewer rows per page
 
-    def test_unset_dimension_falls_back_to_1024(self, store: MilvusVectorStore) -> None:
-        # ``_embedding_dimension`` is None before initialize(); must not crash.
+    def test_unknown_dimension_reads_collection_schema(self, store: MilvusVectorStore) -> None:
+        # Read-only process: dim unset (never indexed), but the live schema
+        # knows the real dimension — page must size to *that*, not a guess.
         assert store._embedding_dimension is None
-        assert store._safe_batch_size(["vector"]) == 3_276
+        store._client.describe_collection.return_value = {
+            "fields": [
+                {"name": "text", "params": {}},
+                {"name": "vector", "params": {"dim": 4096}},
+            ]
+        }
+        page = store._safe_batch_size(["*"])
+        assert page == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
+        # Resolved dim is cached so we don't re-probe Milvus on every query.
+        assert store._embedding_dimension == 4096
+
+    def test_unknown_dimension_falls_back_to_conservative_cap(self, store: MilvusVectorStore) -> None:
+        import services.storage.milvus_store as store_mod
+
+        # Schema probe fails (e.g. collection absent) → conservative large dim,
+        # never a small guess that would under-size a high-dim collection's page.
+        store._client.describe_collection.side_effect = RuntimeError("no collection")
+        page = store._safe_batch_size(["vector"])
+        assert page == (32 * 1024 * 1024) // (store_mod._UNKNOWN_VECTOR_DIM * 4 + 6_144)
+        assert store._embedding_dimension is None  # not cached on failure
 
     def test_page_never_exceeds_default_cap(self, store: MilvusVectorStore) -> None:
         store._embedding_dimension = 1

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -271,6 +271,38 @@ class TestChunkOrderMetadata:
 
 
 # ---------------------------------------------------------------------------
+# _safe_batch_size — shrink the query_iterator page when vectors are requested
+# ---------------------------------------------------------------------------
+
+
+class TestSafeBatchSize:
+    def test_scalar_only_keeps_large_default(self, store: MilvusVectorStore) -> None:
+        # No vector requested → tiny rows → keep the large default page.
+        assert store._safe_batch_size(["*"]) == 16_000
+        assert store._safe_batch_size(["_id"]) == 16_000
+
+    def test_vector_request_shrinks_page(self, store: MilvusVectorStore) -> None:
+        store._embedding_dimension = 1024
+        # 32 MiB budget / (1024*4 + 6144) bytes-per-row = 3276, well under 16k.
+        assert store._safe_batch_size(["*", "vector"]) == 3_276
+
+    def test_larger_embedder_shrinks_further(self, store: MilvusVectorStore) -> None:
+        store._embedding_dimension = 4096
+        page = store._safe_batch_size(["*", "vector"])
+        assert page == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
+        assert page < 3_276  # bigger vectors → fewer rows per page
+
+    def test_unset_dimension_falls_back_to_1024(self, store: MilvusVectorStore) -> None:
+        # ``_embedding_dimension`` is None before initialize(); must not crash.
+        assert store._embedding_dimension is None
+        assert store._safe_batch_size(["vector"]) == 3_276
+
+    def test_page_never_exceeds_default_cap(self, store: MilvusVectorStore) -> None:
+        store._embedding_dimension = 1
+        assert store._safe_batch_size(["vector"]) <= 16_000
+
+
+# ---------------------------------------------------------------------------
 # _chunk_to_entity
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -271,60 +271,87 @@ class TestChunkOrderMetadata:
 
 
 # ---------------------------------------------------------------------------
-# _safe_batch_size — shrink the query_iterator page when vectors are requested
+# _safe_batch_size — shrink the query_iterator page for vector-inclusive reads
 # ---------------------------------------------------------------------------
+
+
+def _set_schema_dim(store: MilvusVectorStore, dim: int) -> None:
+    """Make the store's mocked client report ``dim`` as the vector field size."""
+    store._client.describe_collection.return_value = {
+        "fields": [
+            {"name": "text", "params": {}},
+            {"name": "vector", "params": {"dim": dim}},
+        ]
+    }
+
+
+def _break_schema_probe(store: MilvusVectorStore) -> None:
+    """Make the schema probe raise, forcing the dimension fallback chain."""
+    store._client.describe_collection.side_effect = RuntimeError("no collection")
 
 
 class TestSafeBatchSize:
     def test_explicit_scalar_projection_keeps_large_default(self, store: MilvusVectorStore) -> None:
-        # No vector and no wildcard → tiny rows → keep the large default page.
+        # No vector and no wildcard → tiny rows → keep the large default page,
+        # without even probing the dimension.
         assert store._safe_batch_size(["_id"]) == 16_000
         assert store._safe_batch_size(["partition", "file_id"]) == 16_000
 
     def test_wildcard_is_treated_as_vector_inclusive(self, store: MilvusVectorStore) -> None:
         # Milvus 2.6 returns the dense vector for ``["*"]`` too, so a wildcard
         # page must shrink even without an explicit ``"vector"`` field.
-        store._embedding_dimension = 1024
+        _set_schema_dim(store, 1024)
         assert store._safe_batch_size(["*"]) == 3_276
 
     def test_vector_request_shrinks_page(self, store: MilvusVectorStore) -> None:
-        store._embedding_dimension = 1024
+        _set_schema_dim(store, 1024)
         # 32 MiB budget / (1024*4 + 6144) bytes-per-row = 3276, well under 16k.
         assert store._safe_batch_size(["*", "vector"]) == 3_276
 
     def test_larger_embedder_shrinks_further(self, store: MilvusVectorStore) -> None:
-        store._embedding_dimension = 4096
+        _set_schema_dim(store, 4096)
         page = store._safe_batch_size(["*", "vector"])
         assert page == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
         assert page < 3_276  # bigger vectors → fewer rows per page
 
-    def test_unknown_dimension_reads_collection_schema(self, store: MilvusVectorStore) -> None:
-        # Read-only process: dim unset (never indexed), but the live schema
-        # knows the real dimension — page must size to *that*, not a guess.
-        assert store._embedding_dimension is None
-        store._client.describe_collection.return_value = {
-            "fields": [
-                {"name": "text", "params": {}},
-                {"name": "vector", "params": {"dim": 4096}},
-            ]
-        }
-        page = store._safe_batch_size(["*"])
-        assert page == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
-        # Resolved dim is cached so we don't re-probe Milvus on every query.
-        assert store._embedding_dimension == 4096
+    def test_schema_dim_preferred_over_initialize_value(self, store: MilvusVectorStore) -> None:
+        # The edge case: initialize() recorded 1024, but the existing collection
+        # is really 4096 (initialize's value is ignored for an existing
+        # collection). Page sizing must trust the schema — the real on-the-wire
+        # size — not the possibly-stale initialize() value.
+        store._embedding_dimension = 1024
+        _set_schema_dim(store, 4096)
+        assert store._safe_batch_size(["*"]) == (32 * 1024 * 1024) // (4096 * 4 + 6_144)  # 1489
 
-    def test_unknown_dimension_falls_back_to_conservative_cap(self, store: MilvusVectorStore) -> None:
+    def test_schema_read_is_cached(self, store: MilvusVectorStore) -> None:
+        _set_schema_dim(store, 4096)
+        store._safe_batch_size(["*"])
+        assert store._schema_vector_dim == 4096
+        # Second call must reuse the cache, not re-probe Milvus.
+        store._client.describe_collection.reset_mock()
+        store._safe_batch_size(["*"])
+        store._client.describe_collection.assert_not_called()
+
+    def test_falls_back_to_initialize_value_when_schema_unreadable(self, store: MilvusVectorStore) -> None:
+        # Schema probe fails → use the initialize() value rather than guessing.
+        _break_schema_probe(store)
+        store._embedding_dimension = 1024
+        assert store._safe_batch_size(["*"]) == 3_276
+        assert store._schema_vector_dim is None  # nothing resolved, nothing cached
+
+    def test_falls_back_to_conservative_cap_when_dim_unknown(self, store: MilvusVectorStore) -> None:
         import services.storage.milvus_store as store_mod
 
-        # Schema probe fails (e.g. collection absent) → conservative large dim,
-        # never a small guess that would under-size a high-dim collection's page.
-        store._client.describe_collection.side_effect = RuntimeError("no collection")
+        # No initialize() value AND schema unreadable (e.g. collection absent) →
+        # conservative large dim, never a small guess that would over-size the
+        # page (too many rows) for a high-dim collection.
+        _break_schema_probe(store)
+        assert store._embedding_dimension is None
         page = store._safe_batch_size(["vector"])
         assert page == (32 * 1024 * 1024) // (store_mod._UNKNOWN_VECTOR_DIM * 4 + 6_144)
-        assert store._embedding_dimension is None  # not cached on failure
 
     def test_page_never_exceeds_default_cap(self, store: MilvusVectorStore) -> None:
-        store._embedding_dimension = 1
+        _set_schema_dim(store, 1)
         assert store._safe_batch_size(["vector"]) <= 16_000
 
 


### PR DESCRIPTION
<head></head><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">MilvusVectorStore._iter_query</code> drained Milvus's <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">query_iterator</code> at a fixed <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">batch_size=16_000</code>. That page size is safe for scalar projections, but unsafe when the dense <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">vector</code> is requested: each row then carries <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dim × 4</code> extra bytes, so a 16k-row page can exceed Milvus's gRPC result-size limit (~64 MB) and fail the RPC.</p><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This makes the page size <strong>dimension-aware</strong> — it shrinks only when <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">"vector"</code> is in <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">output_fields</code>, and leaves the common scalar reads untouched.</p><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Three call paths request <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">["*", "vector"]</code> and so hit this:</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">partition_service.list_all_chunks(include_embedding=True)</code><span> </span>— partition-scoped,<span> </span><strong>unbounded at query time</strong><span> </span>(the<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">limit</code><span> </span>is applied<span> </span><em>after</em><span> </span>the full drain), so this is the real exposure on large partitions.</li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dispatcher.update_file_metadata</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dispatcher.copy_file</code><span> </span>— file-scoped; only at risk for a single file with &gt;16k chunks.</li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">At dim=1024 a full 16k-row page of vectors is ~64 MB+ on its own — right at the cap.</p><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What changed</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_safe_batch_size(output_fields)</code>:</p><div class="codeBlockWrapper_-a7MRw" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: repeat rgb(31, 31, 31); border: 1px solid rgb(69, 69, 69); cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s ease 0s, background 0.15s ease 0s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-python" style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">if "vector" not in output_fields:
    return 16_000
dim = self._embedding_dimension or 1024
budget = 32 * 1024 * 1024            # ~half of Milvus's ~64MB cap
per_row = dim * 4 + 6_144            # float32 vector + text/metadata headroom
return max(1, min(16_000, budget // per_row))
</code></pre></div><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_iter_query</code> now takes <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">batch_size: int | None = None</code> and falls back to <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_safe_batch_size(output_fields)</code>. <strong>Total result-set size is unchanged</strong> — the iterator still paginates until the filter is fully drained; only the per-page row count changes.</p>
Projection | Page size
-- | --
["_id"], ["*"] (scalar-only) | 16,000 (unchanged)
["*", "vector"], dim=1024 | 3,276
["*", "vector"], dim=4096 | 1,489

<h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h2><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Adds <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">TestSafeBatchSize</code> (5 cases): scalar-only keeps 16k, vector requests shrink, larger embedders shrink further, unset <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_embedding_dimension</code> falls back to 1024 (no crash before <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">initialize()</code>), and the page never exceeds the 16k cap. <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uv run pytest tests/unit/services/storage/test_milvus_store.py</code> → 71 passed; lint clean.</p><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Scope / non-goals</h2><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; orphans: 2; widows: 2; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Targets the dominant cause (the dense vector). Scalar-only<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">["*"]</code><span> </span>reads stay at 16k; the<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">text</code><span> </span>field (VARCHAR ≤ 65 KB) could in principle also be large for big-chunk configs, but that's left as a follow-up rather than expanded into a full byte-budget model here.</li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">~64 MB</code><span> </span>is the conservative reference limit; the 32 MB budget leaves ~2× headroom even when the per-row estimate runs low.</li></ul>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Milvus query performance and reliability by dynamically selecting iterator page sizes based on the requested fields.
  * Reduced the risk of oversized responses when dense vector data (or wildcard vector-inclusive projections) is included.
  * Added schema-aware dimension handling to size pages accurately, with safe fallback behavior.
  * Cleans cached schema-derived vector dimension when the backing collection is dropped.

* **Tests**
  * Added unit tests covering scalar-only, explicit vector, wildcard behavior, dimension changes, schema-probe fallback, caching, and maximum page-size caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->