### PR TITLE
wip(chat): resolve LLM token preflight against the partition's chat_llm preset

### DIFF
--- a/openrag/api/routers/user/chat.py
+++ b/openrag/api/routers/user/chat.py
@@ -31,6 +31,7 @@ from api.dependencies.llm import (
 from api.routers.user.source_links import build_document_source_link
 from api.schemas.user.chat import OpenAIChatCompletionRequest, OpenAICompletionRequest
 from core.config import load_config
+from core.models.preset import resolve_partition_chat_llm
 from core.utils.exceptions import OpenRAGError
 from core.utils.logging import get_logger
 from core.utils.text import get_num_tokens, sanitize_text
@@ -46,9 +47,10 @@ if TYPE_CHECKING:
 
 # Auto-probed max model token limit. Populated by ``prime_max_model_tokens``
 # which the application lifespan invokes during startup. It is only the *middle*
-# tier of ``get_max_model_tokens``: an admin-configured context size on the
-# default LLM endpoint takes precedence, and ``config.llm_context`` is the final
-# fallback.
+# tier of ``get_max_model_tokens`` and only applies to the "default" LLM
+# endpoint (it is probed against ``config.llm.model`` specifically): an
+# admin-configured context size on the resolved LLM endpoint takes precedence,
+# and ``config.llm_context`` is the final fallback.
 _max_model_tokens: int | None = None
 
 
@@ -176,33 +178,46 @@ async def _fetch_max_model_tokens(config: "Settings") -> int:
         return default_limit
 
 
-def _default_endpoint_context_size(config: "Settings") -> int | None:
-    """Admin-configured context window of the default LLM endpoint, if set."""
-    models = getattr(config, "models", None)
-    return models.default_llm_context_size() if models is not None else None
+def _resolve_llm_endpoint_name(config: "Settings", partitions: list[str] | None) -> str:
+    """Effective LLM endpoint registry name for *partitions*.
+
+    Delegates to ``resolve_partition_chat_llm`` — the same consensus rule
+    ``QueryService._resolve_llm`` uses to pick the LLM that actually answers
+    the request — so the token preflight is checked against the budget of the
+    model that will really be called, not always the global default. Falls
+    back to the ``"default"`` alias (see ``ModelEndpointService``) when no
+    single partition-scoped preset applies.
+    """
+    return resolve_partition_chat_llm(partitions, config.partitions) or "default"
 
 
-def _effective_max_output_tokens(config: "Settings") -> int:
-    """Default output-token budget: the default LLM endpoint's admin-configured
+def _effective_max_output_tokens(config: "Settings", partitions: list[str] | None = None) -> int:
+    """Default output-token budget: the resolved LLM endpoint's admin-configured
     value when set, else the global ``llm_context`` fallback."""
     models = getattr(config, "models", None)
-    configured = models.default_llm_output_tokens() if models is not None else None
+    configured = (
+        models.llm_output_tokens(_resolve_llm_endpoint_name(config, partitions)) if models is not None else None
+    )
     return configured or int(config.llm_context.max_output_tokens)
 
 
-def get_max_model_tokens() -> int:
+def get_max_model_tokens(partitions: list[str] | None = None, settings: "Settings | None" = None) -> int:
     """Effective max context size for the token preflight.
 
-    Precedence: the default LLM endpoint's admin-configured
-    ``max_llm_context_size`` (editable in the admin UI) > the value auto-probed
-    from vLLM at startup > the global ``llm_context`` fallback. An explicit admin
-    setting wins over auto-detection so operators can pin the budget.
+    Precedence: the resolved LLM endpoint's admin-configured
+    ``max_llm_context_size`` (editable in the admin UI; resolved from the
+    partition's ``chat_llm`` preset when the request is scoped to partitions
+    that agree on one, else the "default" endpoint) > the value auto-probed
+    from vLLM at startup for the default endpoint's model (only applies when
+    no partition-scoped preset was resolved — the probed value is specific to
+    that one model) > the global ``llm_context`` fallback.
     """
-    config = _runtime_config()
-    configured = _default_endpoint_context_size(config)
+    config = _runtime_config(settings)
+    name = _resolve_llm_endpoint_name(config, partitions)
+    configured = config.models.llm_context_size(name)
     if configured is not None:
         return configured
-    if _max_model_tokens is not None:
+    if name == "default" and _max_model_tokens is not None:
         return _max_model_tokens
     return int(config.llm_context.max_llm_context_size)
 
@@ -211,6 +226,7 @@ def validate_tokens_limit(
     request: OpenAIChatCompletionRequest | OpenAICompletionRequest,
     max_tokens_allowed: int,
     settings: "Settings | None" = None,
+    partitions: list[str] | None = None,
 ) -> tuple[bool, str]:
     """Validate if the request respects the maximum token limit."""
     try:
@@ -219,7 +235,7 @@ def validate_tokens_limit(
 
         if isinstance(request, OpenAIChatCompletionRequest):
             message_tokens = sum(_length_function(m.content or "") + 4 for m in request.messages)
-            default_output_tokens = _effective_max_output_tokens(config)
+            default_output_tokens = _effective_max_output_tokens(config, partitions)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = message_tokens + requested_tokens
             if total_tokens_needed > max_tokens_allowed:
@@ -233,7 +249,7 @@ def validate_tokens_limit(
 
         elif isinstance(request, OpenAICompletionRequest):
             prompt_tokens = _length_function(request.prompt)
-            default_output_tokens = _effective_max_output_tokens(config)
+            default_output_tokens = _effective_max_output_tokens(config, partitions)
             requested_tokens = request.max_tokens or default_output_tokens
             total_tokens_needed = prompt_tokens + requested_tokens
             if total_tokens_needed > max_tokens_allowed:
@@ -255,12 +271,14 @@ def check_tokens_limit(
     request: OpenAIChatCompletionRequest | OpenAICompletionRequest,
     log,
     settings: "Settings | None" = None,
+    partitions: list[str] | None = None,
 ):
     """Validate token limit and raise HTTPException(413) if exceeded."""
     is_valid, error_message = validate_tokens_limit(
         request,
-        max_tokens_allowed=get_max_model_tokens(),
+        max_tokens_allowed=get_max_model_tokens(partitions=partitions, settings=settings),
         settings=settings,
+        partitions=partitions,
     )
     if not is_valid:
         log.info("Request exceeds token limit", detail=error_message)
@@ -317,10 +335,6 @@ async def openai_chat_completion(
 
     log.debug("Received chat completion request with messages: {}", truncate(str(request.messages)))
 
-    # Bound the caller's input size in every mode. RAG-injected context is added
-    # server-side and separately capped (max_context_tokens), but the user's own
-    # messages must be limited regardless of direct-LLM vs RAG.
-    check_tokens_limit(request, log, config)
     if is_direct_llm_model(request, config):
         partitions = None
     else:
@@ -331,6 +345,13 @@ async def openai_chat_completion(
             is_admin=user["is_admin"],
         )
         log.debug(f"Using partitions: {partitions}")
+
+    # Bound the caller's input size in every mode, against the resolved
+    # partition's chat_llm preset budget when one applies (else the default
+    # LLM endpoint). RAG-injected context is added server-side and separately
+    # capped (max_context_tokens), but the user's own messages must be limited
+    # regardless of direct-LLM vs RAG.
+    check_tokens_limit(request, log, config, partitions=partitions)
 
     def prep(docs, web):
         return __prepare_sources(request2, docs, web)
@@ -418,8 +439,6 @@ async def openai_completion(
             detail="Streaming is not supported for this endpoint",
         )
 
-    # Bound the caller's input size in every mode (RAG context is capped separately).
-    check_tokens_limit(request, log, config)
     if is_direct_llm_model(request, config):
         partitions = None
     else:
@@ -429,6 +448,11 @@ async def openai_completion(
             partition_service=partition_service,
             is_admin=user["is_admin"],
         )
+
+    # Bound the caller's input size in every mode (RAG context is capped
+    # separately), against the resolved partition's chat_llm preset budget
+    # when one applies.
+    check_tokens_limit(request, log, config, partitions=partitions)
 
     resp = await service.complete(
         partitions=partitions,

--- a/openrag/api/schemas/user/chat.py
+++ b/openrag/api/schemas/user/chat.py
@@ -9,7 +9,10 @@ def default_max_tokens():
     config = load_config()
     # Prefer the default LLM endpoint's admin-configured budget over the global
     # llm_context fallback (both editable, but the per-endpoint value wins).
-    return config.models.default_llm_output_tokens() or config.llm_context.max_output_tokens
+    # This factory runs at request-body parse time, before the partition is
+    # resolved, so it can only ever see the default endpoint — the
+    # partition-aware check happens later in check_tokens_limit.
+    return config.models.llm_output_tokens() or config.llm_context.max_output_tokens
 
 
 class OpenAIMessage(BaseModel):

--- a/openrag/core/config/model_endpoints.py
+++ b/openrag/core/config/model_endpoints.py
@@ -63,18 +63,24 @@ class ModelsConfig(ConfigMixin):
     llm: dict[str, ModelEndpointConfig] = Field(default_factory=dict)
     vlm: dict[str, ModelEndpointConfig] = Field(default_factory=dict)
 
-    def default_llm_extra(self) -> dict[str, Any]:
-        """``extra`` payload of the default LLM endpoint (``{}`` if unregistered)."""
-        default = self.llm.get("default")
-        return dict(default.extra) if default is not None else {}
+    def llm_extra(self, name: str = "default") -> dict[str, Any]:
+        """``extra`` payload of the named LLM endpoint (``{}`` if unregistered).
 
-    def default_llm_context_size(self) -> int | None:
-        """Admin-configured context window of the default LLM endpoint, if any."""
-        return _positive_int(self.default_llm_extra().get(LLM_CONTEXT_SIZE_KEY))
+        ``name`` defaults to the ``"default"`` alias (see ``ModelEndpointService``),
+        but any catalogued endpoint name works — in particular a partition's
+        ``chat_llm`` preset, so the token preflight can read that endpoint's
+        budget instead of always falling back to the global default.
+        """
+        endpoint = self.llm.get(name)
+        return dict(endpoint.extra) if endpoint is not None else {}
 
-    def default_llm_output_tokens(self) -> int | None:
-        """Admin-configured max output tokens of the default LLM endpoint, if any."""
-        return _positive_int(self.default_llm_extra().get(LLM_OUTPUT_TOKENS_KEY))
+    def llm_context_size(self, name: str = "default") -> int | None:
+        """Admin-configured context window of the named LLM endpoint, if any."""
+        return _positive_int(self.llm_extra(name).get(LLM_CONTEXT_SIZE_KEY))
+
+    def llm_output_tokens(self, name: str = "default") -> int | None:
+        """Admin-configured max output tokens of the named LLM endpoint, if any."""
+        return _positive_int(self.llm_extra(name).get(LLM_OUTPUT_TOKENS_KEY))
 
 
 class ModelEndpointRow(BaseModel):

--- a/openrag/core/models/preset.py
+++ b/openrag/core/models/preset.py
@@ -56,4 +56,24 @@ class PartitionConfig(BaseModel):
     chat_llm: str | None = None
 
 
-__all__ = ["PresetRow", "PartitionRow", "PartitionConfig", "PresetType"]
+def resolve_partition_chat_llm(
+    partitions: list[str] | None,
+    partition_configs: dict[str, PartitionConfig],
+) -> str | None:
+    """Resolve the ``chat_llm`` preset every partition in *partitions* agrees on.
+
+    ``None`` means "no single owning preset — the caller should fall back to
+    the default LLM": a direct-LLM request (no partitions), the ``"all"``
+    cross-partition sentinel, or a multi-partition request whose partitions
+    disagree (or none set a preset). Shared by the answering-LLM resolution
+    (``QueryService._resolve_llm``) and the chat-completions token preflight
+    (``api.routers.user.chat``), so the LLM that actually answers a request
+    and the budget it was checked against never fall out of sync.
+    """
+    if not partitions or "all" in partitions:
+        return None
+    names = {cfg.chat_llm for name in partitions if (cfg := partition_configs.get(name)) is not None and cfg.chat_llm}
+    return names.pop() if len(names) == 1 else None
+
+
+__all__ = ["PresetRow", "PartitionRow", "PartitionConfig", "PresetType", "resolve_partition_chat_llm"]

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -42,6 +42,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from core.models.preset import resolve_partition_chat_llm
 from core.models.query import Query, SearchQueries
 from core.prompts import (
     SOURCE_SEPARATOR,
@@ -180,20 +181,15 @@ class QueryService:
         unresolvable name here must not fail the chat request; it falls back
         to the default LLM with a warning.
         """
-        if self._llm_factory is None or not partition or "all" in partition:
-            logger.bind(partitions=partition).debug("Answering with the default LLM (no partition-scoped preset)")
+        if self._llm_factory is None:
+            logger.bind(partitions=partition).debug("Answering with the default LLM (no llm_factory wired)")
             return self._llm
-        names = {
-            cfg.chat_llm
-            for name in partition
-            if (cfg := self._config.partitions.get(name)) is not None and cfg.chat_llm
-        }
-        if len(names) != 1:
-            logger.bind(partitions=partition, chat_llm_presets=sorted(names)).debug(
+        chat_llm = resolve_partition_chat_llm(partition, self._config.partitions)
+        if chat_llm is None:
+            logger.bind(partitions=partition).debug(
                 "Answering with the default LLM (no single chat_llm preset among the partitions)"
             )
             return self._llm
-        (chat_llm,) = names
         try:
             llm = self._llm_factory(chat_llm)
         except KeyError:

--- a/tests/unit/core/config/test_model_endpoints.py
+++ b/tests/unit/core/config/test_model_endpoints.py
@@ -71,7 +71,7 @@ def test_model_endpoint_row_non_positive_timeout(timeout: float):
 
 
 # --------------------------------------------------------------------------- #
-# Default-LLM-endpoint token budget accessors
+# Named-LLM-endpoint token budget accessors
 # --------------------------------------------------------------------------- #
 
 
@@ -81,29 +81,44 @@ def _with_default_llm(**extra) -> ModelsConfig:
     return cfg
 
 
-def test_default_llm_token_budgets_none_when_unregistered():
+def test_llm_token_budgets_none_when_unregistered():
     cfg = ModelsConfig()
-    assert cfg.default_llm_extra() == {}
-    assert cfg.default_llm_context_size() is None
-    assert cfg.default_llm_output_tokens() is None
+    assert cfg.llm_extra() == {}
+    assert cfg.llm_context_size() is None
+    assert cfg.llm_output_tokens() is None
 
 
-def test_default_llm_token_budgets_read_from_extra():
+def test_llm_token_budgets_read_from_extra():
     cfg = _with_default_llm(**{LLM_CONTEXT_SIZE_KEY: 32768, LLM_OUTPUT_TOKENS_KEY: 2048})
-    assert cfg.default_llm_context_size() == 32768
-    assert cfg.default_llm_output_tokens() == 2048
+    assert cfg.llm_context_size() == 32768
+    assert cfg.llm_output_tokens() == 2048
 
 
-def test_default_llm_token_budgets_none_when_key_absent():
+def test_llm_token_budgets_none_when_key_absent():
     cfg = _with_default_llm(implementation="vllm")  # unrelated extra key
-    assert cfg.default_llm_context_size() is None
-    assert cfg.default_llm_output_tokens() is None
+    assert cfg.llm_context_size() is None
+    assert cfg.llm_output_tokens() is None
 
 
 @pytest.mark.parametrize("bad", [0, -1, "not-a-number", None, 12.5])
-def test_default_llm_token_budgets_coerce_invalid_to_none(bad):
+def test_llm_token_budgets_coerce_invalid_to_none(bad):
     # A non-positive / non-int stored value means "no override" — the preflight
     # falls back to the global default rather than trusting garbage.
     cfg = _with_default_llm(**{LLM_CONTEXT_SIZE_KEY: bad, LLM_OUTPUT_TOKENS_KEY: bad})
-    assert cfg.default_llm_context_size() is None
-    assert cfg.default_llm_output_tokens() is None
+    assert cfg.llm_context_size() is None
+    assert cfg.llm_output_tokens() is None
+
+
+def test_llm_token_budgets_resolved_by_name():
+    # A partition's chat_llm preset names a catalogued endpoint other than
+    # "default" — the accessor must read that endpoint's extra, not the
+    # default alias's.
+    cfg = ModelsConfig()
+    cfg.llm["default"] = ModelEndpointConfig(endpoint="http://vllm:8000/v1", extra={LLM_CONTEXT_SIZE_KEY: 8192})
+    cfg.llm["mistral"] = ModelEndpointConfig(
+        endpoint="http://mistral:8000/v1", extra={LLM_CONTEXT_SIZE_KEY: 32768, LLM_OUTPUT_TOKENS_KEY: 4096}
+    )
+    assert cfg.llm_context_size("mistral") == 32768
+    assert cfg.llm_output_tokens("mistral") == 4096
+    assert cfg.llm_context_size("default") == 8192
+    assert cfg.llm_context_size("unregistered") is None

--- a/tests/unit/core/models/test_preset_models.py
+++ b/tests/unit/core/models/test_preset_models.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
-from core.models.preset import PartitionConfig, PartitionRow, PresetRow
+from core.models.preset import PartitionConfig, PartitionRow, PresetRow, resolve_partition_chat_llm
 from pydantic import ValidationError
 
 
@@ -55,3 +55,46 @@ def test_partition_config_rejects_negative_chat_history_depth():
             retrieval=RetrievalPipelineConfig(),
             chat_history_depth=-1,
         )
+
+
+def _partition(chat_llm: str | None = None) -> PartitionConfig:
+    return PartitionConfig(
+        name="tenant",
+        indexation=IndexationPipelineConfig(),
+        retrieval=RetrievalPipelineConfig(),
+        chat_llm=chat_llm,
+    )
+
+
+class TestResolvePartitionChatLlm:
+    """resolve_partition_chat_llm — shared by QueryService._resolve_llm (which LLM
+    answers) and the chat-completions token preflight (what budget it's checked
+    against), so both must agree on the same consensus rule."""
+
+    def test_none_partitions_returns_none(self):
+        assert resolve_partition_chat_llm(None, {}) is None
+
+    def test_all_sentinel_returns_none(self):
+        assert resolve_partition_chat_llm(["all"], {"a": _partition(chat_llm="mistral")}) is None
+
+    def test_unknown_partition_returns_none(self):
+        assert resolve_partition_chat_llm(["missing"], {}) is None
+
+    def test_partition_without_preset_returns_none(self):
+        assert resolve_partition_chat_llm(["p"], {"p": _partition()}) is None
+
+    def test_single_partition_preset_resolved(self):
+        configs = {"p": _partition(chat_llm="mistral")}
+        assert resolve_partition_chat_llm(["p"], configs) == "mistral"
+
+    def test_multi_partition_unanimous_preset_resolved(self):
+        configs = {
+            "a": _partition(chat_llm="mistral"),
+            "b": _partition(chat_llm="mistral"),
+            "c": _partition(),  # unset — doesn't veto
+        }
+        assert resolve_partition_chat_llm(["a", "b", "c"], configs) == "mistral"
+
+    def test_multi_partition_conflicting_presets_returns_none(self):
+        configs = {"a": _partition(chat_llm="mistral"), "d": _partition(chat_llm="llama")}
+        assert resolve_partition_chat_llm(["a", "d"], configs) is None

--- a/tests/unit/test_token_validation.py
+++ b/tests/unit/test_token_validation.py
@@ -195,6 +195,71 @@ class TestGetMaxModelTokens:
         assert chat.get_max_model_tokens() == int(s.llm_context.max_llm_context_size)
 
 
+def _partition_config(chat_llm=None):
+    from core.config.indexation_pipeline import IndexationPipelineConfig
+    from core.config.retrieval_pipeline import RetrievalPipelineConfig
+    from core.models.preset import PartitionConfig
+
+    return PartitionConfig(
+        name="p",
+        indexation=IndexationPipelineConfig(),
+        retrieval=RetrievalPipelineConfig(),
+        chat_llm=chat_llm,
+    )
+
+
+class TestPartitionResolvedMaxModelTokens:
+    """get_max_model_tokens resolves the partition's chat_llm preset endpoint
+    over the default when the request is scoped to a partition that sets one —
+    the '639' fix: checking against the LLM that will actually answer, not
+    always the global default."""
+
+    def test_partition_preset_endpoint_budget_wins_over_default(self, monkeypatch):
+        import api.routers.user.chat as chat
+        from core.config.model_endpoints import LLM_CONTEXT_SIZE_KEY, LLM_OUTPUT_TOKENS_KEY, ModelEndpointConfig
+
+        s = _settings_with_default_llm(**{LLM_CONTEXT_SIZE_KEY: 8192})
+        s.models.llm["mistral"] = ModelEndpointConfig(
+            endpoint="http://mistral:8000/v1",
+            extra={LLM_CONTEXT_SIZE_KEY: 32768, LLM_OUTPUT_TOKENS_KEY: 4096},
+        )
+        s.partitions["p"] = _partition_config(chat_llm="mistral")
+        monkeypatch.setattr(chat, "_max_model_tokens", 8000)
+
+        assert chat.get_max_model_tokens(partitions=["p"], settings=s) == 32768
+        # No partition (direct-LLM) still resolves the default endpoint.
+        assert chat.get_max_model_tokens(partitions=None, settings=s) == 8192
+
+    def test_auto_probed_value_not_reused_for_a_non_default_preset(self, monkeypatch):
+        """The startup-primed value is specific to the default endpoint's model —
+        it must not leak into a differently-configured partition preset."""
+        import api.routers.user.chat as chat
+        from core.config.model_endpoints import ModelEndpointConfig
+
+        s = _settings_with_default_llm()  # no explicit context size configured
+        s.models.llm["mistral"] = ModelEndpointConfig(endpoint="http://mistral:8000/v1")
+        s.partitions["p"] = _partition_config(chat_llm="mistral")
+        monkeypatch.setattr(chat, "_max_model_tokens", 8000)
+
+        assert chat.get_max_model_tokens(partitions=["p"], settings=s) == int(s.llm_context.max_llm_context_size)
+        assert chat.get_max_model_tokens(partitions=None, settings=s) == 8000
+
+    def test_conflicting_partition_presets_fall_back_to_default(self, monkeypatch):
+        import api.routers.user.chat as chat
+        from core.config.model_endpoints import LLM_CONTEXT_SIZE_KEY, ModelEndpointConfig
+
+        s = _settings_with_default_llm(**{LLM_CONTEXT_SIZE_KEY: 8192})
+        s.models.llm["mistral"] = ModelEndpointConfig(
+            endpoint="http://mistral:8000/v1", extra={LLM_CONTEXT_SIZE_KEY: 32768}
+        )
+        s.models.llm["llama"] = ModelEndpointConfig(endpoint="http://llama:8000/v1", extra={LLM_CONTEXT_SIZE_KEY: 4096})
+        s.partitions["a"] = _partition_config(chat_llm="mistral")
+        s.partitions["b"] = _partition_config(chat_llm="llama")
+        monkeypatch.setattr(chat, "_max_model_tokens", None)
+
+        assert chat.get_max_model_tokens(partitions=["a", "b"], settings=s) == 8192
+
+
 class TestDefaultMaxTokensFactory:
     """The request-schema default_factory prefers the default endpoint's budget."""
 

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -615,8 +615,8 @@ function EndpointDialog({
                 />
               </div>
               <p className="col-span-2 text-xs text-muted-foreground">
-                Token budgets for this endpoint. Leave blank to use the system default. Applied when this is the
-                default LLM endpoint.
+                Token budgets for this endpoint. Leave blank to use the system default. Applied whenever this
+                endpoint answers a request — as the default LLM, or as a partition&apos;s chat LLM preset.
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary
- The token preflight (`check_tokens_limit` / `get_max_model_tokens`) only ever read the "default" LLM endpoint's admin-configured budgets, even though a partition can be answered by a different `chat_llm` preset endpoint (`QueryService._resolve_llm`) — so the preflight could check against the wrong context window.
- Extracts `resolve_partition_chat_llm()` as a shared consensus rule used by both `QueryService._resolve_llm` (which LLM answers) and the chat-completions preflight (what budget it's checked against), so the two can't fall out of sync.
- Generalizes `ModelsConfig` accessors (`default_llm_context_size` → `llm_context_size(name)`, etc.) to read any catalogued endpoint's budget, not just `"default"`.
- Admin UI copy updated to reflect that the token budget fields apply whenever the endpoint answers a request (default LLM or a partition's chat LLM preset).

**Status: WIP** — parking this increment for review before continuing.

## Test plan
- [x] `uv run pytest tests/unit/` — 1700 passed
- [x] `uv run ruff check openrag/ tests/` — clean
- [x] `npx vitest run` (ui) — passed
- [x] `npx tsc -b` (ui) — clean
- [ ] Manual verification in the admin UI (not yet done)