### PR TITLE
fix(admin-ui): show super admin deployment indicator

### DIFF
--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -45,6 +45,11 @@ _BOLD = "\033[1m"
 _NORMAL = "\033[22m"
 
 
+def _super_admin_mode_enabled() -> bool:
+    """Mirror the backend SUPER_ADMIN_MODE flag used by /config and auth."""
+    return os.environ.get("SUPER_ADMIN_MODE", "false").lower() == "true"
+
+
 def _status_box(version: str, docs_url: str, *, color: bool) -> str:
     """Render the boxed version / docs-URL / status panel shown under the logo.
 
@@ -56,6 +61,8 @@ def _status_box(version: str, docs_url: str, *, color: bool) -> str:
         f"API docs: {docs_url}",
         "Status: ready",
     ]
+    if _super_admin_mode_enabled():
+        plain_lines.insert(-1, "Super Admin Mode: enabled")
     width = max(len(line) for line in plain_lines) + 2
 
     if not color:

--- a/openrag/core/utils/banner.py
+++ b/openrag/core/utils/banner.py
@@ -77,8 +77,10 @@ def _status_box(version: str, docs_url: str, *, color: bool) -> str:
     visible_lines = [
         f"{_BOLD}OpenRAG v{version}{_NORMAL}",
         f"{_BOLD}API docs{_NORMAL}: {docs_url}",
-        f"{_BOLD}Status{_NORMAL}: ready",
     ]
+    if _super_admin_mode_enabled():
+        visible_lines.append(f"{_BOLD}Super Admin Mode{_NORMAL}: enabled")
+    visible_lines.append(f"{_BOLD}Status{_NORMAL}: ready")
     body = [f"│ {visible}{' ' * (width - 2 - len(plain))} │" for visible, plain in zip(visible_lines, plain_lines)]
     return "\n".join(f"{red}{line}{_RESET}" for line in [top, *body, bottom])
 

--- a/tests/unit/core/utils/test_banner.py
+++ b/tests/unit/core/utils/test_banner.py
@@ -19,6 +19,21 @@ def test_startup_banner_mentions_super_admin_mode_when_enabled(monkeypatch):
     assert "Status: ready" in output
 
 
+def test_startup_banner_mentions_super_admin_mode_with_color_enabled(monkeypatch):
+    monkeypatch.setenv("OPENRAG_BANNER", "true")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.setenv("SUPER_ADMIN_MODE", "true")
+    stream = StringIO()
+
+    print_startup_banner("test-version", stream=stream)
+
+    output = stream.getvalue()
+    assert "Super Admin Mode" in output
+    assert "enabled" in output
+    assert "Status" in output
+
+
 def test_startup_banner_omits_super_admin_mode_when_disabled(monkeypatch):
     monkeypatch.setenv("OPENRAG_BANNER", "true")
     monkeypatch.setenv("NO_COLOR", "1")

--- a/tests/unit/core/utils/test_banner.py
+++ b/tests/unit/core/utils/test_banner.py
@@ -1,0 +1,30 @@
+from io import StringIO
+
+from core.utils.banner import print_startup_banner
+
+
+def test_startup_banner_mentions_super_admin_mode_when_enabled(monkeypatch):
+    monkeypatch.setenv("OPENRAG_BANNER", "true")
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("APP_PORT", "8077")
+    monkeypatch.setenv("SUPER_ADMIN_MODE", "true")
+    stream = StringIO()
+
+    print_startup_banner("test-version", stream=stream)
+
+    output = stream.getvalue()
+    assert "OpenRAG vtest-version" in output
+    assert "API docs: http://localhost:8077/docs" in output
+    assert "Super Admin Mode: enabled" in output
+    assert "Status: ready" in output
+
+
+def test_startup_banner_omits_super_admin_mode_when_disabled(monkeypatch):
+    monkeypatch.setenv("OPENRAG_BANNER", "true")
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("SUPER_ADMIN_MODE", "false")
+    stream = StringIO()
+
+    print_startup_banner("test-version", stream=stream)
+
+    assert "Super Admin Mode" not in stream.getvalue()

--- a/ui/src/components/layout/admin-layout.tsx
+++ b/ui/src/components/layout/admin-layout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router-dom";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "./sidebar";
 import { Header } from "./header";
+import { SuperAdminModeIndicator } from "./super-admin-mode-indicator";
 
 export function AdminLayout() {
   return (
@@ -9,6 +10,7 @@ export function AdminLayout() {
       <AppSidebar />
       <SidebarInset>
         <Header />
+        <SuperAdminModeIndicator />
         <main className="flex-1 overflow-auto p-6">
           <Outlet />
         </main>

--- a/ui/src/components/layout/super-admin-mode-indicator.test.tsx
+++ b/ui/src/components/layout/super-admin-mode-indicator.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SuperAdminModeIndicator } from "./super-admin-mode-indicator";
+
+const authState = vi.hoisted(() => ({ isAdmin: false }));
+const configState = vi.hoisted(() => ({ superAdminMode: false }));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ isAdmin: authState.isAdmin }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ enabled }: { enabled?: boolean }) => ({
+    data: enabled ? { super_admin_mode: configState.superAdminMode } : undefined,
+  }),
+}));
+
+describe("SuperAdminModeIndicator", () => {
+  it("shows deployment-wide access context to admins when super admin mode is enabled", () => {
+    authState.isAdmin = true;
+    configState.superAdminMode = true;
+
+    render(<SuperAdminModeIndicator />);
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Super Admin Mode enabled for this deployment.")).toBeTruthy();
+    expect(
+      screen.getByText("Admins can access all partitions and documents in this deployment."),
+    ).toBeTruthy();
+  });
+
+  it("is hidden for admins when super admin mode is disabled", () => {
+    authState.isAdmin = true;
+    configState.superAdminMode = false;
+
+    render(<SuperAdminModeIndicator />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("is hidden for normal users even if the deployment enables super admin mode", () => {
+    authState.isAdmin = false;
+    configState.superAdminMode = true;
+
+    render(<SuperAdminModeIndicator />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/ui/src/components/layout/super-admin-mode-indicator.tsx
+++ b/ui/src/components/layout/super-admin-mode-indicator.tsx
@@ -1,0 +1,36 @@
+import { ShieldAlert } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getConfig } from "@/lib/api/system";
+import { useAuth } from "@/lib/auth";
+
+export function SuperAdminModeIndicator() {
+  const { isAdmin } = useAuth();
+  const { data: config } = useQuery({
+    queryKey: ["system-config"],
+    queryFn: getConfig,
+    enabled: isAdmin,
+    staleTime: Infinity,
+  });
+
+  if (!isAdmin || config?.super_admin_mode !== true) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="border-b border-amber-200 bg-amber-50 px-6 py-3 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+    >
+      <div className="flex items-start gap-3">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="min-w-0 text-sm">
+          <div className="font-medium">Super Admin Mode enabled for this deployment.</div>
+          <div className="text-amber-900/80 dark:text-amber-100/80">
+            Admins can access all partitions and documents in this deployment.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #600.

## Summary

This PR adds a persistent indicator in the Admin UI when the current user is an admin and `SUPER_ADMIN_MODE` is enabled for the deployment. The messaging is intentionally framed as a **deployment-wide configuration**, not as a special per-user role.

The startup banner now also displays **Super Admin Mode: enabled** when the same deployment flag is active, making it immediately visible to operators in the container logs.

This change does **not** modify any roles, permissions, or authorization behavior. It simply improves operator awareness while continuing to rely on the existing backend authorization rules.

## Deferred work

This PR does not implement a confirmation dialog before opening another user's documents. The frontend currently cannot distinguish between partitions owned by the current admin and partitions that are only visible because of the super-admin bypass. Supporting that workflow requires additional backend metadata (for example, an ownership or `via_super_admin` indicator) and is better handled in a follow-up change.

## Validation

* `npm run test -- super-admin-mode-indicator.test.tsx`
* `npm run lint`
* `npm run test`
* `npm run build`
* `uv run --no-env-file pytest tests/unit/core/utils/test_banner.py`
* `uv run ruff check openrag/core/utils/banner.py tests/unit/core/utils/test_banner.py`
* `uv run ruff format --check openrag/core/utils/banner.py tests/unit/core/utils/test_banner.py`
* Browser smoke test: verified that the indicator is displayed for admin users when `SUPER_ADMIN_MODE` is enabled and is not shown to non-admin users.
