### PR TITLE
chore(config): reduce default whisper workers from 3 to 2

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -184,7 +184,7 @@ loader:
   # Env: WHISPER_MODEL, WHISPER_N_WORKERS, WHISPER_NUM_GPUS, WHISPER_CONCURRENCY_PER_WORKER
   local_whisper:
     model: base
-    whisper_n_workers: 3
+    whisper_n_workers: 2
     whisper_num_gpus: 0.01
     whisper_concurrency_per_worker: 2
     # Whisper failures are often deterministic (corrupt audio); 1 retry

--- a/openrag/core/config/indexation.py
+++ b/openrag/core/config/indexation.py
@@ -68,7 +68,7 @@ class OpenAILoaderConfig(ConfigMixin):
 
 class LocalWhisperConfig(ConfigMixin):
     model: str = "base"
-    whisper_n_workers: int = 3
+    whisper_n_workers: int = 2
     whisper_num_gpus: float = 0.01
     whisper_concurrency_per_worker: int = 2
     whisper_timeout: int = 1800


### PR DESCRIPTION
Lower the `LocalWhisper` default worker count from 3 to 2 to trim the baseline GPU/RAM reservation for audio transcription. Two workers cover typical load, and the value stays overridable via `WHISPER_N_WORKERS`.

Changes the default in both `conf/config.yaml` and the Pydantic `LocalWhisperConfig`.