### PR TITLE
ci(nightly): stop tagging the repo for every nightly build

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -18,7 +18,7 @@ jobs:
   build-and-push-dev-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
       attestations: write
     steps:
@@ -71,90 +71,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Create development release (nightly only)
-        if: github.event_name == 'schedule'
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.dev_version.outputs.version }}
-          name: "🌙 Nightly Release ${{ steps.dev_version.outputs.version }}"
-          body: |
-            ## 🌙 Nightly Development Release
-
-            This is an automated nightly release built from the latest `dev` branch.
-
-            **⚠️ This is a development build - not recommended for production use**
-
-            ### Docker Image
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.dev_version.outputs.version }}
-            # or
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly
-            ```
-
-            ### Build Information
-            - **Branch**: `dev`
-            - **Commit**: `${{ github.sha }}`
-            - **Build Date**: `$(date -u)`
-            - **Triggered by**: Nightly schedule
-
-            Full changelog: https://github.com/${{ github.repository }}/compare/main...dev
-          generateReleaseNotes: false
-          draft: false
-          prerelease: true
-          makeLatest: false
-
-  cleanup-old-dev-releases:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    needs: [build-and-push-dev-image]
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Clean up old nightly releases
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const releases = await github.rest.repos.listReleases({
-              owner,
-              repo,
-              per_page: 100
-            });
-
-            // Keep only the last 7 nightly releases
-            const nightlyReleases = releases.data
-              .filter(release => release.tag_name.startsWith('nightly-'))
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
-              .slice(7); // Keep first 7, delete the rest
-
-            for (const release of nightlyReleases) {
-              console.log(`Deleting old nightly release: ${release.tag_name}`);
-              
-              // Delete the release
-              await github.rest.repos.deleteRelease({
-                owner,
-                repo,
-                release_id: release.id
-              });
-              
-              // Delete the tag
-              try {
-                await github.rest.git.deleteRef({
-                  owner,
-                  repo,
-                  ref: `tags/${release.tag_name}`
-                });
-              } catch (error) {
-                console.log(`Could not delete tag ${release.tag_name}: ${error.message}`);
-              }
-            }
-
   build-and-push-dev-image-ray:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
       attestations: write
     steps:
@@ -206,35 +126,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Create development release (nightly only)
-        if: github.event_name == 'schedule'
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.dev_version.outputs.version }}
-          name: "🌙 Nightly Release ${{ steps.dev_version.outputs.version }}"
-          body: |
-            ## 🌙 Nightly Development Release
-
-            This is an automated nightly release built from the latest `dev` branch.
-
-            **⚠️ This is a development build - not recommended for production use**
-
-            ### Docker Image
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray:${{ steps.dev_version.outputs.version }}
-            # or
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ray:nightly
-            ```
-
-            ### Build Information
-            - **Branch**: `dev`
-            - **Commit**: `${{ github.sha }}`
-            - **Build Date**: `$(date -u)`
-            - **Triggered by**: Nightly schedule
-
-            Full changelog: https://github.com/${{ github.repository }}/compare/main...dev
-          generateReleaseNotes: false
-          draft: false
-          prerelease: true
-          makeLatest: false


### PR DESCRIPTION
The `/tags` page is cluttered with `nightly-*` and `dev-*` git tags, drowning the real `v*` releases.

**Cause:** `build_dev.yml` created a GitHub Release (via `ncipollo/release-action`) per nightly — and a Release requires a git tag. The ray job did it again with a `-ray` suffix, so **2 git tags per night**. The `cleanup-old-dev-releases` job only pruned `nightly-*` *releases* (not `dev-*`, and tag deletion was best-effort), so tags accumulated.

**Fix:** nightlies are now **image-only artifacts**. Removed both `Create development release` steps and the cleanup job. The nightly still builds and pushes to ghcr with `nightly`, `dev-latest`, and `nightly-YYYYMMDD-sha` **Docker** tags (traceability preserved); it no longer writes any git tag or Release. Also dropped `contents: write` (least privilege — no longer needed).

Result: `/tags` will only ever show real `v*` releases going forward. A separate one-time purge will remove the existing `nightly-*`/`dev-*` tags.