### PR TITLE
fix(chat): run preflight against the resolved LLM, not the default

### DIFF
--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -44,9 +44,11 @@ router = APIRouter()
 if TYPE_CHECKING:
     from core.config.root import Settings
 
-# Cached max model token limit. Populated by ``prime_max_model_tokens``
-# which the application lifespan invokes during startup; ``get_max_model_tokens``
-# falls back to ``config.llm_context.max_llm_context_size`` until then.
+# Auto-probed max model token limit. Populated by ``prime_max_model_tokens``
+# which the application lifespan invokes during startup. It is only the *middle*
+# tier of ``get_max_model_tokens``: an admin-configured context size on the
+# default LLM endpoint takes precedence, and ``config.llm_context`` is the final
+# fallback.
 _max_model_tokens: int | None = None
 
 
@@ -174,11 +176,34 @@ async def _fetch_max_model_tokens(config: "Settings") -> int:
         return default_limit
 
 
+def _default_endpoint_context_size(config: "Settings") -> int | None:
+    """Admin-configured context window of the default LLM endpoint, if set."""
+    models = getattr(config, "models", None)
+    return models.default_llm_context_size() if models is not None else None
+
+
+def _effective_max_output_tokens(config: "Settings") -> int:
+    """Default output-token budget: the default LLM endpoint's admin-configured
+    value when set, else the global ``llm_context`` fallback."""
+    models = getattr(config, "models", None)
+    configured = models.default_llm_output_tokens() if models is not None else None
+    return configured or int(config.llm_context.max_output_tokens)
+
+
 def get_max_model_tokens() -> int:
-    """Return the cached max model token limit (populated at startup)."""
+    """Effective max context size for the token preflight.
+
+    Precedence: the default LLM endpoint's admin-configured
+    ``max_llm_context_size`` (editable in the admin UI) > the value auto-probed
+    from vLLM at startup > the global ``llm_context`` fallback. An explicit admin
+    setting wins over auto-detection so operators can pin the budget.
+    """
+    config = _runtime_config()
+    configured = _default_endpoint_context_size(config)
+    if configured is not None:
+        return configured
     if _max_model_tokens is not None:
         return _max_model_tokens
-    config = _runtime_config()
     return int(config.llm_context.max_llm_context_size)
 
 
@@ -194,7 +219,7 @@ def validate_tokens_limit(
 
         if isinstance(request, OpenAIChatCompletionRequest):
             message_tokens = sum(_length_function(m.content or "") + 4 for m in request.messages)
-            default_output_tokens = int(config.llm_context.max_output_tokens)
+            default_output_tokens = _effective_max_output_tokens(config)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = message_tokens + requested_tokens
             if total_tokens_needed > max_tokens_allowed:
@@ -208,7 +233,7 @@ def validate_tokens_limit(
 
         elif isinstance(request, OpenAICompletionRequest):
             prompt_tokens = _length_function(request.prompt)
-            default_output_tokens = int(config.llm_context.max_output_tokens)
+            default_output_tokens = _effective_max_output_tokens(config)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = prompt_tokens + requested_tokens
             if total_tokens_needed > max_tokens_allowed:

--- a/openrag/api/schemas/admin/model_endpoint_schemas.py
+++ b/openrag/api/schemas/admin/model_endpoint_schemas.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
+from core.config.model_endpoints import LLM_CONTEXT_SIZE_KEY, LLM_OUTPUT_TOKENS_KEY
 from core.utils.redaction import redact_secret_mapping
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ModelEndpointType = Literal["embedder", "reranker", "llm", "vlm"]
+
+# LLM token budgets that the admin UI edits as first-class fields but stores in
+# ``extra`` — validated here so a typo can't persist a nonsensical value.
+_LLM_TOKEN_EXTRA_KEYS = (LLM_CONTEXT_SIZE_KEY, LLM_OUTPUT_TOKENS_KEY)
 
 
 def _normalize_name(value: str) -> str:
@@ -25,6 +30,23 @@ def _normalize_endpoint(value: str) -> str:
     if not normalized:
         raise ValueError("endpoint must be non-empty")
     return normalized
+
+
+def _validate_llm_token_extra(extra: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Reject non-positive-int LLM token budgets carried in ``extra``.
+
+    ``bool`` is an ``int`` subclass in Python, so it is excluded explicitly —
+    ``true`` must not slip through as ``1``.
+    """
+    if not extra:
+        return extra
+    for key in _LLM_TOKEN_EXTRA_KEYS:
+        if key not in extra:
+            continue
+        value = extra[key]
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"extra.{key} must be a positive integer")
+    return extra
 
 
 class CreateModelEndpointRequest(BaseModel):
@@ -53,6 +75,12 @@ class CreateModelEndpointRequest(BaseModel):
         """Normalize the endpoint URL."""
         return _normalize_endpoint(value)
 
+    @field_validator("extra")
+    @classmethod
+    def validate_extra_token_budgets(cls, value: dict[str, Any]) -> dict[str, Any]:
+        """Reject non-positive-int LLM token budgets in ``extra``."""
+        return _validate_llm_token_extra(value)
+
 
 class UpdateModelEndpointRequest(BaseModel):
     """Request body for updating a registered model endpoint."""
@@ -80,6 +108,12 @@ class UpdateModelEndpointRequest(BaseModel):
         if value is None:
             return None
         return _normalize_endpoint(value)
+
+    @field_validator("extra")
+    @classmethod
+    def validate_extra_token_budgets(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Reject non-positive-int LLM token budgets in ``extra``."""
+        return _validate_llm_token_extra(value)
 
     @model_validator(mode="after")
     def require_at_least_one_update(self) -> UpdateModelEndpointRequest:

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -6,7 +6,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 def default_max_tokens():
     from core.config import load_config
 
-    return load_config().llm_context.max_output_tokens
+    config = load_config()
+    # Prefer the default LLM endpoint's admin-configured budget over the global
+    # llm_context fallback (both editable, but the per-endpoint value wins).
+    return config.models.default_llm_output_tokens() or config.llm_context.max_output_tokens
 
 
 class OpenAIMessage(BaseModel):

--- a/openrag/core/config/model_endpoints.py
+++ b/openrag/core/config/model_endpoints.py
@@ -28,6 +28,28 @@ class ModelEndpointConfig(BaseModel):
     extra: dict[str, Any] = Field(default_factory=dict)
 
 
+def _positive_int(value: Any) -> int | None:
+    """Return *value* if it is a positive int, else ``None``.
+
+    Used for the admin-tunable LLM token budgets stored in an endpoint's
+    ``extra``. Strict on purpose (mirrors the write-side schema validation): a
+    missing key, a non-int (``bool``, ``float``, ``str``), or a non-positive
+    number all mean "no override — fall back to the global default", rather than
+    silently truncating a float or coercing a string.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+# Well-known ``extra`` keys carrying the LLM's admin-configurable token budgets
+# (surfaced as first-class fields in the admin UI). Kept in ``extra`` rather than
+# as dedicated columns so they stay LLM-only and need no migration, mirroring the
+# existing ``max_model_len`` / ``embed_concurrency`` convention.
+LLM_CONTEXT_SIZE_KEY = "max_llm_context_size"
+LLM_OUTPUT_TOKENS_KEY = "max_output_tokens"
+
+
 class ModelsConfig(ConfigMixin):
     """Named endpoint dictionaries — one per model type.
 
@@ -40,6 +62,19 @@ class ModelsConfig(ConfigMixin):
     reranker: dict[str, ModelEndpointConfig] = Field(default_factory=dict)
     llm: dict[str, ModelEndpointConfig] = Field(default_factory=dict)
     vlm: dict[str, ModelEndpointConfig] = Field(default_factory=dict)
+
+    def default_llm_extra(self) -> dict[str, Any]:
+        """``extra`` payload of the default LLM endpoint (``{}`` if unregistered)."""
+        default = self.llm.get("default")
+        return dict(default.extra) if default is not None else {}
+
+    def default_llm_context_size(self) -> int | None:
+        """Admin-configured context window of the default LLM endpoint, if any."""
+        return _positive_int(self.default_llm_extra().get(LLM_CONTEXT_SIZE_KEY))
+
+    def default_llm_output_tokens(self) -> int | None:
+        """Admin-configured max output tokens of the default LLM endpoint, if any."""
+        return _positive_int(self.default_llm_extra().get(LLM_OUTPUT_TOKENS_KEY))
 
 
 class ModelEndpointRow(BaseModel):
@@ -57,4 +92,11 @@ class ModelEndpointRow(BaseModel):
     updated_at: datetime
 
 
-__all__ = ["ModelEndpointConfig", "ModelsConfig", "ModelEndpointRow", "ModelEndpointType"]
+__all__ = [
+    "LLM_CONTEXT_SIZE_KEY",
+    "LLM_OUTPUT_TOKENS_KEY",
+    "ModelEndpointConfig",
+    "ModelsConfig",
+    "ModelEndpointRow",
+    "ModelEndpointType",
+]

--- a/tests/unit/api/schemas/admin/test_phase14_schemas.py
+++ b/tests/unit/api/schemas/admin/test_phase14_schemas.py
@@ -52,6 +52,32 @@ def test_update_model_endpoint_requires_at_least_one_field():
         UpdateModelEndpointRequest()
 
 
+@pytest.mark.parametrize("key", ["max_llm_context_size", "max_output_tokens"])
+@pytest.mark.parametrize("bad", [0, -1, 2.5, "4096", True])
+def test_create_model_endpoint_rejects_bad_llm_token_budget(key, bad):
+    """LLM token budgets in extra must be positive ints (bool/float/str rejected)."""
+    with pytest.raises(ValidationError, match=key):
+        CreateModelEndpointRequest(name="default", model_type="llm", endpoint="http://host", extra={key: bad})
+
+
+@pytest.mark.parametrize("key", ["max_llm_context_size", "max_output_tokens"])
+@pytest.mark.parametrize("bad", [0, -1, 2.5, "4096", True])
+def test_update_model_endpoint_rejects_bad_llm_token_budget(key, bad):
+    with pytest.raises(ValidationError, match=key):
+        UpdateModelEndpointRequest(extra={key: bad})
+
+
+def test_create_model_endpoint_accepts_valid_llm_token_budgets():
+    request = CreateModelEndpointRequest(
+        name="default",
+        model_type="llm",
+        endpoint="http://host",
+        extra={"max_llm_context_size": 32768, "max_output_tokens": 2048, "implementation": "vllm"},
+    )
+    assert request.extra["max_llm_context_size"] == 32768
+    assert request.extra["max_output_tokens"] == 2048
+
+
 def test_create_preset_accepts_indexation_and_retrieval_configs():
     """Preset creation accepts both supported preset families."""
     indexation = CreatePresetRequest(name="fast", preset_type="indexation", config={"chunk_size": 512})

--- a/tests/unit/core/config/test_model_endpoints.py
+++ b/tests/unit/core/config/test_model_endpoints.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
-from core.config.model_endpoints import ModelEndpointConfig, ModelEndpointRow, ModelsConfig
+from core.config.model_endpoints import (
+    LLM_CONTEXT_SIZE_KEY,
+    LLM_OUTPUT_TOKENS_KEY,
+    ModelEndpointConfig,
+    ModelEndpointRow,
+    ModelsConfig,
+)
 from pydantic import ValidationError
 
 
@@ -62,3 +68,42 @@ def test_model_endpoint_row_non_positive_timeout(timeout: float):
     """Persisted endpoint rows reject non-positive timeouts."""
     with pytest.raises(ValidationError):
         ModelEndpointRow(**_row_payload(timeout=timeout))
+
+
+# --------------------------------------------------------------------------- #
+# Default-LLM-endpoint token budget accessors
+# --------------------------------------------------------------------------- #
+
+
+def _with_default_llm(**extra) -> ModelsConfig:
+    cfg = ModelsConfig()
+    cfg.llm["default"] = ModelEndpointConfig(endpoint="http://vllm:8000/v1", extra=dict(extra))
+    return cfg
+
+
+def test_default_llm_token_budgets_none_when_unregistered():
+    cfg = ModelsConfig()
+    assert cfg.default_llm_extra() == {}
+    assert cfg.default_llm_context_size() is None
+    assert cfg.default_llm_output_tokens() is None
+
+
+def test_default_llm_token_budgets_read_from_extra():
+    cfg = _with_default_llm(**{LLM_CONTEXT_SIZE_KEY: 32768, LLM_OUTPUT_TOKENS_KEY: 2048})
+    assert cfg.default_llm_context_size() == 32768
+    assert cfg.default_llm_output_tokens() == 2048
+
+
+def test_default_llm_token_budgets_none_when_key_absent():
+    cfg = _with_default_llm(implementation="vllm")  # unrelated extra key
+    assert cfg.default_llm_context_size() is None
+    assert cfg.default_llm_output_tokens() is None
+
+
+@pytest.mark.parametrize("bad", [0, -1, "not-a-number", None, 12.5])
+def test_default_llm_token_budgets_coerce_invalid_to_none(bad):
+    # A non-positive / non-int stored value means "no override" — the preflight
+    # falls back to the global default rather than trusting garbage.
+    cfg = _with_default_llm(**{LLM_CONTEXT_SIZE_KEY: bad, LLM_OUTPUT_TOKENS_KEY: bad})
+    assert cfg.default_llm_context_size() is None
+    assert cfg.default_llm_output_tokens() is None

--- a/tests/unit/test_token_validation.py
+++ b/tests/unit/test_token_validation.py
@@ -127,3 +127,90 @@ class TestValidateTokensLimit:
             is_valid, msg = validate_tokens_limit(req, max_tokens_allowed=1)
             assert is_valid is True
             assert msg == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint token budgets (admin-configurable, default-endpoint sourced)
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_default_llm(**extra):
+    """Fresh Settings whose default LLM endpoint carries the given extra keys."""
+    from core.config.model_endpoints import ModelEndpointConfig
+    from core.config.root import Settings
+
+    s = Settings()
+    s.models.llm["default"] = ModelEndpointConfig(endpoint="http://llm:8000/v1", extra=dict(extra))
+    return s
+
+
+class TestEndpointConfiguredOutputTokens:
+    """validate_tokens_limit uses the default LLM endpoint's max_output_tokens
+    as the fallback when the request doesn't set max_tokens."""
+
+    def test_uses_endpoint_output_tokens_default(self):
+        from core.config.model_endpoints import LLM_OUTPUT_TOKENS_KEY
+
+        s = _settings_with_default_llm(**{LLM_OUTPUT_TOKENS_KEY: 2048})
+        # Explicit None bypasses the schema default_factory so the fallback runs.
+        req = OpenAIChatCompletionRequest(messages=[{"role": "user", "content": "hello"}], max_tokens=None)
+        # 1 word + 4 overhead + 2048 endpoint default = 2053
+        assert validate_tokens_limit(req, max_tokens_allowed=2053, settings=s)[0] is True
+        assert validate_tokens_limit(req, max_tokens_allowed=2052, settings=s)[0] is False
+
+    def test_falls_back_to_global_when_endpoint_has_no_override(self):
+        s = _settings_with_default_llm()  # no override → global default (1024)
+        req = OpenAIChatCompletionRequest(messages=[{"role": "user", "content": "hello"}], max_tokens=None)
+        # 1 + 4 + 1024 global default = 1029
+        assert validate_tokens_limit(req, max_tokens_allowed=1029, settings=s)[0] is True
+        assert validate_tokens_limit(req, max_tokens_allowed=1028, settings=s)[0] is False
+
+
+class TestGetMaxModelTokens:
+    """get_max_model_tokens precedence: endpoint config > startup-primed > global."""
+
+    def test_endpoint_config_wins_over_primed(self, monkeypatch):
+        import api.routers.user.chat as chat
+        from core.config.model_endpoints import LLM_CONTEXT_SIZE_KEY
+
+        s = _settings_with_default_llm(**{LLM_CONTEXT_SIZE_KEY: 32768})
+        monkeypatch.setattr(chat, "load_config", lambda: s)
+        monkeypatch.setattr(chat, "_max_model_tokens", 8000)  # auto-probed value present
+        assert chat.get_max_model_tokens() == 32768
+
+    def test_primed_used_when_no_endpoint_config(self, monkeypatch):
+        import api.routers.user.chat as chat
+
+        s = _settings_with_default_llm()  # no override
+        monkeypatch.setattr(chat, "load_config", lambda: s)
+        monkeypatch.setattr(chat, "_max_model_tokens", 8000)
+        assert chat.get_max_model_tokens() == 8000
+
+    def test_global_fallback_when_nothing_configured(self, monkeypatch):
+        import api.routers.user.chat as chat
+
+        s = _settings_with_default_llm()  # no override
+        monkeypatch.setattr(chat, "load_config", lambda: s)
+        monkeypatch.setattr(chat, "_max_model_tokens", None)
+        assert chat.get_max_model_tokens() == int(s.llm_context.max_llm_context_size)
+
+
+class TestDefaultMaxTokensFactory:
+    """The request-schema default_factory prefers the default endpoint's budget."""
+
+    def test_prefers_endpoint_output_tokens(self, monkeypatch):
+        import core.config
+        from api.schemas.user.chat import default_max_tokens
+        from core.config.model_endpoints import LLM_OUTPUT_TOKENS_KEY
+
+        s = _settings_with_default_llm(**{LLM_OUTPUT_TOKENS_KEY: 4096})
+        monkeypatch.setattr(core.config, "load_config", lambda: s)
+        assert default_max_tokens() == 4096
+
+    def test_global_fallback(self, monkeypatch):
+        import core.config
+        from api.schemas.user.chat import default_max_tokens
+
+        s = _settings_with_default_llm()  # no override
+        monkeypatch.setattr(core.config, "load_config", lambda: s)
+        assert default_max_tokens() == s.llm_context.max_output_tokens

--- a/ui/src/lib/api/models.test.ts
+++ b/ui/src/lib/api/models.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   displayModelEndpointExtra,
   mergeModelEndpointApiKeyExtra,
+  mergeModelEndpointLlmContext,
   pickDefaultEndpoint,
   prepareModelEndpointExtraForSubmit,
   revealModelEndpointApiKey,
   resolveEmbedderName,
   splitModelEndpointApiKeyExtra,
+  splitModelEndpointLlmContext,
   validateModelEndpoint,
 } from "./models";
 import type { ModelEndpointResponse } from "./models";
@@ -253,6 +255,63 @@ describe("model endpoint secret placeholders", () => {
       ),
     ).toEqual({
       implementation: "vllm",
+    });
+  });
+});
+
+describe("LLM context token-budget extra fields", () => {
+  it("splits the two budgets out of extra into form-field strings", () => {
+    expect(
+      splitModelEndpointLlmContext({
+        implementation: "vllm",
+        max_llm_context_size: 32768,
+        max_output_tokens: 2048,
+      }),
+    ).toEqual({
+      llmContext: { maxContextSize: "32768", maxOutputTokens: "2048" },
+      extra: { implementation: "vllm" },
+    });
+  });
+
+  it("yields blank fields when the budgets are absent", () => {
+    expect(splitModelEndpointLlmContext({ implementation: "vllm" })).toEqual({
+      llmContext: { maxContextSize: "", maxOutputTokens: "" },
+      extra: { implementation: "vllm" },
+    });
+  });
+
+  it("merges non-blank budget fields back into extra as numbers", () => {
+    expect(
+      mergeModelEndpointLlmContext(
+        { implementation: "vllm" },
+        { maxContextSize: "32768", maxOutputTokens: "2048" },
+      ),
+    ).toEqual({
+      implementation: "vllm",
+      max_llm_context_size: 32768,
+      max_output_tokens: 2048,
+    });
+  });
+
+  it("clears a budget key when its field is left blank", () => {
+    expect(
+      mergeModelEndpointLlmContext(
+        { implementation: "vllm", max_llm_context_size: 8192, max_output_tokens: 1024 },
+        { maxContextSize: "16384", maxOutputTokens: "" },
+      ),
+    ).toEqual({
+      implementation: "vllm",
+      max_llm_context_size: 16384,
+    });
+  });
+
+  it("round-trips split → merge without touching unrelated extra keys", () => {
+    const stored = { implementation: "vllm", api_key: "sk-x", max_output_tokens: 512 };
+    const { llmContext, extra } = splitModelEndpointLlmContext(stored);
+    expect(mergeModelEndpointLlmContext(extra, llmContext)).toEqual({
+      implementation: "vllm",
+      api_key: "sk-x",
+      max_output_tokens: 512,
     });
   });
 });

--- a/ui/src/lib/api/models.ts
+++ b/ui/src/lib/api/models.ts
@@ -184,6 +184,53 @@ export function mergeModelEndpointApiKeyExtra(
   return prepared;
 }
 
+// LLM token budgets stored in `extra` but surfaced as first-class number fields
+// in the endpoint modal (LLM endpoints only). Kept out of the raw "Extra (JSON)"
+// box, same as the API key. Backend: core/config/model_endpoints.py.
+export const LLM_CONTEXT_SIZE_KEY = "max_llm_context_size";
+export const LLM_OUTPUT_TOKENS_KEY = "max_output_tokens";
+
+export interface LlmContextFields {
+  maxContextSize: string;
+  maxOutputTokens: string;
+}
+
+/** Pull the two LLM budget keys out of `extra` into form-field strings. */
+export function splitModelEndpointLlmContext(extra: Record<string, unknown>): {
+  llmContext: LlmContextFields;
+  extra: Record<string, unknown>;
+} {
+  const { [LLM_CONTEXT_SIZE_KEY]: ctx, [LLM_OUTPUT_TOKENS_KEY]: out, ...rest } = extra;
+  const asField = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? String(v) : "");
+  return {
+    llmContext: { maxContextSize: asField(ctx), maxOutputTokens: asField(out) },
+    extra: rest,
+  };
+}
+
+/** Merge the two LLM budget fields back into `extra`. Blank clears the override
+ *  (deletes the key → server falls back to the global default); a non-blank
+ *  value is sent as a number for the server to validate as a positive int. */
+export function mergeModelEndpointLlmContext(
+  extra: Record<string, unknown>,
+  fields: LlmContextFields,
+): Record<string, unknown> {
+  const result = { ...extra };
+  const apply = (key: string, raw: string) => {
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      delete result[key];
+      return;
+    }
+    const n = Number(trimmed);
+    if (Number.isFinite(n)) result[key] = n;
+    else delete result[key];
+  };
+  apply(LLM_CONTEXT_SIZE_KEY, fields.maxContextSize);
+  apply(LLM_OUTPUT_TOKENS_KEY, fields.maxOutputTokens);
+  return result;
+}
+
 /** List endpoints (bare array). Optionally filter by model type. */
 export function listModelEndpoints(modelType?: ModelType) {
   const qs = modelType ? `?model_type=${enc(modelType)}` : "";

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -19,11 +19,13 @@ import {
   updateModelEndpoint,
   deleteModelEndpoint,
   mergeModelEndpointApiKeyExtra,
+  mergeModelEndpointLlmContext,
   prepareModelEndpointExtraForSubmit,
   revealModelEndpointApiKey,
   REDACTED_SECRET,
   setDefaultModelEndpoint,
   splitModelEndpointApiKeyExtra,
+  splitModelEndpointLlmContext,
   validateModelEndpoint,
 } from "@/lib/api/models";
 import type {
@@ -272,7 +274,12 @@ function EndpointDialog({
   const [batchSize, setBatchSize] = useState("32");
   const [timeout, setTimeout] = useState("30");
   const [apiKey, setApiKey] = useState("");
+  const [maxContextSize, setMaxContextSize] = useState("");
+  const [maxOutputTokens, setMaxOutputTokens] = useState("");
   const [extraJson, setExtraJson] = useState("{}");
+
+  // LLM token-budget fields (max context / max output) apply to LLM endpoints only.
+  const isLlm = (editing ? editing.model_type : activeTab) === "llm";
   const [validated, setValidated] = useState<boolean | null>(null);
   const [validating, setValidating] = useState(false);
   const [validationMsg, setValidationMsg] = useState<string | null>(null);
@@ -294,13 +301,16 @@ function EndpointDialog({
       setApiKeyVisible(false);
       setRevealingApiKey(false);
       if (editing) {
-        const { apiKey: displayApiKey, extra: displayExtra } = splitModelEndpointApiKeyExtra(editing.extra);
+        const { apiKey: displayApiKey, extra: apiExtra } = splitModelEndpointApiKeyExtra(editing.extra);
+        const { llmContext, extra: displayExtra } = splitModelEndpointLlmContext(apiExtra);
         setName(editing.name);
         setEndpoint(editing.endpoint);
         setModelName(editing.model_name || "");
         setBatchSize(String(editing.batch_size));
         setTimeout(String(editing.timeout));
         setApiKey(displayApiKey);
+        setMaxContextSize(llmContext.maxContextSize);
+        setMaxOutputTokens(llmContext.maxOutputTokens);
         setExtraJson(JSON.stringify(displayExtra, null, 2));
         setValidated(true);
         setValidationMsg(
@@ -315,6 +325,8 @@ function EndpointDialog({
         setBatchSize("32");
         setTimeout("30");
         setApiKey("");
+        setMaxContextSize("");
+        setMaxOutputTokens("");
         setExtraJson("{}");
         setValidated(null);
         setValidationMsg(null);
@@ -322,15 +334,18 @@ function EndpointDialog({
     }
   }, [open, editing]);
 
-  // Reset validation when relevant fields change
+  // Reset validation when relevant fields change. The LLM token-budget fields
+  // don't affect endpoint reachability, so they're deliberately excluded — the
+  // raw extra is compared with them stripped out (as the textarea shows them).
   useEffect(() => {
     const editingExtra = editing ? splitModelEndpointApiKeyExtra(editing.extra) : null;
+    const editingRawExtra = editingExtra ? splitModelEndpointLlmContext(editingExtra.extra).extra : null;
     if (
       editing &&
       endpoint === editing.endpoint &&
       (modelName || "") === (editing.model_name || "") &&
       apiKey === editingExtra?.apiKey &&
-      extraJson === JSON.stringify(editingExtra.extra, null, 2)
+      extraJson === JSON.stringify(editingRawExtra, null, 2)
     ) {
       setValidated(true);
       setValidationMsg(
@@ -508,6 +523,9 @@ function EndpointDialog({
       toast.error("Invalid JSON in extra field");
       return;
     }
+    if (isLlm) {
+      extra = mergeModelEndpointLlmContext(extra, { maxContextSize, maxOutputTokens });
+    }
 
     if (editing) {
       const updateData: UpdateModelEndpointRequest = {
@@ -572,6 +590,36 @@ function EndpointDialog({
               <Input type="number" step="0.1" value={timeout} onChange={(e) => setTimeout(e.target.value)} />
             </div>
           </div>
+          {isLlm && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Max context size</Label>
+                <Input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={maxContextSize}
+                  onChange={(e) => setMaxContextSize(e.target.value)}
+                  placeholder="Default"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Max output tokens</Label>
+                <Input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={maxOutputTokens}
+                  onChange={(e) => setMaxOutputTokens(e.target.value)}
+                  placeholder="Default"
+                />
+              </div>
+              <p className="col-span-2 text-xs text-muted-foreground">
+                Token budgets for this endpoint. Leave blank to use the system default. Applied when this is the
+                default LLM endpoint.
+              </p>
+            </div>
+          )}
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <Label>API key</Label>


### PR DESCRIPTION
**Draft — scaffolding only. To be implemented later.**

## Problem

The chat preflight validates only the default LLM (`config.llm`), so it is out of step with the LLM that actually answers once partition `chat_llm` presets are honored:

- **Availability** — `check_llm_model_availability` (`openrag/api/dependencies/llm.py`) probes only `config.llm`. A partition with a healthy custom `chat_llm` is rejected (503/404) when the *default* endpoint is down.
- **Token / context sizing** — `get_max_model_tokens` / `validate_tokens_limit` (`openrag/api/routers/user/chat.py`) use a single startup-primed global from the default model, so requests are sized against the wrong context window.

## Plan

- [ ] Resolve the request's effective LLM (partition → `chat_llm`, mirroring `QueryService._resolve_llm`) **before** the availability/token preflight.
- [ ] Validate availability against the *resolved* endpoint — make the check body-aware or move it into the handler (the partition→endpoint mapping isn't known until the body is parsed).
- [ ] Size token/context per resolved endpoint; fall back to `config.llm_context`.
- [ ] Tests: default-down + healthy custom `chat_llm` succeeds; per-endpoint context sizing.

## Notes

Pre-existing limitation of the preflight layer, surfaced once answer generation routes through non-default endpoints. Separately, per-endpoint `max_llm_context_size` / `max_output_tokens` are being made admin-configurable, which covers the *default* endpoint's sizing; this PR extends the preflight to the *resolved* endpoint.

Closes #639.
