### PR TITLE
feat(loader)!: default PDF parser to PyMuPDFLoader and rename PDFLoader env to PDFLOADER

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -193,10 +193,10 @@ loader:
     whisper_max_task_retry: 1
     whisper_retry_base_delay: 2.0
 
-  # Env: PDFLoader, AUDIOLOADER (per-extension overrides)
+  # Env: PDFLOADER, AUDIOLOADER (per-extension overrides)
   file_loaders:
     txt: TextLoader
-    pdf: MarkerLoader
+    pdf: PyMuPDFLoader
     eml: EmlLoader
     docx: DocxLoader
     pptx: PPTXLoader

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -369,7 +369,7 @@ env:
     # set PROMPTS_DIR only to override with a custom template directory.
 
     # Loaders
-    PDFLoader: "MarkerLoader"
+    PDFLOADER: "PyMuPDFLoader"
     XDG_CACHE_HOME: "/app/model_weights"
     MARKER_MAX_TASKS_PER_CHILD: "10"
     MARKER_MAX_PROCESSES: "15"

--- a/infra/compose/.env.ollama
+++ b/infra/compose/.env.ollama
@@ -43,5 +43,5 @@ RAY_memory_monitor_refresh_ms=0
 SUPER_ADMIN_MODE=true
 AUTH_TOKEN=sk-1234
 SAVE_UPLOADED_FILES=true
-PDFLoader=PyMuPDFLoader
+PDFLOADER=PyMuPDFLoader
 WHISPER_N_WORKERS=0

--- a/openrag/api/routers/admin/presets.py
+++ b/openrag/api/routers/admin/presets.py
@@ -21,7 +21,7 @@ _DEFAULT_RERANKER_PROVIDERS = ["infinity", "openai", "tei"]
 
 # The selectable PDF backends. Shares the IndexationPipelineConfig constant so
 # the exposed options can never drift from what the model accepts. ``None``
-# (inherit the global PDFLoader) is the field default, not an explicit choice,
+# (inherit the global PDFLOADER) is the field default, not an explicit choice,
 # so it is not surfaced here.
 _PARSING_STRATEGIES = list(PARSING_STRATEGIES)
 

--- a/openrag/core/config/indexation.py
+++ b/openrag/core/config/indexation.py
@@ -83,7 +83,7 @@ class LocalWhisperConfig(ConfigMixin):
 
 class FileLoadersConfig(ConfigMixin):
     txt: str = "TextLoader"
-    pdf: str = "MarkerLoader"
+    pdf: str = "PyMuPDFLoader"
     eml: str = "EmlLoader"
     docx: str = "DocxLoader"
     pptx: str = "PPTXLoader"

--- a/openrag/core/config/indexation_pipeline.py
+++ b/openrag/core/config/indexation_pipeline.py
@@ -13,7 +13,7 @@ from core.config.chunking import ChunkerConfig
 from pydantic import BaseModel, ConfigDict, Field
 
 # PDF parsing backends a preset may explicitly select. ``None`` (the default)
-# means "inherit the deployment's global PDFLoader" — a preset that doesn't care
+# means "inherit the deployment's global PDFLOADER" — a preset that doesn't care
 # about PDF parsing follows the operator's global ``file_loaders.pdf`` choice
 # instead of silently forcing one backend (and, with it, lazily spinning up that
 # backend's Ray pool). See pipeline_builder._select_parser.
@@ -26,7 +26,7 @@ class IndexationPipelineConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     chunking: ChunkerConfig = Field(default_factory=ChunkerConfig)
-    # None => inherit the global PDFLoader (see PARSING_STRATEGIES above).
+    # None => inherit the global PDFLOADER (see PARSING_STRATEGIES above).
     parsing_strategy: Literal["pymupdf", "marker", "docling"] | None = None
 
     # VLM / image captioning

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -96,7 +96,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("IMAGE_CAPTIONING_URL", "loader.image_captioning_url", bool),
     ("SAVE_MARKDOWN", "loader.save_markdown", bool),
     ("SAVE_UPLOADED_FILES", "loader.save_uploaded_files", bool),
-    ("PDFLoader", "loader.file_loaders.pdf", str),
+    ("PDFLOADER", "loader.file_loaders.pdf", str),
     ("AUDIOLOADER", "loader.file_loaders.wav", str),
     ("MARKER_MAX_TASKS_PER_CHILD", "loader.marker_max_tasks_per_child", int),
     ("MARKER_POOL_SIZE", "loader.marker_pool_size", int),

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -38,13 +38,13 @@ _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
     # omitted from the ``default`` indexation preset below. The former is injected
     # at seed time from the global ``chunker.contextual_retrieval``
     # (``CONTEXTUAL_RETRIEVAL``) toggle in _finalize_seed; the latter stays unset
-    # so the default preset inherits the global ``file_loaders.pdf`` (``PDFLoader``)
+    # so the default preset inherits the global ``file_loaders.pdf`` (``PDFLOADER``)
     # backend at parse time. Named presets (legal/finance) keep their explicit choice.
     "indexation": {
         "default": {
             "chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 0.2},
             # ``parsing_strategy`` is intentionally omitted so the default preset
-            # inherits the deployment's global PDFLoader (``file_loaders.pdf``)
+            # inherits the deployment's global PDFLOADER (``file_loaders.pdf``)
             # rather than forcing one PDF backend on every partition. A hardcoded
             # value here would override the operator's global choice and lazily
             # spin up that backend's Ray pool — e.g. forcing marker on a

--- a/tests/integration/api/api_run/docker-compose.yaml
+++ b/tests/integration/api/api_run/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
       - WITH_OPENAI_API=true
       - IMAGE_CAPTIONING=false
       - LOG_LEVEL=INFO
-      - PDFLoader=PyMuPDFLoader
+      - PDFLOADER=PyMuPDFLoader
       - RAY_POOL_SIZE=1
       - RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
       - RAY_memory_monitor_refresh_ms=0

--- a/tests/unit/core/config/test_pdf_loader_env.py
+++ b/tests/unit/core/config/test_pdf_loader_env.py
@@ -1,0 +1,38 @@
+"""Tests for the PDF loader env override contract (PDFLOADER, ex-PDFLoader)."""
+
+from __future__ import annotations
+
+from core.config import load_config
+
+_MINIMAL_YAML = "retriever:\n  type: single\n"
+
+
+def test_pdf_loader_defaults_to_pymupdf(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text(_MINIMAL_YAML, encoding="utf-8")
+    # Empty string is skipped by the override loop, and load_dotenv() never
+    # overrides an existing var — this shields the test from any local .env.
+    monkeypatch.setenv("PDFLOADER", "")
+
+    settings = load_config(config_path=tmp_path)
+
+    assert settings.loader.file_loaders.pdf == "PyMuPDFLoader"
+
+
+def test_pdfloader_env_overrides_default(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text(_MINIMAL_YAML, encoding="utf-8")
+    monkeypatch.setenv("PDFLOADER", "MarkerLoader")
+
+    settings = load_config(config_path=tmp_path)
+
+    assert settings.loader.file_loaders.pdf == "MarkerLoader"
+
+
+def test_legacy_mixed_case_pdfloader_env_is_ignored(monkeypatch, tmp_path):
+    """The pre-rename ``PDFLoader`` name must no longer be honored."""
+    (tmp_path / "config.yaml").write_text(_MINIMAL_YAML, encoding="utf-8")
+    monkeypatch.setenv("PDFLOADER", "")
+    monkeypatch.setenv("PDFLoader", "MarkerLoader")
+
+    settings = load_config(config_path=tmp_path)
+
+    assert settings.loader.file_loaders.pdf == "PyMuPDFLoader"


### PR DESCRIPTION
## What

- Switch the **default PDF backend** from `MarkerLoader` to **`PyMuPDFLoader`** — lightweight, fast, CPU-friendly, well suited to searchable PDFs and quick local testing.
- Rename the env override **`PDFLoader` → `PDFLOADER`** for casing consistency with the other loader vars (e.g. `AUDIOLOADER`).

Touches `conf/config.yaml`, the Pydantic defaults (`indexation.py`), the env-override map (`loader.py`), the Helm values, preset comments, and the API integration compose file.

## ⚠️ Breaking change

The `PDFLoader` environment variable is **no longer read**. Set **`PDFLOADER`** instead.

**Upgrade:**
- To keep the previous behaviour (OCR / scanned PDFs, complex layouts, embedded images), set `PDFLOADER=MarkerLoader`.
- `PyMuPDFLoader` (the new default) cannot process non-searchable / image-based PDFs and does not run OCR or extract embedded images.

## Notes

Docs for the rename + new default are handled separately in the docs PR (#624).