### PR TITLE
perf(workers): lazily provision parser pools instead of pre-warming at startup

### DIFF
--- a/openrag/services/workers/bootstrap.py
+++ b/openrag/services/workers/bootstrap.py
@@ -136,6 +136,4 @@ def initialize_worker_bootstrap(settings: "Settings") -> None:
     init_llm_semaphore()
     init_vlm_semaphore()
     init_audio_semaphore()
-    init_audio_actor()
-    get_marker_pool()
     get_task_state_manager()

--- a/openrag/services/workers/bootstrap.py
+++ b/openrag/services/workers/bootstrap.py
@@ -4,8 +4,13 @@ Imported at startup (explicitly by ``main.py``) to create the long-lived
 detached actors the request path looks up by name:
 
 * TaskStateManager  — shared task-state actor
-* MarkerPool / DoclingPool / WhisperPool / WhisperActor — GPU parsers
 * llmSemaphore / vlmSemaphore / audioSemaphore — cluster-wide rate limiters
+
+The GPU parser pools (MarkerPool / DoclingPool / WhisperPool / WhisperActor)
+are *not* created here: their loaders self-provision them on first use via
+``get_or_create_actor``. Bootstrap only registers their restart factories
+(see ``register_parser_pool_restart_factories``) so the admin restart
+endpoint can manage them from the API process.
 
 This is the **only** non-startup module outside ``services/workers/`` that
 imports Ray — the phase-9 plan permits Ray in ``services/workers/`` plus
@@ -64,32 +69,47 @@ def get_task_state_manager():
     return get_or_create_actor("TaskStateManager", TaskStateManager, lifetime="detached")
 
 
-def get_marker_pool():
-    from services.workers.parsers.docling_workers import DoclingPool
-    from services.workers.parsers.marker_workers import MarkerPool
+def register_parser_pool_restart_factories() -> None:
+    """Register restart factories for the lazily-created parser pools.
 
-    config = _require_settings()
-    pdf_loader = config.loader.file_loaders.pdf
-    match pdf_loader:
-        case "DoclingLoader":
-            return get_or_create_actor("DoclingPool", DoclingPool, lifetime="detached")
-        case "MarkerLoader":
-            return get_or_create_actor("MarkerPool", MarkerPool, lifetime="detached")
+    Parser pools are provisioned on first use, usually inside an indexer
+    worker process — but ``actor_creation_map`` is process-local, so the API
+    process would never learn how to (re)create them and
+    ``POST /cluster/{actor}/restart`` would 404 for every parser pool.
+    Register the factories for *all* pools here without creating any actor
+    (a per-preset ``parsing_strategy`` can bring up any of them at runtime,
+    not just the globally-configured backend). Restarting a pool that was
+    never created simply creates it.
 
+    Imports stay inside the factories so the API process doesn't pay for
+    the heavy parser dependencies (torch, marker, docling) at startup.
+    """
 
-def init_audio_actor():
-    from services.workers.parsers.whisper_workers import WhisperActor, WhisperPool, whisper_actor_options
+    def marker_pool():
+        from services.workers.parsers.marker_workers import MarkerPool
 
-    config = _require_settings()
-    use_whisper_lang_detector = config.loader.transcriber.use_whisper_lang_detector
-    file_loaders = config.loader.file_loaders
-    loader_values = set(file_loaders.values()) if file_loaders else set()
+        return get_or_create_actor("MarkerPool", MarkerPool, lifetime="detached")
 
-    if "LocalWhisperLoader" in loader_values:
+    def docling_pool():
+        from services.workers.parsers.docling_workers import DoclingPool
+
+        return get_or_create_actor("DoclingPool", DoclingPool, lifetime="detached")
+
+    def whisper_pool():
+        from services.workers.parsers.whisper_workers import WhisperPool
+
         return get_or_create_actor("WhisperPool", WhisperPool, lifetime="detached")
 
-    if "OpenAIAudioLoader" in loader_values and use_whisper_lang_detector:
+    def whisper_actor():
+        from services.workers.parsers.whisper_workers import WhisperActor, whisper_actor_options
+
+        config = _require_settings()
         return get_or_create_actor("WhisperActor", WhisperActor, lifetime="detached", **whisper_actor_options(config))
+
+    actor_creation_map["MarkerPool"] = marker_pool
+    actor_creation_map["DoclingPool"] = docling_pool
+    actor_creation_map["WhisperPool"] = whisper_pool
+    actor_creation_map["WhisperActor"] = whisper_actor
 
 
 def init_llm_semaphore():
@@ -129,7 +149,11 @@ def init_audio_semaphore():
 
 
 def initialize_worker_bootstrap(settings: "Settings") -> None:
-    """Create the detached worker actors required by the request path."""
+    """Create the detached worker actors required by the request path.
+
+    Parser pools are exempt: they are created lazily by their loaders, and
+    bootstrap only registers their restart factories.
+    """
     global _settings
     _settings = settings
 
@@ -137,3 +161,4 @@ def initialize_worker_bootstrap(settings: "Settings") -> None:
     init_vlm_semaphore()
     init_audio_semaphore()
     get_task_state_manager()
+    register_parser_pool_restart_factories()

--- a/openrag/services/workers/parsers/parser_dispatcher.py
+++ b/openrag/services/workers/parsers/parser_dispatcher.py
@@ -24,8 +24,8 @@ from core.utils.logging import get_logger
 logger = get_logger()
 
 # Translate the legacy ``file_loaders`` class-name values into new registry
-# backend names. Mirrors ``bootstrap.get_marker_pool`` / ``init_audio_actor`` so
-# the dispatcher always resolves to a backend whose pool actually exists.
+# backend names. Every pooled backend self-provisions its Ray pool on first
+# use, so the dispatcher can resolve to any of them.
 _PDF_BACKENDS: dict[str, str] = {
     "MarkerLoader": "marker",
     "DoclingLoader": "docling",

--- a/openrag/services/workers/parsers/whisper_workers.py
+++ b/openrag/services/workers/parsers/whisper_workers.py
@@ -205,7 +205,7 @@ class LocalWhisperLoader(BasePooledParser):
         # eager init_audio_actor() pre-warm at startup.
         from services.workers.bootstrap import get_or_create_actor
 
-        self.whisper_actor: WhisperPool = get_or_create_actor("WhisperPool", WhisperPool, lifetime="detached")
+        self.worker: WhisperPool = get_or_create_actor("WhisperPool", WhisperPool, lifetime="detached")
 
     def supported_types(self) -> list[str]:
         return [DocumentType.AUDIO.value, DocumentType.VIDEO.value]
@@ -219,7 +219,7 @@ class LocalWhisperLoader(BasePooledParser):
 
         async with document.as_temporary_file() as path:
             try:
-                text = await self.whisper_actor.transcribe.remote(str(path))
+                text = await self.worker.transcribe.remote(str(path))
             except Exception as e:
                 logger.error("Error transcribing audio", error=str(e))
                 raise

--- a/openrag/services/workers/parsers/whisper_workers.py
+++ b/openrag/services/workers/parsers/whisper_workers.py
@@ -200,9 +200,8 @@ class LocalWhisperLoader(BasePooledParser):
 
     def __init__(self):
         self.config = load_config()
-        # Lazily create the pool if bootstrap didn't — mirrors MarkerLoader so
-        # audio ingestion self-provisions WhisperPool instead of relying on the
-        # eager init_audio_actor() pre-warm at startup.
+        # Self-provision the pool on first use — mirrors MarkerLoader; bootstrap
+        # no longer pre-warms parser pools at startup.
         from services.workers.bootstrap import get_or_create_actor
 
         self.worker: WhisperPool = get_or_create_actor("WhisperPool", WhisperPool, lifetime="detached")

--- a/openrag/services/workers/parsers/whisper_workers.py
+++ b/openrag/services/workers/parsers/whisper_workers.py
@@ -200,7 +200,12 @@ class LocalWhisperLoader(BasePooledParser):
 
     def __init__(self):
         self.config = load_config()
-        self.whisper_actor: WhisperPool = ray.get_actor("WhisperPool", namespace="openrag")
+        # Lazily create the pool if bootstrap didn't — mirrors MarkerLoader so
+        # audio ingestion self-provisions WhisperPool instead of relying on the
+        # eager init_audio_actor() pre-warm at startup.
+        from services.workers.bootstrap import get_or_create_actor
+
+        self.whisper_actor: WhisperPool = get_or_create_actor("WhisperPool", WhisperPool, lifetime="detached")
 
     def supported_types(self) -> list[str]:
         return [DocumentType.AUDIO.value, DocumentType.VIDEO.value]

--- a/tests/integration/api/test_oidc_lifecycle.py
+++ b/tests/integration/api/test_oidc_lifecycle.py
@@ -249,7 +249,6 @@ def _install_stubs():
     stub.get_task_state_manager = lambda: _stub_task_state_manager
     stub.get_serializer = lambda: None
     stub.get_indexer = lambda: None
-    stub.get_marker_pool = lambda: None
     sys.modules["utils.dependencies"] = stub
 
     def _logger():

--- a/tests/unit/services/workers/parsers/test_pool_loaders.py
+++ b/tests/unit/services/workers/parsers/test_pool_loaders.py
@@ -1,10 +1,10 @@
-"""The pooled PDF loaders must create their Ray pool lazily via
+"""The pooled loaders must create their Ray pool lazily via
 ``get_or_create_actor`` rather than assuming bootstrap already created it.
 
-Bootstrap only pre-warms the *globally* configured PDF backend, but a per-preset
+Bootstrap no longer pre-warms any parser pool, and a per-preset
 ``parsing_strategy`` can select any backend at runtime (#569). A get-only
 ``ray.get_actor`` then fails with "Failed to look up actor 'DoclingPool'"
-(#575); lazy creation makes whichever backend a preset picks work on first use.
+(#575); lazy creation makes whichever backend is picked work on first use.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ import pytest
     [
         ("services.workers.parsers.docling_workers", "DoclingLoader", "DoclingPool", "DoclingPool"),
         ("services.workers.parsers.marker_workers", "MarkerLoader", "MarkerPool", "MarkerPool"),
+        ("services.workers.parsers.whisper_workers", "LocalWhisperLoader", "WhisperPool", "WhisperPool"),
     ],
 )
 def test_pool_loader_lazily_creates_its_pool(monkeypatch, module_name, loader_name, pool_name, pool_attr):

--- a/tests/unit/services/workers/test_bootstrap.py
+++ b/tests/unit/services/workers/test_bootstrap.py
@@ -1,0 +1,88 @@
+"""Bootstrap must register restart factories for the lazy parser pools.
+
+``actor_creation_map`` is process-local and read by the admin restart
+endpoint (``POST /cluster/{actor}/restart``) from the API process. Parser
+pools are created on first use — possibly inside another Ray worker
+process — so bootstrap has to register their restart factories eagerly,
+without creating the actors, or the endpoint 404s for every parser pool.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import services.workers.bootstrap as bootstrap
+
+PARSER_POOL_ACTORS = ("MarkerPool", "DoclingPool", "WhisperPool", "WhisperActor")
+
+
+def _capture_actor_creations(monkeypatch) -> list[tuple]:
+    calls: list[tuple] = []
+
+    def fake_get_or_create_actor(name, cls, **options):
+        calls.append((name, cls, options))
+        return "actor-handle"
+
+    monkeypatch.setattr(bootstrap, "actor_creation_map", {})
+    monkeypatch.setattr(bootstrap, "get_or_create_actor", fake_get_or_create_actor)
+    return calls
+
+
+def test_registers_all_parser_pools_without_creating_actors(monkeypatch):
+    calls = _capture_actor_creations(monkeypatch)
+
+    bootstrap.register_parser_pool_restart_factories()
+
+    assert set(bootstrap.actor_creation_map) == set(PARSER_POOL_ACTORS)
+    assert calls == []
+
+
+def test_initialize_worker_bootstrap_registers_parser_pool_factories(monkeypatch):
+    from core.config.root import Settings
+
+    monkeypatch.setattr(bootstrap, "actor_creation_map", {})
+    monkeypatch.setattr(bootstrap, "_settings", None)
+    for creator in ("init_llm_semaphore", "init_vlm_semaphore", "init_audio_semaphore", "get_task_state_manager"):
+        monkeypatch.setattr(bootstrap, creator, lambda: None)
+
+    bootstrap.initialize_worker_bootstrap(Settings())
+
+    assert set(PARSER_POOL_ACTORS) <= set(bootstrap.actor_creation_map)
+
+
+@pytest.mark.parametrize(
+    ("actor_name", "module_name"),
+    [
+        ("MarkerPool", "services.workers.parsers.marker_workers"),
+        ("DoclingPool", "services.workers.parsers.docling_workers"),
+        ("WhisperPool", "services.workers.parsers.whisper_workers"),
+    ],
+)
+def test_pool_factory_creates_the_named_pool(monkeypatch, actor_name, module_name):
+    calls = _capture_actor_creations(monkeypatch)
+    bootstrap.register_parser_pool_restart_factories()
+
+    assert bootstrap.actor_creation_map[actor_name]() == "actor-handle"
+
+    pool_cls = getattr(importlib.import_module(module_name), actor_name)
+    assert calls == [(actor_name, pool_cls, {"lifetime": "detached"})]
+
+
+def test_whisper_actor_factory_passes_actor_options(monkeypatch):
+    from core.config.root import Settings
+    from services.workers.parsers.whisper_workers import WhisperActor
+
+    calls = _capture_actor_creations(monkeypatch)
+    monkeypatch.setattr(bootstrap, "_settings", Settings())
+    bootstrap.register_parser_pool_restart_factories()
+
+    assert bootstrap.actor_creation_map["WhisperActor"]() == "actor-handle"
+
+    ((name, cls, options),) = calls
+    assert name == "WhisperActor"
+    assert cls is WhisperActor
+    assert options["lifetime"] == "detached"
+    # The per-actor Ray options (GPU reservation, restarts, concurrency) must
+    # be recomputed at restart time, matching detect_language_via_actor.
+    assert {"num_gpus", "max_restarts", "max_concurrency"} <= options.keys()

--- a/tests/unit/test_auth_router.py
+++ b/tests/unit/test_auth_router.py
@@ -44,7 +44,6 @@ def _install_dependencies_stub() -> dict[str, types.ModuleType | None]:
     stub.actor_creation_map = {}
     stub.get_task_state_manager = lambda: None
     stub.get_serializer = lambda: None
-    stub.get_marker_pool = lambda: None
     sys.modules["services.workers.bootstrap"] = stub
 
     def _logger():


### PR DESCRIPTION
## What

Drop the eager `get_marker_pool()` and `init_audio_actor()` calls from `initialize_worker_bootstrap`. Parser pools are now created on first use instead of at startup.

## Why it's safe

Every parser pool consumer already self-provisions its Ray actor via `get_if_exists=True`:
- `MarkerLoader` → `MarkerPool`
- `DoclingLoader` → `DoclingPool`
- `WhisperActor` (OpenAI lang-detector)

The one gap was `LocalWhisperLoader`, which used a bare `ray.get_actor("WhisperPool")` that fails if nothing pre-created it. This PR makes it self-provision through `get_or_create_actor`, closing the gap — so both dropped bootstrap calls become redundant.

## Effect

Startup no longer spins up parser pools a deployment may never use — e.g. the Marker pool when the default PDF backend is PyMuPDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser workers now start lazily, provisioning each backend only when it’s first needed (including audio transcription).
  * Backend selection can happen per parsing preset at runtime without requiring pre-warmed pools.

* **Bug Fixes**
  * Improved worker startup reliability by ensuring parser pool restart/provisioning is correctly registered up front.
  * Updated whisper parsing to use the lazily created pool for transcription requests.

* **Tests**
  * Expanded unit coverage for lazy pool creation and factory registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Behavior note

For deployments whose configured backend is a pooled one (Marker / Docling / local Whisper), pool warm-up (heavy imports + Ray actor spin-up) moves from startup to the first parsed document. Boot gets faster for every deployment, but first-document latency after a cold start increases for those backends. The admin restart endpoint still knows every parser pool: bootstrap registers restart factories for all of them without creating actors, and restarting a never-created pool simply creates it.
