### PR TITLE
ci: repoint workflow triggers from dev/refactor to develop

### DIFF
--- a/.github/workflows/api_tests.yml
+++ b/.github/workflows/api_tests.yml
@@ -2,7 +2,7 @@ name: API Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: "0 2 * * *"
   push:
-    branches: [dev]
+    branches: [develop]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - dev
+      - develop
     paths:
       - "infra/charts/**"
   workflow_dispatch:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-      - dev
-      - "refactor/hexagonal"
-      - "refactor/phase-**"
+      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/layer_guard.yml
+++ b/.github/workflows/layer_guard.yml
@@ -3,11 +3,12 @@ name: Layer guard
 on:
   push:
     branches:
-      - "refactor/hexagonal"
-      - "refactor/phase-**"
+      - main
+      - develop
   pull_request:
     branches:
-      - "refactor/hexagonal"
+      - main
+      - develop
 
 jobs:
   layer-import-guard:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,14 +4,11 @@ on:
   push:
     branches:
       - main
-      - dev
-      - "refactor/hexagonal"
-      - "refactor/phase-**"
+      - develop
   pull_request:
     branches:
       - main
-      - dev
-      - "refactor/hexagonal"
+      - develop
 
 jobs:
   lint:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-      - dev
-      - "refactor/hexagonal"
-      - "refactor/phase-**"
+      - develop
   pull_request:
 
 jobs:


### PR DESCRIPTION
Prerequisite for enabling branch protection on `main` + `develop`.

The CI `on:` filters still referenced the now-deleted `dev` branch and the retired `refactor/hexagonal` / `refactor/phase-**` branches, so **`lint` and `layer-import-guard` did not run on PRs targeting `develop`** — requiring them in branch protection would deadlock PRs.

Changes (7 workflows): `dev` → `develop`, drop `refactor/*` refs, so `lint`, `layer-guard`, unit/integration/api tests, and helm publish all fire on `main` + `develop`.

After this merges, all five PR checks run on every `develop`/`main` PR and can be marked required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI, testing, linting, and release workflows to run on the `develop` branch instead of older branch names.
  * Simplified branch filters for push and pull request checks so automation now focuses on `main` and `develop`.
  * Integration, unit, API, and Helm publishing jobs continue to behave the same aside from the updated triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->