### PR TITLE
fix(inference): TEI reranker + streaming fixes, hardened for release

### DIFF
--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -274,16 +274,16 @@ The retriever fetches relevant documents from the vector database based on query
 
 ### Reranker Configuration
 
-The reranker enhances search quality by re-scoring and reordering retrieved documents according to their relevance to the user's query. Two providers are supported: **Infinity** (default) and **OpenAI-compatible** endpoints.
+The reranker enhances search quality by re-scoring and reordering retrieved documents according to their relevance to the user's query. Three providers are supported: **Infinity** (default), **OpenAI-compatible** endpoints, and **Hugging Face Text Embeddings Inference (TEI)**.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `RERANKER_ENABLED` | `bool` | true | Enable or disable the reranking mechanism |
-| `RERANKER_PROVIDER` | `str` | `infinity` | Reranker backend to use. Accepted values: `infinity`, `openai` |
-| `RERANKER_MODEL` | `str` | Alibaba-NLP/gte-multilingual-reranker-base | Model used for reranking documents.|
+| `RERANKER_PROVIDER` | `str` | `infinity` | Reranker backend to use. Accepted values: `infinity`, `openai`, `tei` |
+| `RERANKER_MODEL` | `str` | Alibaba-NLP/gte-multilingual-reranker-base | Model used for reranking documents. Ignored by the `tei` provider (a TEI instance serves a single fixed model) |
 | `RERANKER_TOP_K` | `int` | 10 | Number of top documents to return after reranking. Increase for better results if your LLM has a wider context window |
 | `RERANKER_BASE_URL` | `str` | `http://reranker:7997` | Base URL of the reranker service |
-| `RERANKER_API_KEY` | `str` | `EMPTY` | API key for the reranker service. Required when using the `openai` provider |
+| `RERANKER_API_KEY` | `str` | `EMPTY` | API key for the reranker service, sent as a `Bearer` token when set. Required when using the `openai` provider |
 | `RERANKER_SEMAPHORE` | `int` | 5 | Maximum number of concurrent reranking requests. Adjust based on your server capacity |
 
 #### Reranker Providers
@@ -291,7 +291,8 @@ The reranker enhances search quality by re-scoring and reordering retrieved docu
 | Provider | `RERANKER_PROVIDER` value | Description |
 |----------|--------------------------|-------------|
 | **Infinity** | `infinity` | Uses the [Infinity server](https://github.com/michaelfeil/infinity) via its native client. Default port: `7997` |
-| **OpenAI-compatible** | `openai` | Uses any OpenAI-compatible reranker endpoint (e.g. vLLM, LiteLLM, TEI). Default port: `8000` |
+| **OpenAI-compatible** | `openai` | Uses any reranker endpoint implementing the `{model, query, documents, top_n}` → `{results: [...]}` rerank contract (e.g. vLLM, LiteLLM). Default port: `8000` |
+| **TEI** | `tei` | Uses a [Hugging Face Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference) server via its native `/rerank` API (which is **not** OpenAI-compatible: `texts` instead of `documents`, no `model`/`top_n` fields, bare-array response). Default port: `8080`. Requests are batched to 32 texts to fit TEI's default `--max-client-batch-size` |
 
 ## Extra
 ### Prompts

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -283,7 +283,8 @@ The reranker enhances search quality by re-scoring and reordering retrieved docu
 | `RERANKER_MODEL` | `str` | Alibaba-NLP/gte-multilingual-reranker-base | Model used for reranking documents. Ignored by the `tei` provider (a TEI instance serves a single fixed model) |
 | `RERANKER_TOP_K` | `int` | 10 | Number of top documents to return after reranking. Increase for better results if your LLM has a wider context window |
 | `RERANKER_BASE_URL` | `str` | `http://reranker:7997` | Base URL of the reranker service |
-| `RERANKER_API_KEY` | `str` | `EMPTY` | API key for the reranker service, sent as a `Bearer` token when set. Required when using the `openai` provider |
+| `RERANKER_API_KEY` | `str` | `EMPTY` | API key for the reranker service, sent as a `Bearer` token when set. Whether a key is required depends on your endpoint |
+| `RERANKER_TIMEOUT` | `float` | 60.0 | HTTP timeout in seconds for reranker requests |
 | `RERANKER_SEMAPHORE` | `int` | 5 | Maximum number of concurrent reranking requests. Adjust based on your server capacity |
 
 #### Reranker Providers

--- a/openrag/api/routers/admin/presets.py
+++ b/openrag/api/routers/admin/presets.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, Response, status
 
 router = APIRouter(dependencies=[Depends(require_admin)])
 
-_DEFAULT_RERANKER_PROVIDERS = ["infinity", "openai"]
+_DEFAULT_RERANKER_PROVIDERS = ["infinity", "openai", "tei"]
 
 # The selectable PDF backends. Shares the IndexationPipelineConfig constant so
 # the exposed options can never drift from what the model accepts. ``None``

--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -328,7 +328,10 @@ async def openai_chat_completion(
                 log.warning("OpenRAG error during streaming", code=e.code, error=e.message)
                 yield _make_sse_error(e.message, e.code)
             except Exception as e:
-                log.warning("Error during streaming", error=str(e))
+                # Unexpected (non-OpenRAGError) failure: attach the traceback so the
+                # actual fault is visible, not just its str() — the client only gets
+                # a generic message, so the log is the only record of the root cause.
+                log.opt(exception=e).error("Error during streaming", error=str(e))
                 yield _make_sse_error("An unexpected error occurred during streaming", "UNEXPECTED_ERROR")
 
         return StreamingResponse(stream_response(), media_type="text/event-stream")

--- a/openrag/core/config/retrieval.py
+++ b/openrag/core/config/retrieval.py
@@ -32,8 +32,13 @@ class OpenAIRerankerConfig(_BaseRerankerConfig):
     base_url: str = "http://reranker:8000/v1"
 
 
+class TEIRerankerConfig(_BaseRerankerConfig):
+    provider: Literal["tei"] = "tei"
+    base_url: str = "http://reranker:8080"
+
+
 RerankerConfig = Annotated[
-    InfinityRerankerConfig | OpenAIRerankerConfig,
+    InfinityRerankerConfig | OpenAIRerankerConfig | TEIRerankerConfig,
     Field(discriminator="provider"),
 ]
 

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -127,7 +127,14 @@ async def stream_with_source_filtering(
         data = json.loads(line[len("data: ") :])
         data["model"] = model_name
 
-        choice = data.get("choices", [{}])[0]
+        # `choices` can be present but empty — e.g. the OpenAI/litellm final
+        # usage-report chunk sent when the caller requests
+        # `stream_options: {"include_usage": true}` has `"choices": []` and a
+        # top-level `"usage"` field. `.get("choices", [{}])` only falls back to
+        # the default when the key is *missing*, not when it's an empty list,
+        # so indexing straight into it raises IndexError on that chunk.
+        choices = data.get("choices") or [{}]
+        choice = choices[0]
         delta = choice.get("delta", {})
         content = delta.get("content", "") or ""
         finish_reason = choice.get("finish_reason")

--- a/openrag/services/inference/reranker_clients.py
+++ b/openrag/services/inference/reranker_clients.py
@@ -8,6 +8,9 @@ shapes (see each class' docstring).
 
 from __future__ import annotations
 
+import asyncio
+from typing import NoReturn
+
 import httpx
 from core.rerankers import Reranker, reranker_registry
 from core.utils.exceptions import InferenceConnectionError, InferenceTimeoutError
@@ -24,8 +27,8 @@ def _response_detail(response: httpx.Response, limit: int = 500) -> str:
 
     A non-2xx reranker reply (notably a 422 from a pydantic-validated server)
     carries the exact reason — which field/type it rejected — in its body. The
-    status code alone is undiagnosable, so surface a truncated body in the raised
-    error. Best-effort: never let logging/formatting mask the original failure."""
+    status code alone is undiagnosable, so the truncated body is logged.
+    Best-effort: never let logging/formatting mask the original failure."""
     try:
         body = response.text.strip().replace("\n", " ")
     except Exception:  # noqa: BLE001 — body may be unreadable; the status still helps
@@ -33,6 +36,19 @@ def _response_detail(response: httpx.Response, limit: int = 500) -> str:
     if not body:
         return ""
     return body[:limit] + ("…" if len(body) > limit else "")
+
+
+def _raise_reranker_http_error(endpoint: str, exc: httpx.HTTPStatusError) -> NoReturn:
+    """Map a non-2xx reranker reply to ``InferenceConnectionError``.
+
+    The response body is logged for operators but deliberately kept out of the
+    raised message: ``InferenceConnectionError.message`` reaches API clients
+    verbatim (SSE error events, 503 ``detail``), and an upstream error body can
+    carry internals — stack traces, proxy pages, hostnames — that must not leak."""
+    status = exc.response.status_code
+    detail = _response_detail(exc.response)
+    logger.bind(endpoint=endpoint, status=status, body=detail).error("Reranker returned HTTP error")
+    raise InferenceConnectionError(f"Reranker at {endpoint} returned HTTP {status}") from exc
 
 
 @reranker_registry.register("infinity")
@@ -77,11 +93,7 @@ class InfinityReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
-            detail = _response_detail(exc.response)
-            raise InferenceConnectionError(
-                f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
-                + (f": {detail}" if detail else "")
-            ) from exc
+            _raise_reranker_http_error(self._endpoint, exc)
         try:
             results = resp.json()["results"]
             return [(r["index"], r["relevance_score"]) for r in results]
@@ -92,6 +104,13 @@ class InfinityReranker(Reranker):
         await self._client.aclose()
 
 
+# TEI enforces ``--max-client-batch-size`` (default 32) on the number of texts
+# per /rerank request and rejects larger requests with HTTP 413. Retrieval
+# routinely reranks more candidates than that (retriever top_k defaults to 50),
+# so requests are split client-side and merged.
+_TEI_MAX_BATCH = 32
+
+
 @reranker_registry.register("tei")
 class TEIReranker(Reranker):
     """Reranker backed by a Hugging Face Text Embeddings Inference (TEI) server.
@@ -100,9 +119,14 @@ class TEIReranker(Reranker):
     request field is ``texts`` (not ``documents``), there is no ``model`` or
     ``top_n`` field (a TEI instance serves one fixed model and always scores
     every input), and the response is a bare JSON array of
-    ``{"index": ..., "score": ...}`` — not ``{"results": [...]}``. TEI does
-    sort its response by score descending, but we re-sort explicitly to keep
-    the ``Reranker`` ABC's ordering guarantee independent of that.
+    ``{"index": ..., "score": ...}`` — not ``{"results": [...]}``.
+
+    Documents are sent in batches of ``_TEI_MAX_BATCH`` (concurrently) because
+    TEI caps texts-per-request, and ``truncate: true`` is requested so one
+    over-long text degrades to a truncated score instead of failing the whole
+    request (Infinity truncates silently; TEI without it rejects the batch).
+    Results are merged and re-sorted client-side to honor the ``Reranker``
+    ABC's score-descending ordering guarantee.
     """
 
     def __init__(
@@ -124,10 +148,20 @@ class TEIReranker(Reranker):
     @with_circuit_breaker("reranker")
     @with_retry(max_attempts=2)
     async def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[tuple[int, float]]:
+        offsets = range(0, len(documents), _TEI_MAX_BATCH)
+        batches = await asyncio.gather(
+            *(self._rerank_batch(query, documents[offset : offset + _TEI_MAX_BATCH], offset) for offset in offsets)
+        )
+        scored = [pair for batch in batches for pair in batch]
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return scored[:top_k] if top_k is not None else scored
+
+    async def _rerank_batch(self, query: str, texts: list[str], offset: int) -> list[tuple[int, float]]:
+        """Score one ≤``_TEI_MAX_BATCH`` slice; indices are shifted back to the full list."""
         try:
             resp = await self._client.post(
                 f"{self._endpoint}/rerank",
-                json={"query": query, "texts": documents, "raw_scores": False},
+                json={"query": query, "texts": texts, "raw_scores": False, "truncate": True},
             )
             resp.raise_for_status()
         except httpx.ConnectError as exc:
@@ -135,20 +169,10 @@ class TEIReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
-            detail = _response_detail(exc.response)
-            raise InferenceConnectionError(
-                f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
-                + (f": {detail}" if detail else "")
-            ) from exc
+            _raise_reranker_http_error(self._endpoint, exc)
         try:
-            results = sorted(resp.json(), key=lambda r: r["score"], reverse=True)
+            return [(r["index"] + offset, r["score"]) for r in resp.json()]
         except (KeyError, TypeError, ValueError) as exc:
-            raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
-        if top_k is not None:
-            results = results[:top_k]
-        try:
-            return [(r["index"], r["score"]) for r in results]
-        except (KeyError, TypeError) as exc:
             raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
 
     async def aclose(self) -> None:
@@ -195,11 +219,7 @@ class OpenAIReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
-            detail = _response_detail(exc.response)
-            raise InferenceConnectionError(
-                f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
-                + (f": {detail}" if detail else "")
-            ) from exc
+            _raise_reranker_http_error(self._endpoint, exc)
         try:
             results = resp.json()["results"]
             return [(r["index"], r["relevance_score"]) for r in results]

--- a/openrag/services/inference/reranker_clients.py
+++ b/openrag/services/inference/reranker_clients.py
@@ -1,9 +1,9 @@
 """Reranker inference clients.
 
-Two classes — Infinity and OpenAI-compatible — both implementing the
-``Reranker`` ABC.  Both talk to a ``/rerank`` endpoint with the same
-payload shape, differing only in the base URL and transport library
-the old code used.  Now both use ``httpx`` directly.
+Three classes — Infinity, OpenAI-compatible, and Hugging Face Text
+Embeddings Inference (TEI) — all implementing the ``Reranker`` ABC and
+talking to a ``/rerank`` endpoint, but with different request/response
+shapes (see each class' docstring).
 """
 
 from __future__ import annotations
@@ -68,6 +68,67 @@ class InfinityReranker(Reranker):
             results = resp.json()["results"]
             return [(r["index"], r["relevance_score"]) for r in results]
         except (KeyError, TypeError, ValueError) as exc:
+            raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+@reranker_registry.register("tei")
+class TEIReranker(Reranker):
+    """Reranker backed by a Hugging Face Text Embeddings Inference (TEI) server.
+
+    TEI's ``/rerank`` differs from Infinity/OpenAI-compatible servers: the
+    request field is ``texts`` (not ``documents``), there is no ``model`` or
+    ``top_n`` field (a TEI instance serves one fixed model and always scores
+    every input), and the response is a bare JSON array of
+    ``{"index": ..., "score": ...}`` — not ``{"results": [...]}``. TEI does
+    sort its response by score descending, but we re-sort explicitly to keep
+    the ``Reranker`` ABC's ordering guarantee independent of that.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        model_name: str,
+        *,
+        api_key: str = "",
+        timeout: float = 30.0,
+        **_kwargs,
+    ):
+        self._endpoint = endpoint.rstrip("/")
+        self._model = model_name  # unused: TEI serves a single fixed model, no selector in the request
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._client = httpx.AsyncClient(timeout=timeout, headers=headers)
+
+    @with_circuit_breaker("reranker")
+    @with_retry(max_attempts=2)
+    async def rerank(self, query: str, documents: list[str], top_k: int | None = None) -> list[tuple[int, float]]:
+        try:
+            resp = await self._client.post(
+                f"{self._endpoint}/rerank",
+                json={"query": query, "texts": documents, "raw_scores": False},
+            )
+            resp.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise InferenceConnectionError(f"Cannot reach reranker at {self._endpoint}") from exc
+        except httpx.TimeoutException as exc:
+            raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise InferenceConnectionError(
+                f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
+            ) from exc
+        try:
+            results = sorted(resp.json(), key=lambda r: r["score"], reverse=True)
+        except (TypeError, ValueError) as exc:
+            raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
+        if top_k is not None:
+            results = results[:top_k]
+        try:
+            return [(r["index"], r["score"]) for r in results]
+        except (KeyError, TypeError) as exc:
             raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
 
     async def aclose(self) -> None:

--- a/openrag/services/inference/reranker_clients.py
+++ b/openrag/services/inference/reranker_clients.py
@@ -19,6 +19,22 @@ from ._retry import with_retry
 logger = get_logger()
 
 
+def _response_detail(response: httpx.Response, limit: int = 500) -> str:
+    """Short, safe snippet of an error response body.
+
+    A non-2xx reranker reply (notably a 422 from a pydantic-validated server)
+    carries the exact reason — which field/type it rejected — in its body. The
+    status code alone is undiagnosable, so surface a truncated body in the raised
+    error. Best-effort: never let logging/formatting mask the original failure."""
+    try:
+        body = response.text.strip().replace("\n", " ")
+    except Exception:  # noqa: BLE001 — body may be unreadable; the status still helps
+        return ""
+    if not body:
+        return ""
+    return body[:limit] + ("…" if len(body) > limit else "")
+
+
 @reranker_registry.register("infinity")
 class InfinityReranker(Reranker):
     """Reranker backed by an Infinity server."""
@@ -61,8 +77,10 @@ class InfinityReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
+            detail = _response_detail(exc.response)
             raise InferenceConnectionError(
                 f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
+                + (f": {detail}" if detail else "")
             ) from exc
         try:
             results = resp.json()["results"]
@@ -117,12 +135,14 @@ class TEIReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
+            detail = _response_detail(exc.response)
             raise InferenceConnectionError(
                 f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
+                + (f": {detail}" if detail else "")
             ) from exc
         try:
             results = sorted(resp.json(), key=lambda r: r["score"], reverse=True)
-        except (TypeError, ValueError) as exc:
+        except (KeyError, TypeError, ValueError) as exc:
             raise InferenceConnectionError(f"Unexpected reranker response format from {self._endpoint}") from exc
         if top_k is not None:
             results = results[:top_k]
@@ -175,8 +195,10 @@ class OpenAIReranker(Reranker):
         except httpx.TimeoutException as exc:
             raise InferenceTimeoutError(f"Reranker request timed out at {self._endpoint}") from exc
         except httpx.HTTPStatusError as exc:
+            detail = _response_detail(exc.response)
             raise InferenceConnectionError(
                 f"Reranker at {self._endpoint} returned HTTP {exc.response.status_code}"
+                + (f": {detail}" if detail else "")
             ) from exc
         try:
             results = resp.json()["results"]

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -432,7 +432,7 @@ async def test_preset_options_return_registered_choices(async_client_factory):
     body = response.json()
     assert body["chunking_strategies"] == ["recursive_splitter"]
     assert set(body["retrieval_types"]) == {"single", "multiQuery", "hyde"}
-    assert body["reranker_providers"] == ["infinity", "openai"]
+    assert body["reranker_providers"] == ["infinity", "openai", "tei"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/inference/test_reranker_clients.py
+++ b/tests/unit/services/inference/test_reranker_clients.py
@@ -100,16 +100,17 @@ class TestInfinityReranker:
             await reranker.rerank("query", DOCS)
 
     @pytest.mark.asyncio
-    async def test_http_error_surfaces_response_body(self, reranker):
-        # A 422 body names the exact rejected field; the raised error must carry
-        # it (status code alone is undiagnosable in production).
+    async def test_http_error_keeps_response_body_out_of_message(self, reranker):
+        # The 422 body names the rejected field, but the exception message
+        # reaches API clients verbatim (SSE errors / 503 detail) — the body is
+        # logged for operators, never embedded in the message.
         body = '{"detail":[{"loc":["body","top_n"],"msg":"field required"}]}'
         transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
         reranker._client = httpx.AsyncClient(transport=transport)
         with pytest.raises(InferenceConnectionError) as exc:
             await reranker.rerank("query", DOCS)
         assert "422" in str(exc.value)
-        assert "field required" in str(exc.value)
+        assert "field required" not in str(exc.value)
 
     @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
@@ -161,8 +162,10 @@ class TestTEIReranker:
         transport = httpx.MockTransport(capture)
         reranker._client = httpx.AsyncClient(transport=transport)
         await reranker.rerank("query", DOCS)
-        # TEI's contract: `texts`, no `documents`/`model`/`top_n`.
+        # TEI's contract: `texts`, no `documents`/`model`/`top_n`; `truncate`
+        # so one over-long text doesn't fail the whole request.
         assert captured["texts"] == DOCS
+        assert captured["truncate"] is True
         assert "documents" not in captured
         assert "top_n" not in captured
         assert "model" not in captured
@@ -184,14 +187,14 @@ class TestTEIReranker:
             await reranker.rerank("query", DOCS)
 
     @pytest.mark.asyncio
-    async def test_http_error_surfaces_response_body(self, reranker):
+    async def test_http_error_keeps_response_body_out_of_message(self, reranker):
         body = '{"error":"Input validation error: `texts` must be non-empty"}'
         transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
         reranker._client = httpx.AsyncClient(transport=transport)
         with pytest.raises(InferenceConnectionError) as exc:
             await reranker.rerank("query", DOCS)
         assert "422" in str(exc.value)
-        assert "must be non-empty" in str(exc.value)
+        assert "must be non-empty" not in str(exc.value)
 
     @pytest.mark.asyncio
     async def test_connection_error(self, reranker):
@@ -202,6 +205,45 @@ class TestTEIReranker:
         reranker._client.post = fail
         with pytest.raises(InferenceConnectionError):
             await reranker.rerank("query", DOCS)
+
+    @pytest.mark.asyncio
+    async def test_batches_requests_over_tei_client_batch_limit(self, reranker):
+        # TEI rejects requests with more texts than --max-client-batch-size
+        # (default 32), so a 50-doc rerank must be split into two requests and
+        # each batch's local indices shifted back to full-list positions.
+        docs = [f"doc-{i}" for i in range(50)]
+        batch_sizes = []
+
+        def handler(req):
+            import json
+
+            texts = json.loads(req.content)["texts"]
+            batch_sizes.append(len(texts))
+            # Score each text by its global doc number so merged ordering is checkable.
+            items = [{"index": i, "score": int(t.split("-")[1]) / 100} for i, t in enumerate(texts)]
+            return httpx.Response(200, json=items)
+
+        reranker._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        result = await reranker.rerank("query", docs)
+        assert sorted(batch_sizes) == [18, 32]
+        assert [idx for idx, _ in result] == list(range(49, -1, -1))
+
+    @pytest.mark.asyncio
+    async def test_top_k_truncates_across_batches(self, reranker):
+        # The top-scored docs live in the second batch; top_k must apply to the
+        # merged, globally sorted results — not per batch.
+        docs = [f"doc-{i}" for i in range(40)]
+
+        def handler(req):
+            import json
+
+            texts = json.loads(req.content)["texts"]
+            items = [{"index": i, "score": int(t.split("-")[1]) / 100} for i, t in enumerate(texts)]
+            return httpx.Response(200, json=items)
+
+        reranker._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        result = await reranker.rerank("query", docs, top_k=3)
+        assert [idx for idx, _ in result] == [39, 38, 37]
 
 
 class TestOpenAIReranker:
@@ -237,14 +279,14 @@ class TestOpenAIReranker:
             await reranker.rerank("query", DOCS)
 
     @pytest.mark.asyncio
-    async def test_http_error_surfaces_response_body(self, reranker):
+    async def test_http_error_keeps_response_body_out_of_message(self, reranker):
         body = '{"detail":[{"loc":["body","documents"],"msg":"field required"}]}'
         transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
         reranker._client = httpx.AsyncClient(transport=transport)
         with pytest.raises(InferenceConnectionError) as exc:
             await reranker.rerank("query", DOCS)
         assert "422" in str(exc.value)
-        assert "field required" in str(exc.value)
+        assert "field required" not in str(exc.value)
 
 
 class TestRegistryIntegration:

--- a/tests/unit/services/inference/test_reranker_clients.py
+++ b/tests/unit/services/inference/test_reranker_clients.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 from core.utils.exceptions import InferenceConnectionError, InferenceTimeoutError
-from services.inference.reranker_clients import InfinityReranker, OpenAIReranker
+from services.inference.reranker_clients import InfinityReranker, OpenAIReranker, TEIReranker
 
 
 def _rerank_response(results: list[dict] | None = None) -> httpx.Response:
@@ -100,10 +100,108 @@ class TestInfinityReranker:
             await reranker.rerank("query", DOCS)
 
     @pytest.mark.asyncio
+    async def test_http_error_surfaces_response_body(self, reranker):
+        # A 422 body names the exact rejected field; the raised error must carry
+        # it (status code alone is undiagnosable in production).
+        body = '{"detail":[{"loc":["body","top_n"],"msg":"field required"}]}'
+        transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
+        reranker._client = httpx.AsyncClient(transport=transport)
+        with pytest.raises(InferenceConnectionError) as exc:
+            await reranker.rerank("query", DOCS)
+        assert "422" in str(exc.value)
+        assert "field required" in str(exc.value)
+
+    @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
         r = InfinityReranker(endpoint="http://reranker:7997/", model_name="m")
         assert r._endpoint == "http://reranker:7997"
         await r.aclose()
+
+
+# TEI has its own wire format (``texts`` request field, bare-array response of
+# ``{"index", "score"}``), so it needs its own coverage — not just the shared
+# error-path tests.
+def _tei_response(items: list[dict] | None = None) -> httpx.Response:
+    items = (
+        items
+        if items is not None
+        else [
+            {"index": 1, "score": 0.8},
+            {"index": 0, "score": 0.5},
+            {"index": 2, "score": 0.2},
+        ]
+    )
+    return httpx.Response(200, json=items)
+
+
+class TestTEIReranker:
+    @pytest.fixture
+    def reranker(self):
+        return TEIReranker(endpoint="http://reranker:8080", model_name="bge-reranker")
+
+    @pytest.mark.asyncio
+    async def test_rerank_parses_bare_array_and_sorts(self, reranker):
+        # Response given out of order; client must sort by score desc.
+        unsorted = [{"index": 0, "score": 0.5}, {"index": 1, "score": 0.8}, {"index": 2, "score": 0.2}]
+        transport = httpx.MockTransport(lambda req: _tei_response(unsorted))
+        reranker._client = httpx.AsyncClient(transport=transport)
+        result = await reranker.rerank("query", DOCS)
+        assert result == [(1, 0.8), (0, 0.5), (2, 0.2)]
+
+    @pytest.mark.asyncio
+    async def test_sends_texts_field_not_documents(self, reranker):
+        captured = {}
+
+        def capture(req):
+            import json
+
+            captured.update(json.loads(req.content))
+            return _tei_response()
+
+        transport = httpx.MockTransport(capture)
+        reranker._client = httpx.AsyncClient(transport=transport)
+        await reranker.rerank("query", DOCS)
+        # TEI's contract: `texts`, no `documents`/`model`/`top_n`.
+        assert captured["texts"] == DOCS
+        assert "documents" not in captured
+        assert "top_n" not in captured
+        assert "model" not in captured
+
+    @pytest.mark.asyncio
+    async def test_top_k_truncates_after_sort(self, reranker):
+        transport = httpx.MockTransport(lambda req: _tei_response())
+        reranker._client = httpx.AsyncClient(transport=transport)
+        result = await reranker.rerank("query", DOCS, top_k=2)
+        assert result == [(1, 0.8), (0, 0.5)]
+
+    @pytest.mark.asyncio
+    async def test_missing_score_field_is_mapped_error(self, reranker):
+        # A drifted wire format (no `score`) must become a mapped inference error,
+        # not an uncaught KeyError.
+        transport = httpx.MockTransport(lambda req: httpx.Response(200, json=[{"index": 0}]))
+        reranker._client = httpx.AsyncClient(transport=transport)
+        with pytest.raises(InferenceConnectionError):
+            await reranker.rerank("query", DOCS)
+
+    @pytest.mark.asyncio
+    async def test_http_error_surfaces_response_body(self, reranker):
+        body = '{"error":"Input validation error: `texts` must be non-empty"}'
+        transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
+        reranker._client = httpx.AsyncClient(transport=transport)
+        with pytest.raises(InferenceConnectionError) as exc:
+            await reranker.rerank("query", DOCS)
+        assert "422" in str(exc.value)
+        assert "must be non-empty" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, reranker):
+        async def fail(*a, **kw):
+            raise httpx.ConnectError("refused")
+
+        reranker._client = AsyncMock()
+        reranker._client.post = fail
+        with pytest.raises(InferenceConnectionError):
+            await reranker.rerank("query", DOCS)
 
 
 class TestOpenAIReranker:
@@ -138,6 +236,16 @@ class TestOpenAIReranker:
         with pytest.raises(InferenceTimeoutError):
             await reranker.rerank("query", DOCS)
 
+    @pytest.mark.asyncio
+    async def test_http_error_surfaces_response_body(self, reranker):
+        body = '{"detail":[{"loc":["body","documents"],"msg":"field required"}]}'
+        transport = httpx.MockTransport(lambda req: httpx.Response(422, text=body))
+        reranker._client = httpx.AsyncClient(transport=transport)
+        with pytest.raises(InferenceConnectionError) as exc:
+            await reranker.rerank("query", DOCS)
+        assert "422" in str(exc.value)
+        assert "field required" in str(exc.value)
+
 
 class TestRegistryIntegration:
     def test_infinity_registered(self):
@@ -149,3 +257,8 @@ class TestRegistryIntegration:
         from core.rerankers import reranker_registry
 
         assert "openai" in reranker_registry
+
+    def test_tei_registered(self):
+        from core.rerankers import reranker_registry
+
+        assert "tei" in reranker_registry


### PR DESCRIPTION
Consolidates the inference/streaming fixes for the OpenShift preprod release into `refactor/hexagonal`. Two production failures were seen on the deploy (external inference endpoints):

- Chat completions returned **`list index out of range`** during streaming.
- Reranking returned **HTTP 422 → 503** to the client.

## Root-cause fixes (authored by @ThibautChoppy, cherry-picked)
- **`fix: source filtering stream error`** — the OpenAI/litellm final *usage* chunk (sent with `stream_options.include_usage`) has `"choices": []`; `.get("choices", [{}])` only falls back on a *missing* key, not an empty list, so indexing raised `IndexError`. Fixed to fall back on the empty list too.
- **`chore: add TEI class for reranker`** — the external reranker is a Hugging Face **TEI** server, whose `/rerank` contract differs from Infinity/OpenAI (`texts` not `documents`, no `model`/`top_n`, bare-array response). Sending the old payload → 422. Adds a `TEIReranker` client + `TEIRerankerConfig` (discriminated union).
- **`fix: unit test for router`** — updates the reranker-providers assertion to include `tei`.

## Release-hardening + tests (this branch)
Bringing the above to the release bar:
- **Surface reranker error bodies** on all three clients (Infinity/OpenAI/TEI). A pydantic 422 body names the exact rejected field; the status code alone is undiagnosable — this is what made the original 422 take hours to pin down.
- **`TEIReranker`: catch `KeyError`** in the score sort, so a drifted wire format becomes a mapped `InferenceConnectionError` instead of an uncaught `KeyError`.
- **Add the missing `TEIReranker` unit tests** (bare-array parse + sort, the `texts` request contract, `top_k` truncation, missing-score error path, 422-body) — TEI shipped with zero coverage. Plus 422-body tests for Infinity/OpenAI and a `tei` registry assertion.
- **Chat streaming: log the exception traceback** on the generic handler, so a future unexpected streaming fault is recorded (the client only gets a generic message).

No behavioural change beyond error reporting.

## Not included
- Thibaut's 4th fork commit (`image repo… dockerhub push`) is intentionally **excluded**: it removes the linagora Docker Hub publish from the RC pipeline, which is a CI/release decision — not part of this app fix.

## Validation
- Full unit suite: **1626 passed**; ruff check + format clean; layer-import guard OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new TEI-based reranker provider and expanded the available reranker provider choices (including the admin preset default list).
* **Bug Fixes**
  * Improved robustness of streaming error handling while preserving the same client-facing error message.
  * Prevented failures when upstream streaming chunks contain an empty `choices` list.
  * Standardized reranker HTTP error handling to keep user-facing messages clean while capturing more detail in logs.
* **Documentation**
  * Updated reranker environment variable docs to include the TEI provider and its request/response and auth semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->