### PR TITLE
fix(admin-ui): add Chainlit chat shortcut

### DIFF
--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -56,6 +56,7 @@ from api.routers.user.download import router as download_router
 from api.routers.user.extract import router as extract_router
 from api.routers.user.health import router as health_router
 from api.routers.user.search import router as search_router
+from api.runtime_flags import WITH_CHAINLIT_UI, WITH_OPENAI_API
 from core.config import load_config
 from core.utils.banner import print_startup_banner
 from core.utils.logging import get_logger
@@ -92,8 +93,6 @@ AUTH_TOKEN: str | None = os.getenv("AUTH_TOKEN")
 # host port — so this is the Origin it sends on cross-origin API calls.
 ADMIN_UI_PORT: str = os.getenv("ADMIN_UI_PORT", "8081")
 CORS_EXTRA_ORIGINS: list[str] = [o.strip() for o in os.getenv("CORS_EXTRA_ORIGINS", "").split(";") if o.strip()]
-WITH_CHAINLIT_UI: bool = os.getenv("WITH_CHAINLIT_UI", "true").lower() == "true"
-WITH_OPENAI_API: bool = os.getenv("WITH_OPENAI_API", "true").lower() == "true"
 
 # AUTH_MODE / OIDC_* env validation lives on OIDCConfig.from_env() so
 # the rules are configuration, not module-load code. ServiceContainer

--- a/openrag/api/main.py
+++ b/openrag/api/main.py
@@ -337,7 +337,11 @@ def get_config():
     from core.utils.redaction import redact_secrets
     from fastapi.encoders import jsonable_encoder
 
-    return {**redact_secrets(jsonable_encoder(settings)), "super_admin_mode": SUPER_ADMIN_MODE}
+    return {
+        **redact_secrets(jsonable_encoder(settings)),
+        "super_admin_mode": SUPER_ADMIN_MODE,
+        "chainlit_enabled": WITH_CHAINLIT_UI,
+    }
 
 
 # Router mounts. Phase 10F finished moving these into

--- a/openrag/api/routers/admin/users.py
+++ b/openrag/api/routers/admin/users.py
@@ -14,6 +14,8 @@ orchestrators must not touch directly; that handler will move to a
 service once the queue is de-Ray'd.
 """
 
+import os
+
 from api.dependencies.auth import current_user, require_admin, require_admin_or_self
 from api.schemas.admin.users import UserCreate, UserPublic, UserUpdate
 from core.utils.logging import get_logger
@@ -23,6 +25,10 @@ from fastapi.responses import JSONResponse
 
 logger = get_logger()
 router = APIRouter()
+
+
+def _chainlit_enabled() -> bool:
+    return os.getenv("WITH_CHAINLIT_UI", "true").lower() == "true"
 
 
 @router.get(
@@ -63,6 +69,7 @@ Returns current user details including:
 - `id`: User identifier
 - `display_name`: User's display name
 - `is_admin`: Admin status
+- `chainlit_enabled`: Whether this deployment exposes the Chainlit chat UI
 - Additional user metadata
     - indexed_files: Number of files currently indexed for this user
     - pending_files: Number of files pending indexing for this user
@@ -79,9 +86,11 @@ async def get_current_user_info(
     service=Depends(get_user_service),
 ):
     """Get current authenticated user info"""
+    content = await service.get_current_user_info(user)
+    content["chainlit_enabled"] = _chainlit_enabled()
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content=await service.get_current_user_info(user),
+        content=content,
     )
 
 

--- a/openrag/api/routers/admin/users.py
+++ b/openrag/api/routers/admin/users.py
@@ -14,9 +14,8 @@ orchestrators must not touch directly; that handler will move to a
 service once the queue is de-Ray'd.
 """
 
-import os
-
 from api.dependencies.auth import current_user, require_admin, require_admin_or_self
+from api.runtime_flags import WITH_CHAINLIT_UI
 from api.schemas.admin.users import UserCreate, UserPublic, UserUpdate
 from core.utils.logging import get_logger
 from di.providers import get_user_service
@@ -25,10 +24,6 @@ from fastapi.responses import JSONResponse
 
 logger = get_logger()
 router = APIRouter()
-
-
-def _chainlit_enabled() -> bool:
-    return os.getenv("WITH_CHAINLIT_UI", "true").lower() == "true"
 
 
 @router.get(
@@ -87,7 +82,7 @@ async def get_current_user_info(
 ):
     """Get current authenticated user info"""
     content = await service.get_current_user_info(user)
-    content["chainlit_enabled"] = _chainlit_enabled()
+    content["chainlit_enabled"] = WITH_CHAINLIT_UI
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=content,

--- a/openrag/api/runtime_flags.py
+++ b/openrag/api/runtime_flags.py
@@ -1,0 +1,16 @@
+"""Runtime feature flags shared by the API routers."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() == "true"
+
+
+WITH_CHAINLIT_UI: bool = env_bool("WITH_CHAINLIT_UI", True)
+WITH_OPENAI_API: bool = env_bool("WITH_OPENAI_API", True)

--- a/tests/integration/api/test_users.py
+++ b/tests/integration/api/test_users.py
@@ -10,6 +10,7 @@ class TestUserManagement:
         assert response.status_code == 200
         data = response.json()
         assert "id" in data
+        assert isinstance(data.get("chainlit_enabled"), bool)
 
     def test_list_users(self, api_client):
         """Test listing users."""

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "./header";
+
+const authState = vi.hoisted(() => ({
+  chainlitEnabled: true,
+}));
 
 vi.mock("@/lib/auth", () => ({
   useAuth: () => ({
@@ -10,6 +14,7 @@ vi.mock("@/lib/auth", () => ({
       display_name: "Admin User",
       email: "admin@example.com",
       is_admin: true,
+      chainlit_enabled: authState.chainlitEnabled,
     },
     logout: vi.fn(),
   }),
@@ -20,6 +25,10 @@ vi.mock("@/components/ui/sidebar", () => ({
 }));
 
 describe("Header", () => {
+  beforeEach(() => {
+    authState.chainlitEnabled = true;
+  });
+
   it("links to the Chainlit chat", () => {
     render(
       <MemoryRouter>
@@ -30,5 +39,18 @@ describe("Header", () => {
     const chatLink = screen.getByRole("link", { name: /chat/i });
     expect(chatLink.getAttribute("href")).toBe("/chainlit/");
     expect(chatLink.getAttribute("target")).toBe("_blank");
+    expect(chatLink.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("hides the Chainlit chat link when Chainlit is disabled", () => {
+    authState.chainlitEnabled = false;
+
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: /chat/i })).toBeNull();
   });
 });

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -56,7 +56,7 @@ describe("Header", () => {
       </MemoryRouter>,
     );
 
-    const chatLink = screen.getByRole("link", { name: /open openrag chat/i });
+    const chatLink = screen.getByRole("link", { name: /open chat in a new tab/i });
     expect(chatLink.getAttribute("href")).toBe("https://api.example.test/chainlit/");
   });
 

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "./header";
 
 const authState = vi.hoisted(() => ({
@@ -27,6 +27,11 @@ vi.mock("@/components/ui/sidebar", () => ({
 describe("Header", () => {
   beforeEach(() => {
     authState.chainlitEnabled = true;
+    vi.stubEnv("VITE_API_BASE_URL", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("links to the Chainlit chat", () => {
@@ -40,6 +45,19 @@ describe("Header", () => {
     expect(chatLink.getAttribute("href")).toBe("/chainlit/");
     expect(chatLink.getAttribute("target")).toBe("_blank");
     expect(chatLink.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("uses the configured API origin for the Chainlit chat link", () => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
+
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const chatLink = screen.getByRole("link", { name: /open openrag chat/i });
+    expect(chatLink.getAttribute("href")).toBe("https://api.example.test/chainlit/");
   });
 
   it("hides the Chainlit chat link when Chainlit is disabled", () => {

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { Header } from "./header";
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      display_name: "Admin User",
+      email: "admin@example.com",
+      is_admin: true,
+    },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarTrigger: () => <button type="button">Toggle sidebar</button>,
+}));
+
+describe("Header", () => {
+  it("links to the Chainlit chat", () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const chatLink = screen.getByRole("link", { name: /chat/i });
+    expect(chatLink.getAttribute("href")).toBe("/chainlit/");
+    expect(chatLink.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,13 +1,16 @@
 import { useAuth } from "@/lib/auth";
+import { apiUrl } from "@/lib/api/client";
 import { useNavigate } from "react-router-dom";
-import { LogOut, MessageSquare } from "lucide-react";
+import { ExternalLink, LogOut, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export function Header() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const chatHref = apiUrl("/chainlit/");
 
   const handleLogout = () => {
     const wasOidcSession = logout();
@@ -26,24 +29,34 @@ export function Header() {
       <div className="h-5 w-px bg-border" />
       <div className="flex-1" />
       {user && (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-5">
           {user.chainlit_enabled === true && (
-            <Button variant="outline" size="sm" asChild>
-              <a href="/chainlit/" target="_blank" rel="noopener noreferrer" title="Open Chainlit chat">
-                <MessageSquare className="h-4 w-4" />
-                Chat
-              </a>
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={chatHref} target="_blank" rel="noopener noreferrer" aria-label="Open OpenRAG Chat">
+                      <MessageSquare className="h-4 w-4" />
+                      Chat
+                      <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                    </a>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Open OpenRAG Chat</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
-          <span className="text-sm text-muted-foreground">
-            {user.display_name || user.email || `User #${user.id}`}
-          </span>
-          <Badge className="bg-primary/10 text-primary border-primary/20 hover:bg-primary/15">
-            {user.is_admin ? "Admin" : "User"}
-          </Badge>
-          <Button variant="ghost" size="icon" onClick={handleLogout} className="text-muted-foreground hover:text-destructive">
-            <LogOut className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">
+              {user.display_name || user.email || `User #${user.id}`}
+            </span>
+            <Badge className="bg-primary/10 text-primary border-primary/20 hover:bg-primary/15">
+              {user.is_admin ? "Admin" : "User"}
+            </Badge>
+            <Button variant="ghost" size="icon" onClick={handleLogout} className="text-muted-foreground hover:text-destructive">
+              <LogOut className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       )}
     </header>

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "@/lib/auth";
 import { useNavigate } from "react-router-dom";
-import { LogOut } from "lucide-react";
+import { LogOut, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -27,6 +27,12 @@ export function Header() {
       <div className="flex-1" />
       {user && (
         <div className="flex items-center gap-3">
+          <Button variant="outline" size="sm" asChild>
+            <a href="/chainlit/" target="_blank" rel="noopener noreferrer" title="Open Chainlit chat">
+              <MessageSquare className="h-4 w-4" />
+              Chat
+            </a>
+          </Button>
           <span className="text-sm text-muted-foreground">
             {user.display_name || user.email || `User #${user.id}`}
           </span>

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -27,12 +27,14 @@ export function Header() {
       <div className="flex-1" />
       {user && (
         <div className="flex items-center gap-3">
-          <Button variant="outline" size="sm" asChild>
-            <a href="/chainlit/" target="_blank" rel="noopener noreferrer" title="Open Chainlit chat">
-              <MessageSquare className="h-4 w-4" />
-              Chat
-            </a>
-          </Button>
+          {user.chainlit_enabled === true && (
+            <Button variant="outline" size="sm" asChild>
+              <a href="/chainlit/" target="_blank" rel="noopener noreferrer" title="Open Chainlit chat">
+                <MessageSquare className="h-4 w-4" />
+                Chat
+              </a>
+            </Button>
+          )}
           <span className="text-sm text-muted-foreground">
             {user.display_name || user.email || `User #${user.id}`}
           </span>

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@/lib/auth";
 import { apiUrl } from "@/lib/api/client";
 import { useNavigate } from "react-router-dom";
-import { ExternalLink, LogOut, MessageSquare } from "lucide-react";
+import { LogOut, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -35,14 +35,13 @@ export function Header() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="sm" asChild>
-                    <a href={chatHref} target="_blank" rel="noopener noreferrer" aria-label="Open OpenRAG Chat">
+                    <a href={chatHref} target="_blank" rel="noopener noreferrer" aria-label="Open Chat in a new tab">
                       <MessageSquare className="h-4 w-4" />
                       Chat
-                      <ExternalLink className="h-3 w-3" aria-hidden="true" />
                     </a>
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Open OpenRAG Chat</TooltipContent>
+                <TooltipContent>Open Chat in a new tab</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}

--- a/ui/src/lib/api/account.ts
+++ b/ui/src/lib/api/account.ts
@@ -7,6 +7,7 @@ export interface MyInfo {
   id: number;
   display_name: string | null;
   is_admin: boolean;
+  chainlit_enabled?: boolean;
   file_quota: number | null;
   file_count?: number;
   indexed_files?: number;

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -2,7 +2,15 @@
 // missing env must fail closed: never fall back to an absolute host, which would
 // send the bearer token cross-origin. To target a remote API in dev, set
 // VITE_API_BASE_URL explicitly.
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const apiBase = () => import.meta.env.VITE_API_BASE_URL ?? "";
+
+export function apiUrl(path: string): string {
+  const base = apiBase();
+  if (!base) return path;
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${base.replace(/\/+$/, "")}${normalizedPath}`;
+}
 
 // OpenRag bearer token (the user's `or-…` token). Sent as Authorization for
 // token-mode auth; in OIDC mode the same-origin session cookie is used instead.
@@ -55,7 +63,7 @@ export async function request<T>(
     headers["Content-Type"] = "application/json";
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(apiUrl(path), {
     ...fetchOptions,
     headers,
     // Send the OIDC `openrag_session` cookie. A no-op for the same-origin

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -204,6 +204,7 @@ export const handlers = [
       external_user_id: null,
       email: "admin@example.com",
       is_admin: true,
+      chainlit_enabled: true,
       file_quota: -1,
       indexed_files: 42,
       pending_files: 3,
@@ -662,6 +663,7 @@ export const handlers = [
       // super_admin_mode is a top-level runtime flag on /config (see api/main.py),
       // not nested under auth — the permission layer reads config.super_admin_mode.
       super_admin_mode: true,
+      chainlit_enabled: true,
       auth: { auth_mode: "oidc" },
       milvus: { host: "milvus", port: 19530, database: "openrag" },
       ray: { address: "ray://ray-head:10001", pool_size: 2, max_tasks_per_worker: 2 },


### PR DESCRIPTION
## Summary

Adds a small Chat button in the Admin UI header so admins and users can jump from the console to the Chainlit chat experience without manually changing URLs.

The link uses the existing same-origin `/chainlit/` route, so it works through the Admin UI nginx proxy and does not hardcode a server IP or backend port.

## Validation

- `npm test -- --run src/components/layout/header.test.tsx`
- `npm run lint`
- `npm run build`
- Local compose visual check on `http://localhost:8068/app/partitions`

## Notes

This is frontend-only. It does not change backend routing or authorization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Chat** button in the header for signed-in users when the chat experience is enabled; it opens in a new tab with proper security attributes.
  * Exposed a `chainlit_enabled` flag in admin/config and authenticated user info so the UI can conditionally show the button.
* **Tests**
  * Added UI test coverage for the chat link’s presence and `href` behavior when enabled/disabled.
  * Extended integration tests to confirm `chainlit_enabled` is returned as a boolean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->