### PR TITLE
chore(compose): pin app images to v2.0.0-rc.2 instead of latest

### DIFF
--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -5,7 +5,7 @@ include:
   - ${TRANSCRIBER_COMPOSE:-../../extern/dummy.yaml}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:latest
+  image: linagoraai/openrag:v2.0.0-rc.2
   # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
   # writable dirs (data/, logs/, the HF cache) — which a non-root container
   # can't write when Docker auto-creates them root-owned — then it immediately
@@ -98,7 +98,7 @@ x-vllm: &vllm_template
 services:
   # ── Admin UI (React SPA + nginx, same-origin reverse proxy to the API) ──
   admin-ui:
-    image: linagoraai/openrag-admin-ui:latest
+    image: linagoraai/openrag-admin-ui:v2.0.0-rc.2
     build:
       context: ../..
       dockerfile: infra/docker/ui.Dockerfile


### PR DESCRIPTION
## What

Pin the two application images in `infra/compose/docker-compose.yaml` to the current published v2 tag instead of the floating `latest`:

- `linagoraai/openrag:latest` → `linagoraai/openrag:v2.0.0-rc.2`
- `linagoraai/openrag-admin-ui:latest` → `linagoraai/openrag-admin-ui:v2.0.0-rc.2`

## Why

`latest` is unsafe for this branch:

- On Docker Hub, `linagoraai/openrag:latest` still points at the **old v1.1.13 GA** image (the last release built from `main`) — the v2 RC pipeline never tags `latest`.
- `linagoraai/openrag-admin-ui` has **no `latest` tag at all**.

So `docker compose up` (without `--build`) today either pulls a stale v1 image or fails on the missing admin-ui tag. Pinning to `v2.0.0-rc.2` — the latest tag actually published for this branch — makes the pull reproducible and correct.

## Notes

- Only the two app images are pinned; third-party images (Milvus, Infinity, etc.) are untouched.
- The `build:` sections are unchanged, so local `docker compose up --build` still builds from source.
- Bump this pin to `v2.0.0` once the GA image is published (no such tag exists on Docker Hub yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container images used by the compose setup to a newer release-candidate version.
  * This affects both the main API service and the admin UI, while leaving all service settings and wiring unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->