### PR TITLE
fix(admin-ui): copy button silently fails to copy token in new-user dialog

### DIFF
--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { intOr, numOr } from "./utils";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { intOr, numOr, copyToClipboard } from "./utils";
 
 // These guard against `parseInt("")` / `parseFloat("")` → NaN, which
 // JSON.stringify serializes as `null` when sent to the API.
@@ -37,5 +37,76 @@ describe("numOr", () => {
 
   it("falls back on non-numeric input", () => {
     expect(numOr("x", 2.5)).toBe(2.5);
+  });
+});
+
+describe("copyToClipboard", () => {
+  const originalClipboard = navigator.clipboard;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      configurable: true,
+    });
+    // jsdom doesn't implement execCommand; the fallback tests stub it directly.
+    delete (document as unknown as { execCommand?: unknown }).execCommand;
+    vi.restoreAllMocks();
+  });
+
+  // Simulates browsers/deployments without the async Clipboard API (plain
+  // HTTP), forcing the execCommand fallback.
+  function dropAsyncClipboard() {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+  }
+
+  it("inserts the fallback textarea next to the anchor, not document.body", async () => {
+    dropAsyncClipboard();
+
+    const container = document.createElement("div");
+    const anchor = document.createElement("button");
+    container.appendChild(anchor);
+    document.body.appendChild(container);
+
+    let taInContainerDuringCopy = false;
+    document.execCommand = vi.fn(() => {
+      taInContainerDuringCopy = container.querySelector("textarea") !== null;
+      return true;
+    });
+
+    const ok = await copyToClipboard("or-secret-token", anchor);
+
+    expect(ok).toBe(true);
+    expect(taInContainerDuringCopy).toBe(true);
+    // Cleaned up afterwards, and never leaked onto document.body.
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(document.body.querySelector("textarea")).toBeNull();
+
+    document.body.removeChild(container);
+  });
+
+  it("falls back to document.body when no anchor is given", async () => {
+    dropAsyncClipboard();
+    document.execCommand = vi.fn(() => true);
+
+    const ok = await copyToClipboard("or-secret-token");
+
+    expect(ok).toBe(true);
+    expect(document.body.querySelector("textarea")).toBeNull();
+  });
+
+  it("uses the async Clipboard API when available, ignoring the anchor", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const ok = await copyToClipboard("or-secret-token");
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("or-secret-token");
   });
 });

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -39,9 +39,17 @@ export function numOr(value: string, fallback: number): number {
  * Copy text to the clipboard, working outside secure contexts too.
  * navigator.clipboard is only available over HTTPS/localhost; over plain HTTP
  * it's undefined, so fall back to a hidden textarea + execCommand("copy").
+ *
+ * `anchor` (typically the clicked button) anchors the hidden textarea inside
+ * the same DOM subtree instead of `document.body`. This matters when the
+ * caller lives inside a focus-trapped container (e.g. a Radix Dialog): the
+ * trap treats a `document.body` child as "outside" and yanks focus straight
+ * back before `execCommand("copy")` can read the selection, so the command
+ * silently copies nothing while still reporting success.
+ *
  * Returns whether the copy succeeded.
  */
-export async function copyToClipboard(text: string): Promise<boolean> {
+export async function copyToClipboard(text: string, anchor?: Element | null): Promise<boolean> {
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
@@ -51,15 +59,16 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     }
   }
   try {
+    const container = anchor?.parentElement ?? document.body;
     const ta = document.createElement("textarea");
     ta.value = text;
     ta.style.position = "fixed";
     ta.style.opacity = "0";
-    document.body.appendChild(ta);
+    container.appendChild(ta);
     ta.focus();
     ta.select();
     const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
+    container.removeChild(ta);
     return ok;
   } catch {
     return false;

--- a/ui/src/pages/admin/users/detail.tsx
+++ b/ui/src/pages/admin/users/detail.tsx
@@ -517,9 +517,9 @@ function ApiTokenTab({ userId }: { userId: number }) {
     onError: (e) => toast.error((e as Error).message),
   });
 
-  const copyToken = async () => {
+  const copyToken = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (token) {
-      const ok = await copyToClipboard(token);
+      const ok = await copyToClipboard(token, e.currentTarget);
       toast[ok ? "success" : "error"](
         ok ? "Token copied to clipboard" : "Couldn't copy — copy it manually",
       );

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -215,9 +215,9 @@ function PreProvisionDialog({
     onError: (e) => toast.error((e as Error).message),
   });
 
-  const copyToken = async () => {
+  const copyToken = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (created?.token) {
-      const ok = await copyToClipboard(created.token);
+      const ok = await copyToClipboard(created.token, e.currentTarget);
       toast[ok ? "success" : "error"](
         ok ? "Token copied to clipboard" : "Couldn't copy — copy it manually",
       );

--- a/ui/src/pages/app/settings.tsx
+++ b/ui/src/pages/app/settings.tsx
@@ -22,9 +22,9 @@ export default function SettingsPage() {
     onError: (e) => toast.error(e.message),
   });
 
-  const copyToken = async () => {
+  const copyToken = async (e: React.MouseEvent<HTMLButtonElement>) => {
     if (token) {
-      const ok = await copyToClipboard(token);
+      const ok = await copyToClipboard(token, e.currentTarget);
       toast[ok ? "success" : "error"](
         ok ? "Token copied to clipboard" : "Couldn't copy — copy it manually",
       );


### PR DESCRIPTION
## Summary

- Fixes the "New user" pre-provision dialog's copy button — it toasted "Token copied to clipboard" without actually copying anything, on both Firefox and Chrome.
- Root cause: `copyToClipboard()`'s `execCommand("copy")` fallback appended its hidden `<textarea>` to `document.body`. When the button lives inside a focus-trapped container (the Radix `Dialog` used by `PreProvisionDialog`), the trap treats a `document.body` child as focus escaping the modal and yanks focus straight back — synchronously, before `ta.select()` + `execCommand("copy")` can read the selection. `execCommand` still returns `true` (nothing selected ≠ command failure), so the toast lies. The other two token-copy flows (admin regenerate, self-service regenerate in Settings) render the token in a plain `Card`, not inside a `Dialog`, so they never hit this.
- Fix: `copyToClipboard()` now takes an optional `anchor` element and inserts the temporary textarea next to it instead of at `document.body`, so it stays inside whatever focus-trapped subtree the button is already in. All three call sites now pass `e.currentTarget` (the clicked button) as the anchor.

## Test plan

- [x] `npx vitest run` — all 110 tests pass, including 3 new `copyToClipboard` tests covering: fallback textarea anchored next to the trigger (not `document.body`), fallback with no anchor still works, and the async `navigator.clipboard.writeText` path is preferred/unaffected.
- [x] `npx tsc -b` — clean.
- [x] `npx eslint` on changed files — clean.

Fixes #661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “Copy token” reliability across user administration and settings pages.
  - Clipboard fallback now keeps temporary copy elements within the relevant interface area, helping prevent focus-trap issues.
  - Copying works with both modern browser clipboard support and legacy fallback behavior.
  - Existing success and error notifications remain unchanged.

- **Tests**
  - Added coverage for modern clipboard copying, fallback behavior, anchored copying, cleanup, and missing-anchor scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->