### PR TITLE
fix(admin-ui): clarify self-service partition creation

### DIFF
--- a/ui/src/pages/admin/overview.test.tsx
+++ b/ui/src/pages/admin/overview.test.tsx
@@ -5,21 +5,36 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import OverviewPage from "./overview";
 
-const queryData = vi.hoisted(() => ({
-  partitions: [
-    {
+type TestPartition = {
+  partition: string;
+  name: string;
+  role: string;
+  document_count: number;
+  created_at: string;
+};
+
+const makePartition = vi.hoisted(
+  () =>
+    (overrides: Partial<TestPartition> = {}): TestPartition => ({
       partition: "shared-docs",
       name: "Shared docs display name",
       role: "viewer",
       document_count: 3,
       created_at: "2026-01-01T00:00:00Z",
-    },
-  ],
+      ...overrides,
+    }),
+);
+const queryData = vi.hoisted(() => ({
+  partitions: [makePartition()],
   isError: false,
   isLoading: false,
 }));
 const permissions = vi.hoisted(() => ({
   canCreatePartition: true,
+  canManagePartitions: false,
+}));
+const authUser = vi.hoisted(() => ({
+  is_admin: false,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -51,7 +66,7 @@ vi.mock("@/lib/auth", () => ({
     user: {
       id: 2,
       display_name: "Viewer",
-      is_admin: false,
+      is_admin: authUser.is_admin,
       file_quota: 10,
       file_count: 0,
     },
@@ -62,6 +77,7 @@ vi.mock("@/lib/permissions", () => ({
   usePermissions: () => ({
     canManageUsers: false,
     canViewSystem: false,
+    canManagePartitions: permissions.canManagePartitions,
     canCreatePartition: permissions.canCreatePartition,
     canWrite: (role: string | null | undefined) => role === "editor" || role === "owner",
   }),
@@ -71,17 +87,61 @@ describe("OverviewPage quick actions", () => {
   beforeEach(() => {
     sessionStorage.clear();
     permissions.canCreatePartition = true;
+    permissions.canManagePartitions = false;
+    authUser.is_admin = false;
     queryData.isError = false;
     queryData.isLoading = false;
-    queryData.partitions = [
-      {
-        partition: "shared-docs",
-        name: "Shared docs display name",
-        role: "viewer",
-        document_count: 3,
-        created_at: "2026-01-01T00:00:00Z",
-      },
-    ];
+    queryData.partitions = [makePartition()];
+  });
+
+  it("describes partition creation as self-service for normal users", () => {
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Create Personal Partition")).not.toBeNull();
+    expect(screen.getByText("Create a personal partition for your documents")).not.toBeNull();
+  });
+
+  it("keeps the management create partition wording general", () => {
+    permissions.canManagePartitions = true;
+    authUser.is_admin = true;
+
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Create Partition")).not.toBeNull();
+    expect(screen.getByText("Set up a new document partition")).not.toBeNull();
+    expect(screen.queryByText("Create Personal Partition")).toBeNull();
+    expect(screen.queryByText("Your file quota")).toBeNull();
+  });
+
+  it("updates create partition wording when management permission resolves", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Create Personal Partition")).not.toBeNull();
+
+    permissions.canManagePartitions = true;
+    authUser.is_admin = true;
+
+    rerender(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Create Partition")).not.toBeNull();
+    expect(screen.getByText("Set up a new document partition")).not.toBeNull();
+    expect(screen.queryByText("Create Personal Partition")).toBeNull();
   });
 
   it("keeps one upload action and explains when no writable partition exists", async () => {
@@ -106,20 +166,17 @@ describe("OverviewPage quick actions", () => {
 
   it("keeps upload available when the user has a writable partition", () => {
     queryData.partitions = [
-      {
+      makePartition({
         partition: "shared-docs",
         name: "Shared docs display name",
         role: "viewer",
-        document_count: 3,
-        created_at: "2026-01-01T00:00:00Z",
-      },
-      {
+      }),
+      makePartition({
         partition: "team-upload",
         name: "Team upload display name",
         role: "editor",
         document_count: 0,
-        created_at: "2026-01-01T00:00:00Z",
-      },
+      }),
     ];
 
     render(
@@ -136,20 +193,18 @@ describe("OverviewPage quick actions", () => {
   it("prefers the remembered partition when it is writable", () => {
     sessionStorage.setItem("documents.partition", "remembered-upload");
     queryData.partitions = [
-      {
+      makePartition({
         partition: "first-upload",
         name: "First writable display name",
         role: "editor",
         document_count: 0,
-        created_at: "2026-01-01T00:00:00Z",
-      },
-      {
+      }),
+      makePartition({
         partition: "remembered-upload",
         name: "Remembered writable display name",
         role: "owner",
         document_count: 0,
-        created_at: "2026-01-01T00:00:00Z",
-      },
+      }),
     ];
 
     render(

--- a/ui/src/pages/admin/overview.tsx
+++ b/ui/src/pages/admin/overview.tsx
@@ -132,7 +132,13 @@ function RecentTasks({ isLoading, tasks }: { isLoading: boolean; tasks: TaskList
 }
 
 export default function OverviewPage() {
-  const { canManageUsers, canViewSystem, canCreatePartition, canWrite } = usePermissions();
+  const {
+    canManageUsers,
+    canViewSystem,
+    canManagePartitions,
+    canCreatePartition,
+    canWrite,
+  } = usePermissions();
   const [uploadHelpOpen, setUploadHelpOpen] = useState(false);
   const [rememberedPartition] = useState(() => sessionStorage.getItem("documents.partition") || "");
 
@@ -178,6 +184,10 @@ export default function OverviewPage() {
   const quotaIndexed = me?.file_count ?? 0;
   const quotaEff: number | "unlimited" =
     me?.file_quota == null || me.file_quota < 0 ? "unlimited" : me.file_quota;
+  const createPartitionLabel = canManagePartitions ? "Create Partition" : "Create Personal Partition";
+  const createPartitionDescription = canManagePartitions
+    ? "Set up a new document partition"
+    : "Create a personal partition for your documents";
   const writablePartitions = partitions.filter((partition) => canWrite(partition.role));
   const rememberedWritablePartition = writablePartitions.find(
     (partition) => partition.partition === rememberedPartition || partition.name === rememberedPartition,
@@ -300,9 +310,9 @@ export default function OverviewPage() {
                   <Link to="/partitions?create=1">
                     <Plus className="h-4 w-4 mr-2" />
                     <div className="text-left">
-                      <div className="font-medium">Create Partition</div>
+                      <div className="font-medium">{createPartitionLabel}</div>
                       <div className="text-xs text-muted-foreground">
-                        Set up a new document partition
+                        {createPartitionDescription}
                       </div>
                     </div>
                     <ArrowRight className="h-4 w-4 ml-auto" />

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PartitionListPage from "./list";
+
+const permissions = vi.hoisted(() => ({
+  canManagePartitions: false,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  usePermissions: () => permissions,
+}));
+vi.mock("@/lib/api/partitions", () => ({
+  listPartitions: vi.fn().mockResolvedValue({ partitions: [] }),
+  createPartition: vi.fn(),
+  deletePartition: vi.fn(),
+}));
+vi.mock("@/lib/api/presets", () => ({
+  listPresets: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/api/models", () => ({
+  listModelEndpoints: vi.fn().mockResolvedValue([]),
+  validateStoredModelEndpoint: vi.fn(),
+  pickDefaultEndpoint: vi.fn().mockReturnValue(null),
+  resolveEmbedderName: vi.fn().mockReturnValue("default"),
+}));
+
+function renderPartitions() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PartitionListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("PartitionListPage create partition copy", () => {
+  beforeEach(() => {
+    permissions.canManagePartitions = false;
+  });
+
+  it("describes create partition as a personal self-service action for normal users", async () => {
+    renderPartitions();
+
+    expect(screen.getByRole("button", { name: /create personal partition/i })).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /create personal partition/i }));
+
+    expect(screen.getByRole("heading", { name: /create personal partition/i })).not.toBeNull();
+    expect(
+      screen.getByText(
+        "Create a personal document partition. You will be the owner and can upload documents to it.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("keeps the admin create dialog wording general", async () => {
+    permissions.canManagePartitions = true;
+
+    renderPartitions();
+
+    expect(screen.getByRole("button", { name: /^create partition$/i })).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /^create partition$/i }));
+
+    expect(screen.getByRole("heading", { name: /^create partition$/i })).not.toBeNull();
+    expect(screen.getByText("Create a new document partition with its configuration.")).not.toBeNull();
+    expect(screen.queryByText("Create Personal Partition")).toBeNull();
+  });
+});

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -303,6 +303,11 @@ export default function PartitionListPage() {
     createMutation.mutate();
   };
 
+  const createPartitionLabel = canManagePartitions ? "Create Partition" : "Create Personal Partition";
+  const createPartitionDescription = canManagePartitions
+    ? "Create a new document partition with its configuration."
+    : "Create a personal document partition. You will be the owner and can upload documents to it.";
+
   return (
     <div>
       <PageHeader
@@ -310,7 +315,7 @@ export default function PartitionListPage() {
         description={canManagePartitions ? "Manage document partitions and their configurations" : "Your assigned document partitions"}
         actions={
           <Button onClick={() => setDialogOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" /> Create Partition
+            <Plus className="mr-2 h-4 w-4" /> {createPartitionLabel}
           </Button>
         }
       />
@@ -434,9 +439,9 @@ export default function PartitionListPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Create Partition</DialogTitle>
+            <DialogTitle>{createPartitionLabel}</DialogTitle>
             <DialogDescription>
-              Create a new document partition with its configuration.
+              {createPartitionDescription}
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary

This clarifies that partition creation is an intended self-service action for regular users, not an admin-only control leaking into their UI.

Normal users now see personal-partition wording in the quick action and create dialog. Admins keep the broader partition-management wording.

Closes #599

## Validation

- UI tests passed
- UI build passed
- Manual Playwright smoke check passed for a normal user and an admin

Known note: the existing local dev warning about the parent Astro tsconfig still appears, but it does not block the UI build or tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated admin quick actions and “create partition” UI copy to be permission-aware, showing the correct titles/descriptions for admins vs non-admins and matching the create dialog content accordingly.

* **Tests**
  * Expanded end-to-end UI test coverage for the admin overview and partitions list to verify permission-specific quick action/button/dialog wording, including upload-guidance visibility and availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->