### PR TITLE
ci: add release-candidate build workflow; harden GA latest tag

### DIFF
--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -32,6 +32,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -83,6 +85,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -126,6 +130,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -1,19 +1,31 @@
-name: Build and Release
+# Build and publish release-candidate images.
+#
+# Git flow: release candidates are cut from a `release/X.Y.Z` branch. Tagging
+# that branch with `vX.Y.Z-rc.N` publishes the api, ray, and admin-ui images
+# under the `vX.Y.Z-rc.N` tag — mirroring the GA pipeline (`build.yml`) but
+# guarded to `release/*` instead of `main`, and NEVER tagging `latest`.
+#
+# api + admin-ui -> ghcr + Docker Hub; ray -> ghcr only (same split as build.yml).
+#
+# The GA pipeline (`build.yml`) also triggers on `v*` tags, but its jobs are
+# guarded to `base_ref == refs/heads/main`, so an rc tag on a release branch is
+# a no-op there. This workflow is the mirror image: it only runs for rc tags
+# whose base branch is `release/*`.
+name: Build RC
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v*-rc.*"]
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  PYTHON_VERSION: "3.12"
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release/')
     permissions:
       contents: read
       packages: write
@@ -49,11 +61,6 @@ jobs:
             linagoraai/openrag
           tags: |
             type=ref,event=tag
-            type=raw,value=latest
-
-      - name: Extract tag version
-        id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -69,7 +76,7 @@ jobs:
 
   build-and-push-image-ray:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release/')
     permissions:
       contents: read
       packages: write
@@ -97,11 +104,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray
           tags: |
             type=ref,event=tag
-            type=raw,value=latest
-
-      - name: Extract tag version
-        id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -117,7 +119,7 @@ jobs:
 
   build-and-push-image-admin-ui:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release/')
     permissions:
       contents: read
       packages: write
@@ -153,7 +155,6 @@ jobs:
             linagoraai/openrag-admin-ui
           tags: |
             type=ref,event=tag
-            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build_rc.yml
+++ b/.github/workflows/build_rc.yml
@@ -16,7 +16,6 @@ name: Build RC
 on:
   push:
     tags: ["v*-rc.*"]
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Adds the git-flow release-candidate image pipeline and removes a latent `latest`-tagging fragility.

**`build_rc.yml` (new)** — RC images off `release/*`:
- Triggers on `v*-rc.*` tags; jobs guarded to `base_ref` starting `refs/heads/release/`.
- Builds all 3 images (api, ray, admin-ui), same registry split as `build.yml` (api+admin-ui → ghcr + Docker Hub; ray → ghcr only).
- Tag = `vX.Y.Z-rc.N` via `type=ref,event=tag`; **never tags `latest`**.
- No overlap with `build.yml`: its jobs require `base_ref==main`, so an rc tag on a release branch is a no-op there, and vice-versa.

**`build.yml` (hardened)** — `latest` was gated on `enable={{is_default_branch}}`, which resolved true only while `main` was the default branch. With the default branch now `develop`, that expression could silently stop tagging `latest` on main-based GA releases. Since those jobs are already guarded to `base_ref==main`, any tag reaching them is a GA release and should be `latest` — so it's now unconditional (`type=raw,value=latest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Release Candidate (RC) build workflow that builds and publishes API, Ray, and Admin UI container images for `v*-rc.*` tags on `release/*` branches.

* **Bug Fixes**
  * Updated container image tagging so the `latest` tag is always applied for main image builds (API, Ray, and Admin UI), rather than only when running on the default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->