### PR TITLE
fix(admin-ui): keep card actions, badges, and long config values inside the card on resize

### DIFF
--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -165,11 +165,11 @@ export default function ModelsPage() {
                     return (
                       <Card key={`${ep.model_type}-${ep.name}`}>
                         <CardHeader className="pb-3">
-                          <div className="flex items-center justify-between">
-                            <CardTitle className="text-base truncate">
+                          <div className="flex items-center justify-between gap-2">
+                            <CardTitle className="text-base truncate min-w-0">
                               {ep.name}
                             </CardTitle>
-                            <div className="flex items-center gap-1.5">
+                            <div className="flex items-center gap-1.5 shrink-0">
                               {isDefault && (
                                 <Badge variant="secondary" className="text-xs">Default</Badge>
                               )}
@@ -197,7 +197,7 @@ export default function ModelsPage() {
                           <div className="text-xs text-muted-foreground">
                             Updated {formatDate(ep.updated_at)}
                           </div>
-                          <div className="flex gap-2 pt-2">
+                          <div className="flex flex-wrap gap-2 pt-2">
                             {!isDefault && (
                               <Button
                                 size="sm"

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -156,7 +156,7 @@ export default function PresetsPage() {
                     <Card key={`${preset.preset_type}-${preset.name}`} className="flex flex-col">
                       <CardHeader className="pb-3">
                         <div className="flex items-center justify-between gap-2">
-                          <CardTitle className="text-base">{preset.name}</CardTitle>
+                          <CardTitle className="text-base truncate min-w-0">{preset.name}</CardTitle>
                           <Badge
                             variant="outline"
                             className={
@@ -174,7 +174,11 @@ export default function PresetsPage() {
                       <CardContent className="flex flex-col flex-1 text-sm">
                         <div className="flex flex-wrap gap-1 flex-1">
                           {summarizeConfig(preset.config).map((s, i) => (
-                            <Badge key={i} variant="secondary" className="text-xs h-fit">
+                            <Badge
+                              key={i}
+                              variant="secondary"
+                              className="text-xs h-fit max-w-full whitespace-normal break-words text-left"
+                            >
                               {s}
                             </Badge>
                           ))}
@@ -187,7 +191,7 @@ export default function PresetsPage() {
                         <div className="text-xs text-muted-foreground mt-3">
                           Updated {formatDate(preset.updated_at)}
                         </div>
-                        <div className="flex gap-2 pt-3">
+                        <div className="flex flex-wrap gap-2 pt-3">
                           <Button
                             size="sm"
                             variant="outline"


### PR DESCRIPTION
## What

Keep card content inside the card on the admin **LLM Endpoints** and **Presets** pages when the window narrows. Fixes three overflow cases that all stem from the shadcn `Button`/`Badge` primitives being `whitespace-nowrap shrink-0` while `Card` has no overflow clip.

## Changes

`ui/src/pages/admin/models.tsx`
- Button row `flex gap-2 pt-2` → `flex flex-wrap gap-2 pt-2` (buttons wrap instead of spilling).
- Header row gains `gap-2`; title `truncate` gains `min-w-0` (so it actually truncates); badge wrapper gains `shrink-0` (stays pinned).

`ui/src/pages/admin/presets.tsx`
- Button row `flex gap-2 pt-3` → `flex flex-wrap gap-2 pt-3`.
- Title gains `truncate min-w-0`.
- Config summary chips gain `max-w-full whitespace-normal break-words text-left`, so a long value (e.g. `topic_tagging_llm: Mistral-Small-3.2-24B-Instruct-2506-FP8`) wraps within the card.

Seven class changes, no layout/structure changes.

## Testing

- `tsc -b` clean; `eslint` clean on both files.
- Verified visually at narrow widths (mock data) on the Models and Presets pages: buttons wrap, title truncates, badge stays pinned, long config chips wrap — all contained within the card, light and dark.

Fixes #666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the admin Models card header spacing and title behavior for narrow screens.
  * Updated title constraints to preserve truncation without layout glitches.
  * Enhanced Presets configuration badges to wrap, break long text, and stay readable.
  * Changed admin card action/footer areas to wrap onto additional lines when space is constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->