### PR TITLE
fix(search): validate user-supplied filter expression

### DIFF
--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -17,6 +17,7 @@ from api.dependencies.auth import (
     require_partitions_viewer,
 )
 from api.dependencies.files import validate_file_id
+from core.utils.filter_validation import validate_search_filter
 from core.utils.logging import get_logger
 from di.providers import get_retrieval_service, get_workspace_service
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -58,6 +59,10 @@ class CommonSearchParams:
             description="""Milvus filter expression string.""",
         ),
     ):
+        # Reject filter expressions that could break out of the partition
+        # scope (unbalanced parens rebalancing the `(partition …) and (…)`
+        # wrapper) before the raw string reaches the store. Raises 400.
+        validate_search_filter(filter)
         self.text = text
         self.top_k = top_k
         self.similarity_threshold = similarity_threshold

--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -322,7 +322,10 @@ async def search_file(
         partition=partition, file_id=file_id, query_len=len(search_params.text), top_k=search_params.top_k
     )
 
-    filter = "file_id == {_file_id}" + (f" AND {search_params.filter}" if search_params.filter else "")
+    # Parenthesise the caller filter so it stays a single AND-operand and can't
+    # break out of the file scope (e.g. ``page > 5 OR 1==1`` must not widen the
+    # ``file_id ==`` constraint). It is already validated by CommonSearchParams.
+    filter = "file_id == {_file_id}" + (f" AND ({search_params.filter})" if search_params.filter else "")
     params = {"_file_id": file_id}
 
     results = await service.search(

--- a/openrag/core/utils/filter_validation.py
+++ b/openrag/core/utils/filter_validation.py
@@ -22,7 +22,11 @@ are ignored):
   partition wrapper. This is the core isolation guarantee.
 * **No ``partition`` reference** — the tenant boundary is set by the route and
   auth, never by the caller (defense-in-depth).
-* **No bare tautology**, and a bounded length.
+* A bounded length, and a best-effort reject of trivial tautologies
+  (``1==1`` / ``true``). The tautology reject is defense-in-depth only —
+  tenant isolation is guaranteed by the two rules above, not by it, since an
+  always-true predicate is still confined to the caller's partitions by the
+  outer ``and``.
 
 ``or`` / ``not`` remain allowed: once parentheses are balanced, the top-level
 ``and`` with the partition clause confines the result set to the caller's
@@ -49,6 +53,31 @@ def _reject(reason: str) -> None:
         status_code=400,
         code="INVALID_FILTER",
     )
+
+
+def _strip_wrapping_parens(s: str) -> str:
+    """Strip parentheses that wrap the *entire* string, one layer at a time.
+
+    ``(1==1)`` -> ``1==1``; ``((true))`` -> ``true``. A leading ``(`` that
+    closes before the end (e.g. ``(a)and(b)``) is left untouched. Used so the
+    tautology check can't be defeated by simply wrapping the expression in
+    parentheses.
+    """
+    while len(s) >= 2 and s[0] == "(" and s[-1] == ")":
+        depth = 0
+        wraps = True
+        for i, ch in enumerate(s):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0 and i != len(s) - 1:
+                    wraps = False
+                    break
+        if not wraps:
+            break
+        s = s[1:-1]
+    return s
 
 
 def validate_search_filter(expr: str | None) -> None:
@@ -105,7 +134,11 @@ def validate_search_filter(expr: str | None) -> None:
     if any(ident.lower() in _RESERVED_FIELDS for ident in identifiers):
         _reject("`partition` is not a permitted filter field")
 
-    if "".join(expr.split()).lower() in _TAUTOLOGIES:
+    # Best-effort tautology reject (defense-in-depth only — tenant isolation is
+    # guaranteed by the balanced-paren + reserved-field rules above, not by
+    # this). Strip whitespace and any wrapping parens so `(1==1)` / `( true )`
+    # can't trivially slip past the literal match.
+    if _strip_wrapping_parens("".join(expr.split()).lower()) in _TAUTOLOGIES:
         _reject("tautological expression")
 
 

--- a/openrag/core/utils/filter_validation.py
+++ b/openrag/core/utils/filter_validation.py
@@ -1,0 +1,112 @@
+"""Validation for caller-supplied Milvus filter expressions on search routes.
+
+The public search routes accept a raw ``filter`` expression that the vector
+store appends to the partition-scoped query as
+``(partition in [...]) and (<filter>)``. That wrapping only confines the
+caller's expression while its parentheses are *balanced*: Milvus binds ``and``
+tighter than ``or``, so an unbalanced ``)`` can close the partition wrapper
+early and an ``or`` tautology then matches every row —
+
+    filter = 1==1) or (1==1
+    -> (partition in ["mine"]) and (1==1) or (1==1)   # always true
+
+returning other tenants' chunks (``partition`` is a Milvus partition_key —
+routing, not a hard boundary). This module rejects such expressions before they
+reach the store.
+
+Guarantees enforced (quote-aware, so operators/parens inside string literals
+are ignored):
+
+* **Balanced parentheses** — the caller's expression stays confined to the
+  single ``and``-joined operand it is wrapped in and cannot rebalance the
+  partition wrapper. This is the core isolation guarantee.
+* **No ``partition`` reference** — the tenant boundary is set by the route and
+  auth, never by the caller (defense-in-depth).
+* **No bare tautology**, and a bounded length.
+
+``or`` / ``not`` remain allowed: once parentheses are balanced, the top-level
+``and`` with the partition clause confines the result set to the caller's
+partitions regardless of the operators inside their expression.
+"""
+
+from __future__ import annotations
+
+from core.utils.exceptions import ValidationError
+
+#: Upper bound on a caller-supplied filter expression (chars).
+MAX_FILTER_LENGTH = 2048
+
+#: Whitespace-stripped, lowercased expressions that match every row.
+_TAUTOLOGIES = frozenset({"true", "1==1"})
+
+#: The partition_key column — the tenant boundary, never caller-filterable.
+_RESERVED_FIELDS = frozenset({"partition"})
+
+
+def _reject(reason: str) -> None:
+    raise ValidationError(
+        f"Invalid filter expression: {reason}",
+        status_code=400,
+        code="INVALID_FILTER",
+    )
+
+
+def validate_search_filter(expr: str | None) -> None:
+    """Reject an unsafe caller-supplied Milvus filter (raises HTTP 400).
+
+    A ``None`` or empty expression is valid (no extra filtering). Raises
+    :class:`~core.utils.exceptions.ValidationError` (status 400) otherwise.
+    """
+    if not expr:
+        return
+    if len(expr) > MAX_FILTER_LENGTH:
+        _reject("expression too long")
+
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    token: list[str] = []
+    identifiers: list[str] = []
+
+    for ch in expr:
+        if quote is not None:
+            # Inside a string literal: ignore parens/operators, only track the
+            # closing quote and backslash escapes so a quoted `)` or `partition`
+            # cannot trip the checks (or hide a real breakout).
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                _reject("unbalanced parentheses")
+        if ch.isalnum() or ch == "_":
+            token.append(ch)
+        elif token:
+            identifiers.append("".join(token))
+            token = []
+
+    if quote is not None:
+        _reject("unterminated string literal")
+    if depth != 0:
+        _reject("unbalanced parentheses")
+    if token:
+        identifiers.append("".join(token))
+
+    if any(ident.lower() in _RESERVED_FIELDS for ident in identifiers):
+        _reject("`partition` is not a permitted filter field")
+
+    if "".join(expr.split()).lower() in _TAUTOLOGIES:
+        _reject("tautological expression")
+
+
+__all__ = ["validate_search_filter", "MAX_FILTER_LENGTH"]

--- a/tests/unit/api/routers/user/test_search.py
+++ b/tests/unit/api/routers/user/test_search.py
@@ -60,3 +60,34 @@ def test_search_rejects_cross_tenant_filter_injection():
     )
 
     assert response.status_code == 400
+    # Confirm the rejection is the filter guard specifically — the code is
+    # embedded in the detail (``"[INVALID_FILTER]: ..."``), not a generic 400.
+    assert "INVALID_FILTER" in response.json()["detail"]
+
+
+def test_search_file_parenthesises_caller_filter():
+    # The by-file route must wrap the caller filter so an OR predicate cannot
+    # widen the file_id scope (``page > 5 OR 1==1`` must stay a single operand).
+    from api.dependencies.auth import require_partition_viewer
+    from api.dependencies.files import validate_file_id
+
+    captured: dict = {}
+
+    class _CapturingRetrieval:
+        async def search(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[require_partition_viewer] = lambda: None
+    app.dependency_overrides[validate_file_id] = lambda: "abc123"
+    app.dependency_overrides[get_retrieval_service] = lambda: _CapturingRetrieval()
+
+    resp = TestClient(app).get(
+        "/search/partition/mine/file/abc123", params={"text": "q", "filter": "page > 5 OR page < 2"}
+    )
+
+    assert resp.status_code == 200
+    assert captured["filter"] == "file_id == {_file_id} AND (page > 5 OR page < 2)"

--- a/tests/unit/api/routers/user/test_search.py
+++ b/tests/unit/api/routers/user/test_search.py
@@ -3,6 +3,7 @@ from api.dependencies.auth import (
     current_user_or_admin_partitions_list,
     current_user_partitions,
 )
+from api.error_handlers import register_error_handlers
 from api.routers.user.search import router as search_router
 from di.providers import get_auth_service, get_partition_service, get_retrieval_service, get_workspace_service
 from fastapi import FastAPI
@@ -27,6 +28,7 @@ class _RetrievalService:
 
 def _client(*, user_partitions):
     app = FastAPI()
+    register_error_handlers(app)
     app.include_router(search_router, prefix="/search")
     app.dependency_overrides[current_user] = lambda: {"id": 7, "is_admin": False}
     app.dependency_overrides[current_user_partitions] = lambda: user_partitions
@@ -45,3 +47,16 @@ def test_search_default_all_fails_closed_when_user_has_no_partitions():
 
     assert response.status_code == 403
     assert response.json()["detail"] == "No accessible partitions"
+
+
+def test_search_rejects_cross_tenant_filter_injection():
+    # An authorized viewer on one partition must not be able to break out of the
+    # partition scope via an unbalanced-paren filter. The guard fires during
+    # dependency resolution, so retrieval never runs (``_RetrievalService.search``
+    # raises if it does) and the request is rejected with 400 — not a 500 or a
+    # leaked result set.
+    response = _client(user_partitions=[{"partition": "mine", "role": "viewer"}]).get(
+        "/search", params={"text": "hello", "filter": "1==1) or (1==1"}
+    )
+
+    assert response.status_code == 400

--- a/tests/unit/core/utils/test_filter_validation.py
+++ b/tests/unit/core/utils/test_filter_validation.py
@@ -31,6 +31,11 @@ from core.utils.filter_validation import MAX_FILTER_LENGTH, validate_search_filt
         "1 == 1",
         "true",
         "TRUE",
+        # Tautologies must not slip past by wrapping in parentheses.
+        "(1==1)",
+        "( 1 == 1 )",
+        "((1==1))",
+        "(true)",
         # Unterminated string literal.
         'file_id == "abc',
     ],

--- a/tests/unit/core/utils/test_filter_validation.py
+++ b/tests/unit/core/utils/test_filter_validation.py
@@ -1,0 +1,69 @@
+"""Tests for the search-filter injection guard (``validate_search_filter``).
+
+Covers the cross-tenant breakout the guard exists to stop (unbalanced parens
+rebalancing the ``(partition …) and (…)`` wrapper) plus the reserved-field and
+tautology rules, and confirms legitimate documented filters still pass.
+"""
+
+import pytest
+from core.utils.exceptions import ValidationError
+from core.utils.filter_validation import MAX_FILTER_LENGTH, validate_search_filter
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        # The audit's headline payload: the trailing `)` closes the partition
+        # wrapper early so `or (1==1)` matches every tenant's rows.
+        "1==1) or (1==1",
+        # Other unbalanced-paren breakouts.
+        'file_id == "x") or (1==1',
+        ")",
+        "(page > 5",
+        "page > 5)",
+        '((file_id == "x")',
+        # Referencing the tenant boundary column directly.
+        'partition == "other"',
+        'partition in ["a", "b"]',
+        'page > 5 or PARTITION == "other"',
+        # Bare tautologies.
+        "1==1",
+        "1 == 1",
+        "true",
+        "TRUE",
+        # Unterminated string literal.
+        'file_id == "abc',
+    ],
+)
+def test_rejects_unsafe_filters(expr):
+    with pytest.raises(ValidationError) as exc:
+        validate_search_filter(expr)
+    assert exc.value.status_code == 400
+
+
+def test_length_bound():
+    with pytest.raises(ValidationError):
+        validate_search_filter("a" * (MAX_FILTER_LENGTH + 1))
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        None,
+        "",
+        'file_id == "abc123"',
+        "page >= 5 AND page <= 10",
+        'file_id in ["id1", "id2", "id3"]',
+        'created_at > ISO "2024-01-01T00:00:00+00:00"',
+        # Balanced parens with `or` are safe — confined by the outer `and`.
+        "(page > 5 or page < 2)",
+        'NOT (file_id == "x")',
+        # `partition` only as a substring of another field name is fine.
+        'partition_group == "g1"',
+        # A quoted `)` / `partition` must not trip the checks.
+        'filename == "weird)name"',
+        'meta["partition"] == "sub"',
+    ],
+)
+def test_allows_legitimate_filters(expr):
+    validate_search_filter(expr)  # must not raise


### PR DESCRIPTION
## What

Validates the user-supplied `filter` query parameter on the search routes before it is combined with the partition scope in the Milvus query.

## Why

The raw `filter` string is appended alongside the partition clause and wrapped as `(partition …) and (…)`. That wrapping only holds while the caller's expression has balanced parentheses — an unbalanced expression can rebalance the wrapper and widen the query beyond the caller's partitions. Tracked as `GHSA-3gvv-h672-gj2c`.

## How

New `validate_search_filter` (`core/utils/filter_validation.py`), called in `CommonSearchParams.__init__` so all three search routes are covered at one boundary. It is quote-aware (operators/parens inside string literals are ignored) and rejects:

- **unbalanced parentheses** — the core guarantee; keeps the caller's expression confined to the single `and`-joined operand it is wrapped in,
- references to the reserved **`partition`** field,
- bare **tautologies**,
- **over-long** input.

`or` / `not` stay allowed — once parentheses balance, the top-level `and` with the partition clause always confines results to the caller's partitions regardless of the operators inside.

Scope: the chat/retrieval path is unaffected (it builds filters from a structured, validated model, never a raw string); MCP builds its filter server-side. `_build_filter_expr` (the sink) is unchanged — validation is applied where untrusted input enters.

## Tests

- Unit tests for the validator: rejected cases (incl. the unbalanced-paren breakout, `partition` reference, tautologies, unterminated string) and allowed cases (incl. balanced `or`, quoted `)` / `partition`, `partition_group`, `IN`, `ISO`).
- End-to-end route test: a malformed filter returns **400** during dependency resolution, before retrieval runs.
- Full unit suite green (1569 passed); ruff + layer-import checks pass.

Refs `GHSA-3gvv-h672-gj2c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search requests now reject unsafe or malformed filter expressions with a clear 400-level error instead of passing them through.
  * Added protection against overly long filters, unbalanced parentheses, unterminated strings, tautologies, and reserved terms that could affect search scope.
  * Standardized API error responses during search requests.
* **Tests**
  * Added coverage for valid and invalid filter expressions, including cross-scope injection attempts and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->