### PR TITLE
fix(admin-ui): persist preset parsing_strategy instead of a display-only default

### DIFF
--- a/ui/src/pages/admin/preset-config.test.ts
+++ b/ui/src/pages/admin/preset-config.test.ts
@@ -35,6 +35,33 @@ describe("applyParsingStrategyChange", () => {
     expect(applyParsingStrategyChange({}, "docling")).not.toHaveProperty("enable_image_captioning");
   });
 
+  it("clears the forced-off captioning flag when leaving pymupdf for another backend", () => {
+    // pymupdf forced captioning off; switching to marker/docling (which can
+    // caption) must revert to the sparse/default (enabled) behavior.
+    expect(
+      applyParsingStrategyChange({ parsing_strategy: "pymupdf", enable_image_captioning: false }, "marker"),
+    ).toEqual({ parsing_strategy: "marker" });
+    expect(
+      applyParsingStrategyChange({ parsing_strategy: "pymupdf", enable_image_captioning: false }, "docling"),
+    ).toEqual({ parsing_strategy: "docling" });
+  });
+
+  it("clears the forced-off captioning flag when leaving pymupdf for inherit-default", () => {
+    expect(
+      applyParsingStrategyChange(
+        { parsing_strategy: "pymupdf", enable_image_captioning: false },
+        PARSING_STRATEGY_INHERIT,
+      ),
+    ).toEqual({});
+  });
+
+  it("preserves an explicit captioning choice when not coming from pymupdf", () => {
+    // marker -> docling is not a pymupdf exit, so a user-set false is kept.
+    expect(
+      applyParsingStrategyChange({ parsing_strategy: "marker", enable_image_captioning: false }, "docling"),
+    ).toEqual({ parsing_strategy: "docling", enable_image_captioning: false });
+  });
+
   it("does not mutate the input config", () => {
     const input = { parsing_strategy: "marker" };
     applyParsingStrategyChange(input, PARSING_STRATEGY_INHERIT);

--- a/ui/src/pages/admin/preset-config.test.ts
+++ b/ui/src/pages/admin/preset-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { applyParsingStrategyChange, PARSING_STRATEGY_INHERIT } from "./preset-config";
+
+// Regression guard for the bug where the parsing Strategy dropdown displayed a
+// fabricated "marker" default that was never written to config unless the user
+// actively changed the selection — so a marker preset saved no parsing_strategy
+// and silently fell back to the deployment's global PDF loader (e.g. pymupdf).
+describe("applyParsingStrategyChange", () => {
+  it("persists an explicitly chosen strategy into config", () => {
+    expect(applyParsingStrategyChange({}, "marker")).toEqual({ parsing_strategy: "marker" });
+    expect(applyParsingStrategyChange({}, "docling")).toEqual({ parsing_strategy: "docling" });
+  });
+
+  it("clears parsing_strategy when choosing the inherit-global default", () => {
+    const cleared = applyParsingStrategyChange({ parsing_strategy: "marker" }, PARSING_STRATEGY_INHERIT);
+    expect(cleared).not.toHaveProperty("parsing_strategy");
+    expect(cleared).toEqual({});
+  });
+
+  it("keeps unrelated config keys intact when changing strategy", () => {
+    expect(
+      applyParsingStrategyChange({ topic_tagging_llm: "some-llm" }, "marker"),
+    ).toEqual({ parsing_strategy: "marker", topic_tagging_llm: "some-llm" });
+  });
+
+  it("disables image captioning when switching to pymupdf (text-only backend)", () => {
+    expect(applyParsingStrategyChange({}, "pymupdf")).toEqual({
+      parsing_strategy: "pymupdf",
+      enable_image_captioning: false,
+    });
+  });
+
+  it("does not toggle image captioning for marker/docling", () => {
+    expect(applyParsingStrategyChange({}, "marker")).not.toHaveProperty("enable_image_captioning");
+    expect(applyParsingStrategyChange({}, "docling")).not.toHaveProperty("enable_image_captioning");
+  });
+
+  it("does not mutate the input config", () => {
+    const input = { parsing_strategy: "marker" };
+    applyParsingStrategyChange(input, PARSING_STRATEGY_INHERIT);
+    expect(input).toEqual({ parsing_strategy: "marker" });
+  });
+});

--- a/ui/src/pages/admin/preset-config.ts
+++ b/ui/src/pages/admin/preset-config.ts
@@ -37,13 +37,24 @@ export const PARSING_STRATEGY_INHERIT = "__inherit__";
 // preset created while leaving "marker" showing saved no parsing_strategy and
 // silently fell back to the global loader (e.g. pymupdf).
 export function applyParsingStrategyChange(config: Config, value: string): Config {
+  // While pymupdf is selected the captioning toggle is disabled, so a stored
+  // enable_image_captioning:false is always system-forced (never a user choice).
+  const leavingPymupdf = config.parsing_strategy === "pymupdf" && value !== "pymupdf";
+
+  let next: Config;
   if (value === PARSING_STRATEGY_INHERIT) {
     // Explicitly clear so the preset inherits the global loader.
-    return configUnset(config, "parsing_strategy");
+    next = configUnset(config, "parsing_strategy");
+  } else {
+    next = configSet(config, "parsing_strategy", value);
+    // pymupdf is text-only (no images), so captioning can't apply — force it off.
+    if (value === "pymupdf") next = configSet(next, "enable_image_captioning", false);
   }
-  let next = configSet(config, "parsing_strategy", value);
-  // pymupdf is text-only (no images), so captioning can't apply — turn it off
-  // when switching to it (see the disabled captioning toggle in presets.tsx).
-  if (value === "pymupdf") next = configSet(next, "enable_image_captioning", false);
+
+  // Leaving pymupdf (for any other strategy, including inherit): drop the
+  // forced-off flag so captioning reverts to the sparse/default (enabled)
+  // behavior instead of staying stuck off on a backend that can caption.
+  if (leavingPymupdf) next = configUnset(next, "enable_image_captioning");
+
   return next;
 }

--- a/ui/src/pages/admin/preset-config.ts
+++ b/ui/src/pages/admin/preset-config.ts
@@ -1,0 +1,49 @@
+/* Pure helpers for the preset config editor (see presets.tsx).
+ *
+ * Kept in their own module (not presets.tsx) so they can be unit-tested and so
+ * the component file only exports components (react-refresh/only-export-components).
+ */
+
+export type Config = Record<string, unknown>;
+
+export function configGet<T>(config: Config, key: string, fallback: T): T {
+  const v = config[key];
+  if (v === undefined || v === null) return fallback;
+  return v as T;
+}
+
+export function configSet(prev: Config, key: string, value: unknown): Config {
+  return { ...prev, [key]: value };
+}
+
+export function configUnset(prev: Config, key: string): Config {
+  const next = { ...prev };
+  delete next[key];
+  return next;
+}
+
+// Sentinel for "no explicit parsing_strategy". An absent key means the preset
+// inherits the deployment's global PDF loader (file_loaders.pdf), so we surface
+// that as an explicit "Default" choice instead of a fabricated concrete value.
+// Mirrors the retrieval form's "__none__" convention so the shown value always
+// matches what gets persisted (WYSIWYG).
+export const PARSING_STRATEGY_INHERIT = "__inherit__";
+
+// Map a parsing-strategy selection to the next config. Kept pure so the
+// persistence behavior is unit-testable without driving the Radix Select.
+//
+// Fixes the bug where the dropdown *displayed* a default of "marker" that was
+// never written to config unless the user actively changed the selection — a
+// preset created while leaving "marker" showing saved no parsing_strategy and
+// silently fell back to the global loader (e.g. pymupdf).
+export function applyParsingStrategyChange(config: Config, value: string): Config {
+  if (value === PARSING_STRATEGY_INHERIT) {
+    // Explicitly clear so the preset inherits the global loader.
+    return configUnset(config, "parsing_strategy");
+  }
+  let next = configSet(config, "parsing_strategy", value);
+  // pymupdf is text-only (no images), so captioning can't apply — turn it off
+  // when switching to it (see the disabled captioning toggle in presets.tsx).
+  if (value === "pymupdf") next = configSet(next, "enable_image_captioning", false);
+  return next;
+}

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -39,6 +39,13 @@ import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, intOr, numOr } from "@/lib/utils";
+import {
+  type Config,
+  configGet,
+  configSet,
+  applyParsingStrategyChange,
+  PARSING_STRATEGY_INHERIT,
+} from "./preset-config";
 
 const PRESET_TYPES = ["indexation", "retrieval"] as const;
 
@@ -213,20 +220,6 @@ export default function PresetsPage() {
   );
 }
 
-/* ---------- helpers ---------- */
-
-type Config = Record<string, unknown>;
-
-function configGet<T>(config: Config, key: string, fallback: T): T {
-  const v = config[key];
-  if (v === undefined || v === null) return fallback;
-  return v as T;
-}
-
-function configSet(prev: Config, key: string, value: unknown): Config {
-  return { ...prev, [key]: value };
-}
-
 /* ---------- Indexation form ---------- */
 
 function IndexationPresetForm({
@@ -334,19 +327,14 @@ function IndexationPresetForm({
         <div className="space-y-1.5">
           <Label className="text-xs">Strategy</Label>
           <Select
-            value={configGet(config, "parsing_strategy", "marker")}
-            onValueChange={(v) => {
-              // pymupdf is text-only (no images), so captioning can't apply —
-              // turn it off when switching to it (see the disabled toggle below).
-              let next = configSet(config, "parsing_strategy", v);
-              if (v === "pymupdf") next = configSet(next, "enable_image_captioning", false);
-              onChange(next);
-            }}
+            value={configGet(config, "parsing_strategy", PARSING_STRATEGY_INHERIT)}
+            onValueChange={(v) => onChange(applyParsingStrategyChange(config, v))}
           >
             <SelectTrigger size="sm">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={PARSING_STRATEGY_INHERIT}>Default (inherit global loader)</SelectItem>
               {parsingStrategies.map((s) => (
                 <SelectItem key={s} value={s}>
                   {s}
@@ -370,7 +358,7 @@ function IndexationPresetForm({
           // reads "off" while the backend still captions during indexing (#453).
           enabled={configGet(config, "enable_image_captioning", true)}
           onToggle={(on) => toggleFeature("enable_image_captioning", "vlm", on)}
-          disabled={configGet<string>(config, "parsing_strategy", "marker") === "pymupdf"}
+          disabled={configGet<string>(config, "parsing_strategy", PARSING_STRATEGY_INHERIT) === "pymupdf"}
           disabledHint="pymupdf extracts text only — use marker or docling for image captioning."
           modelLabel="VLM"
           modelValue={configGet(config, "vlm", "")}


### PR DESCRIPTION
## What

Fixes a frontend bug where the admin UI preset editor's **Parsing → Strategy** dropdown showed a hard-coded `marker` default that was never written to the preset config unless the user actively changed the selection. A preset created/edited while leaving the dropdown on `marker` saved a config with **no** `parsing_strategy` key, so it silently inherited the deployment's global PDF loader (pymupdf where `PDFLoader=PyMuPDFLoader`) instead of marker.

Closes #622.

## Root cause

`ui/src/pages/admin/presets.tsx`:

```tsx
value={configGet(config, "parsing_strategy", "marker")}   // display-only fallback
onValueChange={(v) => { /* persists — but only fires on change */ }}
```

`configGet(..., "marker")` only affects what is *shown*; the value is persisted solely by `onValueChange`. Picking any strategy other than `marker` saved correctly; keeping/choosing `marker` wrote nothing. Preset configs are stored sparse and an absent `parsing_strategy` legitimately means "inherit the global loader" (how the seeded `default` preset works), so the omission was silent (`IndexationPipelineConfig` uses `extra="ignore"`).

## Fix

Replace the fabricated `marker` default with an explicit **"Default (inherit global loader)"** sentinel option — the same `__none__` → "Default" pattern the retrieval form already uses for `reranker`/`llm`. Now the shown value always matches what is persisted:

- Pick a concrete strategy (`marker`/`pymupdf`/`docling`) → it is written to config.
- Leave "Default" → `parsing_strategy` stays absent and the preset inherits the global loader honestly.

The `pymupdf` → disable-image-captioning behavior is preserved.

The pure config helpers (`configGet`/`configSet`/`configUnset` + the parsing-strategy mapping) are extracted into `preset-config.ts` so the persistence behavior is unit-testable without driving the Radix Select, and so the component file only exports components.

## Audit of the other preset fields

`parsing_strategy` is the only field with this defect. Every other control's shown default numerically equals the backend Pydantic default (`type`→single, `top_k`→50, `top_n`→10, `similarity_threshold`→0.6, `enable_reranker`/`include_related`/`include_ancestors`→true, `rrf_k`→60, `chunk_size`→512, `chunk_overlap_rate`→0.2), so "shown but not persisted" yields the same effective value. `parsing_strategy` is unique because absent means "inherit the global loader" (context-dependent), not a fixed value.

## Testing

- New `ui/src/pages/admin/preset-config.test.ts` (6 cases): concrete strategy persists, "Default" clears the key, unrelated keys preserved, pymupdf disables captioning, marker/docling don't, input not mutated.
- `npx tsc -b` — passes.
- `npx eslint` on the changed files — 0 errors, 0 warnings.
- `npx vitest run` — 91/91 tests pass.

## Notes

Existing presets already saved without `parsing_strategy` are unaffected by this change — they continue to inherit the global loader. To make such a preset use marker, re-select `marker` in the editor (now persisted) or `PUT` the config with `parsing_strategy: "marker"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear “Default (inherit global loader)” option for parsing strategy in admin preset settings.

* **Bug Fixes**
  * Parsing strategy changes are now applied consistently and preserve unrelated preset fields.
  * Switching to the PyMuPDF parsing option reliably disables image captioning; switching away (including inherit) no longer keeps it forced-off.
  * Updated captioning enable/disable logic to follow the effective inherited parsing strategy.

* **Tests**
  * Added coverage to validate parsing strategy and captioning behavior, including immutability of the input config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->