### PR TITLE
fix(admin-ui): guide upload action by partition capability

### DIFF
--- a/ui/src/pages/admin/overview.test.tsx
+++ b/ui/src/pages/admin/overview.test.tsx
@@ -95,11 +95,11 @@ describe("OverviewPage quick actions", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /upload documents/i }));
 
-    expect(screen.getByRole("heading", { name: /create a partition before uploading/i })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: /create a partition before uploading/i })).toBeTruthy();
     expect(
-      screen.getByText("You don't have a partition you can upload to yet. Create one first?"),
+      await screen.findByText("You don't have a partition you can upload to yet. Create one first?"),
     ).toBeTruthy();
-    expect(screen.getByRole("link", { name: /^create partition$/i }).getAttribute("href")).toBe(
+    expect((await screen.findByRole("link", { name: /^create partition$/i })).getAttribute("href")).toBe(
       "/partitions?create=1",
     );
   });

--- a/ui/src/pages/admin/overview.test.tsx
+++ b/ui/src/pages/admin/overview.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,12 +9,17 @@ const queryData = vi.hoisted(() => ({
   partitions: [
     {
       partition: "shared-docs",
-      name: "shared-docs",
+      name: "Shared docs display name",
       role: "viewer",
       document_count: 3,
       created_at: "2026-01-01T00:00:00Z",
     },
   ],
+  isError: false,
+  isLoading: false,
+}));
+const permissions = vi.hoisted(() => ({
+  canCreatePartition: true,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -22,7 +28,8 @@ vi.mock("@tanstack/react-query", () => ({
     if (key === "partitions") {
       return {
         data: { partitions: queryData.partitions },
-        isLoading: false,
+        isError: queryData.isError,
+        isLoading: queryData.isLoading,
       };
     }
     if (key === "tasks") {
@@ -55,17 +62,21 @@ vi.mock("@/lib/permissions", () => ({
   usePermissions: () => ({
     canManageUsers: false,
     canViewSystem: false,
-    canCreatePartition: true,
+    canCreatePartition: permissions.canCreatePartition,
     canWrite: (role: string | null | undefined) => role === "editor" || role === "owner",
   }),
 }));
 
 describe("OverviewPage quick actions", () => {
   beforeEach(() => {
+    sessionStorage.clear();
+    permissions.canCreatePartition = true;
+    queryData.isError = false;
+    queryData.isLoading = false;
     queryData.partitions = [
       {
         partition: "shared-docs",
-        name: "shared-docs",
+        name: "Shared docs display name",
         role: "viewer",
         document_count: 3,
         created_at: "2026-01-01T00:00:00Z",
@@ -73,32 +84,38 @@ describe("OverviewPage quick actions", () => {
     ];
   });
 
-  it("guides users without a writable partition to create one before upload", () => {
+  it("keeps one upload action and explains when no writable partition exists", async () => {
     render(
       <MemoryRouter>
         <OverviewPage />
       </MemoryRouter>,
     );
 
-    expect(screen.queryByText("Upload Documents")).toBeNull();
+    expect(screen.queryByText("Create Partition to Upload")).toBeNull();
 
-    const action = screen.getByRole("link", { name: /create partition to upload/i });
-    expect(action.getAttribute("href")).toBe("/partitions?create=1");
-    expect(screen.getByText("Create a partition first, then add documents")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: /upload documents/i }));
+
+    expect(screen.getByRole("heading", { name: /create a partition before uploading/i })).toBeTruthy();
+    expect(
+      screen.getByText("You don't have a partition you can upload to yet. Create one first?"),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: /^create partition$/i }).getAttribute("href")).toBe(
+      "/partitions?create=1",
+    );
   });
 
   it("keeps upload available when the user has a writable partition", () => {
     queryData.partitions = [
       {
         partition: "shared-docs",
-        name: "shared-docs",
+        name: "Shared docs display name",
         role: "viewer",
         document_count: 3,
         created_at: "2026-01-01T00:00:00Z",
       },
       {
         partition: "team-upload",
-        name: "team-upload",
+        name: "Team upload display name",
         role: "editor",
         document_count: 0,
         created_at: "2026-01-01T00:00:00Z",
@@ -113,6 +130,63 @@ describe("OverviewPage quick actions", () => {
 
     const action = screen.getByRole("link", { name: /upload documents/i });
     expect(action.getAttribute("href")).toBe("/documents?partition=team-upload");
+    expect(screen.queryByText("Create Partition to Upload")).toBeNull();
+  });
+
+  it("prefers the remembered partition when it is writable", () => {
+    sessionStorage.setItem("documents.partition", "remembered-upload");
+    queryData.partitions = [
+      {
+        partition: "first-upload",
+        name: "First writable display name",
+        role: "editor",
+        document_count: 0,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        partition: "remembered-upload",
+        name: "Remembered writable display name",
+        role: "owner",
+        document_count: 0,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    const action = screen.getByRole("link", { name: /upload documents/i });
+    expect(action.getAttribute("href")).toBe("/documents?partition=remembered-upload");
+  });
+
+  it("does not show a derived upload action while partitions fail to load", () => {
+    queryData.isError = true;
+
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: /upload documents/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /upload documents/i })).toBeNull();
+    expect(screen.queryByText("Create Partition to Upload")).toBeNull();
+  });
+
+  it("hides upload guidance when nothing is writable and partition creation is unavailable", () => {
+    permissions.canCreatePartition = false;
+
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("button", { name: /upload documents/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /upload documents/i })).toBeNull();
     expect(screen.queryByText("Create Partition to Upload")).toBeNull();
   });
 });

--- a/ui/src/pages/admin/overview.test.tsx
+++ b/ui/src/pages/admin/overview.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import OverviewPage from "./overview";
+
+const queryData = vi.hoisted(() => ({
+  partitions: [
+    {
+      partition: "shared-docs",
+      name: "shared-docs",
+      role: "viewer",
+      document_count: 3,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+    const key = queryKey[0];
+    if (key === "partitions") {
+      return {
+        data: { partitions: queryData.partitions },
+        isLoading: false,
+      };
+    }
+    if (key === "tasks") {
+      return {
+        data: { tasks: [] },
+        isLoading: false,
+      };
+    }
+    return {
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+    };
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: 2,
+      display_name: "Viewer",
+      is_admin: false,
+      file_quota: 10,
+      file_count: 0,
+    },
+  }),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  usePermissions: () => ({
+    canManageUsers: false,
+    canViewSystem: false,
+    canCreatePartition: true,
+    canWrite: (role: string | null | undefined) => role === "editor" || role === "owner",
+  }),
+}));
+
+describe("OverviewPage quick actions", () => {
+  beforeEach(() => {
+    queryData.partitions = [
+      {
+        partition: "shared-docs",
+        name: "shared-docs",
+        role: "viewer",
+        document_count: 3,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+  });
+
+  it("guides users without a writable partition to create one before upload", () => {
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Upload Documents")).toBeNull();
+
+    const action = screen.getByRole("link", { name: /create partition to upload/i });
+    expect(action.getAttribute("href")).toBe("/partitions?create=1");
+    expect(screen.getByText("Create a partition first, then add documents")).toBeTruthy();
+  });
+
+  it("keeps upload available when the user has a writable partition", () => {
+    queryData.partitions = [
+      {
+        partition: "shared-docs",
+        name: "shared-docs",
+        role: "viewer",
+        document_count: 3,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        partition: "team-upload",
+        name: "team-upload",
+        role: "editor",
+        document_count: 0,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    const action = screen.getByRole("link", { name: /upload documents/i });
+    expect(action.getAttribute("href")).toBe("/documents?partition=team-upload");
+    expect(screen.queryByText("Create Partition to Upload")).toBeNull();
+  });
+});

--- a/ui/src/pages/admin/overview.tsx
+++ b/ui/src/pages/admin/overview.tsx
@@ -124,7 +124,7 @@ function RecentTasks({ isLoading, tasks }: { isLoading: boolean; tasks: TaskList
 }
 
 export default function OverviewPage() {
-  const { canManageUsers, canViewSystem, canCreatePartition } = usePermissions();
+  const { canManageUsers, canViewSystem, canCreatePartition, canWrite } = usePermissions();
 
   // `GET /partition/` and `/queue/tasks` are membership-scoped server-side, so the
   // same queries serve admins and partition members. Platform-only data is gated.
@@ -168,6 +168,25 @@ export default function OverviewPage() {
   const quotaIndexed = me?.file_count ?? 0;
   const quotaEff: number | "unlimited" =
     me?.file_quota == null || me.file_quota < 0 ? "unlimited" : me.file_quota;
+  const writablePartition = partitions.find((partition) => canWrite(partition.role));
+  const uploadQuickAction = partitionsQuery.isLoading
+    ? null
+    : writablePartition
+      ? {
+          href: `/documents?partition=${encodeURIComponent(writablePartition.name)}`,
+          title: "Upload Documents",
+          description: "Add documents to a writable partition",
+          icon: Upload,
+        }
+      : canCreatePartition
+        ? {
+            href: "/partitions?create=1",
+            title: "Create Partition to Upload",
+            description: "Create a partition first, then add documents",
+            icon: Plus,
+          }
+        : null;
+  const UploadQuickActionIcon = uploadQuickAction?.icon;
 
   return (
     <div>
@@ -278,18 +297,20 @@ export default function OverviewPage() {
                   </Link>
                 </Button>
               )}
-              <Button variant="outline" className="justify-start h-auto py-3" asChild>
-                <Link to="/documents">
-                  <Upload className="h-4 w-4 mr-2" />
-                  <div className="text-left">
-                    <div className="font-medium">Upload Documents</div>
-                    <div className="text-xs text-muted-foreground">
-                      Add documents to a partition
+              {uploadQuickAction && (
+                <Button variant="outline" className="justify-start h-auto py-3" asChild>
+                  <Link to={uploadQuickAction.href}>
+                    {UploadQuickActionIcon && <UploadQuickActionIcon className="h-4 w-4 mr-2" />}
+                    <div className="text-left">
+                      <div className="font-medium">{uploadQuickAction.title}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {uploadQuickAction.description}
+                      </div>
                     </div>
-                  </div>
-                  <ArrowRight className="h-4 w-4 ml-auto" />
-                </Link>
-              </Button>
+                    <ArrowRight className="h-4 w-4 ml-auto" />
+                  </Link>
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/ui/src/pages/admin/overview.tsx
+++ b/ui/src/pages/admin/overview.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import { useState, type ComponentType } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import {
@@ -15,6 +15,14 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { QuotaUsageMeter } from "@/components/shared/quota-usage-meter";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useAuth } from "@/lib/auth";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -125,6 +133,8 @@ function RecentTasks({ isLoading, tasks }: { isLoading: boolean; tasks: TaskList
 
 export default function OverviewPage() {
   const { canManageUsers, canViewSystem, canCreatePartition, canWrite } = usePermissions();
+  const [uploadHelpOpen, setUploadHelpOpen] = useState(false);
+  const [rememberedPartition] = useState(() => sessionStorage.getItem("documents.partition") || "");
 
   // `GET /partition/` and `/queue/tasks` are membership-scoped server-side, so the
   // same queries serve admins and partition members. Platform-only data is gated.
@@ -168,25 +178,27 @@ export default function OverviewPage() {
   const quotaIndexed = me?.file_count ?? 0;
   const quotaEff: number | "unlimited" =
     me?.file_quota == null || me.file_quota < 0 ? "unlimited" : me.file_quota;
-  const writablePartition = partitions.find((partition) => canWrite(partition.role));
-  const uploadQuickAction = partitionsQuery.isLoading
+  const writablePartitions = partitions.filter((partition) => canWrite(partition.role));
+  const rememberedWritablePartition = writablePartitions.find(
+    (partition) => partition.partition === rememberedPartition || partition.name === rememberedPartition,
+  );
+  const writablePartition = rememberedWritablePartition ?? writablePartitions[0];
+  const uploadQuickAction = partitionsQuery.isLoading || partitionsQuery.isError
     ? null
     : writablePartition
       ? {
-          href: `/documents?partition=${encodeURIComponent(writablePartition.name)}`,
+          href: `/documents?partition=${encodeURIComponent(writablePartition.partition)}`,
           title: "Upload Documents",
           description: "Add documents to a writable partition",
-          icon: Upload,
+          type: "link" as const,
         }
       : canCreatePartition
         ? {
-            href: "/partitions?create=1",
-            title: "Create Partition to Upload",
+            title: "Upload Documents",
             description: "Create a partition first, then add documents",
-            icon: Plus,
+            type: "dialog" as const,
           }
         : null;
-  const UploadQuickActionIcon = uploadQuickAction?.icon;
 
   return (
     <div>
@@ -297,10 +309,10 @@ export default function OverviewPage() {
                   </Link>
                 </Button>
               )}
-              {uploadQuickAction && (
+              {uploadQuickAction?.type === "link" && (
                 <Button variant="outline" className="justify-start h-auto py-3" asChild>
                   <Link to={uploadQuickAction.href}>
-                    {UploadQuickActionIcon && <UploadQuickActionIcon className="h-4 w-4 mr-2" />}
+                    <Upload className="h-4 w-4 mr-2" />
                     <div className="text-left">
                       <div className="font-medium">{uploadQuickAction.title}</div>
                       <div className="text-xs text-muted-foreground">
@@ -311,10 +323,45 @@ export default function OverviewPage() {
                   </Link>
                 </Button>
               )}
+              {uploadQuickAction?.type === "dialog" && (
+                <Button
+                  variant="outline"
+                  className="justify-start h-auto py-3"
+                  onClick={() => setUploadHelpOpen(true)}
+                >
+                  <Upload className="h-4 w-4 mr-2" />
+                  <div className="text-left">
+                    <div className="font-medium">{uploadQuickAction.title}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {uploadQuickAction.description}
+                    </div>
+                  </div>
+                  <ArrowRight className="h-4 w-4 ml-auto" />
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>
       </div>
+
+      <Dialog open={uploadHelpOpen} onOpenChange={setUploadHelpOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create a partition before uploading</DialogTitle>
+            <DialogDescription>
+              You don't have a partition you can upload to yet. Create one first?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUploadHelpOpen(false)}>
+              Cancel
+            </Button>
+            <Button asChild>
+              <Link to="/partitions?create=1">Create Partition</Link>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <RecentTasks isLoading={tasksQuery.isLoading} tasks={tasks.slice(0, 5)} />
     </div>


### PR DESCRIPTION
## Summary

Fixes #598.

The Overview upload quick action now checks whether the current user has a writable partition.

- Users with an `owner` or `editor` partition still get **Upload Documents**, pre-filtered to that writable partition.
- Users with no writable partition are guided to create a partition first, instead of seeing an upload action that later disappears on the Documents page.

This keeps the UI aligned with the partition-scoped role model: a viewer on one partition may still create and own another partition.

## Validation

- `npm run test -- overview.test.tsx`
- `npm run lint`
- `npm run test`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The admin overview’s “Upload Documents” quick action now adapts to partition write access, routing uploads to the best available partition.
  * Remembers a previously used partition in the session to improve upload destination selection.
  * When no writable partition is available, it prompts users to create one via an in-page dialog and a “create partition” link.

* **Bug Fixes**
  * Hides the upload action when partitions are still loading or fail to load, and when partition creation isn’t available.

* **Tests**
  * Added coverage for the overview quick-action rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->