### PR TITLE
chore(chart): bump appVersion to 2.0.0

### DIFF
--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.3"
+appVersion: "2.0.0"
 
 dependencies:
   - name: kuberay-operator


### PR DESCRIPTION
Pre-release chart metadata bump: `appVersion` `1.1.3` → `2.0.0`, chart `version` `0.5.0` → `0.5.1`.

Metadata only — no template/behavior change. Verified the chart still renders (`helm lint` clean, `helm template` → valid manifests; app labels now show `2.0.0`).

> NOTE: the openrag/ray **image tags** in `values.yaml` are still `1.1.13` and must be bumped to the published 2.0.0 tags **at cutover** (once the RC images exist) — deliberately not in this PR.

The `RATE_LIMIT_AUTH_FAILURE` doc row planned alongside this is already present on the branch, so it's not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart release version to `0.5.1`.
  * Updated the application version to `2.0.0` in the chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->