### PR TITLE
feat(indexation): disable topic tagging by default

### DIFF
--- a/openrag/core/config/indexation_pipeline.py
+++ b/openrag/core/config/indexation_pipeline.py
@@ -52,8 +52,10 @@ class IndexationPipelineConfig(BaseModel):
         default_factory=lambda: ["person", "organization", "location", "event"],
     )
 
-    # Topic tagging
-    enable_topic_tagging: bool = True
+    # Topic tagging. Off by default: the generated tags are not yet surfaced in
+    # the API or used for retrieval, so enabling it only buys an extra LLM call
+    # per document. Partitions that want the tags opt in on their preset.
+    enable_topic_tagging: bool = False
     max_topic_tags: int = Field(default=7, ge=1, le=50)
     topic_tagging_llm: str | None = None
 

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -52,7 +52,7 @@ _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
             # spin up that backend's Ray pool — e.g. forcing marker on a
             # pymupdf-configured deployment. Named presets below opt in explicitly.
             "enable_entity_extraction": True,
-            "enable_topic_tagging": True,
+            "enable_topic_tagging": False,
         },
         "legal": {
             "chunking": {"name": "recursive_splitter", "chunk_size": 1024, "chunk_overlap_rate": 0.25},

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -159,7 +159,10 @@ async def _replace_topic_tags_if_needed(
         return
 
     has_topic_tags = "topic_tags" in row
-    topic_tagging_disabled = indexation_config is not None and indexation_config.get("enable_topic_tagging") is False
+    # Mirrors IndexationPipelineConfig.enable_topic_tagging: an absent key means
+    # disabled, so a re-index under a preset that never enabled tagging still
+    # clears tags left behind by an earlier run.
+    topic_tagging_disabled = indexation_config is not None and not indexation_config.get("enable_topic_tagging", False)
     if not has_topic_tags and not topic_tagging_disabled:
         return
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -358,7 +358,7 @@ def _required_llm_names(indexation_config: dict[str, Any] | None) -> list[str]:
     names: list[str] = []
     if indexation_config.get("enable_contextualization"):
         names.append(indexation_config.get("contextualization_llm") or "default")
-    if indexation_config.get("enable_topic_tagging", True):
+    if indexation_config.get("enable_topic_tagging", False):
         names.append(indexation_config.get("topic_tagging_llm") or "default")
     return names
 

--- a/tests/unit/core/config/test_pipeline_configs.py
+++ b/tests/unit/core/config/test_pipeline_configs.py
@@ -41,6 +41,11 @@ def test_indexation_pipeline_rejects_unknown_contextualization_mode():
         IndexationPipelineConfig(contextualization_mode="verbose")
 
 
+def test_indexation_pipeline_topic_tagging_defaults_off():
+    """Topic tagging is opt-in: tags are not yet surfaced or used in retrieval."""
+    assert IndexationPipelineConfig().enable_topic_tagging is False
+
+
 def test_retrieval_pipeline_rejects_unknown_type():
     """Retrieval presets reject unsupported retrieval modes."""
     with pytest.raises(ValidationError):

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -156,6 +156,17 @@ async def test_seed_defaults_inserts_six_presets_when_empty():
 
 
 @pytest.mark.asyncio
+async def test_seed_defaults_indexation_leaves_topic_tagging_off():
+    repo = _FakePresetRepo()
+    svc = _make_service(repo)
+    await svc.seed_defaults()
+
+    idx = [r for r in repo._store.values() if r["preset_type"] == "indexation"]
+    assert idx  # sanity: indexation presets were seeded
+    assert all(r["config"].get("enable_topic_tagging", False) is False for r in idx)
+
+
+@pytest.mark.asyncio
 async def test_seed_defaults_retrieval_inherits_reranker_enabled():
     from core.config.root import Settings
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -480,9 +480,10 @@ def test_required_llm_names_mirrors_pipeline_selection() -> None:
     from services.workers.indexer_pool import _required_llm_names
 
     assert _required_llm_names(None) == []
-    # Topic tagging defaults on, contextualization defaults off.
-    assert _required_llm_names({}) == ["default"]
+    # Both topic tagging and contextualization default off.
+    assert _required_llm_names({}) == []
     assert _required_llm_names({"enable_topic_tagging": False}) == []
+    assert _required_llm_names({"enable_topic_tagging": True}) == ["default"]
     assert _required_llm_names(
         {
             "enable_contextualization": True,

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -558,6 +558,40 @@ async def test_process_file_deletes_topic_tags_when_tagging_is_disabled(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_process_file_deletes_topic_tags_when_tagging_key_absent(tmp_path: Path) -> None:
+    """An absent ``enable_topic_tagging`` key means disabled (mirrors the config
+    default), so a re-index under a preset that never enabled tagging — e.g.
+    ``legal``/``finance`` — still purges tags left behind by an earlier run.
+    Guards against reverting the absent-key semantics to explicit ``is False``."""
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+
+    class UntaggedPipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            row["stored_count"] = 1
+            row["stage"] = "stored"
+            return row
+
+    repo = FakeTopicTagRepo()
+    worker = IndexerWorker(
+        pipeline=UntaggedPipeline(),
+        task_state_manager=_fake_tsm(),
+        topic_tag_repo=repo,
+    )
+
+    await worker.process_file(
+        task_id="t-absent-tags",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="tenant-a",
+        indexation_config={"enable_image_captioning": True},
+    )
+
+    assert repo.deleted == [("f1", "tenant-a")]
+    assert repo.inserted == []
+
+
+@pytest.mark.asyncio
 async def test_process_file_rejects_malformed_topic_tags_before_delete(tmp_path: Path) -> None:
     path = tmp_path / "doc.txt"
     path.write_bytes(b"content")

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -406,7 +406,7 @@ function IndexationPresetForm({
         />
         <FeatureToggle
           label="Topic tagging"
-          enabled={configGet(config, "enable_topic_tagging", true)}
+          enabled={configGet(config, "enable_topic_tagging", false)}
           onToggle={(on) => toggleFeature("enable_topic_tagging", "topic_tagging_llm", on)}
           // Postponed: tags are generated but not yet surfaced or used in
           // retrieval, so the control is disabled until the feature ships.


### PR DESCRIPTION
## Why

Topic tagging is currently **on by default** for every partition, so every indexed document pays an extra LLM call to generate tags that nothing consumes: they are not surfaced in the API and not used in retrieval. The admin UI already acknowledges this — the toggle ships `disabled` with the hint *"Coming soon — generated tags aren't surfaced or used in retrieval yet."*

This makes the feature opt-in until it actually ships.

## What changed

| File | Change |
|---|---|
| `core/config/indexation_pipeline.py` | `enable_topic_tagging` default `True` → `False` |
| `services/orchestrators/preset_service.py` | seeded `default` indexation preset sets it `False` |
| `services/workers/indexer_pool.py` | `_required_llm_names` no longer resolves an LLM for an absent key |
| `services/workers/indexer_actor.py` | `_replace_topic_tags_if_needed` treats an absent key as disabled |
| `ui/src/pages/admin/presets.tsx` | toggle fallback `true` → `false`, matching the backend |

## Reviewer note — one behavior change beyond the flag

`_replace_topic_tags_if_needed` previously purged tags only when a preset set `enable_topic_tagging` **explicitly** to `False`. Now that an absent key *means* disabled, the purge must apply to absent-key presets too (`legal`, `finance`) — otherwise they would silently stop tagging but never clear tags written by an earlier run.

The cost is one indexed `DELETE FROM topic_tags WHERE document_id = ? AND partition = ?` per indexed document on the (now default) disabled path. It is a no-op for fresh files. Happy to scope it back to `is False` semantics if you'd rather not pay that on the hot path, at the price of leaving stale tags unreachable for those two presets.

## Upgrade impact

**Existing deployments keep their current behavior.** `seed_defaults()` only inserts when a preset type has zero rows, so a database that already seeded `default` with tagging on retains it. Only fresh deployments get the new default. Operators who want tagging back set `enable_topic_tagging: true` on the partition's indexation preset.

## Testing

- Added `test_indexation_pipeline_topic_tagging_defaults_off` pinning the model default.
- Added `test_seed_defaults_indexation_leaves_topic_tagging_off` covering the seeded presets.
- Updated `test_required_llm_names_mirrors_pipeline_selection` — `{}` now resolves no LLM, and an explicit `True` still resolves `default`.
- `uv run pytest tests/unit/` → 1663 passed. The 2 failures in `tests/unit/api/middleware/test_rate_limit.py` are timing-flaky and reproduce unchanged on `origin/main`.
- `uv run ruff check` / `format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Topic tagging is now off by default in pipeline configuration, seeded indexation presets, and the admin preset UI unless explicitly enabled.
  * Re-indexing now clears previously stored topic tags when topic tagging wasn’t enabled (including when the setting is omitted).
  * Indexer endpoint/model selection no longer assumes topic tagging is enabled when the flag is missing.

* **Tests**
  * Added/updated unit tests validating default-off behavior, preset seeding defaults, topic-tag purging when the key is absent, and required-model selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->