### PR TITLE
fix(chainlit): render source PDF previews in the chat side panel

### DIFF
--- a/openrag/api/chainlit_assets.py
+++ b/openrag/api/chainlit_assets.py
@@ -1,0 +1,34 @@
+"""Serve Chainlit's bundled root-absolute static assets (the pdf.js worker).
+
+Chainlit is submounted at ``/chainlit``, so its HTML asset references are
+rewritten to ``/chainlit/assets/*``. Its bundled pdf.js worker URL, however, is
+computed at runtime in JS as the root-absolute ``/assets/pdf.worker*.mjs`` (no
+mount prefix), so react-pdf fetches the worker from the origin root. That path
+is not under the ``/chainlit`` auth bypass, so it returns a 403 JSON body and
+the browser blocks the module worker on a bad MIME type — source PDF previews
+then fail with "Failed to load PDF file". Serving the same asset files at
+``/assets`` too (``AuthMiddleware`` bypasses ``/assets/*``) lets the worker load
+with a JavaScript MIME type.
+
+Both browser origins that load Chainlit must expose this route: the mounted
+deployment (``api.main``) and the standalone Ray Serve Chainlit process
+(``chainlit_api``, served on its own port). This mirrors how ``chainlit_api``
+already replicates the ``/static`` download route for the same
+separate-origin reason.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+
+
+def mount_chainlit_root_assets(app: FastAPI) -> None:
+    """Mount Chainlit's ``frontend/dist/assets`` at ``/assets`` (no-op if absent)."""
+    import chainlit
+    from starlette.staticfiles import StaticFiles
+
+    assets_dir = Path(chainlit.__file__).parent / "frontend" / "dist" / "assets"
+    if assets_dir.is_dir():
+        app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="chainlit_root_assets")

--- a/openrag/api/chainlit_assets.py
+++ b/openrag/api/chainlit_assets.py
@@ -29,6 +29,13 @@ def mount_chainlit_root_assets(app: FastAPI) -> None:
     import chainlit
     from starlette.staticfiles import StaticFiles
 
-    assets_dir = Path(chainlit.__file__).parent / "frontend" / "dist" / "assets"
+    # A regularly installed ``chainlit`` always has ``__file__``; a namespace
+    # package or a test double (bare ``ModuleType``) may not — treat that as
+    # "bundled assets unavailable" and no-op rather than raising AttributeError.
+    chainlit_file = getattr(chainlit, "__file__", None)
+    if not chainlit_file:
+        return
+
+    assets_dir = Path(chainlit_file).parent / "frontend" / "dist" / "assets"
     if assets_dir.is_dir():
         app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="chainlit_root_assets")

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -362,9 +362,26 @@ if WITH_OPENAI_API or WITH_CHAINLIT_UI:
     app.include_router(openai_router, prefix="/v1", tags=[Tags.OPENAI])
 
 if WITH_CHAINLIT_UI:
+    from pathlib import Path as _Path
+
+    import chainlit as _chainlit
     from chainlit.utils import mount_chainlit
+    from starlette.staticfiles import StaticFiles
 
     mount_chainlit(app, "./app_front.py", path="/chainlit")
+
+    # Chainlit is submounted at /chainlit, so its HTML asset references are
+    # rewritten to /chainlit/assets/*. Its bundled pdf.js worker URL, however,
+    # is computed at runtime in JS as the root-absolute /assets/pdf.worker*.mjs
+    # (no mount prefix), so react-pdf fetches the worker from the origin root.
+    # That path is not under the /chainlit auth bypass, so it returns a 403 JSON
+    # body and the browser blocks the module worker on a bad MIME type — source
+    # PDF previews then fail with "Failed to load PDF file". Serve the same asset
+    # files at /assets too (AuthMiddleware bypasses /assets/*) so the worker
+    # loads with a JavaScript MIME type.
+    _chainlit_assets = _Path(_chainlit.__file__).parent / "frontend" / "dist" / "assets"
+    if _chainlit_assets.is_dir():
+        app.mount("/assets", StaticFiles(directory=str(_chainlit_assets)), name="chainlit_root_assets")
 
 
 if __name__ == "__main__":

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -362,26 +362,14 @@ if WITH_OPENAI_API or WITH_CHAINLIT_UI:
     app.include_router(openai_router, prefix="/v1", tags=[Tags.OPENAI])
 
 if WITH_CHAINLIT_UI:
-    from pathlib import Path as _Path
-
-    import chainlit as _chainlit
+    from api.chainlit_assets import mount_chainlit_root_assets
     from chainlit.utils import mount_chainlit
-    from starlette.staticfiles import StaticFiles
 
     mount_chainlit(app, "./app_front.py", path="/chainlit")
 
-    # Chainlit is submounted at /chainlit, so its HTML asset references are
-    # rewritten to /chainlit/assets/*. Its bundled pdf.js worker URL, however,
-    # is computed at runtime in JS as the root-absolute /assets/pdf.worker*.mjs
-    # (no mount prefix), so react-pdf fetches the worker from the origin root.
-    # That path is not under the /chainlit auth bypass, so it returns a 403 JSON
-    # body and the browser blocks the module worker on a bad MIME type — source
-    # PDF previews then fail with "Failed to load PDF file". Serve the same asset
-    # files at /assets too (AuthMiddleware bypasses /assets/*) so the worker
-    # loads with a JavaScript MIME type.
-    _chainlit_assets = _Path(_chainlit.__file__).parent / "frontend" / "dist" / "assets"
-    if _chainlit_assets.is_dir():
-        app.mount("/assets", StaticFiles(directory=str(_chainlit_assets)), name="chainlit_root_assets")
+    # Also serve Chainlit's bundled pdf.js worker at the origin root so source
+    # PDF previews load (see mount_chainlit_root_assets for the full rationale).
+    mount_chainlit_root_assets(app)
 
 
 if __name__ == "__main__":

--- a/openrag/api/middleware/auth.py
+++ b/openrag/api/middleware/auth.py
@@ -82,9 +82,17 @@ def is_bypass_path(path: str, *, bypass_config: AuthBypassConfig | None = None) 
     Matches a literal bypass list (``/docs``, health probes, OIDC
     callback endpoints) plus the entire ``/chainlit`` subtree — Chainlit
     handles its own header-auth callback for those routes.
+
+    ``/assets/`` is also bypassed: Chainlit is submounted at ``/chainlit`` but
+    its bundled pdf.js worker requests itself from the origin-root
+    ``/assets/pdf.worker*.mjs`` (a runtime-computed URL the HTML root-path
+    rewrite never sees). Those files are public frontend bundles — the same
+    ones already served (and bypassed) under ``/chainlit/assets`` — so serving
+    them at ``/assets`` lets the module worker load with a JS MIME type instead
+    of a 403 JSON body that breaks source PDF previews.
     """
     cfg = bypass_config or _DEFAULT_BYPASS_CONFIG
-    return path in cfg.bypass_paths or path == "/chainlit" or path.startswith("/chainlit/")
+    return path in cfg.bypass_paths or path == "/chainlit" or path.startswith(("/chainlit/", "/assets/"))
 
 
 def _allow_no_auth() -> bool:

--- a/openrag/api/routers/user/download.py
+++ b/openrag/api/routers/user/download.py
@@ -8,6 +8,7 @@ stored ``source`` path and confines it to ``DATA_DIR``. The URL lives under
 ``/static`` so the middleware's browser ``?token=`` access works the same way.
 """
 
+import mimetypes
 from pathlib import Path
 
 from api.dependencies.auth import current_user_or_admin_partitions_list
@@ -62,4 +63,27 @@ async def download_source(
         log.warning("Resolved source path is outside DATA_DIR or missing.")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found.")
 
-    return FileResponse(file_path, filename=file_path.name)
+    # Serve inline (not as an attachment) so browser viewers can render the
+    # source in place — the Chainlit source preview embeds this URL in cl.Pdf /
+    # cl.Image / cl.Video / cl.Audio elements, which display the resource rather
+    # than download it. FileResponse defaults to ``Content-Disposition:
+    # attachment`` when ``filename`` is set, which makes the browser download the
+    # file and leaves the PDF viewer with nothing to render ("Failed to load PDF
+    # file"). ``filename`` is kept so a manual "Save as" still gets a sane name.
+    #
+    # FileResponse already infers the Content-Type from ``filename`` (guess_type),
+    # so we don't set media_type here — we only need the guessed type to choose the
+    # disposition. Restrict inline rendering to media types that cannot execute
+    # script in the app's origin: HTML / SVG / etc. stay ``attachment`` so a crafted
+    # indexed file can't turn this same-origin route into a stored-XSS vector.
+    media_type, _ = mimetypes.guess_type(file_path.name)
+    inline_ok = bool(media_type) and (
+        media_type == "application/pdf"
+        or media_type.startswith(("audio/", "video/"))
+        or (media_type.startswith("image/") and media_type != "image/svg+xml")
+    )
+    return FileResponse(
+        file_path,
+        filename=file_path.name,
+        content_disposition_type="inline" if inline_ok else "attachment",
+    )

--- a/openrag/api/routers/user/download.py
+++ b/openrag/api/routers/user/download.py
@@ -82,8 +82,15 @@ async def download_source(
         or media_type.startswith(("audio/", "video/"))
         or (media_type.startswith("image/") and media_type != "image/svg+xml")
     )
+    # ``X-Content-Type-Options: nosniff`` stops the browser from MIME-sniffing
+    # the body into a type other than the one we declare. Since this route serves
+    # some files inline and the Content-Type is only inferred from the filename,
+    # nosniff ensures a mislabeled file can't be reinterpreted as an executable
+    # type (e.g. HTML/JS) in the app's origin — defense-in-depth alongside the
+    # attachment fallback for HTML/SVG above.
     return FileResponse(
         file_path,
         filename=file_path.name,
         content_disposition_type="inline" if inline_ok else "attachment",
+        headers={"X-Content-Type-Options": "nosniff"},
     )

--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 
 from api.chainlit_assets import mount_chainlit_root_assets
 from api.middleware.auth import AuthMiddleware
+from api.middleware.request_id import RequestIdMiddleware
 from api.routers.user.download import router as download_router
 from chainlit.utils import mount_chainlit
 from core.config import load_config
@@ -79,6 +80,15 @@ app.add_middleware(
     AuthMiddleware,
     get_auth_service=_get_auth_service,
 )
+# AuthMiddleware's ``/static`` branch authenticates via the ``?token=`` query
+# param, but it reads it from ``request.state.original_token`` — which only
+# RequestIdMiddleware populates (it stashes the raw token there before redacting
+# the query string for logs). The mounted deployment (``api.main``) registers
+# this; without it here, source-file downloads on this standalone origin see no
+# token and 403 with "Missing token" (the Ray Serve source-preview failure).
+# Registered after AuthMiddleware so it wraps it — i.e. runs first and sets
+# ``original_token`` before auth reads it (add_middleware adds outermost-last).
+app.add_middleware(RequestIdMiddleware)
 
 # Ray Serve mode runs the API and Chainlit on separate ports. Source previews
 # rewrite their file download links to the browser origin (the Chainlit host),

--- a/openrag/chainlit_api.py
+++ b/openrag/chainlit_api.py
@@ -17,6 +17,7 @@ the crash only surfaced under ``AUTH_MODE=oidc``.
 
 from contextlib import asynccontextmanager
 
+from api.chainlit_assets import mount_chainlit_root_assets
 from api.middleware.auth import AuthMiddleware
 from api.routers.user.download import router as download_router
 from chainlit.utils import mount_chainlit
@@ -88,3 +89,8 @@ app.add_middleware(
 app.include_router(download_router)
 
 mount_chainlit(app=app, target="./app_front.py", path="/chainlit")
+
+# Ray Serve mode serves this standalone Chainlit app on its own origin, so it
+# must also expose Chainlit's root-absolute pdf.js worker at /assets — the same
+# separate-origin reason the /static download route is replicated above.
+mount_chainlit_root_assets(app)


### PR DESCRIPTION
## Summary

Source **PDF previews in the Chainlit chat side panel were broken** — clicking a source rendered **"Failed to load PDF file"** even though the document was indexed and retrievable. This turned out to be **two independent bugs**; fixing only one is not enough.

| Symptom | Root cause |
| --- | --- |
| The PDF panel shows *"Failed to load PDF file"* and the PDF is **never even fetched** | react-pdf's **pdf.js worker** can't load — it's requested at the origin-root `/assets/…` which isn't auth-bypassed → `403 application/json` → the browser blocks the module worker on a forbidden MIME type |
| Even with the worker loading, the byte stream would download instead of display | `/static/{chunk_id}` served the file as `Content-Disposition: attachment` (a download), not `inline` |

The browser console made the primary cause explicit:

> Loading the worker at `http://<host>/assets/pdf.worker.min-*.mjs` was blocked due to a forbidden MIME type (**"application/json"**).

---

## Root cause

Chainlit is sub-mounted at `/chainlit`, and its HTML asset references are rewritten to `/chainlit/assets/*`. But react-pdf computes its worker URL **at runtime in JS** as the **origin-root** `/assets/pdf.worker*.mjs` — the HTML root-path rewrite never sees it, so it misses the `/chainlit` prefix and lands on a path that isn't auth-bypassed.

### Before — the worker request is rejected

```mermaid
sequenceDiagram
    participant B as Browser<br/>(Chainlit UI @ /chainlit)
    participant A as OpenRag API

    Note over B: react-pdf boots its pdf.js worker
    B->>A: GET /assets/pdf.worker.min-*.mjs
    Note over A: /assets is NOT under the<br/>/chainlit auth bypass,<br/>and nothing serves it
    A-->>B: 403 {"detail":"Missing token"}<br/>Content-Type: application/json
    Note over B: module worker blocked —<br/>forbidden MIME "application/json"
    Note over B: ❌ "Failed to load PDF file"<br/>(the PDF /static request never happens)
```

### After — the worker (and the PDF) load

```mermaid
sequenceDiagram
    participant B as Browser<br/>(Chainlit UI @ /chainlit)
    participant A as OpenRag API

    B->>A: GET /assets/pdf.worker.min-*.mjs
    Note over A: /assets/* bypassed in auth +<br/>StaticFiles mount serves the file
    A-->>B: 200 Content-Type: application/javascript
    Note over B: pdf.js worker starts ✅
    B->>A: GET /static/{chunk_id}?token=… (Range)
    Note over A: FileResponse, Content-Disposition: inline
    A-->>B: 206 Partial Content · application/pdf
    Note over B: ✅ PDF renders in the side panel
```

---

## Changes

**`openrag/api/main.py`** — serve Chainlit's frontend asset dir at the origin-root `/assets` too (in addition to `/chainlit/assets`), so the runtime-computed worker URL resolves with a JavaScript MIME type.

**`openrag/api/middleware/auth.py`** — bypass `/assets/*` in `AuthMiddleware`. These are public frontend bundles — the same files already served (and already bypassed) under `/chainlit/assets` — so the module worker gets `application/javascript` instead of a `403 application/json`.

**`openrag/api/routers/user/download.py`** — serve `/static/{chunk_id}` **inline** for safe previewable media types (PDF / image / audio / video) so the viewers render in place. `FileResponse` defaults to `attachment` when `filename` is set. HTML / SVG deliberately stay `attachment` so a crafted indexed file can't turn this same-origin route into a stored-XSS vector.

> Note: the two `/assets` changes are a pair — the `main.py` mount **serves** the file (turns `404`→`200`), the `auth.py` bypass **lets the request reach** it (turns `403`→ reaches the mount). Removing either regresses the preview.

---

## Verification

Fresh request (no browser cache), against a running stack:

| Request | Before | After |
| --- | --- | --- |
| `GET /assets/pdf.worker.min-*.mjs` | `403 application/json` (worker blocked) | **`200 application/javascript`** |
| `GET /static/{chunk_id}?token=…` | `200 … attachment` (download) | **`inline · application/pdf`** (renders); range fetches return `206` |
| Path traversal on the new mount (`/assets/../…`) | — | blocked (`403` / `404`) |

Confirmed end-to-end in a **private/incognito tab** (no cache): the source PDF now renders in the Chainlit side panel.

- `ruff check` clean on all three files.
- `pytest tests/unit/api/routers/user/test_download.py` — passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Chainlit UI asset delivery by serving required frontend/static files from the root `/assets` path (including the pdf.js worker).

* **Bug Fixes**
  * Prevented public asset requests from being blocked by expanding the authentication bypass to include `/assets/`.
  * Fixed standalone source downloads by restoring the correct request-token context.

* **Security / Improvements**
  * Updated static file downloads to be more browser-safe: only previewable MIME types render inline; others download as attachments, and responses now include `nosniff`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->