### PR TITLE
fix(admin): redact saved model endpoint secrets

### DIFF
--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -327,9 +327,10 @@ def get_config():
     instead of assuming every admin has partition access.
     """
     from api.dependencies.auth import SUPER_ADMIN_MODE
+    from core.utils.redaction import redact_secrets
     from fastapi.encoders import jsonable_encoder
 
-    return {**jsonable_encoder(settings), "super_admin_mode": SUPER_ADMIN_MODE}
+    return {**redact_secrets(jsonable_encoder(settings)), "super_admin_mode": SUPER_ADMIN_MODE}
 
 
 # Router mounts. Phase 10F finished moving these into

--- a/openrag/api/routers/admin/model_endpoints.py
+++ b/openrag/api/routers/admin/model_endpoints.py
@@ -18,10 +18,12 @@ from api.schemas.admin.model_endpoint_schemas import (
     ValidateEndpointResponse,
 )
 from core.config.model_endpoints import ModelEndpointRow
+from core.utils.logging import get_logger
 from di.providers import get_model_endpoint_service
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 
 router = APIRouter(dependencies=[Depends(require_admin)])
+logger = get_logger()
 
 
 def _same_endpoint_url(left: str, right: str) -> bool:
@@ -112,6 +114,11 @@ async def reveal_model_endpoint_api_key(
     """Return the stored API key only after an explicit admin reveal action."""
     endpoint = await service.get_model_endpoint(name=name, model_type=model_type)
     api_key = endpoint.extra.get("api_key")
+    logger.bind(
+        model_type=model_type,
+        name=name,
+        has_api_key=isinstance(api_key, str),
+    ).info("Model endpoint API key revealed.")
     return {"api_key": api_key if isinstance(api_key, str) else None}
 
 

--- a/openrag/api/routers/admin/model_endpoints.py
+++ b/openrag/api/routers/admin/model_endpoints.py
@@ -12,15 +12,21 @@ from api.schemas.admin.model_endpoint_schemas import (
     CreateModelEndpointRequest,
     ModelEndpointResponse,
     ModelEndpointType,
+    RevealApiKeyResponse,
     UpdateModelEndpointRequest,
     ValidateEndpointRequest,
     ValidateEndpointResponse,
 )
 from core.config.model_endpoints import ModelEndpointRow
 from di.providers import get_model_endpoint_service
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 
 router = APIRouter(dependencies=[Depends(require_admin)])
+
+
+def _same_endpoint_url(left: str, right: str) -> bool:
+    """Compare endpoint URLs after the schema-level normalization rules."""
+    return left.strip().rstrip("/") == right.strip().rstrip("/")
 
 
 @router.post(
@@ -97,6 +103,18 @@ async def set_default_model_endpoint(
     return await service.get_model_endpoint(name=name, model_type=model_type)
 
 
+@router.post("/{model_type}/{name}/reveal-api-key", response_model=RevealApiKeyResponse)
+async def reveal_model_endpoint_api_key(
+    model_type: ModelEndpointType,
+    name: str,
+    service=Depends(get_model_endpoint_service),
+):
+    """Return the stored API key only after an explicit admin reveal action."""
+    endpoint = await service.get_model_endpoint(name=name, model_type=model_type)
+    api_key = endpoint.extra.get("api_key")
+    return {"api_key": api_key if isinstance(api_key, str) else None}
+
+
 @router.post("/validate", response_model=ValidateEndpointResponse)
 async def validate_endpoint_draft(
     body: ValidateEndpointRequest,
@@ -110,6 +128,11 @@ async def validate_endpoint_draft(
             name=body.stored_api_key_name,
             model_type=body.stored_api_key_model_type,
         )
+        if not _same_endpoint_url(body.endpoint, endpoint.endpoint):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Stored API key can only be reused with its saved endpoint URL.",
+            )
         api_key = endpoint.extra.get("api_key")
     return await service.validate_endpoint(
         url=body.endpoint,

--- a/openrag/api/routers/admin/model_endpoints.py
+++ b/openrag/api/routers/admin/model_endpoints.py
@@ -104,10 +104,17 @@ async def validate_endpoint_draft(
 ):
     """Probe arbitrary endpoint values (before they are saved) for reachability
     and model availability."""
+    api_key = body.api_key
+    if api_key is None and body.stored_api_key_model_type and body.stored_api_key_name:
+        endpoint = await service.get_model_endpoint(
+            name=body.stored_api_key_name,
+            model_type=body.stored_api_key_model_type,
+        )
+        api_key = endpoint.extra.get("api_key")
     return await service.validate_endpoint(
         url=body.endpoint,
         model_name=body.model_name,
-        api_key=body.api_key,
+        api_key=api_key,
     )
 
 

--- a/openrag/api/schemas/admin/model_endpoint_schemas.py
+++ b/openrag/api/schemas/admin/model_endpoint_schemas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
+from core.utils.redaction import redact_secret_mapping
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ModelEndpointType = Literal["embedder", "reranker", "llm", "vlm"]
@@ -98,9 +99,24 @@ class ModelEndpointResponse(BaseModel):
     batch_size: int
     timeout: float
     extra: dict[str, Any]
+    has_api_key: bool = False
     is_default: bool
     created_at: datetime
     updated_at: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def redact_secret_extra(cls, value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            data = value.model_dump()
+        elif isinstance(value, dict):
+            data = dict(value)
+        else:
+            data = dict(value)
+        extra = dict(data.get("extra") or {})
+        data["has_api_key"] = bool(extra.get("api_key"))
+        data["extra"] = redact_secret_mapping(extra)
+        return data
 
 
 class ValidateEndpointRequest(BaseModel):
@@ -109,6 +125,23 @@ class ValidateEndpointRequest(BaseModel):
     endpoint: str
     model_name: str | None = None
     api_key: str | None = None
+    stored_api_key_model_type: ModelEndpointType | None = None
+    stored_api_key_name: str | None = None
+
+    @field_validator("stored_api_key_name")
+    @classmethod
+    def validate_stored_api_key_name(cls, value: str | None) -> str | None:
+        """Normalize the optional saved endpoint name used as credential source."""
+        return _normalize_name(value) if value is not None else None
+
+    @model_validator(mode="after")
+    def require_complete_stored_api_key_source(self) -> ValidateEndpointRequest:
+        """Require both fields when draft validation reuses a stored key."""
+        has_type = self.stored_api_key_model_type is not None
+        has_name = self.stored_api_key_name is not None
+        if has_type != has_name:
+            raise ValueError("stored_api_key_model_type and stored_api_key_name must be provided together")
+        return self
 
 
 class ValidateEndpointResponse(BaseModel):

--- a/openrag/api/schemas/admin/model_endpoint_schemas.py
+++ b/openrag/api/schemas/admin/model_endpoint_schemas.py
@@ -128,6 +128,12 @@ class ValidateEndpointRequest(BaseModel):
     stored_api_key_model_type: ModelEndpointType | None = None
     stored_api_key_name: str | None = None
 
+    @field_validator("endpoint")
+    @classmethod
+    def validate_endpoint(cls, value: str) -> str:
+        """Normalize the draft endpoint URL before probing it."""
+        return _normalize_endpoint(value)
+
     @field_validator("stored_api_key_name")
     @classmethod
     def validate_stored_api_key_name(cls, value: str | None) -> str | None:
@@ -153,10 +159,17 @@ class ValidateEndpointResponse(BaseModel):
     detail: str | None = None
 
 
+class RevealApiKeyResponse(BaseModel):
+    """Response body for explicitly revealing a stored endpoint API key."""
+
+    api_key: str | None = None
+
+
 __all__ = [
     "CreateModelEndpointRequest",
     "ModelEndpointResponse",
     "ModelEndpointType",
+    "RevealApiKeyResponse",
     "UpdateModelEndpointRequest",
     "ValidateEndpointRequest",
     "ValidateEndpointResponse",

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -1,0 +1,92 @@
+"""Helpers for shaping public data without exposing secrets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+REDACTED_SECRET = "<redacted>"
+
+SECRET_FIELD_NAMES = frozenset(
+    {
+        "api_key",
+        "api_token",
+        "auth_token",
+        "chainlit_auth_secret",
+        "client_secret",
+        "hf_token",
+        "oidc_client_secret",
+        "oidc_token_encryption_key",
+        "password",
+        "secret",
+        "secret_key",
+        "token",
+        "token_encryption_key",
+    }
+)
+
+
+def is_secret_field(key: str) -> bool:
+    """Return true only for known secret field names, not fuzzy token matches."""
+    return key.lower() in SECRET_FIELD_NAMES
+
+
+def redact_secrets(value: Any) -> Any:
+    """Recursively redact values for known secret fields without mutating input."""
+    if isinstance(value, Mapping):
+        return {
+            key: REDACTED_SECRET if is_secret_field(str(key)) else redact_secrets(item) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_secrets(item) for item in value)
+    return value
+
+
+def redact_secret_mapping(extra: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Drop secret fields from endpoint extras while preserving non-secret metadata."""
+    return {key: redact_secrets(item) for key, item in dict(extra or {}).items() if not is_secret_field(str(key))}
+
+
+def preserve_existing_secrets(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep stored secrets when an update payload omits or echoes a redacted value."""
+    return _preserve_existing_secrets(existing or {}, incoming)
+
+
+def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(incoming)
+    for key, value in existing.items():
+        incoming_value = merged.get(key)
+        if is_secret_field(str(key)):
+            if key not in merged or incoming_value == REDACTED_SECRET:
+                merged[key] = value
+            continue
+        if isinstance(value, Mapping) and isinstance(incoming_value, Mapping):
+            merged[key] = _preserve_existing_secrets(value, incoming_value)
+        elif isinstance(value, list) and isinstance(incoming_value, list):
+            merged[key] = _preserve_existing_secret_lists(value, incoming_value)
+    return merged
+
+
+def _preserve_existing_secret_lists(existing: list[Any], incoming: list[Any]) -> list[Any]:
+    merged = list(incoming)
+    for index, existing_item in enumerate(existing):
+        if index >= len(merged):
+            break
+        incoming_item = merged[index]
+        if isinstance(existing_item, Mapping) and isinstance(incoming_item, Mapping):
+            merged[index] = _preserve_existing_secrets(existing_item, incoming_item)
+        elif isinstance(existing_item, list) and isinstance(incoming_item, list):
+            merged[index] = _preserve_existing_secret_lists(existing_item, incoming_item)
+    return merged
+
+
+__all__ = [
+    "REDACTED_SECRET",
+    "SECRET_FIELD_NAMES",
+    "is_secret_field",
+    "preserve_existing_secrets",
+    "redact_secret_mapping",
+    "redact_secrets",
+]

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -71,8 +71,7 @@ def redact_secrets(value: Any) -> Any:
     """Recursively redact values for known secret fields without mutating input."""
     if isinstance(value, Mapping):
         return {
-            key: REDACTED_SECRET if is_secret_field(str(key)) else redact_secrets(item)
-            for key, item in value.items()
+            key: REDACTED_SECRET if is_secret_field(str(key)) else redact_secrets(item) for key, item in value.items()
         }
     if isinstance(value, list):
         return [redact_secrets(item) for item in value]

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -71,7 +71,7 @@ def redact_secrets(value: Any) -> Any:
     """Recursively redact values for known secret fields without mutating input."""
     if isinstance(value, Mapping):
         return {
-            key: mask_secret_value(item) if is_secret_field(str(key)) else redact_secrets(item)
+            key: REDACTED_SECRET if is_secret_field(str(key)) else redact_secrets(item)
             for key, item in value.items()
         }
     if isinstance(value, list):

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -82,13 +82,19 @@ def redact_secrets(value: Any) -> Any:
 
 def redact_secret_mapping(extra: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return the public model-endpoint extra shape shown in Admin UI."""
-    source = dict(extra or {})
-    redacted: dict[str, Any] = {}
-    if "api_key" in source:
-        redacted["api_key"] = mask_secret_value(source.get("api_key"))
-    if "implementation" in source:
-        redacted["implementation"] = source["implementation"]
-    return redacted
+    return _redact_endpoint_extra(dict(extra or {}))
+
+
+def _redact_endpoint_extra(value: Any, key: str | None = None) -> Any:
+    if key is not None and is_secret_field(key):
+        return mask_secret_value(value)
+    if isinstance(value, Mapping):
+        return {entry_key: _redact_endpoint_extra(item, str(entry_key)) for entry_key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_endpoint_extra(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_endpoint_extra(item) for item in value)
+    return value
 
 
 def preserve_existing_secrets(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict[str, Any]:

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -67,6 +67,11 @@ def is_masked_secret_value(value: Any) -> bool:
     )
 
 
+def is_clear_secret_value(value: Any) -> bool:
+    """Return true when an update explicitly clears a stored secret."""
+    return value is None or value == ""
+
+
 def redact_secrets(value: Any) -> Any:
     """Recursively redact values for known secret fields without mutating input."""
     if isinstance(value, Mapping):
@@ -107,6 +112,9 @@ def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[st
     for key, value in existing.items():
         incoming_value = merged.get(key)
         if is_secret_field(str(key)):
+            if key in merged and is_clear_secret_value(incoming_value):
+                merged.pop(key, None)
+                continue
             if key not in merged or incoming_value == REDACTED_SECRET or is_masked_secret_value(incoming_value):
                 merged[key] = value
             continue
@@ -114,6 +122,9 @@ def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[st
             merged[key] = _preserve_existing_secrets(value, incoming_value)
         elif isinstance(value, list) and isinstance(incoming_value, list):
             merged[key] = _preserve_existing_secret_lists(value, incoming_value)
+    for key, value in list(merged.items()):
+        if is_secret_field(str(key)) and is_clear_secret_value(value):
+            merged.pop(key, None)
     return merged
 
 
@@ -135,6 +146,7 @@ __all__ = [
     "SECRET_FIELD_NAMES",
     "is_masked_secret_value",
     "is_secret_field",
+    "is_clear_secret_value",
     "mask_secret_value",
     "preserve_existing_secrets",
     "redact_secret_mapping",

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -72,6 +72,11 @@ def is_clear_secret_value(value: Any) -> bool:
     return value is None or value == ""
 
 
+def is_secret_placeholder_value(value: Any) -> bool:
+    """Return true for redacted values that should never be stored as secrets."""
+    return value == REDACTED_SECRET or is_masked_secret_value(value)
+
+
 def redact_secrets(value: Any) -> Any:
     """Recursively redact values for known secret fields without mutating input."""
     if isinstance(value, Mapping):
@@ -115,7 +120,7 @@ def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[st
             if key in merged and is_clear_secret_value(incoming_value):
                 merged.pop(key, None)
                 continue
-            if key not in merged or incoming_value == REDACTED_SECRET or is_masked_secret_value(incoming_value):
+            if key not in merged or is_secret_placeholder_value(incoming_value):
                 merged[key] = value
             continue
         if isinstance(value, Mapping) and isinstance(incoming_value, Mapping):
@@ -123,22 +128,78 @@ def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[st
         elif isinstance(value, list) and isinstance(incoming_value, list):
             merged[key] = _preserve_existing_secret_lists(value, incoming_value)
     for key, value in list(merged.items()):
-        if is_secret_field(str(key)) and is_clear_secret_value(value):
+        if is_secret_field(str(key)) and (is_clear_secret_value(value) or is_secret_placeholder_value(value)):
             merged.pop(key, None)
     return merged
 
 
 def _preserve_existing_secret_lists(existing: list[Any], incoming: list[Any]) -> list[Any]:
-    merged = list(incoming)
-    for index, existing_item in enumerate(existing):
-        if index >= len(merged):
-            break
-        incoming_item = merged[index]
-        if isinstance(existing_item, Mapping) and isinstance(incoming_item, Mapping):
-            merged[index] = _preserve_existing_secrets(existing_item, incoming_item)
-        elif isinstance(existing_item, list) and isinstance(incoming_item, list):
-            merged[index] = _preserve_existing_secret_lists(existing_item, incoming_item)
+    if len(existing) == 1 and len(incoming) == 1:
+        return [_preserve_existing_list_item(existing[0], incoming[0])]
+
+    remaining_existing = list(existing)
+    merged: list[Any] = []
+    for incoming_item in incoming:
+        match_index = _find_matching_secret_list_item(remaining_existing, incoming_item)
+        if match_index is None:
+            merged.append(_drop_unbacked_secret_placeholders(incoming_item))
+            continue
+        existing_item = remaining_existing.pop(match_index)
+        merged.append(_preserve_existing_list_item(existing_item, incoming_item))
     return merged
+
+
+def _preserve_existing_list_item(existing_item: Any, incoming_item: Any) -> Any:
+    if isinstance(existing_item, Mapping) and isinstance(incoming_item, Mapping):
+        return _preserve_existing_secrets(existing_item, incoming_item)
+    if isinstance(existing_item, list) and isinstance(incoming_item, list):
+        return _preserve_existing_secret_lists(existing_item, incoming_item)
+    return incoming_item
+
+
+def _find_matching_secret_list_item(existing: list[Any], incoming_item: Any) -> int | None:
+    incoming_identity = _non_secret_identity(incoming_item)
+    if not _has_non_secret_identity(incoming_identity):
+        return None
+    matches = [
+        index
+        for index, existing_item in enumerate(existing)
+        if _non_secret_identity(existing_item) == incoming_identity
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _non_secret_identity(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _non_secret_identity(item) for key, item in value.items() if not is_secret_field(str(key))}
+    if isinstance(value, list):
+        return [_non_secret_identity(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_non_secret_identity(item) for item in value)
+    return value
+
+
+def _has_non_secret_identity(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(_has_non_secret_identity(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_non_secret_identity(item) for item in value)
+    return True
+
+
+def _drop_unbacked_secret_placeholders(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        cleaned: dict[Any, Any] = {}
+        for key, item in value.items():
+            if is_secret_field(str(key)) and (is_clear_secret_value(item) or is_secret_placeholder_value(item)):
+                continue
+            cleaned[key] = _drop_unbacked_secret_placeholders(item)
+        return cleaned
+    if isinstance(value, list):
+        return [_drop_unbacked_secret_placeholders(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_drop_unbacked_secret_placeholders(item) for item in value)
+    return value
 
 
 __all__ = [
@@ -147,6 +208,7 @@ __all__ = [
     "is_masked_secret_value",
     "is_secret_field",
     "is_clear_secret_value",
+    "is_secret_placeholder_value",
     "mask_secret_value",
     "preserve_existing_secrets",
     "redact_secret_mapping",

--- a/openrag/core/utils/redaction.py
+++ b/openrag/core/utils/redaction.py
@@ -6,11 +6,15 @@ from collections.abc import Mapping
 from typing import Any
 
 REDACTED_SECRET = "<redacted>"
+MASK_SUFFIX = "********"
+MASK_PREFIX_LENGTH = 3
+MIN_PREFIX_MASK_LENGTH = 8
 
 SECRET_FIELD_NAMES = frozenset(
     {
         "api_key",
         "api_token",
+        "access_key",
         "auth_token",
         "chainlit_auth_secret",
         "client_secret",
@@ -18,24 +22,57 @@ SECRET_FIELD_NAMES = frozenset(
         "oidc_client_secret",
         "oidc_token_encryption_key",
         "password",
+        "private_key",
+        "refresh_token",
         "secret",
         "secret_key",
+        "signing_key",
         "token",
         "token_encryption_key",
+    }
+)
+SECRET_FIELD_SUFFIXES = frozenset(
+    {
+        "_access_key",
+        "_api_key",
+        "_auth_token",
+        "_password",
+        "_private_key",
+        "_refresh_token",
+        "_secret",
+        "_signing_key",
+        "_token",
+        "_token_encryption_key",
     }
 )
 
 
 def is_secret_field(key: str) -> bool:
     """Return true only for known secret field names, not fuzzy token matches."""
-    return key.lower() in SECRET_FIELD_NAMES
+    normalized = key.lower()
+    return normalized in SECRET_FIELD_NAMES or any(normalized.endswith(suffix) for suffix in SECRET_FIELD_SUFFIXES)
+
+
+def mask_secret_value(value: Any) -> str:
+    """Return a public masked value with a short prefix when that is useful."""
+    if not isinstance(value, str) or len(value) < MIN_PREFIX_MASK_LENGTH:
+        return REDACTED_SECRET
+    return f"{value[:MASK_PREFIX_LENGTH]}{MASK_SUFFIX}"
+
+
+def is_masked_secret_value(value: Any) -> bool:
+    """Return true for placeholders produced by the public redaction layer."""
+    return (
+        isinstance(value, str) and len(value) == MASK_PREFIX_LENGTH + len(MASK_SUFFIX) and value.endswith(MASK_SUFFIX)
+    )
 
 
 def redact_secrets(value: Any) -> Any:
     """Recursively redact values for known secret fields without mutating input."""
     if isinstance(value, Mapping):
         return {
-            key: REDACTED_SECRET if is_secret_field(str(key)) else redact_secrets(item) for key, item in value.items()
+            key: mask_secret_value(item) if is_secret_field(str(key)) else redact_secrets(item)
+            for key, item in value.items()
         }
     if isinstance(value, list):
         return [redact_secrets(item) for item in value]
@@ -45,8 +82,14 @@ def redact_secrets(value: Any) -> Any:
 
 
 def redact_secret_mapping(extra: Mapping[str, Any] | None) -> dict[str, Any]:
-    """Drop secret fields from endpoint extras while preserving non-secret metadata."""
-    return {key: redact_secrets(item) for key, item in dict(extra or {}).items() if not is_secret_field(str(key))}
+    """Return the public model-endpoint extra shape shown in Admin UI."""
+    source = dict(extra or {})
+    redacted: dict[str, Any] = {}
+    if "api_key" in source:
+        redacted["api_key"] = mask_secret_value(source.get("api_key"))
+    if "implementation" in source:
+        redacted["implementation"] = source["implementation"]
+    return redacted
 
 
 def preserve_existing_secrets(existing: Mapping[str, Any] | None, incoming: Mapping[str, Any]) -> dict[str, Any]:
@@ -59,7 +102,7 @@ def _preserve_existing_secrets(existing: Mapping[str, Any], incoming: Mapping[st
     for key, value in existing.items():
         incoming_value = merged.get(key)
         if is_secret_field(str(key)):
-            if key not in merged or incoming_value == REDACTED_SECRET:
+            if key not in merged or incoming_value == REDACTED_SECRET or is_masked_secret_value(incoming_value):
                 merged[key] = value
             continue
         if isinstance(value, Mapping) and isinstance(incoming_value, Mapping):
@@ -85,7 +128,9 @@ def _preserve_existing_secret_lists(existing: list[Any], incoming: list[Any]) ->
 __all__ = [
     "REDACTED_SECRET",
     "SECRET_FIELD_NAMES",
+    "is_masked_secret_value",
     "is_secret_field",
+    "mask_secret_value",
     "preserve_existing_secrets",
     "redact_secret_mapping",
     "redact_secrets",

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 from core.config.model_endpoints import ModelEndpointConfig, ModelEndpointRow
 from core.utils.exceptions import NotFoundError, ValidationError
@@ -340,10 +341,17 @@ class ModelEndpointService:
             "models_served": None,
             "detail": None,
         }
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            result["detail"] = "Endpoint URL must be an absolute HTTP(S) URL."
+            return result
+        if parsed.username or parsed.password:
+            result["detail"] = "Endpoint URL must not include credentials."
+            return result
         models_url = url.rstrip("/") + "/models"
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         try:
-            async with httpx.AsyncClient(timeout=5.0, headers=headers) as client:
+            async with httpx.AsyncClient(timeout=5.0, headers=headers, follow_redirects=False) as client:
                 resp = await client.get(models_url)
             result["reachable"] = True
             if resp.status_code == 200:

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -341,7 +341,11 @@ class ModelEndpointService:
             "models_served": None,
             "detail": None,
         }
-        parsed = urlsplit(url)
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            result["detail"] = "Endpoint URL must be an absolute HTTP(S) URL."
+            return result
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             result["detail"] = "Endpoint URL must be an absolute HTTP(S) URL."
             return result

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from core.config.model_endpoints import ModelEndpointConfig, ModelEndpointRow
 from core.utils.exceptions import NotFoundError, ValidationError
 from core.utils.logging import get_logger
+from core.utils.redaction import preserve_existing_secrets
 
 if TYPE_CHECKING:
     from core.config.root import Settings
@@ -244,6 +245,9 @@ class ModelEndpointService:
         # is_default=true row. A false/None value is a no-op here — you switch the
         # default by promoting another endpoint, never by leaving the type with none.
         promote_to_default = bool(fields.pop("is_default", None))
+
+        if isinstance(fields.get("extra"), dict):
+            fields["extra"] = preserve_existing_secrets(existing.extra, fields["extra"])  # type: ignore[arg-type]
 
         if fields:
             updated = await self._repo.update(name, model_type, **fields)

--- a/tests/integration/api/test_model_endpoints.py
+++ b/tests/integration/api/test_model_endpoints.py
@@ -47,7 +47,7 @@ def test_model_endpoint_crud_validate_and_default_selection(api_client):
         assert create_endpoint.status_code == 201, create_endpoint.text
         assert "ci-test-key" not in create_endpoint.text
         assert create_endpoint.json()["has_api_key"] is True
-        assert "api_key" not in create_endpoint.json()["extra"]
+        assert create_endpoint.json()["extra"]["api_key"] == "ci-********"
 
         validate_missing = api_client.post(f"/model-endpoints/llm/{endpoint_name}/validate")
         _assert_success(validate_missing, context="validate missing model")

--- a/tests/integration/api/test_model_endpoints.py
+++ b/tests/integration/api/test_model_endpoints.py
@@ -45,7 +45,9 @@ def test_model_endpoint_crud_validate_and_default_selection(api_client):
             },
         )
         assert create_endpoint.status_code == 201, create_endpoint.text
-        assert create_endpoint.json()["extra"]["api_key"] == "ci-test-key"
+        assert "ci-test-key" not in create_endpoint.text
+        assert create_endpoint.json()["has_api_key"] is True
+        assert "api_key" not in create_endpoint.json()["extra"]
 
         validate_missing = api_client.post(f"/model-endpoints/llm/{endpoint_name}/validate")
         _assert_success(validate_missing, context="validate missing model")

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -244,7 +244,7 @@ async def test_model_endpoint_read_responses_hide_stored_api_key(async_client_fa
     payload = response.json()
     assert "secret-token" not in response.text
     assert payload["has_api_key"] is True
-    assert payload["extra"] == {"api_key": "sec********", "implementation": "vllm"}
+    assert payload["extra"] == {"api_key": "sec********", "implementation": "vllm", "temperature": 0.2}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -248,16 +248,35 @@ async def test_model_endpoint_read_responses_hide_stored_api_key(async_client_fa
 
 
 @pytest.mark.asyncio
-async def test_model_endpoint_reveal_api_key_returns_stored_secret(async_client_factory):
+async def test_model_endpoint_reveal_api_key_returns_stored_secret(async_client_factory, monkeypatch):
     model_service = FakeModelEndpointService()
     model_service.endpoint_extra = {"api_key": "secret-token", "implementation": "vllm"}
     app = _build_app(model_service=model_service)
+    logs: list[tuple[dict[str, Any], str]] = []
+
+    class FakeLogger:
+        def __init__(self, context: dict[str, Any] | None = None) -> None:
+            self.context = context or {}
+
+        def bind(self, **kwargs: Any) -> FakeLogger:
+            return FakeLogger({**self.context, **kwargs})
+
+        def info(self, message: str) -> None:
+            logs.append((self.context, message))
+
+    monkeypatch.setattr(model_endpoints, "logger", FakeLogger())
 
     async with async_client_factory(app) as client:
         response = await client.post("/model-endpoints/llm/default/reveal-api-key")
 
     assert response.status_code == 200
     assert response.json() == {"api_key": "secret-token"}
+    assert logs == [
+        (
+            {"model_type": "llm", "name": "default", "has_api_key": True},
+            "Model endpoint API key revealed.",
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -244,7 +244,20 @@ async def test_model_endpoint_read_responses_hide_stored_api_key(async_client_fa
     payload = response.json()
     assert "secret-token" not in response.text
     assert payload["has_api_key"] is True
-    assert payload["extra"] == {"implementation": "vllm", "temperature": 0.2}
+    assert payload["extra"] == {"api_key": "sec********", "implementation": "vllm"}
+
+
+@pytest.mark.asyncio
+async def test_model_endpoint_reveal_api_key_returns_stored_secret(async_client_factory):
+    model_service = FakeModelEndpointService()
+    model_service.endpoint_extra = {"api_key": "secret-token", "implementation": "vllm"}
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post("/model-endpoints/llm/default/reveal-api-key")
+
+    assert response.status_code == 200
+    assert response.json() == {"api_key": "secret-token"}
 
 
 @pytest.mark.asyncio
@@ -315,7 +328,7 @@ async def test_validate_endpoint_draft_can_reuse_stored_api_key(async_client_fac
         response = await client.post(
             "/model-endpoints/validate",
             json={
-                "endpoint": "http://candidate:8000/v1",
+                "endpoint": "http://llm:8000/v1/",
                 "model_name": "mistral-small",
                 "stored_api_key_model_type": "llm",
                 "stored_api_key_name": "default",
@@ -325,7 +338,31 @@ async def test_validate_endpoint_draft_can_reuse_stored_api_key(async_client_fac
     assert response.status_code == 200
     assert model_service.calls == [
         ("get", {"name": "default", "model_type": "llm"}),
-        ("validate", {"url": "http://candidate:8000/v1", "model_name": "mistral-small", "api_key": "secret-token"}),
+        ("validate", {"url": "http://llm:8000/v1", "model_name": "mistral-small", "api_key": "secret-token"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_draft_rejects_stored_key_for_different_endpoint(async_client_factory):
+    model_service = FakeModelEndpointService()
+    model_service.endpoint_extra = {"api_key": "secret-token"}
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post(
+            "/model-endpoints/validate",
+            json={
+                "endpoint": "http://candidate:8000/v1",
+                "model_name": "mistral-small",
+                "stored_api_key_model_type": "llm",
+                "stored_api_key_name": "default",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Stored API key can only be reused with its saved endpoint URL."
+    assert model_service.calls == [
+        ("get", {"name": "default", "model_type": "llm"}),
     ]
 
 

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -228,6 +228,26 @@ async def test_update_model_endpoint_maps_name_to_new_name(async_client_factory)
 
 
 @pytest.mark.asyncio
+async def test_model_endpoint_read_responses_hide_stored_api_key(async_client_factory):
+    model_service = FakeModelEndpointService()
+    model_service.endpoint_extra = {
+        "implementation": "vllm",
+        "api_key": "secret-token",
+        "temperature": 0.2,
+    }
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.get("/model-endpoints/llm/default")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "secret-token" not in response.text
+    assert payload["has_api_key"] is True
+    assert payload["extra"] == {"implementation": "vllm", "temperature": 0.2}
+
+
+@pytest.mark.asyncio
 async def test_validate_model_endpoint_uses_route_identity(async_client_factory):
     """Endpoint validation should resolve route identity before probing."""
     model_service = FakeModelEndpointService()
@@ -282,6 +302,30 @@ async def test_validate_endpoint_draft_forwards_body_without_lookup(async_client
     assert response.json()["reachable"] is True
     assert model_service.calls == [
         ("validate", {"url": "http://candidate:8000/v1", "model_name": "mistral-small", "api_key": "draft-key"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_draft_can_reuse_stored_api_key(async_client_factory):
+    model_service = FakeModelEndpointService()
+    model_service.endpoint_extra = {"api_key": "secret-token"}
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post(
+            "/model-endpoints/validate",
+            json={
+                "endpoint": "http://candidate:8000/v1",
+                "model_name": "mistral-small",
+                "stored_api_key_model_type": "llm",
+                "stored_api_key_name": "default",
+            },
+        )
+
+    assert response.status_code == 200
+    assert model_service.calls == [
+        ("get", {"name": "default", "model_type": "llm"}),
+        ("validate", {"url": "http://candidate:8000/v1", "model_name": "mistral-small", "api_key": "secret-token"}),
     ]
 
 

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -114,3 +114,38 @@ def test_preserve_existing_secrets_clears_explicit_empty_secret_values():
         "auth": {},
         "headers": [{}],
     }
+
+
+def test_preserve_existing_secrets_matches_list_items_by_non_secret_identity():
+    from core.utils.redaction import preserve_existing_secrets
+
+    merged = preserve_existing_secrets(
+        {
+            "providers": [
+                {"name": "a", "api_key": "key-a"},
+                {"name": "b", "api_key": "key-b"},
+            ]
+        },
+        {
+            "providers": [
+                {"name": "b", "api_key": "<redacted>"},
+            ]
+        },
+    )
+
+    assert merged == {
+        "providers": [
+            {"name": "b", "api_key": "key-b"},
+        ]
+    }
+
+
+def test_preserve_existing_secrets_drops_unmatched_list_placeholders_without_identity():
+    from core.utils.redaction import preserve_existing_secrets
+
+    merged = preserve_existing_secrets(
+        {"headers": [{"api_key": "key-a"}, {"api_key": "key-b"}]},
+        {"headers": [{"api_key": "<redacted>"}]},
+    )
+
+    assert merged == {"headers": [{}]}

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-def test_redact_secrets_hides_known_secret_keys_without_false_token_matches():
+def test_redact_secrets_fully_hides_known_secret_keys_without_false_token_matches():
     from core.utils.redaction import redact_secrets
 
     payload = {
@@ -28,20 +28,20 @@ def test_redact_secrets_hides_known_secret_keys_without_false_token_matches():
 
     redacted = redact_secrets(payload)
 
-    assert redacted["llm"]["api_key"] == "sk-********"
-    assert redacted["object_storage"]["access_key"] == "obj********"
-    assert redacted["rdb"]["password"] == "db-********"
-    assert redacted["websearch"]["api_token"] == "sea********"
+    assert redacted["llm"]["api_key"] == "<redacted>"
+    assert redacted["object_storage"]["access_key"] == "<redacted>"
+    assert redacted["rdb"]["password"] == "<redacted>"
+    assert redacted["websearch"]["api_token"] == "<redacted>"
     assert redacted["websearch"]["max_tokens"] == 2048
-    assert redacted["oidc_client_secret"] == "oid********"
-    assert redacted["chainlit_auth_secret"] == "cha********"
-    assert redacted["future"]["backend_secret"] == "bac********"
-    assert redacted["future"]["session_token"] == "ses********"
-    assert redacted["future"]["storage_access_key"] == "sto********"
-    assert redacted["nested"][0]["private_key"] == "pri********"
-    assert redacted["nested"][0]["refresh_token"] == "ref********"
-    assert redacted["nested"][0]["signing_key"] == "sig********"
-    assert redacted["nested"][0]["token_encryption_key"] == "fer********"
+    assert redacted["oidc_client_secret"] == "<redacted>"
+    assert redacted["chainlit_auth_secret"] == "<redacted>"
+    assert redacted["future"]["backend_secret"] == "<redacted>"
+    assert redacted["future"]["session_token"] == "<redacted>"
+    assert redacted["future"]["storage_access_key"] == "<redacted>"
+    assert redacted["nested"][0]["private_key"] == "<redacted>"
+    assert redacted["nested"][0]["refresh_token"] == "<redacted>"
+    assert redacted["nested"][0]["signing_key"] == "<redacted>"
+    assert redacted["nested"][0]["token_encryption_key"] == "<redacted>"
     assert payload["llm"]["api_key"] == "sk-llm-secret"
 
 

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -2,24 +2,86 @@ from __future__ import annotations
 
 
 def test_redact_secrets_hides_known_secret_keys_without_false_token_matches():
-    from core.utils.redaction import REDACTED_SECRET, redact_secrets
+    from core.utils.redaction import redact_secrets
 
     payload = {
-        "llm": {"api_key": "llm-secret", "model": "mistral"},
-        "rdb": {"password": "db-secret", "host": "rdb"},
+        "llm": {"api_key": "sk-llm-secret", "model": "mistral"},
+        "object_storage": {"access_key": "object-store-secret"},
+        "rdb": {"password": "db-secret-value", "host": "rdb"},
         "websearch": {"api_token": "search-secret", "max_tokens": 2048},
         "oidc_client_secret": "oidc-secret",
         "chainlit_auth_secret": "chainlit-secret",
-        "nested": [{"token_encryption_key": "fernet-secret"}],
+        "future": {
+            "backend_secret": "backend-secret-value",
+            "session_token": "session-token-value",
+            "storage_access_key": "storage-access-key-value",
+        },
+        "nested": [
+            {
+                "private_key": "private-key-secret",
+                "refresh_token": "refresh-token-secret",
+                "signing_key": "signing-key-secret",
+                "token_encryption_key": "fernet-secret",
+            }
+        ],
     }
 
     redacted = redact_secrets(payload)
 
-    assert redacted["llm"]["api_key"] == REDACTED_SECRET
-    assert redacted["rdb"]["password"] == REDACTED_SECRET
-    assert redacted["websearch"]["api_token"] == REDACTED_SECRET
+    assert redacted["llm"]["api_key"] == "sk-********"
+    assert redacted["object_storage"]["access_key"] == "obj********"
+    assert redacted["rdb"]["password"] == "db-********"
+    assert redacted["websearch"]["api_token"] == "sea********"
     assert redacted["websearch"]["max_tokens"] == 2048
-    assert redacted["oidc_client_secret"] == REDACTED_SECRET
-    assert redacted["chainlit_auth_secret"] == REDACTED_SECRET
-    assert redacted["nested"][0]["token_encryption_key"] == REDACTED_SECRET
-    assert payload["llm"]["api_key"] == "llm-secret"
+    assert redacted["oidc_client_secret"] == "oid********"
+    assert redacted["chainlit_auth_secret"] == "cha********"
+    assert redacted["future"]["backend_secret"] == "bac********"
+    assert redacted["future"]["session_token"] == "ses********"
+    assert redacted["future"]["storage_access_key"] == "sto********"
+    assert redacted["nested"][0]["private_key"] == "pri********"
+    assert redacted["nested"][0]["refresh_token"] == "ref********"
+    assert redacted["nested"][0]["signing_key"] == "sig********"
+    assert redacted["nested"][0]["token_encryption_key"] == "fer********"
+    assert payload["llm"]["api_key"] == "sk-llm-secret"
+
+
+def test_redact_secret_mapping_keeps_only_public_endpoint_extra_shape():
+    from core.utils.redaction import redact_secret_mapping
+
+    redacted = redact_secret_mapping(
+        {
+            "api_key": "sk-top-level-secret",
+            "implementation": "vllm",
+            "auth": {"token": "nested-token"},
+            "headers": [{"api_key": "hf-nested-secret"}],
+            "temperature": 0.2,
+        }
+    )
+
+    assert redacted == {
+        "api_key": "sk-********",
+        "implementation": "vllm",
+    }
+
+
+def test_preserve_existing_secrets_accepts_prefix_masked_values():
+    from core.utils.redaction import preserve_existing_secrets
+
+    merged = preserve_existing_secrets(
+        {
+            "api_key": "sk-top-level-secret",
+            "auth": {"token": "nested-token-secret"},
+            "headers": [{"api_key": "hf-nested-secret"}],
+        },
+        {
+            "api_key": "sk-********",
+            "auth": {"token": "nes********"},
+            "headers": [{"api_key": "hf-********"}],
+        },
+    )
+
+    assert merged == {
+        "api_key": "sk-top-level-secret",
+        "auth": {"token": "nested-token-secret"},
+        "headers": [{"api_key": "hf-nested-secret"}],
+    }

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -45,7 +45,7 @@ def test_redact_secrets_fully_hides_known_secret_keys_without_false_token_matche
     assert payload["llm"]["api_key"] == "sk-llm-secret"
 
 
-def test_redact_secret_mapping_keeps_only_public_endpoint_extra_shape():
+def test_redact_secret_mapping_keeps_non_secret_endpoint_extra_shape():
     from core.utils.redaction import redact_secret_mapping
 
     redacted = redact_secret_mapping(
@@ -55,12 +55,17 @@ def test_redact_secret_mapping_keeps_only_public_endpoint_extra_shape():
             "auth": {"token": "nested-token"},
             "headers": [{"api_key": "hf-nested-secret"}],
             "temperature": 0.2,
+            "enable_thinking": True,
         }
     )
 
     assert redacted == {
         "api_key": "sk-********",
         "implementation": "vllm",
+        "auth": {"token": "nes********"},
+        "headers": [{"api_key": "hf-********"}],
+        "temperature": 0.2,
+        "enable_thinking": True,
     }
 
 

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -90,3 +90,27 @@ def test_preserve_existing_secrets_accepts_prefix_masked_values():
         "auth": {"token": "nested-token-secret"},
         "headers": [{"api_key": "hf-nested-secret"}],
     }
+
+
+def test_preserve_existing_secrets_clears_explicit_empty_secret_values():
+    from core.utils.redaction import preserve_existing_secrets
+
+    merged = preserve_existing_secrets(
+        {
+            "api_key": "stored-key",
+            "auth": {"token": "nested-token"},
+            "headers": [{"api_key": "nested-key"}],
+        },
+        {
+            "implementation": "vllm",
+            "api_key": "",
+            "auth": {"token": None},
+            "headers": [{"api_key": ""}],
+        },
+    )
+
+    assert merged == {
+        "implementation": "vllm",
+        "auth": {},
+        "headers": [{}],
+    }

--- a/tests/unit/api/test_secret_redaction.py
+++ b/tests/unit/api/test_secret_redaction.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+def test_redact_secrets_hides_known_secret_keys_without_false_token_matches():
+    from core.utils.redaction import REDACTED_SECRET, redact_secrets
+
+    payload = {
+        "llm": {"api_key": "llm-secret", "model": "mistral"},
+        "rdb": {"password": "db-secret", "host": "rdb"},
+        "websearch": {"api_token": "search-secret", "max_tokens": 2048},
+        "oidc_client_secret": "oidc-secret",
+        "chainlit_auth_secret": "chainlit-secret",
+        "nested": [{"token_encryption_key": "fernet-secret"}],
+    }
+
+    redacted = redact_secrets(payload)
+
+    assert redacted["llm"]["api_key"] == REDACTED_SECRET
+    assert redacted["rdb"]["password"] == REDACTED_SECRET
+    assert redacted["websearch"]["api_token"] == REDACTED_SECRET
+    assert redacted["websearch"]["max_tokens"] == 2048
+    assert redacted["oidc_client_secret"] == REDACTED_SECRET
+    assert redacted["chainlit_auth_secret"] == REDACTED_SECRET
+    assert redacted["nested"][0]["token_encryption_key"] == REDACTED_SECRET
+    assert payload["llm"]["api_key"] == "llm-secret"

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -542,6 +542,18 @@ async def test_update_extra_with_new_api_key_rotates_existing_secret():
     assert updated.extra == {"implementation": "vllm", "api_key": "new-key"}
 
 
+@pytest.mark.asyncio
+async def test_update_extra_with_empty_api_key_clears_existing_secret():
+    existing = _make_row(name="jina", extra={"implementation": "vllm", "api_key": "old-key"})
+    repo = _FakeEndpointRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    await svc.update_model_endpoint("jina", "embedder", extra={"implementation": "vllm", "api_key": ""})
+
+    updated = repo._store[("jina", "embedder")]
+    assert updated.extra == {"implementation": "vllm"}
+
+
 # ------------------------------------------------------------------
 # delete_model_endpoint
 # ------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -670,9 +670,10 @@ async def test_validate_endpoint_probes_url_and_model_name(monkeypatch):
             return {"data": [{"id": "mistral-small"}]}
 
     class FakeClient:
-        def __init__(self, *, timeout, headers):
+        def __init__(self, *, timeout, headers, follow_redirects):
             assert timeout == 5.0
             assert headers == {}
+            assert follow_redirects is False
 
         async def __aenter__(self):
             return self
@@ -711,8 +712,9 @@ async def test_validate_endpoint_sends_api_key(monkeypatch):
             return {"data": [{"id": "mistral-small"}]}
 
     class FakeClient:
-        def __init__(self, *, timeout, headers):
+        def __init__(self, *, timeout, headers, follow_redirects):
             captured_headers.append(headers)
+            assert follow_redirects is False
 
         async def __aenter__(self):
             return self
@@ -728,3 +730,45 @@ async def test_validate_endpoint_sends_api_key(monkeypatch):
     await svc.validate_endpoint("http://llm:8000/v1", "mistral-small", api_key="secret-token")
 
     assert captured_headers == [{"Authorization": "Bearer secret-token"}]
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_rejects_non_http_urls_without_request(monkeypatch):
+    import httpx
+
+    svc = _make_service()
+
+    def fail_client(**_kwargs):
+        raise AssertionError("HTTP client should not be created for invalid URLs")
+
+    monkeypatch.setattr(httpx, "AsyncClient", fail_client)
+
+    result = await svc.validate_endpoint("file:///etc/passwd", "mistral-small")
+
+    assert result == {
+        "reachable": False,
+        "model_found": None,
+        "models_served": None,
+        "detail": "Endpoint URL must be an absolute HTTP(S) URL.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_rejects_url_credentials_without_request(monkeypatch):
+    import httpx
+
+    svc = _make_service()
+
+    def fail_client(**_kwargs):
+        raise AssertionError("HTTP client should not be created for URLs with credentials")
+
+    monkeypatch.setattr(httpx, "AsyncClient", fail_client)
+
+    result = await svc.validate_endpoint("https://user:pass@example.test/v1", "mistral-small")
+
+    assert result == {
+        "reachable": False,
+        "model_found": None,
+        "models_served": None,
+        "detail": "Endpoint URL must not include credentials.",
+    }

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -476,6 +476,72 @@ async def test_update_is_default_false_does_not_demote_or_touch_default_cache():
     assert cache.get("default") is sentinel
 
 
+@pytest.mark.asyncio
+async def test_update_extra_without_api_key_preserves_existing_secret():
+    existing = _make_row(
+        name="jina",
+        extra={"implementation": "vllm", "api_key": "stored-key", "temperature": 0.1},
+    )
+    repo = _FakeEndpointRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    await svc.update_model_endpoint("jina", "embedder", extra={"implementation": "vllm", "temperature": 0.2})
+
+    updated = repo._store[("jina", "embedder")]
+    assert updated.extra == {"implementation": "vllm", "temperature": 0.2, "api_key": "stored-key"}
+
+
+@pytest.mark.asyncio
+async def test_update_extra_preserves_nested_redacted_secrets():
+    existing = _make_row(
+        name="jina",
+        extra={
+            "implementation": "vllm",
+            "auth": {
+                "token": "stored-token",
+                "headers": [{"api_key": "nested-key"}],
+            },
+        },
+    )
+    repo = _FakeEndpointRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    await svc.update_model_endpoint(
+        "jina",
+        "embedder",
+        extra={
+            "implementation": "vllm",
+            "auth": {
+                "token": "<redacted>",
+                "headers": [{"api_key": "<redacted>"}],
+            },
+            "temperature": 0.2,
+        },
+    )
+
+    updated = repo._store[("jina", "embedder")]
+    assert updated.extra == {
+        "implementation": "vllm",
+        "auth": {
+            "token": "stored-token",
+            "headers": [{"api_key": "nested-key"}],
+        },
+        "temperature": 0.2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_extra_with_new_api_key_rotates_existing_secret():
+    existing = _make_row(name="jina", extra={"implementation": "vllm", "api_key": "old-key"})
+    repo = _FakeEndpointRepo(rows=[existing])
+    svc = _make_service(repo)
+
+    await svc.update_model_endpoint("jina", "embedder", extra={"implementation": "vllm", "api_key": "new-key"})
+
+    updated = repo._store[("jina", "embedder")]
+    assert updated.extra == {"implementation": "vllm", "api_key": "new-key"}
+
+
 # ------------------------------------------------------------------
 # delete_model_endpoint
 # ------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -754,6 +754,27 @@ async def test_validate_endpoint_rejects_non_http_urls_without_request(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_validate_endpoint_rejects_malformed_urls_without_request(monkeypatch):
+    import httpx
+
+    svc = _make_service()
+
+    def fail_client(**_kwargs):
+        raise AssertionError("HTTP client should not be created for malformed URLs")
+
+    monkeypatch.setattr(httpx, "AsyncClient", fail_client)
+
+    result = await svc.validate_endpoint("http://[::1", "mistral-small")
+
+    assert result == {
+        "reachable": False,
+        "model_found": None,
+        "models_served": None,
+        "detail": "Endpoint URL must be an absolute HTTP(S) URL.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_validate_endpoint_rejects_url_credentials_without_request(monkeypatch):
     import httpx
 

--- a/ui/src/lib/api/models.test.ts
+++ b/ui/src/lib/api/models.test.ts
@@ -227,4 +227,32 @@ describe("model endpoint secret placeholders", () => {
       api_key: "<redacted>",
     });
   });
+
+  it("submits an explicit empty API key when clearing an existing stored key", () => {
+    expect(
+      mergeModelEndpointApiKeyExtra(
+        {
+          implementation: "vllm",
+        },
+        "",
+        { clearApiKey: true },
+      ),
+    ).toEqual({
+      implementation: "vllm",
+      api_key: "",
+    });
+  });
+
+  it("omits an empty API key when creating an endpoint without a stored key", () => {
+    expect(
+      mergeModelEndpointApiKeyExtra(
+        {
+          implementation: "vllm",
+        },
+        "",
+      ),
+    ).toEqual({
+      implementation: "vllm",
+    });
+  });
 });

--- a/ui/src/lib/api/models.test.ts
+++ b/ui/src/lib/api/models.test.ts
@@ -1,6 +1,36 @@
-import { describe, it, expect } from "vitest";
-import { pickDefaultEndpoint, resolveEmbedderName } from "./models";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  displayModelEndpointExtra,
+  pickDefaultEndpoint,
+  prepareModelEndpointExtraForSubmit,
+  resolveEmbedderName,
+  validateModelEndpoint,
+} from "./models";
 import type { ModelEndpointResponse } from "./models";
+
+function fakeResponse({
+  status = 200,
+  body = "{}",
+}: { status?: number; body?: string } = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (key: string) => (key.toLowerCase() === "content-type" ? "application/json" : null) },
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function ep(name: string, is_default = false): ModelEndpointResponse {
   return {
@@ -62,5 +92,62 @@ describe("resolveEmbedderName", () => {
 
   it("keeps 'default' when the default endpoint is itself named 'default'", () => {
     expect(resolveEmbedderName("default", [ep("default", true)])).toBe("default");
+  });
+});
+
+describe("validateModelEndpoint", () => {
+  it("can request draft validation with a stored server-side API key", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: JSON.stringify({ reachable: true }) }));
+
+    await validateModelEndpoint({
+      endpoint: "http://candidate:8000/v1",
+      model_name: "mistral-small",
+      stored_api_key_model_type: "llm",
+      stored_api_key_name: "private-llm",
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      endpoint: "http://candidate:8000/v1",
+      model_name: "mistral-small",
+      stored_api_key_model_type: "llm",
+      stored_api_key_name: "private-llm",
+    });
+  });
+});
+
+describe("model endpoint secret placeholders", () => {
+  it("shows backend redacted secret sentinels as password-style bullets", () => {
+    expect(
+      displayModelEndpointExtra({
+        auth: { token: "<redacted>" },
+        headers: [{ api_key: "<redacted>" }],
+        note: "<redacted>",
+      }),
+    ).toEqual({
+      auth: { token: "••••••••" },
+      headers: [{ api_key: "sk-********" }],
+      note: "<redacted>",
+    });
+  });
+
+  it("converts unchanged bullet placeholders back to the backend redacted sentinel", () => {
+    expect(
+      prepareModelEndpointExtraForSubmit({
+        auth: { token: "••••••••" },
+        headers: [{ api_key: "sk-********" }],
+        note: "••••••••",
+      }),
+    ).toEqual({
+      auth: { token: "<redacted>" },
+      headers: [{ api_key: "<redacted>" }],
+      note: "••••••••",
+    });
+  });
+
+  it("still accepts the previous API key placeholder when an edit form is already open", () => {
+    expect(prepareModelEndpointExtraForSubmit({ api_key: "********" })).toEqual({
+      api_key: "<redacted>",
+    });
   });
 });

--- a/ui/src/lib/api/models.test.ts
+++ b/ui/src/lib/api/models.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   displayModelEndpointExtra,
+  mergeModelEndpointApiKeyExtra,
   pickDefaultEndpoint,
   prepareModelEndpointExtraForSubmit,
+  revealModelEndpointApiKey,
   resolveEmbedderName,
+  splitModelEndpointApiKeyExtra,
   validateModelEndpoint,
 } from "./models";
 import type { ModelEndpointResponse } from "./models";
@@ -116,18 +119,48 @@ describe("validateModelEndpoint", () => {
   });
 });
 
+describe("revealModelEndpointApiKey", () => {
+  it("requests the admin-only reveal endpoint for the selected model endpoint", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: JSON.stringify({ api_key: "secret-token" }) }));
+
+    const result = await revealModelEndpointApiKey("llm", "private-llm");
+
+    expect(result).toEqual({ api_key: "secret-token" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/model-endpoints/llm/private-llm/reveal-api-key",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+
 describe("model endpoint secret placeholders", () => {
   it("shows backend redacted secret sentinels as password-style bullets", () => {
     expect(
       displayModelEndpointExtra({
         auth: { token: "<redacted>" },
+        backend_secret: "<redacted>",
         headers: [{ api_key: "<redacted>" }],
         note: "<redacted>",
       }),
     ).toEqual({
       auth: { token: "••••••••" },
+      backend_secret: "••••••••",
       headers: [{ api_key: "sk-********" }],
       note: "<redacted>",
+    });
+  });
+
+  it("keeps backend prefix-masked secret values visible without revealing the full secret", () => {
+    expect(
+      displayModelEndpointExtra({
+        auth: { token: "nes********" },
+        headers: [{ api_key: "hf-********" }],
+        note: "abc********",
+      }),
+    ).toEqual({
+      auth: { token: "nes********" },
+      headers: [{ api_key: "hf-********" }],
+      note: "abc********",
     });
   });
 
@@ -135,7 +168,7 @@ describe("model endpoint secret placeholders", () => {
     expect(
       prepareModelEndpointExtraForSubmit({
         auth: { token: "••••••••" },
-        headers: [{ api_key: "sk-********" }],
+        headers: [{ api_key: "hf-********" }],
         note: "••••••••",
       }),
     ).toEqual({
@@ -147,6 +180,50 @@ describe("model endpoint secret placeholders", () => {
 
   it("still accepts the previous API key placeholder when an edit form is already open", () => {
     expect(prepareModelEndpointExtraForSubmit({ api_key: "********" })).toEqual({
+      api_key: "<redacted>",
+    });
+  });
+
+  it("splits the API key out of endpoint extra for the dedicated form field", () => {
+    expect(
+      splitModelEndpointApiKeyExtra({
+        api_key: "sk-real-secret",
+        implementation: "vllm",
+        temperature: 0.2,
+      }),
+    ).toEqual({
+      apiKey: "sk-********",
+      extra: {
+        implementation: "vllm",
+        temperature: 0.2,
+      },
+    });
+  });
+
+  it("merges the dedicated API key field back into the endpoint extra payload", () => {
+    expect(
+      mergeModelEndpointApiKeyExtra(
+        {
+          implementation: "vllm",
+        },
+        "sk-new-secret",
+      ),
+    ).toEqual({
+      implementation: "vllm",
+      api_key: "sk-new-secret",
+    });
+  });
+
+  it("preserves a stored API key when the dedicated field is unchanged", () => {
+    expect(
+      mergeModelEndpointApiKeyExtra(
+        {
+          implementation: "vllm",
+        },
+        "sk-********",
+      ),
+    ).toEqual({
+      implementation: "vllm",
       api_key: "<redacted>",
     });
   });

--- a/ui/src/lib/api/models.ts
+++ b/ui/src/lib/api/models.ts
@@ -9,6 +9,7 @@ import { request } from "./client";
 //   PUT    /model-endpoints/{type}/{name}          update
 //   DELETE /model-endpoints/{type}/{name}          delete → 204
 //   POST   /model-endpoints/{type}/{name}/set-default
+//   POST   /model-endpoints/{type}/{name}/reveal-api-key
 //   POST   /model-endpoints/{type}/{name}/validate → ValidateEndpointResponse (no body)
 
 export type ModelType = "embedder" | "reranker" | "llm" | "vlm";
@@ -56,16 +57,23 @@ export interface ValidateModelEndpointResponse {
   detail?: string | null;
 }
 
+export interface RevealApiKeyResponse {
+  api_key: string | null;
+}
+
 const BASE = "/model-endpoints";
 const enc = encodeURIComponent;
 export const REDACTED_SECRET = "<redacted>";
 export const API_KEY_DISPLAY_PLACEHOLDER = "sk-********";
 export const SECRET_DISPLAY_PLACEHOLDER = "••••••••";
+const MASK_SUFFIX = "********";
+const MASK_PREFIX_LENGTH = 3;
 const LEGACY_API_KEY_DISPLAY_PLACEHOLDER = "********";
 
 const SECRET_FIELD_NAMES = new Set([
   "api_key",
   "api_token",
+  "access_key",
   "auth_token",
   "chainlit_auth_secret",
   "client_secret",
@@ -73,32 +81,57 @@ const SECRET_FIELD_NAMES = new Set([
   "oidc_client_secret",
   "oidc_token_encryption_key",
   "password",
+  "private_key",
+  "refresh_token",
   "secret",
   "secret_key",
+  "signing_key",
   "token",
   "token_encryption_key",
 ]);
+const SECRET_FIELD_SUFFIXES = [
+  "_access_key",
+  "_api_key",
+  "_auth_token",
+  "_password",
+  "_private_key",
+  "_refresh_token",
+  "_secret",
+  "_signing_key",
+  "_token",
+  "_token_encryption_key",
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isSecretField(key: string | undefined): boolean {
-  return key ? SECRET_FIELD_NAMES.has(key.toLowerCase()) : false;
+  if (!key) return false;
+  const normalized = key.toLowerCase();
+  return SECRET_FIELD_NAMES.has(normalized) || SECRET_FIELD_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
 }
 
 function displayPlaceholderFor(key: string | undefined): string {
   return key?.toLowerCase() === "api_key" ? API_KEY_DISPLAY_PLACEHOLDER : SECRET_DISPLAY_PLACEHOLDER;
 }
 
+function isPrefixMaskedSecret(value: string): boolean {
+  return value.length === MASK_PREFIX_LENGTH + MASK_SUFFIX.length && value.endsWith(MASK_SUFFIX);
+}
+
 function isUnchangedPlaceholder(value: string, key: string | undefined): boolean {
   if (value === displayPlaceholderFor(key)) return true;
+  if (isPrefixMaskedSecret(value)) return true;
   return key?.toLowerCase() === "api_key" && value === LEGACY_API_KEY_DISPLAY_PLACEHOLDER;
 }
 
 function transformSecretPlaceholders(value: unknown, direction: "display" | "submit", key?: string): unknown {
   if (isSecretField(key) && typeof value === "string") {
-    if (direction === "display") return displayPlaceholderFor(key);
+    if (direction === "display") {
+      if (isPrefixMaskedSecret(value)) return value;
+      return displayPlaceholderFor(key);
+    }
     if (isUnchangedPlaceholder(value, key)) return REDACTED_SECRET;
   }
   if (Array.isArray(value)) {
@@ -121,6 +154,30 @@ export function displayModelEndpointExtra(extra: Record<string, unknown>): Recor
 
 export function prepareModelEndpointExtraForSubmit(extra: Record<string, unknown>): Record<string, unknown> {
   return transformSecretPlaceholders(extra, "submit") as Record<string, unknown>;
+}
+
+export function splitModelEndpointApiKeyExtra(extra: Record<string, unknown>): {
+  apiKey: string;
+  extra: Record<string, unknown>;
+} {
+  const displayExtra = displayModelEndpointExtra(extra);
+  const { api_key: apiKey, ...rest } = displayExtra;
+  return {
+    apiKey: typeof apiKey === "string" ? apiKey : "",
+    extra: rest,
+  };
+}
+
+export function mergeModelEndpointApiKeyExtra(
+  extra: Record<string, unknown>,
+  apiKey: string,
+): Record<string, unknown> {
+  const prepared = prepareModelEndpointExtraForSubmit(extra);
+  const normalizedApiKey = prepareModelEndpointExtraForSubmit({ api_key: apiKey.trim() }).api_key;
+  if (typeof normalizedApiKey === "string" && normalizedApiKey) {
+    return { ...prepared, api_key: normalizedApiKey };
+  }
+  return prepared;
 }
 
 /** List endpoints (bare array). Optionally filter by model type. */
@@ -154,6 +211,13 @@ export function updateModelEndpoint(
 export function setDefaultModelEndpoint(modelType: ModelType, name: string) {
   return request<ModelEndpointResponse>(
     `${BASE}/${enc(modelType)}/${enc(name)}/set-default`,
+    { method: "POST" },
+  );
+}
+
+export function revealModelEndpointApiKey(modelType: ModelType, name: string) {
+  return request<RevealApiKeyResponse>(
+    `${BASE}/${enc(modelType)}/${enc(name)}/reveal-api-key`,
     { method: "POST" },
   );
 }

--- a/ui/src/lib/api/models.ts
+++ b/ui/src/lib/api/models.ts
@@ -21,6 +21,7 @@ export interface ModelEndpointResponse {
   batch_size: number;
   timeout: number;
   extra: Record<string, unknown>;
+  has_api_key?: boolean;
   is_default: boolean;
   created_at: string;
   updated_at: string;
@@ -57,6 +58,70 @@ export interface ValidateModelEndpointResponse {
 
 const BASE = "/model-endpoints";
 const enc = encodeURIComponent;
+export const REDACTED_SECRET = "<redacted>";
+export const API_KEY_DISPLAY_PLACEHOLDER = "sk-********";
+export const SECRET_DISPLAY_PLACEHOLDER = "••••••••";
+const LEGACY_API_KEY_DISPLAY_PLACEHOLDER = "********";
+
+const SECRET_FIELD_NAMES = new Set([
+  "api_key",
+  "api_token",
+  "auth_token",
+  "chainlit_auth_secret",
+  "client_secret",
+  "hf_token",
+  "oidc_client_secret",
+  "oidc_token_encryption_key",
+  "password",
+  "secret",
+  "secret_key",
+  "token",
+  "token_encryption_key",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSecretField(key: string | undefined): boolean {
+  return key ? SECRET_FIELD_NAMES.has(key.toLowerCase()) : false;
+}
+
+function displayPlaceholderFor(key: string | undefined): string {
+  return key?.toLowerCase() === "api_key" ? API_KEY_DISPLAY_PLACEHOLDER : SECRET_DISPLAY_PLACEHOLDER;
+}
+
+function isUnchangedPlaceholder(value: string, key: string | undefined): boolean {
+  if (value === displayPlaceholderFor(key)) return true;
+  return key?.toLowerCase() === "api_key" && value === LEGACY_API_KEY_DISPLAY_PLACEHOLDER;
+}
+
+function transformSecretPlaceholders(value: unknown, direction: "display" | "submit", key?: string): unknown {
+  if (isSecretField(key) && typeof value === "string") {
+    if (direction === "display") return displayPlaceholderFor(key);
+    if (isUnchangedPlaceholder(value, key)) return REDACTED_SECRET;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => transformSecretPlaceholders(item, direction));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, item]) => [
+        entryKey,
+        transformSecretPlaceholders(item, direction, entryKey),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function displayModelEndpointExtra(extra: Record<string, unknown>): Record<string, unknown> {
+  return transformSecretPlaceholders(extra, "display") as Record<string, unknown>;
+}
+
+export function prepareModelEndpointExtraForSubmit(extra: Record<string, unknown>): Record<string, unknown> {
+  return transformSecretPlaceholders(extra, "submit") as Record<string, unknown>;
+}
 
 /** List endpoints (bare array). Optionally filter by model type. */
 export function listModelEndpoints(modelType?: ModelType) {
@@ -103,6 +168,8 @@ export interface ValidateModelEndpointRequest {
   endpoint: string;
   model_name?: string;
   api_key?: string;
+  stored_api_key_model_type?: ModelType;
+  stored_api_key_name?: string;
 }
 
 /**

--- a/ui/src/lib/api/models.ts
+++ b/ui/src/lib/api/models.ts
@@ -171,11 +171,15 @@ export function splitModelEndpointApiKeyExtra(extra: Record<string, unknown>): {
 export function mergeModelEndpointApiKeyExtra(
   extra: Record<string, unknown>,
   apiKey: string,
+  options: { clearApiKey?: boolean } = {},
 ): Record<string, unknown> {
   const prepared = prepareModelEndpointExtraForSubmit(extra);
   const normalizedApiKey = prepareModelEndpointExtraForSubmit({ api_key: apiKey.trim() }).api_key;
   if (typeof normalizedApiKey === "string" && normalizedApiKey) {
     return { ...prepared, api_key: normalizedApiKey };
+  }
+  if (options.clearApiKey) {
+    return { ...prepared, api_key: "" };
   }
   return prepared;
 }

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -496,7 +496,9 @@ function EndpointDialog({
     e.preventDefault();
     let extra: Record<string, unknown> = {};
     try {
-      extra = mergeModelEndpointApiKeyExtra(JSON.parse(extraJson), apiKey);
+      extra = mergeModelEndpointApiKeyExtra(JSON.parse(extraJson), apiKey, {
+        clearApiKey: editing?.has_api_key === true,
+      });
     } catch {
       toast.error("Invalid JSON in extra field");
       return;

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -54,6 +54,12 @@ import { formatDate, intOr, numOr } from "@/lib/utils";
 
 const MODEL_TYPES = ["embedder", "reranker", "llm", "vlm"] as const;
 
+type RevealedApiKey = {
+  modelType: ModelType;
+  name: string;
+  value: string;
+};
+
 export default function ModelsPage() {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState("embedder");
@@ -268,7 +274,7 @@ function EndpointDialog({
   const [validated, setValidated] = useState<boolean | null>(null);
   const [validating, setValidating] = useState(false);
   const [validationMsg, setValidationMsg] = useState<string | null>(null);
-  const [revealedApiKey, setRevealedApiKey] = useState<string | null>(null);
+  const [revealedApiKey, setRevealedApiKey] = useState<RevealedApiKey | null>(null);
   const [apiKeyVisible, setApiKeyVisible] = useState(false);
   const [revealingApiKey, setRevealingApiKey] = useState(false);
 
@@ -344,20 +350,28 @@ function EndpointDialog({
     return editing?.has_api_key === true && (!preparedApiKey || preparedApiKey === REDACTED_SECRET);
   };
 
+  const revealedApiKeyForEditing =
+    editing &&
+    revealedApiKey?.modelType === editing.model_type &&
+    revealedApiKey.name === editing.name
+      ? revealedApiKey.value
+      : null;
+
   const fetchStoredApiKey = async ({ cache = true }: { cache?: boolean } = {}): Promise<string | null> => {
-    if (!editing?.has_api_key) return null;
-    if (revealedApiKey) {
-      return revealedApiKey;
-    }
+    const target = editing?.has_api_key
+      ? { modelType: editing.model_type, name: editing.name }
+      : null;
+    if (!target) return null;
+    if (revealedApiKeyForEditing) return revealedApiKeyForEditing;
     setRevealingApiKey(true);
     try {
-      const result = await revealModelEndpointApiKey(editing.model_type, editing.name);
+      const result = await revealModelEndpointApiKey(target.modelType, target.name);
       if (!result.api_key) {
         toast.error("No API key is stored for this endpoint");
         return null;
       }
       if (cache) {
-        setRevealedApiKey(result.api_key);
+        setRevealedApiKey({ ...target, value: result.api_key });
       }
       return result.api_key;
     } catch (e) {
@@ -378,7 +392,6 @@ function EndpointDialog({
     if (shouldReuseStoredApiKey()) {
       const storedApiKey = await fetchStoredApiKey();
       if (!storedApiKey) return;
-      setRevealedApiKey(storedApiKey);
       setApiKeyVisible(true);
       return;
     }
@@ -569,7 +582,7 @@ function EndpointDialog({
             <Input
               className="font-mono"
               type={apiKeyVisible ? "text" : "password"}
-              value={apiKeyVisible && revealedApiKey ? revealedApiKey : apiKey}
+              value={apiKeyVisible && revealedApiKeyForEditing ? revealedApiKeyForEditing : apiKey}
               onChange={(e) => {
                 setApiKey(e.target.value);
                 setRevealedApiKey(null);

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -1,16 +1,29 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Plus, Trash2, Pencil, Star, Loader2, CheckCircle, XCircle } from "lucide-react";
+import {
+  Plus,
+  Trash2,
+  Pencil,
+  Star,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  Eye,
+  EyeOff,
+  Copy,
+} from "lucide-react";
 import {
   listModelEndpoints,
   createModelEndpoint,
   updateModelEndpoint,
   deleteModelEndpoint,
-  displayModelEndpointExtra,
+  mergeModelEndpointApiKeyExtra,
   prepareModelEndpointExtraForSubmit,
+  revealModelEndpointApiKey,
   REDACTED_SECRET,
   setDefaultModelEndpoint,
+  splitModelEndpointApiKeyExtra,
   validateModelEndpoint,
 } from "@/lib/api/models";
 import type {
@@ -27,6 +40,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -249,27 +263,41 @@ function EndpointDialog({
   const [modelName, setModelName] = useState("");
   const [batchSize, setBatchSize] = useState("32");
   const [timeout, setTimeout] = useState("30");
+  const [apiKey, setApiKey] = useState("");
   const [extraJson, setExtraJson] = useState("{}");
   const [validated, setValidated] = useState<boolean | null>(null);
   const [validating, setValidating] = useState(false);
   const [validationMsg, setValidationMsg] = useState<string | null>(null);
+  const [revealedApiKey, setRevealedApiKey] = useState<string | null>(null);
+  const [apiKeyVisible, setApiKeyVisible] = useState(false);
+  const [revealingApiKey, setRevealingApiKey] = useState(false);
 
   useEffect(() => {
+    if (!open) {
+      setRevealedApiKey(null);
+      setApiKeyVisible(false);
+      setRevealingApiKey(false);
+      return;
+    }
     if (open) {
       setValidated(null);
       setValidating(false);
+      setRevealedApiKey(null);
+      setApiKeyVisible(false);
+      setRevealingApiKey(false);
       if (editing) {
-        const displayExtra = displayModelEndpointExtra(editing.extra);
+        const { apiKey: displayApiKey, extra: displayExtra } = splitModelEndpointApiKeyExtra(editing.extra);
         setName(editing.name);
         setEndpoint(editing.endpoint);
         setModelName(editing.model_name || "");
         setBatchSize(String(editing.batch_size));
         setTimeout(String(editing.timeout));
+        setApiKey(displayApiKey);
         setExtraJson(JSON.stringify(displayExtra, null, 2));
         setValidated(true);
         setValidationMsg(
           editing.has_api_key
-            ? "API key is stored server-side. Leave api_key out to keep it, or add a new api_key to rotate it."
+            ? "API key is stored server-side. Leave it unchanged to keep it, or type a new key to rotate it."
             : null,
         );
       } else {
@@ -278,6 +306,7 @@ function EndpointDialog({
         setModelName("");
         setBatchSize("32");
         setTimeout("30");
+        setApiKey("");
         setExtraJson("{}");
         setValidated(null);
         setValidationMsg(null);
@@ -287,23 +316,85 @@ function EndpointDialog({
 
   // Reset validation when relevant fields change
   useEffect(() => {
+    const editingExtra = editing ? splitModelEndpointApiKeyExtra(editing.extra) : null;
     if (
       editing &&
       endpoint === editing.endpoint &&
       (modelName || "") === (editing.model_name || "") &&
-      extraJson === JSON.stringify(displayModelEndpointExtra(editing.extra), null, 2)
+      apiKey === editingExtra?.apiKey &&
+      extraJson === JSON.stringify(editingExtra.extra, null, 2)
     ) {
       setValidated(true);
       setValidationMsg(
         editing.has_api_key
-          ? "API key is stored server-side. Leave api_key out to keep it, or add a new api_key to rotate it."
+          ? "API key is stored server-side. Leave it unchanged to keep it, or type a new key to rotate it."
           : null,
       );
       return;
     }
     setValidated(null);
     setValidationMsg(null);
-  }, [endpoint, modelName, extraJson, editing]);
+  }, [endpoint, modelName, apiKey, extraJson, editing]);
+
+  const apiKeySubmitValue = () =>
+    prepareModelEndpointExtraForSubmit({ api_key: apiKey.trim() }).api_key;
+
+  const shouldReuseStoredApiKey = () => {
+    const preparedApiKey = apiKeySubmitValue();
+    return editing?.has_api_key === true && (!preparedApiKey || preparedApiKey === REDACTED_SECRET);
+  };
+
+  const fetchStoredApiKey = async ({ cache = true }: { cache?: boolean } = {}): Promise<string | null> => {
+    if (!editing?.has_api_key) return null;
+    if (revealedApiKey) {
+      return revealedApiKey;
+    }
+    setRevealingApiKey(true);
+    try {
+      const result = await revealModelEndpointApiKey(editing.model_type, editing.name);
+      if (!result.api_key) {
+        toast.error("No API key is stored for this endpoint");
+        return null;
+      }
+      if (cache) {
+        setRevealedApiKey(result.api_key);
+      }
+      return result.api_key;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to reveal API key";
+      toast.error(msg);
+      return null;
+    } finally {
+      setRevealingApiKey(false);
+    }
+  };
+
+  const handleToggleApiKeyVisibility = async () => {
+    if (apiKeyVisible) {
+      setApiKeyVisible(false);
+      setRevealedApiKey(null);
+      return;
+    }
+    if (shouldReuseStoredApiKey()) {
+      const storedApiKey = await fetchStoredApiKey();
+      if (!storedApiKey) return;
+      setRevealedApiKey(storedApiKey);
+      setApiKeyVisible(true);
+      return;
+    }
+    setApiKeyVisible(true);
+  };
+
+  const handleCopyApiKey = async () => {
+    const value = shouldReuseStoredApiKey() ? await fetchStoredApiKey({ cache: false }) : apiKey.trim();
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("API key copied");
+    } catch {
+      toast.error("Could not copy API key");
+    }
+  };
 
   const handleValidate = async () => {
     // Draft validation: probe the values currently in the form (before saving),
@@ -314,8 +405,8 @@ function EndpointDialog({
     }
     let apiKey: string | undefined;
     try {
-      const extra = prepareModelEndpointExtraForSubmit(JSON.parse(extraJson || "{}"));
-      apiKey = (extra.api_key as string) || undefined;
+      const submittedApiKey = apiKeySubmitValue();
+      apiKey = typeof submittedApiKey === "string" ? submittedApiKey : undefined;
     } catch {
       // invalid extra JSON is reported on save; ignore here
     }
@@ -323,8 +414,7 @@ function EndpointDialog({
     setValidationMsg(null);
     try {
       const canUseStoredSecret =
-        editing?.has_api_key === true &&
-        (!apiKey || apiKey === REDACTED_SECRET);
+        editing?.has_api_key === true && (!apiKey || apiKey === REDACTED_SECRET);
       const res = canUseStoredSecret
         ? await validateModelEndpoint({
             endpoint,
@@ -373,7 +463,7 @@ function EndpointDialog({
     e.preventDefault();
     let extra: Record<string, unknown> = {};
     try {
-      extra = prepareModelEndpointExtraForSubmit(JSON.parse(extraJson));
+      extra = mergeModelEndpointApiKeyExtra(JSON.parse(extraJson), apiKey);
     } catch {
       toast.error("Invalid JSON in extra field");
       return;
@@ -411,6 +501,9 @@ function EndpointDialog({
           <DialogTitle>
             {editing ? `Edit ${editing.name}` : `Add ${activeTab} endpoint`}
           </DialogTitle>
+          <DialogDescription>
+            Configure the endpoint connection and stored credentials.
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
@@ -440,6 +533,57 @@ function EndpointDialog({
             </div>
           </div>
           <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>API key</Label>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={handleToggleApiKeyVisibility}
+                  disabled={revealingApiKey || (!apiKey.trim() && !editing?.has_api_key)}
+                  aria-label={apiKeyVisible ? "Hide API key" : "Show API key"}
+                  title={apiKeyVisible ? "Hide API key" : "Show API key"}
+                >
+                  {revealingApiKey ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : apiKeyVisible ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={handleCopyApiKey}
+                  disabled={revealingApiKey || (!apiKey.trim() && !editing?.has_api_key)}
+                  aria-label="Copy API key"
+                  title="Copy API key"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+            <Input
+              className="font-mono"
+              type={apiKeyVisible ? "text" : "password"}
+              value={apiKeyVisible && revealedApiKey ? revealedApiKey : apiKey}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                setRevealedApiKey(null);
+              }}
+              placeholder={editing?.has_api_key ? "Stored API key" : "Optional API key"}
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              {editing?.has_api_key
+                ? "Leave unchanged to keep the stored key, or type a new key to rotate it."
+                : "Stored in the endpoint extra payload when provided."}
+            </p>
+          </div>
+          <div className="space-y-2">
             <Label>Extra (JSON)</Label>
             <Textarea
               className="font-mono text-sm"
@@ -447,11 +591,9 @@ function EndpointDialog({
               onChange={(e) => setExtraJson(e.target.value)}
               rows={4}
             />
-            {editing?.has_api_key && (
-              <p className="text-xs text-muted-foreground">
-                API key is configured and hidden. Leave api_key out to keep it, or add a new api_key to rotate it.
-              </p>
-            )}
+            <p className="text-xs text-muted-foreground">
+              Non-secret endpoint options only. The API key is handled separately above.
+            </p>
           </div>
           {validationMsg && (
             <p

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -7,6 +7,9 @@ import {
   createModelEndpoint,
   updateModelEndpoint,
   deleteModelEndpoint,
+  displayModelEndpointExtra,
+  prepareModelEndpointExtraForSubmit,
+  REDACTED_SECRET,
   setDefaultModelEndpoint,
   validateModelEndpoint,
 } from "@/lib/api/models";
@@ -255,14 +258,20 @@ function EndpointDialog({
     if (open) {
       setValidated(null);
       setValidating(false);
-      setValidationMsg(null);
       if (editing) {
+        const displayExtra = displayModelEndpointExtra(editing.extra);
         setName(editing.name);
         setEndpoint(editing.endpoint);
         setModelName(editing.model_name || "");
         setBatchSize(String(editing.batch_size));
         setTimeout(String(editing.timeout));
-        setExtraJson(JSON.stringify(editing.extra, null, 2));
+        setExtraJson(JSON.stringify(displayExtra, null, 2));
+        setValidated(true);
+        setValidationMsg(
+          editing.has_api_key
+            ? "API key is stored server-side. Leave api_key out to keep it, or add a new api_key to rotate it."
+            : null,
+        );
       } else {
         setName("");
         setEndpoint("");
@@ -270,15 +279,31 @@ function EndpointDialog({
         setBatchSize("32");
         setTimeout("30");
         setExtraJson("{}");
+        setValidated(null);
+        setValidationMsg(null);
       }
     }
   }, [open, editing]);
 
   // Reset validation when relevant fields change
   useEffect(() => {
+    if (
+      editing &&
+      endpoint === editing.endpoint &&
+      (modelName || "") === (editing.model_name || "") &&
+      extraJson === JSON.stringify(displayModelEndpointExtra(editing.extra), null, 2)
+    ) {
+      setValidated(true);
+      setValidationMsg(
+        editing.has_api_key
+          ? "API key is stored server-side. Leave api_key out to keep it, or add a new api_key to rotate it."
+          : null,
+      );
+      return;
+    }
     setValidated(null);
     setValidationMsg(null);
-  }, [endpoint, modelName, extraJson]);
+  }, [endpoint, modelName, extraJson, editing]);
 
   const handleValidate = async () => {
     // Draft validation: probe the values currently in the form (before saving),
@@ -289,18 +314,29 @@ function EndpointDialog({
     }
     let apiKey: string | undefined;
     try {
-      apiKey = (JSON.parse(extraJson || "{}").api_key as string) || undefined;
+      const extra = prepareModelEndpointExtraForSubmit(JSON.parse(extraJson || "{}"));
+      apiKey = (extra.api_key as string) || undefined;
     } catch {
       // invalid extra JSON is reported on save; ignore here
     }
     setValidating(true);
     setValidationMsg(null);
     try {
-      const res = await validateModelEndpoint({
-        endpoint,
-        model_name: modelName || undefined,
-        api_key: apiKey,
-      });
+      const canUseStoredSecret =
+        editing?.has_api_key === true &&
+        (!apiKey || apiKey === REDACTED_SECRET);
+      const res = canUseStoredSecret
+        ? await validateModelEndpoint({
+            endpoint,
+            model_name: modelName || undefined,
+            stored_api_key_model_type: editing.model_type,
+            stored_api_key_name: editing.name,
+          })
+        : await validateModelEndpoint({
+            endpoint,
+            model_name: modelName || undefined,
+            api_key: apiKey,
+          });
       if (!res.reachable) {
         setValidated(false);
         const msg = res.detail || "Endpoint is unreachable.";
@@ -337,7 +373,7 @@ function EndpointDialog({
     e.preventDefault();
     let extra: Record<string, unknown> = {};
     try {
-      extra = JSON.parse(extraJson);
+      extra = prepareModelEndpointExtraForSubmit(JSON.parse(extraJson));
     } catch {
       toast.error("Invalid JSON in extra field");
       return;
@@ -411,6 +447,11 @@ function EndpointDialog({
               onChange={(e) => setExtraJson(e.target.value)}
               rows={4}
             />
+            {editing?.has_api_key && (
+              <p className="text-xs text-muted-foreground">
+                API key is configured and hidden. Leave api_key out to keep it, or add a new api_key to rotate it.
+              </p>
+            )}
           </div>
           {validationMsg && (
             <p

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -349,7 +349,7 @@ function EndpointDialog({
 
   const shouldReuseStoredApiKey = () => {
     const preparedApiKey = apiKeySubmitValue();
-    return editing?.has_api_key === true && (!preparedApiKey || preparedApiKey === REDACTED_SECRET);
+    return editing?.has_api_key === true && preparedApiKey === REDACTED_SECRET;
   };
 
   const revealedApiKeyForEditing =
@@ -434,8 +434,10 @@ function EndpointDialog({
     setValidating(true);
     setValidationMsg(null);
     try {
+      const isClearingStoredApiKey = editing?.has_api_key === true && submittedApiKey === "";
       if (
         editing?.has_api_key === true &&
+        !isClearingStoredApiKey &&
         normalizeEndpointUrl(endpoint) !== normalizeEndpointUrl(editing.endpoint) &&
         !apiKey &&
         (!submittedApiKey || submittedApiKey === REDACTED_SECRET)
@@ -447,7 +449,10 @@ function EndpointDialog({
         return;
       }
       const canUseStoredSecret =
-        editing?.has_api_key === true && !apiKey && (!submittedApiKey || submittedApiKey === REDACTED_SECRET);
+        editing?.has_api_key === true &&
+        !isClearingStoredApiKey &&
+        !apiKey &&
+        (!submittedApiKey || submittedApiKey === REDACTED_SECRET);
       const res = canUseStoredSecret
         ? await validateModelEndpoint({
             endpoint,

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -60,6 +60,8 @@ type RevealedApiKey = {
   value: string;
 };
 
+const normalizeEndpointUrl = (value: string) => value.trim().replace(/\/+$/, "");
+
 export default function ModelsPage() {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState("embedder");
@@ -417,17 +419,35 @@ function EndpointDialog({
       return;
     }
     let apiKey: string | undefined;
+    let submittedApiKey: string | undefined;
     try {
-      const submittedApiKey = apiKeySubmitValue();
-      apiKey = typeof submittedApiKey === "string" ? submittedApiKey : undefined;
+      const preparedApiKey = apiKeySubmitValue();
+      submittedApiKey = typeof preparedApiKey === "string" ? preparedApiKey : undefined;
+      if (submittedApiKey && submittedApiKey !== REDACTED_SECRET) {
+        apiKey = submittedApiKey;
+      } else if (revealedApiKeyForEditing) {
+        apiKey = revealedApiKeyForEditing;
+      }
     } catch {
       // invalid extra JSON is reported on save; ignore here
     }
     setValidating(true);
     setValidationMsg(null);
     try {
+      if (
+        editing?.has_api_key === true &&
+        normalizeEndpointUrl(endpoint) !== normalizeEndpointUrl(editing.endpoint) &&
+        !apiKey &&
+        (!submittedApiKey || submittedApiKey === REDACTED_SECRET)
+      ) {
+        setValidated(false);
+        const msg = "Reveal or enter the API key before validating a changed endpoint URL.";
+        setValidationMsg(msg);
+        toast.error(msg);
+        return;
+      }
       const canUseStoredSecret =
-        editing?.has_api_key === true && (!apiKey || apiKey === REDACTED_SECRET);
+        editing?.has_api_key === true && !apiKey && (!submittedApiKey || submittedApiKey === REDACTED_SECRET);
       const res = canUseStoredSecret
         ? await validateModelEndpoint({
             endpoint,


### PR DESCRIPTION
## Summary

Fixes #614 by redacting saved secrets from admin-facing read responses while keeping the real values available server-side.

Model endpoint responses now hide secret values from `extra` and expose `has_api_key` so the Admin UI can show that a key exists without receiving it. The service also preserves existing stored secrets when an endpoint update omits the key, which prevents the edit form from accidentally clearing private endpoint credentials.

The `/config` response now redacts known secret fields before returning the settings object to the Admin UI.

## Why

The Admin UI needs to manage model endpoints and runtime config, but raw API keys, tokens, and passwords should not be sent back to the browser after they are saved. At the same time, saved model endpoint keys are still required by backend validation and indexing, so this keeps storage/internal use intact.

## Validation

- `uv run --no-env-file pytest tests/unit/api/routers/admin/test_phase14_admin_routers.py tests/unit/services/orchestrators/test_model_endpoint_service.py tests/unit/api/test_secret_redaction.py tests/unit/api/test_main_proxy_headers.py -q`
- `uv run --no-env-file ruff check openrag/core/utils/redaction.py openrag/api/schemas/admin/model_endpoint_schemas.py openrag/api/main.py openrag/services/orchestrators/model_endpoint_service.py tests/unit/api/test_secret_redaction.py tests/unit/api/routers/admin/test_phase14_admin_routers.py tests/unit/services/orchestrators/test_model_endpoint_service.py tests/integration/api/test_model_endpoints.py`
- `git diff --check`
- `cd ui && npm run lint && npm run test && npm run build`
- Local API smoke test: create/list/detail/update model endpoint with a fake API key; no read response contained the fake key, and Postgres still preserved the stored key after update without `api_key`.
- Playwright check against local Admin UI: edit dialog hides the key, shows the preservation hint, keeps Update enabled for an unchanged saved endpoint, and System config does not expose the fake key.

## Notes

I also ran `tests/integration/api/test_model_endpoints.py` against the local CPU stack. Three tests passed; the CRUD validation test failed on the existing local setup because it expects a mock vLLM service at `http://vllm:8000/v1`, which this CPU stack does not start.

TestSprite preflight passed, but I did not run a TestSprite suite because this change is only deployed on localhost and TestSprite requires a publicly reachable target URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin support to reveal a server-stored endpoint API key on demand.
  * Enhanced the model endpoint dialog to reuse an existing API key or enter a new one, including show/hide and copy actions.
  * Endpoint details now indicate whether an API key exists without exposing its full value.
* **Bug Fixes**
  * Sensitive configuration values and endpoint `extra` secret data are now redacted in API responses.
  * Updating endpoint details preserves previously saved API keys when not changed.
  * Draft endpoint validation can reuse stored credentials and now rejects invalid URLs more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->