### PR TITLE
fix: mount host .venv to skip package reinstall on every container start

### DIFF
--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -35,6 +35,7 @@ x-openrag: &openrag_template
     - ${DATA_VOLUME:-../../data}:/app/data
     - ../../i8n:/app/openrag/.chainlit/translations
     - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights # Model weights for RAG
+    - ${VENV_VOLUME:-../../.venv}:/app/.venv # Pre-synced venv — avoids reinstalling packages on every start
     # Dev only: bind-mounting the source tree over the image lets host changes
     # (or a writable host path) override the running code. Uncomment for local
     # development; keep it off in production.

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -16,7 +16,7 @@
 # membership plus the image's group-writable paths already cover it.
 APP_UID="${APP_UID:-10001}"
 if [ "$(id -u)" = "0" ]; then
-  for d in /app/data /app/logs /app/model_weights; do
+  for d in /app/data /app/logs /app/model_weights /app/.venv; do
     mkdir -p "$d" 2>/dev/null || true
     chgrp -R 0 "$d" 2>/dev/null || true
     chmod -R g+rwX "$d" 2>/dev/null || true


### PR DESCRIPTION
## Problem

On every `docker compose up`, the container reinstalled all Python packages from scratch because `uv sync` was commented out in the Dockerfile, leaving the image's `/app/.venv` empty. `uv run` detected the empty/unsynced venv and re-ran the full install before starting the app.

## Solution

Mount the host's pre-synced `.venv` at `/app/.venv` inside the container. `uv run` then sees a venv that matches `uv.lock` and skips the sync entirely.

### Changes

**`infra/compose/docker-compose.yaml`**
- Added `${VENV_VOLUME:-../../.venv}:/app/.venv` to the `x-openrag` template volumes. Defaults to `../../.venv` (the repo root venv). Override via `VENV_VOLUME` in `.env`.

**`infra/scripts/entrypoint.sh`**
- Added `/app/.venv` to the permission-fix loop that runs `chgrp 0 + chmod g+rwX` on bind-mounted dirs when the container starts as root. This is the same pattern already used for `data`, `logs`, and `model_weights` — it grants GID-0 write access before privilege drop so the non-root app user (which is always in GID 0) can use the mounted venv.

## Usage

```bash
# One-time setup on the host (if not already done)
uv sync --no-dev

# Normal start — packages are NOT reinstalled
docker compose up -d
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup so the bundled Python environment is available inside the API container.
  * Added permission handling for the virtual environment directory, helping avoid startup and access issues when running as a non-root user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->