### PR TITLE
fix(admin-ui): preserve public host port in nginx redirects

### DIFF
--- a/infra/compose/nginx/openrag-admin.conf
+++ b/infra/compose/nginx/openrag-admin.conf
@@ -56,7 +56,11 @@ server {
         resolver 127.0.0.11 valid=30s ipv6=off;
         set $openrag_upstream openrag;
         proxy_pass http://$openrag_upstream:8080;
-        proxy_set_header Host              $host;
+        # Preserve the browser-facing host exactly, including a mapped port
+        # such as :8068. The backend uses Host when it emits slash redirects
+        # (/chainlit -> /chainlit/), and $host would strip that port.
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-Host  $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_scheme;

--- a/tests/unit/infra/test_admin_ui_compose.py
+++ b/tests/unit/infra/test_admin_ui_compose.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import yaml
@@ -26,5 +27,5 @@ def test_admin_ui_nginx_preserves_public_host_header_for_api_redirects():
     nginx_conf = Path(__file__).resolve().parents[3] / "infra/compose/nginx/openrag-admin.conf"
     config = nginx_conf.read_text(encoding="utf-8")
 
-    assert "proxy_set_header Host              $http_host;" in config
-    assert "proxy_set_header X-Forwarded-Host  $http_host;" in config
+    assert re.search(r"proxy_set_header\s+Host\s+\$http_host;", config)
+    assert re.search(r"proxy_set_header\s+X-Forwarded-Host\s+\$http_host;", config)

--- a/tests/unit/infra/test_admin_ui_compose.py
+++ b/tests/unit/infra/test_admin_ui_compose.py
@@ -20,3 +20,11 @@ def test_admin_ui_nginx_upload_limit_matches_api_default():
     nginx_conf = Path(__file__).resolve().parents[3] / "infra/compose/nginx/openrag-admin.conf"
 
     assert "client_max_body_size 1024M;" in nginx_conf.read_text(encoding="utf-8")
+
+
+def test_admin_ui_nginx_preserves_public_host_header_for_api_redirects():
+    nginx_conf = Path(__file__).resolve().parents[3] / "infra/compose/nginx/openrag-admin.conf"
+    config = nginx_conf.read_text(encoding="utf-8")
+
+    assert "proxy_set_header Host              $http_host;" in config
+    assert "proxy_set_header X-Forwarded-Host  $http_host;" in config

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -47,7 +47,7 @@ describe("Header", () => {
     expect(chatLink.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  it("uses the configured API origin for the Chainlit chat link", () => {
+  it("keeps Chainlit on the UI front-door origin even when an API origin is configured", () => {
     vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
 
     render(
@@ -57,7 +57,7 @@ describe("Header", () => {
     );
 
     const chatLink = screen.getByRole("link", { name: /open chat in a new tab/i });
-    expect(chatLink.getAttribute("href")).toBe("https://api.example.test/chainlit/");
+    expect(chatLink.getAttribute("href")).toBe("/chainlit/");
   });
 
   it("hides the Chainlit chat link when Chainlit is disabled", () => {

--- a/ui/src/components/layout/header.test.tsx
+++ b/ui/src/components/layout/header.test.tsx
@@ -47,7 +47,7 @@ describe("Header", () => {
     expect(chatLink.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  it("keeps Chainlit on the UI front-door origin even when an API origin is configured", () => {
+  it("uses the configured API origin for Chainlit in browser-direct builds", () => {
     vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test");
 
     render(
@@ -57,7 +57,7 @@ describe("Header", () => {
     );
 
     const chatLink = screen.getByRole("link", { name: /open chat in a new tab/i });
-    expect(chatLink.getAttribute("href")).toBe("/chainlit/");
+    expect(chatLink.getAttribute("href")).toBe("https://api.example.test/chainlit/");
   });
 
   it("hides the Chainlit chat link when Chainlit is disabled", () => {

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from "@/lib/auth";
-import { apiUrl } from "@/lib/api/client";
 import { useNavigate } from "react-router-dom";
 import { LogOut, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -10,7 +9,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 export function Header() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
-  const chatHref = apiUrl("/chainlit/");
 
   const handleLogout = () => {
     const wasOidcSession = logout();
@@ -35,7 +33,7 @@ export function Header() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="sm" asChild>
-                    <a href={chatHref} target="_blank" rel="noopener noreferrer" aria-label="Open Chat in a new tab">
+                    <a href="/chainlit/" target="_blank" rel="noopener noreferrer" aria-label="Open Chat in a new tab">
                       <MessageSquare className="h-4 w-4" />
                       Chat
                     </a>

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -5,10 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { apiUrl } from "@/lib/api/client";
 
 export function Header() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const chatHref = apiUrl("/chainlit/");
 
   const handleLogout = () => {
     const wasOidcSession = logout();
@@ -33,7 +35,7 @@ export function Header() {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="sm" asChild>
-                    <a href="/chainlit/" target="_blank" rel="noopener noreferrer" aria-label="Open Chat in a new tab">
+                    <a href={chatHref} target="_blank" rel="noopener noreferrer" aria-label="Open Chat in a new tab">
                       <MessageSquare className="h-4 w-4" />
                       Chat
                     </a>

--- a/ui/src/components/layout/header.tsx
+++ b/ui/src/components/layout/header.tsx
@@ -1,11 +1,11 @@
 import { useAuth } from "@/lib/auth";
+import { apiUrl } from "@/lib/api/client";
 import { useNavigate } from "react-router-dom";
 import { LogOut, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { apiUrl } from "@/lib/api/client";
 
 export function Header() {
   const { user, logout } = useAuth();


### PR DESCRIPTION
## Summary

This fixes the Admin UI nginx front door so backend redirects keep the browser-facing host and mapped port.

In Docker port-mapped deployments, nginx was not preserving the public port when the backend generated redirects like the Chainlit trailing-slash redirect. That could send the browser back to the right host but the wrong port.

The header behavior is unchanged; the small test rename only makes the existing browser-direct behavior clearer.

## Validation

- uv run pytest tests/unit/infra/test_admin_ui_compose.py -q
- npm test -- --run src/components/layout/header.test.tsx --reporter=dot
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser-direct chat links so they correctly use the configured API address, including when a port is present.
  * Improved request forwarding in the admin UI proxy so the original public host is preserved during redirects and API access.
  * Added coverage to help prevent regressions in host handling and chat-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->