### PR TITLE
fix(admin-ui): simplify account settings copy

### DIFF
--- a/ui/src/pages/app/settings.tsx
+++ b/ui/src/pages/app/settings.tsx
@@ -33,7 +33,7 @@ export default function SettingsPage() {
 
   return (
     <div>
-      <PageHeader title="Account Settings" description="Manage your programmatic API access" />
+      <PageHeader title="Account Settings" description="Manage your API access and authentication." />
 
       <div className="mt-4 grid gap-4 max-w-2xl">
         {/* Sign-in is handled by the IdP — nothing to manage here. */}
@@ -43,8 +43,8 @@ export default function SettingsPage() {
               <ShieldCheck className="h-4 w-4 text-primary" /> Sign-in
             </CardTitle>
             <CardDescription>
-              Authentication is handled by your organization's single sign-on (SSO). There are no
-              passwords to manage here — sign in and out happen through your identity provider.
+              Authentication is managed through your organization's SSO. OpenRAG does not manage
+              passwords.
             </CardDescription>
           </CardHeader>
         </Card>
@@ -56,8 +56,8 @@ export default function SettingsPage() {
               <KeyRound className="h-4 w-4 text-primary" /> API Token
             </CardTitle>
             <CardDescription>
-              Use this bearer token for programmatic access (CLI, scripts). Each account has a single
-              token — regenerating it immediately invalidates the previous one.
+              Use this token to authenticate API requests from the CLI, scripts, or other tools.
+              Regenerating it immediately revokes the previous token.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">


### PR DESCRIPTION
## Summary

This updates the Account Settings copy so it reads more like a product surface and less like generated help text.

The page keeps the same layout and behavior. Only the visible wording changes for the page description, sign-in section, and API token section.

## Validation

- `npm run lint`
- `npm run build`

Note: `npm ci` reported existing dependency audit findings while installing this worktree. This PR does not change dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Settings page text to better explain API access and authentication.
  * Clarified that sign-in is handled through the organization’s SSO and that passwords are not managed in the app.
  * Improved API token guidance for use with CLI tools and scripts, including a clearer note that regenerating a token immediately invalidates the previous one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->