### PR TITLE
fix: cache the venv in a container-synced named volume

### DIFF
--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -35,6 +35,13 @@ x-openrag: &openrag_template
     - ${DATA_VOLUME:-../../data}:/app/data
     - ../../i8n:/app/openrag/.chainlit/translations
     - ${MODEL_WEIGHTS_VOLUME:-~/.cache/huggingface}:/app/model_weights # Model weights for RAG
+    # Container-owned venv cache: `uv run` syncs into this named volume on the
+    # first start and skips the sync on every start after, so packages aren't
+    # reinstalled each `docker compose up`. A named volume (not a host bind
+    # mount) is deliberate — the venv is only ever populated by the container,
+    # so its interpreter/script paths always match the image (a host-synced
+    # venv would point at host paths that don't exist inside the container).
+    - openrag_venv:/app/.venv
     # Dev only: bind-mounting the source tree over the image lets host changes
     # (or a writable host path) override the running code. Uncomment for local
     # development; keep it off in production.
@@ -228,3 +235,4 @@ volumes:
   logs:
   modelweights:
   pgdata:
+  openrag_venv: # Persists the container-synced /app/.venv so packages survive restarts

--- a/infra/docker/api.Dockerfile.dockerignore
+++ b/infra/docker/api.Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+# Scoped ignore for the api image. BuildKit reads `<dockerfile>.dockerignore`
+# (here infra/docker/api.Dockerfile.dockerignore), so this applies only to the
+# api build — not the ui/ray images that share the repo-root build context.
+#
+# Patterns are relative to the build context (repo root, per compose `context: ../..`).
+# The api Dockerfile only COPYs pyproject.toml, uv.lock, openrag/, conf/ and
+# infra/scripts/entrypoint.sh — so keeping the large host-side runtime dirs out
+# of the context avoids shipping a multi-GB tarball (torch, Ray, model weights)
+# to the daemon on every `docker compose build`/`up --build`.
+.venv
+data
+logs
+model_weights
+.git
+**/__pycache__


### PR DESCRIPTION
## Problem

The image ships an **empty** `/app/.venv` (the Dockerfile's `uv sync` is commented out), so on every `docker compose up` `uv run` detected the unsynced venv and reinstalled all Python packages from scratch before starting the app.

## Solution

Cache the venv in a Docker **named volume** (`openrag_venv`) mounted at `/app/.venv`. The container's own `uv run` syncs it **once** on first start (against `uv.lock`) and skips the sync on every start after — the packages persist in the volume across restarts.

A named volume is used **deliberately instead of a host bind mount**: the venv is only ever populated *by the container*, so its interpreter and console-script paths always match the image. A host-synced `.venv` would bake in host paths (`~/.local/share/uv/python`, the host repo path) that don't exist inside the container and would break startup.

### Changes

**`infra/compose/docker-compose.yaml`**
- Mount the named volume `openrag_venv:/app/.venv` in the `x-openrag` template and declare `openrag_venv` under top-level `volumes:`.

**`infra/docker/api.Dockerfile.dockerignore`** (new)
- Keep host-side `.venv`, `data`, `logs`, `model_weights`, `.git` out of the api build context, so `docker compose build` / `up --build` doesn't ship a multi-GB tarball to the daemon. Uses the same per-Dockerfile ignore convention already used by `ui.Dockerfile.dockerignore`.

> No entrypoint change is needed: the named volume seeds from the image's already group-0-writable `/app/.venv` (`chmod g=u` in `api.Dockerfile`), so the non-root app user (GID 0) can write it — without recursively `chmod`-ing the whole torch/Ray tree on every start.

## Usage

Nothing to do on the host — the venv is built and cached by the container:

```bash
docker compose up -d   # first start syncs the venv into the volume;
                       # every start after reuses it and skips the install
```

Changing `uv.lock` makes `uv run` re-sync automatically on the next start. To force a clean rebuild of the cache:

```bash
docker compose down
docker volume ls | grep openrag_venv   # find the <project>_openrag_venv volume
docker volume rm <project>_openrag_venv
docker compose up -d
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent package storage for the container environment, so installed dependencies can survive restarts.
  * Improved the API image build setup to exclude unnecessary files from the build context, helping builds stay leaner and faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->