### PR TITLE
fix(admin-ui): polish table controls

### DIFF
--- a/ui/src/components/shared/data-table.test.tsx
+++ b/ui/src/components/shared/data-table.test.tsx
@@ -70,18 +70,19 @@ describe("DataTable sorting", () => {
 });
 
 describe("DataTable selection", () => {
-  it("supports controlled row selection", () => {
+  it("selects only the currently visible page rows", () => {
     function Harness() {
       const [selection, setSelection] = useState<RowSelectionState>({});
       return (
         <>
           <DataTable
             columns={columns}
-            data={makeRows(3)}
+            data={makeRows(11)}
             enableSelection
             getRowId={(r) => String(r.id)}
             rowSelection={selection}
             onRowSelectionChange={setSelection}
+            pageSize={10}
           />
           <span>{Object.keys(selection).length} selected</span>
           <button onClick={() => setSelection({})}>clear-sel</button>
@@ -93,9 +94,9 @@ describe("DataTable selection", () => {
 
     expect(screen.getByText("0 selected")).toBeTruthy();
 
-    // Header checkbox is the first checkbox; it selects every row.
+    // Header checkbox is the first checkbox; it should select only page 1.
     fireEvent.click(screen.getAllByRole("checkbox")[0]);
-    expect(screen.getByText("3 selected")).toBeTruthy();
+    expect(screen.getByText("10 selected")).toBeTruthy();
 
     fireEvent.click(screen.getByText("clear-sel"));
     expect(screen.getByText("0 selected")).toBeTruthy();

--- a/ui/src/components/shared/data-table.test.tsx
+++ b/ui/src/components/shared/data-table.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import { useState } from "react";
 
 import { DataTable, SortableHeader } from "./data-table";
 
@@ -69,30 +70,48 @@ describe("DataTable sorting", () => {
 });
 
 describe("DataTable selection", () => {
-  it("renders bulk actions for the selected rows and clears them", () => {
+  it("supports controlled row selection", () => {
+    function Harness() {
+      const [selection, setSelection] = useState<RowSelectionState>({});
+      return (
+        <>
+          <DataTable
+            columns={columns}
+            data={makeRows(3)}
+            enableSelection
+            getRowId={(r) => String(r.id)}
+            rowSelection={selection}
+            onRowSelectionChange={setSelection}
+          />
+          <span>{Object.keys(selection).length} selected</span>
+          <button onClick={() => setSelection({})}>clear-sel</button>
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByText("0 selected")).toBeTruthy();
+
+    // Header checkbox is the first checkbox; it selects every row.
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    expect(screen.getByText("3 selected")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("clear-sel"));
+    expect(screen.getByText("0 selected")).toBeTruthy();
+  });
+
+  it("does not render a built-in bulk banner", () => {
     render(
       <DataTable
         columns={columns}
         data={makeRows(3)}
         enableSelection
         getRowId={(r) => String(r.id)}
-        renderBulkActions={({ selected, clear }) => (
-          <div>
-            <span>{selected.length} selected</span>
-            <button onClick={clear}>clear-sel</button>
-          </div>
-        )}
       />,
     );
 
-    // No bulk bar until something is selected.
-    expect(screen.queryByText(/selected/)).toBeNull();
-
-    // Header checkbox is the first checkbox; it selects every row on the page.
     fireEvent.click(screen.getAllByRole("checkbox")[0]);
-    expect(screen.getByText("3 selected")).toBeTruthy();
-
-    fireEvent.click(screen.getByText("clear-sel"));
     expect(screen.queryByText(/selected/)).toBeNull();
   });
 });

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -74,11 +74,11 @@ export function DataTable<TData, TValue>({
       header: ({ table }) => (
         <Checkbox
           checked={
-            table.getIsAllRowsSelected() ||
-            (table.getIsSomeRowsSelected() && "indeterminate")
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && "indeterminate")
           }
-          onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
-          aria-label="Select all rows"
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select visible rows"
         />
       ),
       cell: ({ row }) => (

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -1,6 +1,7 @@
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type OnChangeFn,
   type RowSelectionState,
   type SortingState,
   flexRender,
@@ -10,7 +11,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import {
   Table,
@@ -23,30 +24,18 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 
-export interface BulkActionContext<TData> {
-  /** Rows currently selected (across all pages). */
-  selected: TData[];
-  /** Total selectable rows in the table (all pages). */
-  total: number;
-  /** Whether every row (all pages) is selected. */
-  allSelected: boolean;
-  /** Select every row across all pages. */
-  selectAll: () => void;
-  /** Clear the selection. */
-  clear: () => void;
-}
-
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   pageSize?: number;
   initialSorting?: SortingState;
-  /** Render a leading checkbox column + a contextual bulk-action bar. */
+  /** Render a leading checkbox column. */
   enableSelection?: boolean;
   /** Stable row id (e.g. file_id) so selection survives a data refetch. */
   getRowId?: (row: TData) => string;
-  /** Bulk-action bar content, shown above the table while rows are selected. */
-  renderBulkActions?: (ctx: BulkActionContext<TData>) => ReactNode;
+  /** Optional controlled selection state for pages that render bulk controls in their own toolbar. */
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
 }
 
 export function DataTable<TData, TValue>({
@@ -56,12 +45,15 @@ export function DataTable<TData, TValue>({
   initialSorting = [],
   enableSelection = false,
   getRowId,
-  renderBulkActions,
+  rowSelection: controlledRowSelection,
+  onRowSelectionChange,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>(initialSorting);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize });
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [internalRowSelection, setInternalRowSelection] = useState<RowSelectionState>({});
+  const rowSelection = controlledRowSelection ?? internalRowSelection;
+  const setRowSelection = onRowSelectionChange ?? setInternalRowSelection;
 
   // Prepend a checkbox column when selection is enabled.
   const tableColumns = useMemo<ColumnDef<TData, TValue>[]>(() => {
@@ -72,11 +64,11 @@ export function DataTable<TData, TValue>({
       header: ({ table }) => (
         <Checkbox
           checked={
-            table.getIsAllPageRowsSelected() ||
-            (table.getIsSomePageRowsSelected() && "indeterminate")
+            table.getIsAllRowsSelected() ||
+            (table.getIsSomeRowsSelected() && "indeterminate")
           }
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select all rows on this page"
+          onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
+          aria-label="Select all rows"
         />
       ),
       cell: ({ row }) => (
@@ -120,22 +112,10 @@ export function DataTable<TData, TValue>({
     }
   }, [pageCount, pagination.pageIndex]);
 
-  const selectedRows = table.getSelectedRowModel().rows;
   const columnCount = table.getAllLeafColumns().length;
 
   return (
     <div>
-      {enableSelection && renderBulkActions && selectedRows.length > 0 && (
-        <div className="mb-3 flex flex-wrap items-center gap-3 rounded-lg border bg-primary/5 px-4 py-2.5">
-          {renderBulkActions({
-            selected: selectedRows.map((r) => r.original),
-            total: table.getFilteredRowModel().rows.length,
-            allSelected: table.getIsAllRowsSelected(),
-            selectAll: () => table.toggleAllRowsSelected(true),
-            clear: () => table.resetRowSelection(),
-          })}
-        </div>
-      )}
       <div className="rounded-md border">
         <Table>
           <TableHeader>

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -24,7 +24,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 
-interface DataTableProps<TData, TValue> {
+interface BaseDataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   pageSize?: number;
@@ -33,10 +33,20 @@ interface DataTableProps<TData, TValue> {
   enableSelection?: boolean;
   /** Stable row id (e.g. file_id) so selection survives a data refetch. */
   getRowId?: (row: TData) => string;
-  /** Optional controlled selection state for pages that render bulk controls in their own toolbar. */
-  rowSelection?: RowSelectionState;
-  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
 }
+
+type DataTableSelectionProps =
+  | {
+      /** Controlled selection state for pages that render bulk controls in their own toolbar. */
+      rowSelection: RowSelectionState;
+      onRowSelectionChange: OnChangeFn<RowSelectionState>;
+    }
+  | {
+      rowSelection?: never;
+      onRowSelectionChange?: never;
+    };
+
+type DataTableProps<TData, TValue> = BaseDataTableProps<TData, TValue> & DataTableSelectionProps;
 
 export function DataTable<TData, TValue>({
   columns,

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteFile } from "@/lib/api/indexing";
+import DocumentListPage from "./list";
+
+vi.mock("@/lib/permissions", () => ({
+  usePermissions: () => ({
+    canWrite: () => true,
+  }),
+}));
+
+vi.mock("@/lib/api/partitions", () => ({
+  listPartitions: vi.fn().mockResolvedValue({
+    partitions: [
+      {
+        partition: "docs",
+        name: "docs",
+        role: "owner",
+        created_at: null,
+        document_count: 2,
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/api/documents", () => ({
+  listPartitionFiles: vi.fn().mockResolvedValue({
+    files: [
+      {
+        file_id: "file-a",
+        partition: "docs",
+        filename: "a.pdf",
+        mimetype: "application/pdf",
+        indexed_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        file_id: "file-b",
+        partition: "docs",
+        filename: "b.pdf",
+        mimetype: "application/pdf",
+        indexed_at: "2026-01-02T00:00:00Z",
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/lib/api/indexing", () => ({
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn().mockResolvedValue(undefined),
+  newFileId: vi.fn(() => "new-file-id"),
+}));
+
+const deleteFileMock = vi.mocked(deleteFile);
+
+function renderDocuments() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DocumentListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DocumentListPage bulk actions", () => {
+  beforeEach(() => {
+    deleteFileMock.mockClear();
+  });
+
+  it("selects all documents from the table header and deletes the selected files", async () => {
+    renderDocuments();
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.getByText("b.pdf")).not.toBeNull();
+    expect(screen.queryByText(/selected/i)).toBeNull();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /select all rows/i }));
+
+    expect(screen.getByText("2 selected")).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /delete selected files/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => expect(deleteFileMock).toHaveBeenCalledWith("docs", "file-a"));
+    expect(deleteFileMock).toHaveBeenCalledWith("docs", "file-b");
+  });
+});

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -84,7 +84,7 @@ describe("DocumentListPage bulk actions", () => {
     expect(screen.getByText("b.pdf")).not.toBeNull();
     expect(screen.queryByText(/selected/i)).toBeNull();
 
-    await userEvent.click(screen.getByRole("checkbox", { name: /select all rows/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select visible rows/i }));
 
     expect(screen.getByText("2 selected")).not.toBeNull();
     await userEvent.click(screen.getByRole("button", { name: /delete selected files/i }));

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -137,6 +137,13 @@ export default function DocumentListPage() {
     [fileRows, fileRowSelection],
   );
 
+  useEffect(() => {
+    if (!writable && Object.keys(fileRowSelection).length > 0) {
+      const timeout = window.setTimeout(() => setFileRowSelection({}), 0);
+      return () => window.clearTimeout(timeout);
+    }
+  }, [fileRowSelection, setFileRowSelection, writable]);
+
   const deleteMutation = useMutation({
     mutationFn: (fileId: string) => deleteFile(selected, fileId),
     onSuccess: () => {
@@ -162,7 +169,10 @@ export default function DocumentListPage() {
       queryClient.invalidateQueries({ queryKey: ["partition-files", selected] });
     },
     onError: (err: Error) => toast.error(`Bulk delete failed: ${err.message}`),
-    onSettled: () => setBulkDeleting(false),
+    onSettled: () => {
+      setBulkDeleting(false);
+      setFileRowSelection({});
+    },
   });
 
   // OpenRag indexes one file per request; multi-file upload is a client-side
@@ -317,7 +327,7 @@ export default function DocumentListPage() {
             ))}
           </SelectContent>
         </Select>
-        {selectedFiles.length > 0 && (
+        {writable && selectedFiles.length > 0 && (
           <>
             <ConfirmDialog
               title="Delete files"
@@ -328,7 +338,6 @@ export default function DocumentListPage() {
               }
               onConfirm={() => {
                 bulkDeleteMutation.mutate(selectedFiles.map((file) => file.file_id));
-                setFileRowSelection({});
               }}
             >
               <Button

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
-import { Plus, Eye, Trash2 } from "lucide-react";
+import type { ColumnDef, OnChangeFn, RowSelectionState } from "@tanstack/react-table";
+import { Plus, Eye, Trash2, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/shared/page-header";
@@ -53,6 +53,10 @@ export default function DocumentListPage() {
   const [uploadOpen, setUploadOpen] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [fileSelection, setFileSelection] = useState<{
+    partition: string;
+    rows: RowSelectionState;
+  }>({ partition: "", rows: {} });
   const fileRef = useRef<HTMLInputElement>(null);
 
   const partitionsQuery = useQuery({ queryKey: ["partitions"], queryFn: listPartitions });
@@ -90,6 +94,7 @@ export default function DocumentListPage() {
   }, [selected, searchParams, setSearchParams]);
 
   const selectPartition = (p: string) => {
+    setFileSelection({ partition: p, rows: {} });
     sessionStorage.setItem("documents.partition", p);
     setSearchParams((prev) => {
       prev.set("partition", p);
@@ -112,7 +117,25 @@ export default function DocumentListPage() {
     // refetchIntervalInBackground defaults false, so it only polls when focused.
     refetchInterval: 5000,
   });
-  const fileRows = filesQuery.data?.files ?? [];
+  const fileRows = useMemo(() => filesQuery.data?.files ?? [], [filesQuery.data?.files]);
+  const fileRowSelection = useMemo(
+    () => (fileSelection.partition === selected ? fileSelection.rows : {}),
+    [fileSelection.partition, fileSelection.rows, selected],
+  );
+  const setFileRowSelection = useCallback<OnChangeFn<RowSelectionState>>(
+    (updater) => {
+      setFileSelection((current) => {
+        const currentRows = current.partition === selected ? current.rows : {};
+        const rows = typeof updater === "function" ? updater(currentRows) : updater;
+        return { partition: selected, rows };
+      });
+    },
+    [selected],
+  );
+  const selectedFiles = useMemo(
+    () => fileRows.filter((file) => fileRowSelection[file.file_id]),
+    [fileRows, fileRowSelection],
+  );
 
   const deleteMutation = useMutation({
     mutationFn: (fileId: string) => deleteFile(selected, fileId),
@@ -294,9 +317,53 @@ export default function DocumentListPage() {
             ))}
           </SelectContent>
         </Select>
-        {filesQuery.data && (
-          <p className="text-sm text-muted-foreground ml-auto">{fileRows.length} file(s)</p>
+        {selectedFiles.length > 0 && (
+          <>
+            <ConfirmDialog
+              title="Delete files"
+              description={
+                selectedFiles.length <= 5
+                  ? `Delete ${selectedFiles.length} file(s)? This cannot be undone: ${selectedFiles.map(fileLabel).join(", ")}`
+                  : `Delete ${selectedFiles.length} files? This cannot be undone.`
+              }
+              onConfirm={() => {
+                bulkDeleteMutation.mutate(selectedFiles.map((file) => file.file_id));
+                setFileRowSelection({});
+              }}
+            >
+              <Button
+                variant="outline"
+                size="icon-sm"
+                disabled={bulkDeleting}
+                aria-label="Delete selected files"
+                title="Delete selected files"
+              >
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+              </Button>
+            </ConfirmDialog>
+            <p className="text-sm text-muted-foreground">
+              {selectedFiles.length} selected
+            </p>
+          </>
         )}
+        <div className="ml-auto flex items-center gap-2">
+          {filesQuery.data && (
+            <p className="text-sm text-muted-foreground">{fileRows.length} file(s)</p>
+          )}
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => {
+              partitionsQuery.refetch();
+              if (selected) filesQuery.refetch();
+            }}
+            disabled={partitionsQuery.isFetching || filesQuery.isFetching}
+            aria-label="Refresh documents"
+            title="Refresh documents"
+          >
+            <RefreshCw className={partitionsQuery.isFetching || filesQuery.isFetching ? "animate-spin" : ""} />
+          </Button>
+        </div>
       </div>
 
       {!selected ? (
@@ -328,38 +395,8 @@ export default function DocumentListPage() {
           initialSorting={[{ id: "indexed_at", desc: true }]}
           enableSelection={writable}
           getRowId={(f) => f.file_id}
-          renderBulkActions={({ selected: rows, total, allSelected, selectAll, clear }) => {
-            const names = rows.map(fileLabel);
-            const description =
-              names.length <= 5
-                ? `Delete ${names.length} file(s)? This cannot be undone: ${names.join(", ")}`
-                : `Delete ${names.length} files? This cannot be undone.`;
-            return (
-              <>
-                <span className="text-sm font-medium text-primary">{rows.length} selected</span>
-                <ConfirmDialog
-                  title="Delete files"
-                  description={description}
-                  onConfirm={() => {
-                    bulkDeleteMutation.mutate(rows.map((r) => r.file_id));
-                    clear();
-                  }}
-                >
-                  <Button variant="destructive" size="sm" disabled={bulkDeleting}>
-                    <Trash2 className="h-3.5 w-3.5" /> Delete selected
-                  </Button>
-                </ConfirmDialog>
-                <Button variant="ghost" size="sm" onClick={clear}>
-                  Clear
-                </Button>
-                {!allSelected && rows.length < total && (
-                  <Button variant="link" size="sm" className="ml-auto" onClick={selectAll}>
-                    Select all {total}
-                  </Button>
-                )}
-              </>
-            );
-          }}
+          rowSelection={fileRowSelection}
+          onRowSelectionChange={setFileRowSelection}
         />
       )}
     </div>

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -57,6 +57,7 @@ export default function DocumentListPage() {
     partition: string;
     rows: RowSelectionState;
   }>({ partition: "", rows: {} });
+  const [manualRefreshing, setManualRefreshing] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const partitionsQuery = useQuery({ queryKey: ["partitions"], queryFn: listPartitions });
@@ -139,8 +140,8 @@ export default function DocumentListPage() {
 
   useEffect(() => {
     if (!writable && Object.keys(fileRowSelection).length > 0) {
-      const timeout = window.setTimeout(() => setFileRowSelection({}), 0);
-      return () => window.clearTimeout(timeout);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Clear stale controlled selection when write access is lost.
+      setFileRowSelection({});
     }
   }, [fileRowSelection, setFileRowSelection, writable]);
 
@@ -363,14 +364,17 @@ export default function DocumentListPage() {
             variant="outline"
             size="icon-sm"
             onClick={() => {
-              partitionsQuery.refetch();
-              if (selected) filesQuery.refetch();
+              setManualRefreshing(true);
+              Promise.all([
+                partitionsQuery.refetch(),
+                selected ? filesQuery.refetch() : Promise.resolve(),
+              ]).finally(() => setManualRefreshing(false));
             }}
-            disabled={partitionsQuery.isFetching || filesQuery.isFetching}
+            disabled={manualRefreshing}
             aria-label="Refresh documents"
             title="Refresh documents"
           >
-            <RefreshCw className={partitionsQuery.isFetching || filesQuery.isFetching ? "animate-spin" : ""} />
+            <RefreshCw className={manualRefreshing ? "animate-spin" : ""} />
           </Button>
         </div>
       </div>

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listTasks } from "@/lib/api/jobs";
+import JobListPage from "./list";
+
+vi.mock("@/lib/permissions", () => ({
+  usePermissions: () => ({
+    isAdmin: true,
+  }),
+}));
+
+vi.mock("@/lib/api/jobs", () => ({
+  listTasks: vi.fn(),
+}));
+
+const listTasksMock = vi.mocked(listTasks);
+
+const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string) => ({
+  task_id,
+  state,
+  details: {
+    file_id: task_id,
+    partition: "docs",
+    metadata: { filename },
+    user_id: 1,
+  },
+  url: `/indexer/task/${task_id}`,
+});
+
+function renderJobs() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <JobListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("JobListPage filters", () => {
+  beforeEach(() => {
+    listTasksMock.mockImplementation(async (status?: string) => ({
+      tasks:
+        status === "FAILED"
+          ? [task("failed-task", "FAILED", "failed.pdf")]
+          : [
+              task("completed-task", "COMPLETED", "completed.pdf"),
+              task("failed-task", "FAILED", "failed.pdf"),
+            ],
+    }));
+  });
+
+  it("clears search when switching status tabs", async () => {
+    renderJobs();
+
+    expect(await screen.findByText("completed.pdf")).not.toBeNull();
+    const search = screen.getByPlaceholderText("Search jobs...") as HTMLInputElement;
+
+    await userEvent.type(search, "completed");
+    expect(search.value).toBe("completed");
+
+    await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));
+
+    await waitFor(() => expect(search.value).toBe(""));
+    expect(await screen.findByText("failed.pdf")).not.toBeNull();
+  });
+});

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
+import { RefreshCw, Search } from "lucide-react";
 import { usePermissions } from "@/lib/permissions";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { DataTable } from "@/components/shared/data-table";
 import { StatusBadge } from "@/components/shared/status-badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { listTasks, type TaskListItem } from "@/lib/api/jobs";
 
@@ -45,20 +48,60 @@ const columns: ColumnDef<TaskListItem, unknown>[] = [
 export default function JobListPage() {
   const { isAdmin } = usePermissions();
   const [statusTab, setStatusTab] = useState<string>("ALL");
+  const [search, setSearch] = useState("");
 
   const tasksQuery = useQuery({
     queryKey: ["tasks", statusTab],
     queryFn: () => listTasks(statusTab === "ALL" ? undefined : statusTab === "ACTIVE" ? "active" : statusTab),
-    refetchInterval: 5000, // poll — OpenRag has no task SSE (scale-correct per roadmap)
+    refetchInterval: 2000, // poll — OpenRag has no task SSE (scale-correct per roadmap)
   });
 
-  const tasks = tasksQuery.data?.tasks ?? [];
+  const tasks = useMemo(() => tasksQuery.data?.tasks ?? [], [tasksQuery.data?.tasks]);
+  const filteredTasks = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return tasks;
+    return tasks.filter((task) => {
+      const filename = str(task.details?.metadata?.filename);
+      const fileId = str(task.details?.file_id);
+      const partition = str(task.details?.partition);
+      return [task.task_id, task.state, filename, fileId, partition].some((value) =>
+        str(value).toLowerCase().includes(q),
+      );
+    });
+  }, [tasks, search]);
 
   return (
     <div>
       <PageHeader title="Jobs" description={isAdmin ? "Monitor indexing tasks" : "Monitor your indexing tasks"} />
 
       <Tabs value={statusTab} onValueChange={setStatusTab}>
+        <div className="mb-4 mt-0 flex items-center gap-2">
+          <div className="relative max-w-sm">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Search jobs..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <p className="text-sm text-muted-foreground">
+              {filteredTasks.length} job{filteredTasks.length === 1 ? "" : "s"}
+            </p>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() => tasksQuery.refetch()}
+              disabled={tasksQuery.isFetching}
+              aria-label="Refresh jobs"
+              title="Refresh jobs"
+            >
+              <RefreshCw className={tasksQuery.isFetching ? "animate-spin" : ""} />
+            </Button>
+          </div>
+        </div>
+
         <TabsList>
           {STATUS_TABS.map((tab) => (
             <TabsTrigger key={tab} value={tab}>
@@ -76,7 +119,7 @@ export default function JobListPage() {
                 Failed to load tasks: {(tasksQuery.error as Error).message}
               </div>
             ) : (
-              <DataTable columns={columns} data={tasks} />
+              <DataTable columns={columns} data={filteredTasks} />
             )}
           </TabsContent>
         ))}

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -137,6 +137,7 @@ export default function JobListPage() {
                 Failed to load tasks: {(tasksQuery.error as Error).message}
               </div>
             ) : (
+              // Remounting resets pagination for a new tab/search context; sort state resets with it.
               <DataTable key={`${statusTab}:${debouncedSearch}`} columns={columns} data={filteredTasks} />
             )}
           </TabsContent>

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -15,6 +15,8 @@ import { listTasks, type TaskListItem } from "@/lib/api/jobs";
 
 // OpenRag exposes per-file indexing tasks (TaskStateManager), not batch "jobs".
 const STATUS_TABS = ["ALL", "ACTIVE", "COMPLETED", "FAILED", "CANCELLED"] as const;
+const JOBS_REFETCH_INTERVAL_MS = 5000;
+const JOB_SEARCH_DEBOUNCE_MS = 250;
 
 const str = (v: unknown) => (v == null ? "" : String(v));
 
@@ -49,17 +51,23 @@ export default function JobListPage() {
   const { isAdmin } = usePermissions();
   const [statusTab, setStatusTab] = useState<string>("ALL");
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [manualRefreshing, setManualRefreshing] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedSearch(search), JOB_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [search]);
 
   const tasksQuery = useQuery({
     queryKey: ["tasks", statusTab],
     queryFn: () => listTasks(statusTab === "ALL" ? undefined : statusTab === "ACTIVE" ? "active" : statusTab),
-    refetchInterval: 2000, // poll — OpenRag has no task SSE (scale-correct per roadmap)
+    refetchInterval: JOBS_REFETCH_INTERVAL_MS, // poll — OpenRag has no task SSE
   });
 
   const tasks = useMemo(() => tasksQuery.data?.tasks ?? [], [tasksQuery.data?.tasks]);
   const filteredTasks = useMemo(() => {
-    const q = search.trim().toLowerCase();
+    const q = debouncedSearch.trim().toLowerCase();
     if (!q) return tasks;
     return tasks.filter((task) => {
       const filename = str(task.details?.metadata?.filename);
@@ -69,13 +77,19 @@ export default function JobListPage() {
         str(value).toLowerCase().includes(q),
       );
     });
-  }, [tasks, search]);
+  }, [tasks, debouncedSearch]);
+
+  const handleStatusTabChange = (value: string) => {
+    setStatusTab(value);
+    setSearch("");
+    setDebouncedSearch("");
+  };
 
   return (
     <div>
       <PageHeader title="Jobs" description={isAdmin ? "Monitor indexing tasks" : "Monitor your indexing tasks"} />
 
-      <Tabs value={statusTab} onValueChange={setStatusTab}>
+      <Tabs value={statusTab} onValueChange={handleStatusTabChange}>
         <div className="mb-4 mt-0 flex items-center gap-2">
           <div className="relative max-w-sm">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -123,7 +137,7 @@ export default function JobListPage() {
                 Failed to load tasks: {(tasksQuery.error as Error).message}
               </div>
             ) : (
-              <DataTable key={`${statusTab}:${search}`} columns={columns} data={filteredTasks} />
+              <DataTable key={`${statusTab}:${debouncedSearch}`} columns={columns} data={filteredTasks} />
             )}
           </TabsContent>
         ))}

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -49,6 +49,7 @@ export default function JobListPage() {
   const { isAdmin } = usePermissions();
   const [statusTab, setStatusTab] = useState<string>("ALL");
   const [search, setSearch] = useState("");
+  const [manualRefreshing, setManualRefreshing] = useState(false);
 
   const tasksQuery = useQuery({
     queryKey: ["tasks", statusTab],
@@ -92,12 +93,15 @@ export default function JobListPage() {
             <Button
               variant="outline"
               size="icon-sm"
-              onClick={() => tasksQuery.refetch()}
-              disabled={tasksQuery.isFetching}
+              onClick={() => {
+                setManualRefreshing(true);
+                tasksQuery.refetch().finally(() => setManualRefreshing(false));
+              }}
+              disabled={manualRefreshing}
               aria-label="Refresh jobs"
               title="Refresh jobs"
             >
-              <RefreshCw className={tasksQuery.isFetching ? "animate-spin" : ""} />
+              <RefreshCw className={manualRefreshing ? "animate-spin" : ""} />
             </Button>
           </div>
         </div>
@@ -119,7 +123,7 @@ export default function JobListPage() {
                 Failed to load tasks: {(tasksQuery.error as Error).message}
               </div>
             ) : (
-              <DataTable columns={columns} data={filteredTasks} />
+              <DataTable key={`${statusTab}:${search}`} columns={columns} data={filteredTasks} />
             )}
           </TabsContent>
         ))}

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -645,7 +645,7 @@ function EndpointDialog({
             </p>
           )}
 
-          <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2">
             <Button
               type="button"
               variant="outline"

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -1,31 +1,39 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deletePartition, listPartitions } from "@/lib/api/partitions";
 import PartitionListPage from "./list";
 
 const permissions = vi.hoisted(() => ({
   canManagePartitions: false,
+  canConfigurePartition: vi.fn((role?: string) => role === "owner"),
 }));
 
 vi.mock("@/lib/permissions", () => ({
   usePermissions: () => permissions,
 }));
+
 vi.mock("@/lib/api/partitions", () => ({
   listPartitions: vi.fn().mockResolvedValue({ partitions: [] }),
   createPartition: vi.fn(),
   deletePartition: vi.fn(),
 }));
+
 vi.mock("@/lib/api/presets", () => ({
   listPresets: vi.fn().mockResolvedValue([]),
 }));
+
 vi.mock("@/lib/api/models", () => ({
   listModelEndpoints: vi.fn().mockResolvedValue([]),
   validateStoredModelEndpoint: vi.fn(),
   pickDefaultEndpoint: vi.fn().mockReturnValue(null),
   resolveEmbedderName: vi.fn().mockReturnValue("default"),
 }));
+
+const listPartitionsMock = vi.mocked(listPartitions);
+const deletePartitionMock = vi.mocked(deletePartition);
 
 function renderPartitions() {
   const queryClient = new QueryClient({
@@ -44,37 +52,67 @@ function renderPartitions() {
   );
 }
 
-describe("PartitionListPage create partition copy", () => {
+describe("PartitionListPage bulk actions", () => {
   beforeEach(() => {
     permissions.canManagePartitions = false;
+    permissions.canConfigurePartition.mockImplementation((role?: string) => role === "owner");
+    deletePartitionMock.mockResolvedValue();
+    listPartitionsMock.mockResolvedValue({
+      partitions: [
+        {
+          partition: "owned-a",
+          name: "owned-a",
+          role: "owner",
+          exists: true,
+          description: "",
+          embedder: "",
+          dimension: 0,
+          collection_name: null,
+          chat_history_depth: 0,
+          chat_llm: null,
+          document_count: 0,
+          indexation_preset: "",
+          retrieval_preset: "",
+          indexation_pipeline: {},
+          retrieval_pipeline: {},
+          created_at: null,
+        },
+        {
+          partition: "viewer-b",
+          name: "viewer-b",
+          role: "viewer",
+          exists: true,
+          description: "",
+          embedder: "",
+          dimension: 0,
+          collection_name: null,
+          chat_history_depth: 0,
+          chat_llm: null,
+          document_count: 0,
+          indexation_preset: "",
+          retrieval_preset: "",
+          indexation_pipeline: {},
+          retrieval_pipeline: {},
+          created_at: null,
+        },
+      ],
+    });
   });
 
-  it("describes create partition as a personal self-service action for normal users", async () => {
+  it("selects all deletable partitions and deletes only those partitions", async () => {
     renderPartitions();
 
-    expect(screen.getByRole("button", { name: /create personal partition/i })).not.toBeNull();
+    expect(await screen.findByText("owned-a")).not.toBeNull();
+    expect(screen.getByText("viewer-b")).not.toBeNull();
+    expect(screen.queryByText(/selected/i)).toBeNull();
 
-    await userEvent.click(screen.getByRole("button", { name: /create personal partition/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select all deletable partitions/i }));
 
-    expect(screen.getByRole("heading", { name: /create personal partition/i })).not.toBeNull();
-    expect(
-      screen.getByText(
-        "Create a personal document partition. You will be the owner and can upload documents to it.",
-      ),
-    ).not.toBeNull();
-  });
+    expect(screen.getByText("1 selected")).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /delete selected partitions/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
 
-  it("keeps the admin create dialog wording general", async () => {
-    permissions.canManagePartitions = true;
-
-    renderPartitions();
-
-    expect(screen.getByRole("button", { name: /^create partition$/i })).not.toBeNull();
-
-    await userEvent.click(screen.getByRole("button", { name: /^create partition$/i }));
-
-    expect(screen.getByRole("heading", { name: /^create partition$/i })).not.toBeNull();
-    expect(screen.getByText("Create a new document partition with its configuration.")).not.toBeNull();
-    expect(screen.queryByText("Create Personal Partition")).toBeNull();
+    await waitFor(() => expect(deletePartitionMock).toHaveBeenCalledWith("owned-a"));
+    expect(deletePartitionMock).not.toHaveBeenCalledWith("viewer-b");
   });
 });

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -118,8 +118,7 @@ describe("PartitionListPage bulk actions", () => {
     expect(screen.queryByText("partition-11")).toBeNull();
     expect(screen.getByText("Page 1 of 2")).not.toBeNull();
 
-    const buttons = screen.getAllByRole("button");
-    await userEvent.click(buttons[buttons.length - 1]);
+    await userEvent.click(screen.getByRole("button", { name: /next page/i }));
 
     expect(await screen.findByText("partition-11")).not.toBeNull();
     expect(screen.queryByText("partition-01")).toBeNull();

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -35,6 +35,27 @@ vi.mock("@/lib/api/models", () => ({
 const listPartitionsMock = vi.mocked(listPartitions);
 const deletePartitionMock = vi.mocked(deletePartition);
 
+function makePartition(name: string, role = "owner") {
+  return {
+    partition: name,
+    name,
+    role,
+    exists: true,
+    description: "",
+    embedder: "",
+    dimension: 0,
+    collection_name: null,
+    chat_history_depth: 0,
+    chat_llm: null,
+    document_count: 0,
+    indexation_preset: "",
+    retrieval_preset: "",
+    indexation_pipeline: {},
+    retrieval_pipeline: {},
+    created_at: null,
+  };
+}
+
 function renderPartitions() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -56,45 +77,12 @@ describe("PartitionListPage bulk actions", () => {
   beforeEach(() => {
     permissions.canManagePartitions = false;
     permissions.canConfigurePartition.mockImplementation((role?: string) => role === "owner");
+    deletePartitionMock.mockClear();
     deletePartitionMock.mockResolvedValue();
     listPartitionsMock.mockResolvedValue({
       partitions: [
-        {
-          partition: "owned-a",
-          name: "owned-a",
-          role: "owner",
-          exists: true,
-          description: "",
-          embedder: "",
-          dimension: 0,
-          collection_name: null,
-          chat_history_depth: 0,
-          chat_llm: null,
-          document_count: 0,
-          indexation_preset: "",
-          retrieval_preset: "",
-          indexation_pipeline: {},
-          retrieval_pipeline: {},
-          created_at: null,
-        },
-        {
-          partition: "viewer-b",
-          name: "viewer-b",
-          role: "viewer",
-          exists: true,
-          description: "",
-          embedder: "",
-          dimension: 0,
-          collection_name: null,
-          chat_history_depth: 0,
-          chat_llm: null,
-          document_count: 0,
-          indexation_preset: "",
-          retrieval_preset: "",
-          indexation_pipeline: {},
-          retrieval_pipeline: {},
-          created_at: null,
-        },
+        makePartition("owned-a"),
+        makePartition("viewer-b", "viewer"),
       ],
     });
   });
@@ -114,5 +102,48 @@ describe("PartitionListPage bulk actions", () => {
 
     await waitFor(() => expect(deletePartitionMock).toHaveBeenCalledWith("owned-a"));
     expect(deletePartitionMock).not.toHaveBeenCalledWith("viewer-b");
+  });
+
+  it("paginates partitions with 10 rows per page", async () => {
+    listPartitionsMock.mockResolvedValue({
+      partitions: Array.from({ length: 11 }, (_, i) =>
+        makePartition(`partition-${String(i + 1).padStart(2, "0")}`),
+      ),
+    });
+
+    renderPartitions();
+
+    expect(await screen.findByText("partition-01")).not.toBeNull();
+    expect(screen.getByText("partition-10")).not.toBeNull();
+    expect(screen.queryByText("partition-11")).toBeNull();
+    expect(screen.getByText("Page 1 of 2")).not.toBeNull();
+
+    const buttons = screen.getAllByRole("button");
+    await userEvent.click(buttons[buttons.length - 1]);
+
+    expect(await screen.findByText("partition-11")).not.toBeNull();
+    expect(screen.queryByText("partition-01")).toBeNull();
+    expect(screen.getByText("Page 2 of 2")).not.toBeNull();
+  });
+
+  it("selects only visible partitions from the table header", async () => {
+    listPartitionsMock.mockResolvedValue({
+      partitions: Array.from({ length: 11 }, (_, i) =>
+        makePartition(`partition-${String(i + 1).padStart(2, "0")}`),
+      ),
+    });
+
+    renderPartitions();
+
+    expect(await screen.findByText("partition-01")).not.toBeNull();
+    await userEvent.click(screen.getByRole("checkbox", { name: /select visible deletable partitions/i }));
+
+    expect(screen.getByText("10 selected")).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /delete selected partitions/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => expect(deletePartitionMock).toHaveBeenCalledWith("partition-01"));
+    expect(deletePartitionMock).toHaveBeenCalledTimes(10);
+    expect(deletePartitionMock).not.toHaveBeenCalledWith("partition-11");
   });
 });

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -106,7 +106,7 @@ describe("PartitionListPage bulk actions", () => {
     expect(screen.getByText("viewer-b")).not.toBeNull();
     expect(screen.queryByText(/selected/i)).toBeNull();
 
-    await userEvent.click(screen.getByRole("checkbox", { name: /select all deletable partitions/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select visible deletable partitions/i }));
 
     expect(screen.getByText("1 selected")).not.toBeNull();
     await userEvent.click(screen.getByRole("button", { name: /delete selected partitions/i }));

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -146,6 +147,7 @@ export default function PartitionListPage() {
   const [search, setSearch] = useState("");
   const [sortDir, setSortDir] = useState<SortDir>(null);
   const [sortColumn, setSortColumn] = useState<"name" | "created_at">("created_at");
+  const [selectedPartitionNames, setSelectedPartitionNames] = useState<string[]>([]);
 
   // `GET /partition/` is already membership-scoped server-side (admins with
   // SUPER_ADMIN_MODE see all; regular users see their memberships), so a single
@@ -153,6 +155,7 @@ export default function PartitionListPage() {
   const partitionsQuery = useQuery({
     queryKey: ["partitions"],
     queryFn: listPartitions,
+    refetchInterval: 2000,
   });
 
   const { data: presetsData } = useQuery({
@@ -252,6 +255,33 @@ export default function PartitionListPage() {
   const showActions =
     canManagePartitions || filteredAndSorted.some((p) => canConfigurePartition(p.role));
 
+  const deletablePartitionNames = useMemo(
+    () => filteredAndSorted.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
+    [filteredAndSorted, canConfigurePartition],
+  );
+  const selectedPartitionNameSet = useMemo(() => new Set(selectedPartitionNames), [selectedPartitionNames]);
+  const selectedPartitions = useMemo(
+    () =>
+      filteredAndSorted.filter(
+        (p) => selectedPartitionNameSet.has(p.name) && canConfigurePartition(p.role),
+      ),
+    [filteredAndSorted, selectedPartitionNameSet, canConfigurePartition],
+  );
+  const allDeletableSelected =
+    deletablePartitionNames.length > 0 &&
+    deletablePartitionNames.every((name) => selectedPartitionNameSet.has(name));
+  const someDeletableSelected =
+    deletablePartitionNames.some((name) => selectedPartitionNameSet.has(name)) &&
+    !allDeletableSelected;
+
+  useEffect(() => {
+    const allowed = new Set(deletablePartitionNames);
+    setSelectedPartitionNames((prev) => {
+      const next = prev.filter((name) => allowed.has(name));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [deletablePartitionNames]);
+
   const handleSort = (column: "name" | "created_at") => {
     if (sortColumn !== column) {
       setSortColumn(column);
@@ -294,6 +324,23 @@ export default function PartitionListPage() {
     },
   });
 
+  const bulkDeleteMutation = useMutation({
+    mutationFn: async (names: string[]) => {
+      const results = await Promise.allSettled(names.map((partitionName) => deletePartition(partitionName)));
+      const ok = results.filter((r) => r.status === "fulfilled").length;
+      return { ok, failed: results.length - ok };
+    },
+    onSuccess: ({ ok, failed }) => {
+      if (ok) toast.success(`${ok} partition(s) deleted`);
+      if (failed) toast.error(`${failed} partition(s) failed to delete`);
+      queryClient.invalidateQueries({ queryKey: ["partitions"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Bulk delete failed: ${error.message}`);
+    },
+    onSettled: () => setSelectedPartitionNames([]),
+  });
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) {
@@ -320,7 +367,7 @@ export default function PartitionListPage() {
         }
       />
 
-      <div className="mb-4">
+      <div className="mb-4 flex items-center gap-2">
         <div className="relative max-w-sm">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -329,6 +376,43 @@ export default function PartitionListPage() {
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
           />
+        </div>
+        {selectedPartitions.length > 0 && (
+          <>
+            <ConfirmDialog
+              title="Delete partitions"
+              description={`Delete ${selectedPartitions.length} partition(s)? This cannot be undone.`}
+              onConfirm={() => bulkDeleteMutation.mutate(selectedPartitions.map((p) => p.name))}
+            >
+              <Button
+                variant="outline"
+                size="icon-sm"
+                disabled={bulkDeleteMutation.isPending}
+                aria-label="Delete selected partitions"
+                title="Delete selected partitions"
+              >
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+              </Button>
+            </ConfirmDialog>
+            <p className="text-sm text-muted-foreground">
+              {selectedPartitions.length} selected
+            </p>
+          </>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">
+            {filteredAndSorted.length} partition{filteredAndSorted.length === 1 ? "" : "s"}
+          </p>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => partitionsQuery.refetch()}
+            disabled={partitionsQuery.isFetching}
+            aria-label="Refresh partitions"
+            title="Refresh partitions"
+          >
+            <RefreshCw className={partitionsQuery.isFetching ? "animate-spin" : ""} />
+          </Button>
         </div>
       </div>
 
@@ -343,6 +427,17 @@ export default function PartitionListPage() {
           <Table>
             <TableHeader>
               <TableRow>
+                {deletablePartitionNames.length > 0 && (
+                  <TableHead>
+                    <Checkbox
+                      checked={allDeletableSelected || (someDeletableSelected && "indeterminate")}
+                      onCheckedChange={(value) =>
+                        setSelectedPartitionNames(value ? deletablePartitionNames : [])
+                      }
+                      aria-label="Select all deletable partitions"
+                    />
+                  </TableHead>
+                )}
                 <TableHead>
                   <SortButton
                     label="Name"
@@ -371,6 +466,22 @@ export default function PartitionListPage() {
               {filteredAndSorted.length ? (
                 filteredAndSorted.map((p) => (
                   <TableRow key={p.name}>
+                    {deletablePartitionNames.length > 0 && (
+                      <TableCell>
+                        <Checkbox
+                          checked={selectedPartitionNameSet.has(p.name)}
+                          disabled={!canConfigurePartition(p.role)}
+                          onCheckedChange={(value) =>
+                            setSelectedPartitionNames((prev) =>
+                              value
+                                ? Array.from(new Set([...prev, p.name]))
+                                : prev.filter((name) => name !== p.name),
+                            )
+                          }
+                          aria-label={`Select partition ${p.name}`}
+                        />
+                      </TableCell>
+                    )}
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <Link
@@ -424,7 +535,11 @@ export default function PartitionListPage() {
               ) : (
                 <TableRow>
                   <TableCell
-                    colSpan={(canManagePartitions ? 7 : 4) + (showActions ? 1 : 0)}
+                    colSpan={
+                      (canManagePartitions ? 7 : 4) +
+                      (showActions ? 1 : 0) +
+                      (deletablePartitionNames.length > 0 ? 1 : 0)
+                    }
                     className="h-24 text-center text-muted-foreground"
                   >
                     {search.trim() ? "No partitions match your search." : "No partitions."}

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -255,9 +255,14 @@ export default function PartitionListPage() {
   const showActions =
     canManagePartitions || filteredAndSorted.some((p) => canConfigurePartition(p.role));
 
-  const deletablePartitionNames = useMemo(
+  const visiblePartitions = filteredAndSorted;
+  const visibleDeletablePartitionNames = useMemo(
     () => filteredAndSorted.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
     [filteredAndSorted, canConfigurePartition],
+  );
+  const visibleDeletablePartitionNameSet = useMemo(
+    () => new Set(visibleDeletablePartitionNames),
+    [visibleDeletablePartitionNames],
   );
   const selectedPartitionNameSet = useMemo(() => new Set(selectedPartitionNames), [selectedPartitionNames]);
   const selectedPartitions = useMemo(
@@ -268,19 +273,21 @@ export default function PartitionListPage() {
     [filteredAndSorted, selectedPartitionNameSet, canConfigurePartition],
   );
   const allDeletableSelected =
-    deletablePartitionNames.length > 0 &&
-    deletablePartitionNames.every((name) => selectedPartitionNameSet.has(name));
+    visibleDeletablePartitionNames.length > 0 &&
+    visibleDeletablePartitionNames.every((name) => selectedPartitionNameSet.has(name));
   const someDeletableSelected =
-    deletablePartitionNames.some((name) => selectedPartitionNameSet.has(name)) &&
+    visibleDeletablePartitionNames.some((name) => selectedPartitionNameSet.has(name)) &&
     !allDeletableSelected;
 
   useEffect(() => {
-    const allowed = new Set(deletablePartitionNames);
+    const allowed = new Set(
+      filteredAndSorted.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
+    );
     setSelectedPartitionNames((prev) => {
       const next = prev.filter((name) => allowed.has(name));
       return next.length === prev.length ? prev : next;
     });
-  }, [deletablePartitionNames]);
+  }, [filteredAndSorted, canConfigurePartition]);
 
   const handleSort = (column: "name" | "created_at") => {
     if (sortColumn !== column) {
@@ -427,14 +434,18 @@ export default function PartitionListPage() {
           <Table>
             <TableHeader>
               <TableRow>
-                {deletablePartitionNames.length > 0 && (
+                {visibleDeletablePartitionNames.length > 0 && (
                   <TableHead>
                     <Checkbox
                       checked={allDeletableSelected || (someDeletableSelected && "indeterminate")}
-                      onCheckedChange={(value) =>
-                        setSelectedPartitionNames(value ? deletablePartitionNames : [])
-                      }
-                      aria-label="Select all deletable partitions"
+                      onCheckedChange={(value) => {
+                        setSelectedPartitionNames((prev) =>
+                          value
+                            ? Array.from(new Set([...prev, ...visibleDeletablePartitionNames]))
+                            : prev.filter((name) => !visibleDeletablePartitionNameSet.has(name)),
+                        );
+                      }}
+                      aria-label="Select visible deletable partitions"
                     />
                   </TableHead>
                 )}
@@ -463,10 +474,10 @@ export default function PartitionListPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredAndSorted.length ? (
-                filteredAndSorted.map((p) => (
+              {visiblePartitions.length ? (
+                visiblePartitions.map((p) => (
                   <TableRow key={p.name}>
-                    {deletablePartitionNames.length > 0 && (
+                    {visibleDeletablePartitionNames.length > 0 && (
                       <TableCell>
                         <Checkbox
                           checked={selectedPartitionNameSet.has(p.name)}
@@ -538,7 +549,7 @@ export default function PartitionListPage() {
                     colSpan={
                       (canManagePartitions ? 7 : 4) +
                       (showActions ? 1 : 0) +
-                      (deletablePartitionNames.length > 0 ? 1 : 0)
+                      (visibleDeletablePartitionNames.length > 0 ? 1 : 0)
                     }
                     className="h-24 text-center text-muted-foreground"
                   >

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw } from "lucide-react";
+import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -52,6 +52,7 @@ import { intOr } from "@/lib/utils";
 import { partitionDetailPath } from "@/lib/routes";
 
 type SortDir = "asc" | "desc" | null;
+const PARTITIONS_PAGE_SIZE = 10;
 
 function RowActions({
   partition,
@@ -148,6 +149,7 @@ export default function PartitionListPage() {
   const [sortDir, setSortDir] = useState<SortDir>(null);
   const [sortColumn, setSortColumn] = useState<"name" | "created_at">("created_at");
   const [selectedPartitionNames, setSelectedPartitionNames] = useState<string[]>([]);
+  const [pageIndex, setPageIndex] = useState(0);
 
   // `GET /partition/` is already membership-scoped server-side (admins with
   // SUPER_ADMIN_MODE see all; regular users see their memberships), so a single
@@ -255,10 +257,20 @@ export default function PartitionListPage() {
   const showActions =
     canManagePartitions || filteredAndSorted.some((p) => canConfigurePartition(p.role));
 
-  const visiblePartitions = filteredAndSorted;
+  const pageCount = Math.ceil(filteredAndSorted.length / PARTITIONS_PAGE_SIZE);
+  useEffect(() => {
+    if (pageIndex > 0 && pageIndex > pageCount - 1) {
+      setPageIndex(Math.max(0, pageCount - 1));
+    }
+  }, [pageCount, pageIndex]);
+
+  const visiblePartitions = useMemo(() => {
+    const start = pageIndex * PARTITIONS_PAGE_SIZE;
+    return filteredAndSorted.slice(start, start + PARTITIONS_PAGE_SIZE);
+  }, [filteredAndSorted, pageIndex]);
   const visibleDeletablePartitionNames = useMemo(
-    () => filteredAndSorted.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
-    [filteredAndSorted, canConfigurePartition],
+    () => visiblePartitions.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
+    [visiblePartitions, canConfigurePartition],
   );
   const visibleDeletablePartitionNameSet = useMemo(
     () => new Set(visibleDeletablePartitionNames),
@@ -559,6 +571,32 @@ export default function PartitionListPage() {
               )}
             </TableBody>
           </Table>
+        </div>
+      )}
+
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between py-4">
+          <p className="text-sm text-muted-foreground">
+            Page {pageIndex + 1} of {pageCount}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPageIndex((prev) => Math.max(0, prev - 1))}
+              disabled={pageIndex === 0}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPageIndex((prev) => Math.min(pageCount - 1, prev + 1))}
+              disabled={pageIndex >= pageCount - 1}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       )}
 

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -53,6 +53,7 @@ import { partitionDetailPath } from "@/lib/routes";
 
 type SortDir = "asc" | "desc" | null;
 const PARTITIONS_PAGE_SIZE = 10;
+const PARTITIONS_REFETCH_INTERVAL_MS = 5000;
 
 function RowActions({
   partition,
@@ -150,6 +151,7 @@ export default function PartitionListPage() {
   const [sortColumn, setSortColumn] = useState<"name" | "created_at">("created_at");
   const [selectedPartitionNames, setSelectedPartitionNames] = useState<string[]>([]);
   const [pageIndex, setPageIndex] = useState(0);
+  const [manualRefreshing, setManualRefreshing] = useState(false);
 
   // `GET /partition/` is already membership-scoped server-side (admins with
   // SUPER_ADMIN_MODE see all; regular users see their memberships), so a single
@@ -157,7 +159,7 @@ export default function PartitionListPage() {
   const partitionsQuery = useQuery({
     queryKey: ["partitions"],
     queryFn: listPartitions,
-    refetchInterval: 2000,
+    refetchInterval: PARTITIONS_REFETCH_INTERVAL_MS,
   });
 
   const { data: presetsData } = useQuery({
@@ -271,6 +273,10 @@ export default function PartitionListPage() {
   const visibleDeletablePartitionNames = useMemo(
     () => visiblePartitions.filter((p) => canConfigurePartition(p.role)).map((p) => p.name),
     [visiblePartitions, canConfigurePartition],
+  );
+  const hasDeletablePartitions = useMemo(
+    () => filteredAndSorted.some((p) => canConfigurePartition(p.role)),
+    [filteredAndSorted, canConfigurePartition],
   );
   const visibleDeletablePartitionNameSet = useMemo(
     () => new Set(visibleDeletablePartitionNames),
@@ -425,12 +431,15 @@ export default function PartitionListPage() {
           <Button
             variant="outline"
             size="icon-sm"
-            onClick={() => partitionsQuery.refetch()}
-            disabled={partitionsQuery.isFetching}
+            onClick={() => {
+              setManualRefreshing(true);
+              partitionsQuery.refetch().finally(() => setManualRefreshing(false));
+            }}
+            disabled={manualRefreshing}
             aria-label="Refresh partitions"
             title="Refresh partitions"
           >
-            <RefreshCw className={partitionsQuery.isFetching ? "animate-spin" : ""} />
+            <RefreshCw className={manualRefreshing ? "animate-spin" : ""} />
           </Button>
         </div>
       </div>
@@ -446,10 +455,11 @@ export default function PartitionListPage() {
           <Table>
             <TableHeader>
               <TableRow>
-                {visibleDeletablePartitionNames.length > 0 && (
+                {hasDeletablePartitions && (
                   <TableHead>
                     <Checkbox
                       checked={allDeletableSelected || (someDeletableSelected && "indeterminate")}
+                      disabled={visibleDeletablePartitionNames.length === 0}
                       onCheckedChange={(value) => {
                         setSelectedPartitionNames((prev) =>
                           value
@@ -489,7 +499,7 @@ export default function PartitionListPage() {
               {visiblePartitions.length ? (
                 visiblePartitions.map((p) => (
                   <TableRow key={p.name}>
-                    {visibleDeletablePartitionNames.length > 0 && (
+                    {hasDeletablePartitions && (
                       <TableCell>
                         <Checkbox
                           checked={selectedPartitionNameSet.has(p.name)}
@@ -561,7 +571,7 @@ export default function PartitionListPage() {
                     colSpan={
                       (canManagePartitions ? 7 : 4) +
                       (showActions ? 1 : 0) +
-                      (visibleDeletablePartitionNames.length > 0 ? 1 : 0)
+                      (hasDeletablePartitions ? 1 : 0)
                     }
                     className="h-24 text-center text-muted-foreground"
                   >
@@ -585,6 +595,7 @@ export default function PartitionListPage() {
               size="sm"
               onClick={() => setPageIndex((prev) => Math.max(0, prev - 1))}
               disabled={pageIndex === 0}
+              aria-label="Previous page"
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -593,6 +604,7 @@ export default function PartitionListPage() {
               size="sm"
               onClick={() => setPageIndex((prev) => Math.min(pageCount - 1, prev + 1))}
               disabled={pageIndex >= pageCount - 1}
+              aria-label="Next page"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Summary

This PR makes the Admin UI table controls easier to scan and use without changing the overall layout or visual language.

It keeps table-related actions close to the tables they affect: refresh controls sit with the table toolbar, Jobs separates search from status filters, and bulk deletion now appears only when there is an active selection.

## Why

The previous bulk-selection banner took attention away from the table and made simple actions feel heavier than needed. The Jobs toolbar was also crowded because search and status filters were competing on the same row.

This keeps the interface closer to the existing OpenRAG design while making common table workflows clearer.

## Validation

- `npm test -- --run src/components/shared/data-table.test.tsx src/pages/admin/documents/list.test.tsx src/pages/admin/partitions/list.test.tsx src/lib/api/models.test.ts src/pages/admin/preset-config.test.ts src/pages/admin/overview.test.tsx`
- `npm run lint`
- `npm run build`
- Local Admin UI container rebuild
- Playwright smoke check on the Jobs page toolbar layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controlled multi-row selection and bulk delete for partitions and documents, with page/visibility-aware “select all” checkboxes and confirm flow in the page header.
  * Added debounced client-side search and live filtered counts to the jobs admin list.
  * Added manual refresh controls with loading/spinner feedback on documents, partitions, and jobs.
* **Bug Fixes**
  * Selection is now synchronized per active partition/tab and restricted to deletable/configurable items.
  * Selection UI (counts/indeterminate “select all”) and bulk-selection clearing after deletion are now consistent.
* **Tests**
  * Expanded selection and bulk-action test coverage for tables and admin list pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->