### PR TITLE
ci(build): build the admin-ui image on release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,3 +114,55 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-and-push-image-admin-ui:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-admin-ui
+            linagoraai/openrag-admin-ui
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: infra/docker/ui.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What
Add the `admin-ui` build job to the GA release workflow (`build.yml`), mirroring the one already in `build_rc.yml`.

## Why
`build.yml` (runs on `v*` tags) built only `openrag` (api) + `openrag-ray`. The `openrag-admin-ui` image was produced **only** by the RC workflow, so a GA tag would publish the backend + ray images but **no admin-ui** — the UI container would `ImagePullBackOff` at that version.

## Details
Same build recipe as `build_rc.yml`'s admin-ui job: `infra/docker/ui.Dockerfile`, context `.`, pushes to `ghcr.io/linagora/openrag-admin-ui` + `linagoraai/openrag-admin-ui`, same `base_ref == main` tag guard and `type=ref,event=tag` + `latest` tags. No build-args (matches the RC build exactly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of the admin UI Docker image when new tags are released.
  * The release process now produces tagged images for both GitHub Container Registry and Docker Hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->