### PR TITLE
fix(compose): stop Marker PDF conversion failing with PermissionError

### DIFF
--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -15,7 +15,7 @@ x-openrag-env: &openrag_env
   # root-owned venv volume -> every conversion dies with PermissionError. Point
   # the font at a bind-mounted dir the app user owns, so the ~15MB download
   # happens once and persists across restarts.
-  FONT_PATH: /app/data/fonts/GoNotoCurrent-Regular.ttf
+  FONT_PATH: ${FONT_PATH:-/app/data/fonts/GoNotoCurrent-Regular.ttf}
 
 x-openrag: &openrag_template
   image: linagoraai/openrag:v2.0.0

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -4,6 +4,19 @@ include:
   - ../../extern/reranker/${RERANKER_PROVIDER:-infinity}.yaml
   - ${TRANSCRIBER_COMPOSE:-../../extern/dummy.yaml}
 
+# Env shared by both API variants. Kept as its own anchor because a service's
+# own `environment:` key REPLACES the one merged in via `<<:` (YAML merge is
+# shallow) — so each variant must merge this explicitly rather than rely on the
+# template. Merging requires mapping form, not list form.
+x-openrag-env: &openrag_env
+  # Marker lazily downloads its rendering font on first PDF conversion, and its
+  # default target is inside the installed package (site-packages/static/fonts/).
+  # The app drops to a non-root user (see entrypoint.sh) which cannot write the
+  # root-owned venv volume -> every conversion dies with PermissionError. Point
+  # the font at a bind-mounted dir the app user owns, so the ~15MB download
+  # happens once and persists across restarts.
+  FONT_PATH: /app/data/fonts/GoNotoCurrent-Regular.ttf
+
 x-openrag: &openrag_template
   image: linagoraai/openrag:v2.0.0
   # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
@@ -61,6 +74,8 @@ x-openrag: &openrag_template
         - openrag
   env_file:
     - ${SHARED_ENV:-.env}
+  environment:
+    <<: *openrag_env
   shm_size: 10.24gb
 
 x-vllm-env: &vllm_env
@@ -124,9 +139,12 @@ services:
   openrag:
     <<: *openrag_template
     runtime: nvidia
+    # Mapping form (not a list) so the shared env can be merged in; a bare
+    # `environment:` here would drop *openrag_env entirely.
     environment:
-     - NVIDIA_VISIBLE_DEVICES=all
-     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      <<: *openrag_env
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Problem

Every PDF ingestion fails in Marker with:

```
PermissionError: [Errno 13] Permission denied: '/app/.venv/lib/python3.12/site-packages/static'
```

Marker downloads its rendering font lazily on the first conversion, defaulting to a path **inside the installed package** (`site-packages/static/fonts/`). `entrypoint.sh` drops the app to a non-root user (`APP_UID`, GID 0), while the venv lives in the root-owned `openrag_venv` named volume whose `site-packages` is `root:root drwxr-xr-x`. So the app user cannot create `static/`.

## Fix

Point `FONT_PATH` at `/app/data/fonts/`, a bind-mounted directory the app user already owns (`entrypoint.sh` grants GID-0 write on `/app/data`). The ~15MB download happens once and persists across restarts.

`FONT_PATH` is the only knob needed: marker's `Settings` is a pydantic `BaseSettings` with no env prefix, `FONT_DIR` is dead except as the default for `FONT_PATH`, and the two other readers (`providers/__init__.py`, `processors/debug.py`) both go through `FONT_PATH`.

## Why the extra anchor

Adding `environment:` to `x-openrag` alone **silently does nothing** for the GPU service: a service's own `environment:` key *replaces* the merged one (YAML `<<:` is shallow), and `openrag` declares its own. The shared env is hoisted into `x-openrag-env` so both variants merge it explicitly, and the GPU service's list form is converted to mapping form to allow merging.

## Verification

On a live stack, after recreating the container:

- PDF ingested end-to-end reaches `task_state: COMPLETED`
- marker logs `Processed /tmp/tmpw2kxewk9.pdf in 33.75s`
- `PermissionError` count since restart: **0**
- `docker compose config` confirms `FONT_PATH` resolves for **both** `openrag` and `openrag-cpu`, and the `NVIDIA_*` vars survive the list->mapping conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment configuration to ensure fonts are consistently available across related services.
  - Updated GPU-enabled deployments to apply NVIDIA runtime settings more reliably.
  - Enhanced shared environment inheritance for services using the common template, ensuring required environment values are correctly merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->