### PR TITLE
fix(indexer): re-index no longer duplicates a file's chunks in Milvus

### DIFF
--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -273,9 +273,10 @@ async def put_file(
             detail=f"'{file_id}' not found in partition '{partition}'",
         )
 
-    # No Milvus deletion here. The Indexer's add_file(replace=True) flow uses
-    # insert-before-delete: it snapshots old chunk IDs, inserts new chunks,
-    # then deletes old ones — so the file is never left in a half-replaced state.
+    # No Milvus deletion here. The indexing pipeline is insert-before-delete on
+    # replace: it snapshots the file's existing chunk ids, stores the new chunks,
+    # then deletes the old set (see ``IndexingPipeline.run``, #657) — so the file
+    # is never left in a half-replaced state.
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
     file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -275,8 +275,10 @@ async def put_file(
 
     # No Milvus deletion here. The indexing pipeline is insert-before-delete on
     # replace: it snapshots the file's existing chunk ids, stores the new chunks,
-    # then deletes the old set (see ``IndexingPipeline.run``, #657) — so the file
-    # is never left in a half-replaced state.
+    # then deletes the old set (see ``IndexingPipeline.run``, #657). The guarantee
+    # is "no empty window" — a failed/crashed re-index keeps the old chunks rather
+    # than zero — not atomicity: a crash between store and delete can leave stale
+    # duplicates behind (recoverable; #658/#660 reconciliation covers that).
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
     file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -187,7 +187,18 @@ class IndexingPipeline:
                     per_chunk_timeout=self.timeouts.store_per_chunk,
                 ),
             )
-            if replace and old_chunk_ids:
+            # BUG (#657 follow-up): ``store_stage`` completes successfully even
+            # when it stores zero chunks — an empty/whitespace-only file, a
+            # parser that extracts no text, etc. all legitimately chunk down to
+            # ``[]`` without raising (see chunk_stage / BaseChunker.chunk). If the
+            # delete below fired on ``old_chunk_ids`` alone, a re-index that
+            # produces no new chunks would delete the *entire* previous chunk set
+            # and leave the file with zero chunks in Milvus — worse than the
+            # pre-fix duplication bug, and a violation of the "no empty window"
+            # guarantee this whole insert-before-delete design is built on.
+            # Gating on ``stored_count`` ensures cleanup only runs once we know
+            # the new set actually replaced the old one.
+            if replace and old_chunk_ids and row.get("stored_count"):
                 await self._delete_replaced_chunks(row, old_chunk_ids)
             return row
         finally:

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -15,6 +15,7 @@ from core.models.document import Document, DocumentType
 from core.utils.logging import get_logger
 from core.vector_stores.vector_store import VectorStore
 from core.vlm.vlm import VLM
+from services.workers.stages._common import run_with_optional_timeout
 from services.workers.stages.caption import caption_stage
 from services.workers.stages.chunk import chunk_stage
 from services.workers.stages.contextualize import contextualize_stage
@@ -209,10 +210,16 @@ class IndexingPipeline:
         file_id, partition = _replace_target(row)
         if not file_id or not partition:
             return []
-        try:
+
+        async def _lookup() -> list[str]:
             if not await self.vector_store.collection_exists("default"):
                 return []
             return await self.vector_store.query_ids_by_filter("default", {"partition": partition, "file_id": file_id})
+
+        try:
+            # Bound the lookup by the store budget so a stalled Milvus can't hang
+            # replace indexing indefinitely (a timeout just skips cleanup).
+            return await run_with_optional_timeout(_lookup, self.timeouts.store)
         except Exception as exc:  # noqa: BLE001 - cleanup lookup must not fail the index
             logger.bind(task_id=row.get("task_id"), file_id=file_id, partition=partition).warning(
                 f"re-index: could not snapshot existing chunks; skipping stale-chunk cleanup: {exc}"
@@ -227,7 +234,11 @@ class IndexingPipeline:
         reconciliation), mirroring ``WorkerDispatcher.delete_file``.
         """
         try:
-            deleted = await self.vector_store.delete(ids, "default")
+            # Bound by the store budget: the new chunks are already stored, so a
+            # stalled delete must not hang the task — it degrades to duplicates.
+            deleted = await run_with_optional_timeout(
+                lambda: self.vector_store.delete(ids, "default"), self.timeouts.store
+            )
             logger.bind(task_id=row.get("task_id")).debug(f"re-index: removed {deleted} stale chunk(s) after replace")
         except Exception as exc:  # noqa: BLE001 - new chunks are stored; cleanup is best-effort
             logger.bind(task_id=row.get("task_id")).error(

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -156,6 +156,27 @@ class IndexingPipeline:
                     per_chunk_timeout=self.timeouts.embed_per_chunk,
                 ),
             )
+            # Re-index (``replace=True``) is insert-before-delete: snapshot the
+            # file's existing chunk ids *before* the store stage inserts the new
+            # set, then delete exactly that old set *after* a successful insert.
+            # The Milvus collection is ``auto_id``, so a plain insert can never
+            # overwrite the previous chunks — without this cleanup every re-index
+            # duplicates the whole file (#657). Insert-before-delete also means a
+            # re-index that fails before/at store leaves the old chunks intact
+            # (never an empty window).
+            #
+            # KNOWN SEAMS (Milvus has no transactions — both are strictly better
+            # than the pre-fix behaviour, which duplicated on every re-index):
+            #   * Not atomic under concurrency. Two overlapping re-indexes of the
+            #     *same* file snapshot the same old ids and both keep their new
+            #     set, leaving duplicates. Serializing replace per (partition,
+            #     file_id) belongs with the durable job/lifecycle work (#658/#660).
+            #   * A crash between store and delete orphans the old chunks with no
+            #     reconciler yet (the delete below logs for reconciliation, same
+            #     best-effort contract as WorkerDispatcher.delete_file) — the
+            #     reconciliation job is tracked in #658/#660.
+            replace = bool(row.get("replace"))
+            old_chunk_ids = await self._existing_chunk_ids(row) if replace else []
             await _timed(
                 "store",
                 store_stage(
@@ -165,6 +186,8 @@ class IndexingPipeline:
                     per_chunk_timeout=self.timeouts.store_per_chunk,
                 ),
             )
+            if replace and old_chunk_ids:
+                await self._delete_replaced_chunks(row, old_chunk_ids)
             return row
         finally:
             logger.bind(
@@ -174,6 +197,43 @@ class IndexingPipeline:
                 **{f"ms_{name}": round(value) for name, value in timings.items()},
                 ms_total=round(sum(timings.values())),
             ).info("indexing stage timings (ms)")
+
+    async def _existing_chunk_ids(self, row: MutableMapping[str, Any]) -> list[str]:
+        """Snapshot the chunk ids currently stored for this file (re-index only).
+
+        Returns an empty list — skipping stale-chunk cleanup — when the target
+        can't be resolved or the lookup fails. A snapshot failure must never lose
+        the newly-indexed chunks: leftover duplicates are recoverable, deleting
+        blindly is not.
+        """
+        file_id, partition = _replace_target(row)
+        if not file_id or not partition:
+            return []
+        try:
+            if not await self.vector_store.collection_exists("default"):
+                return []
+            return await self.vector_store.query_ids_by_filter("default", {"partition": partition, "file_id": file_id})
+        except Exception as exc:  # noqa: BLE001 - cleanup lookup must not fail the index
+            logger.bind(task_id=row.get("task_id"), file_id=file_id, partition=partition).warning(
+                f"re-index: could not snapshot existing chunks; skipping stale-chunk cleanup: {exc}"
+            )
+            return []
+
+    async def _delete_replaced_chunks(self, row: MutableMapping[str, Any], ids: list[str]) -> None:
+        """Delete the pre-re-index chunk set after the new chunks are stored.
+
+        Best-effort: the new chunks are already safely inserted, so a delete
+        failure only leaves recoverable duplicates behind (logged for
+        reconciliation), mirroring ``WorkerDispatcher.delete_file``.
+        """
+        try:
+            deleted = await self.vector_store.delete(ids, "default")
+            logger.bind(task_id=row.get("task_id")).debug(f"re-index: removed {deleted} stale chunk(s) after replace")
+        except Exception as exc:  # noqa: BLE001 - new chunks are stored; cleanup is best-effort
+            logger.bind(task_id=row.get("task_id")).error(
+                f"re-index: stored new chunks but failed to delete {len(ids)} stale chunk(s); "
+                f"duplicates remain until reconciliation: {exc}"
+            )
 
     def _effective_indexation_config(self, row: MutableMapping[str, Any]) -> IndexationPipelineConfig | None:
         raw_config = row.get("indexation_config", self.indexation_config)
@@ -317,6 +377,19 @@ def build_indexing_pipeline(
         contextualizer_factory=contextualizer_factory,
         topic_tagger_factory=topic_tagger_factory,
     )
+
+
+def _replace_target(row: MutableMapping[str, Any]) -> tuple[str | None, str | None]:
+    """Resolve ``(file_id, partition)`` for a re-index row.
+
+    ``file_id`` is the document's identity (``Document.id`` == ``Chunk.file_id``
+    in Milvus); ``partition`` scopes the delete so only this file's chunks in
+    this partition are ever touched.
+    """
+    document = row.get("document")
+    file_id = getattr(document, "id", None)
+    partition = row.get("partition") or getattr(document, "partition", None)
+    return file_id, partition
 
 
 __all__ = ["IndexingPipeline", "PipelineTimeouts", "build_indexing_pipeline"]

--- a/tests/integration/test_reindex_no_duplicate_integration.py
+++ b/tests/integration/test_reindex_no_duplicate_integration.py
@@ -160,3 +160,35 @@ async def test_reindex_does_not_touch_other_files(store: MilvusVectorStore) -> N
 
     assert await _count_chunks(store, partition, "file-a") == 2
     assert await _count_chunks(store, partition, "file-b") == 2
+
+
+@pytest.mark.asyncio
+async def test_reindex_is_scoped_by_partition(store: MilvusVectorStore) -> None:
+    # Cleanup is filtered by (partition, file_id): the SAME file_id in a different
+    # partition must be untouched when one partition's copy is re-indexed.
+    file_id = "shared-id"
+    pipeline = build_indexing_pipeline(
+        parser=_FakeParser(n_blocks=2),
+        chunker=_FakeChunker(),
+        embedder=_FakeEmbedder(),
+        vector_store=store,
+    )
+
+    def _row(partition: str, replace: bool) -> dict:
+        return {
+            "document": Document(id=file_id, filename="doc.txt", text="x", partition=partition),
+            "partition": partition,
+            "replace": replace,
+        }
+
+    await pipeline.run(_row("tenant-a", replace=False))
+    await pipeline.run(_row("tenant-b", replace=False))
+    tenant_b_ids = set(await store.query_ids_by_filter("default", {"partition": "tenant-b", "file_id": file_id}))
+    assert len(tenant_b_ids) == 2
+
+    # Re-index the file in tenant-a only.
+    await pipeline.run(_row("tenant-a", replace=True))
+
+    assert await _count_chunks(store, "tenant-a", file_id) == 2
+    # tenant-b's chunks are the exact same rows as before — untouched.
+    assert set(await store.query_ids_by_filter("default", {"partition": "tenant-b", "file_id": file_id})) == tenant_b_ids

--- a/tests/integration/test_reindex_no_duplicate_integration.py
+++ b/tests/integration/test_reindex_no_duplicate_integration.py
@@ -191,4 +191,6 @@ async def test_reindex_is_scoped_by_partition(store: MilvusVectorStore) -> None:
 
     assert await _count_chunks(store, "tenant-a", file_id) == 2
     # tenant-b's chunks are the exact same rows as before — untouched.
-    assert set(await store.query_ids_by_filter("default", {"partition": "tenant-b", "file_id": file_id})) == tenant_b_ids
+    assert (
+        set(await store.query_ids_by_filter("default", {"partition": "tenant-b", "file_id": file_id})) == tenant_b_ids
+    )

--- a/tests/integration/test_reindex_no_duplicate_integration.py
+++ b/tests/integration/test_reindex_no_duplicate_integration.py
@@ -1,0 +1,162 @@
+"""Integration proof for #657 — re-indexing must not duplicate Milvus chunks.
+
+Drives the real :class:`IndexingPipeline` (with trivial parser/chunker/embedder
+fakes) against a live Milvus 2.6, indexing a file and then re-indexing it with
+``replace=True``. Asserts the file's chunk count stays stable (insert-before-
+delete) instead of doubling on every re-index.
+
+Auto-skips when Milvus isn't reachable. Run against the integration stack:
+
+    docker compose -f tests/integration/repos/docker-compose.yaml up -d
+    uv run pytest tests/integration/test_reindex_no_duplicate_integration.py -m integration
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from core.config.infrastructure import VectorDBConfig
+from core.models.chunk import Chunk, ChunkType
+from core.models.document import Document, ProcessedDocument, TextBlock
+from services.storage.milvus_store import MilvusVectorStore
+from services.workers.pipeline_builder import build_indexing_pipeline
+
+pytestmark = pytest.mark.integration
+
+
+def _milvus_reachable(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture
+def store() -> Iterator[MilvusVectorStore]:
+    host = os.getenv("OPENRAG_TEST_VDB_HOST", "localhost")
+    port = int(os.getenv("OPENRAG_TEST_VDB_PORT", "19530"))
+    if not _milvus_reachable(host, port):
+        pytest.skip(f"Milvus not reachable at {host}:{port}")
+    config = VectorDBConfig(
+        host=host,
+        port=port,
+        collection_name=f"itest_{uuid.uuid4().hex[:12]}",
+        hybrid_search=True,
+        schema_version=1,
+    )
+    s = MilvusVectorStore(config)
+    try:
+        yield s
+    finally:
+        try:
+            if s._client.has_collection(config.collection_name):
+                s._client.drop_collection(config.collection_name)
+        except Exception:
+            pass
+
+
+class _FakeParser:
+    def __init__(self, n_blocks: int) -> None:
+        self.n_blocks = n_blocks
+
+    async def parse(self, document: Document) -> ProcessedDocument:
+        return ProcessedDocument(
+            document_id=document.id,
+            text_blocks=[TextBlock(text=f"{document.id} block {i}") for i in range(self.n_blocks)],
+        )
+
+    def supported_types(self) -> list[str]:
+        return ["text"]
+
+
+class _FakeChunker:
+    """One chunk per text block, carrying the file identity Milvus filters on."""
+
+    def chunk(self, document: ProcessedDocument, partition: str = "default") -> list[Chunk]:
+        return [
+            Chunk(
+                id=f"{document.document_id}-{i}",
+                text=block.text,
+                partition=partition,
+                document_id=document.document_id,
+                chunk_type=ChunkType.TEXT,
+            )
+            for i, block in enumerate(document.text_blocks)
+        ]
+
+
+class _FakeEmbedder:
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+
+async def _count_chunks(store: MilvusVectorStore, partition: str, file_id: str) -> int:
+    ids = await store.query_ids_by_filter("default", {"partition": partition, "file_id": file_id})
+    return len(ids)
+
+
+@pytest.mark.asyncio
+async def test_reindex_replaces_chunks_instead_of_duplicating(store: MilvusVectorStore) -> None:
+    partition = "tenant-a"
+    file_id = "reindex-me"
+    pipeline = build_indexing_pipeline(
+        parser=_FakeParser(n_blocks=3),
+        chunker=_FakeChunker(),
+        embedder=_FakeEmbedder(),
+        vector_store=store,
+    )
+
+    def _row(replace: bool) -> dict:
+        return {
+            "document": Document(id=file_id, filename="doc.txt", text="x", partition=partition),
+            "partition": partition,
+            "replace": replace,
+            "task_id": "t-657",
+        }
+
+    # First index: 3 chunks.
+    await pipeline.run(_row(replace=False))
+    first_ids = set(await store.query_ids_by_filter("default", {"partition": partition, "file_id": file_id}))
+    assert len(first_ids) == 3
+
+    # Re-index twice with replace=True: count must stay at 3, not grow to 6 then 9.
+    await pipeline.run(_row(replace=True))
+    assert await _count_chunks(store, partition, file_id) == 3
+
+    await pipeline.run(_row(replace=True))
+    second_ids = set(await store.query_ids_by_filter("default", {"partition": partition, "file_id": file_id}))
+    assert len(second_ids) == 3
+
+    # The surviving chunks are the freshly-stored set — the originals were deleted.
+    assert first_ids.isdisjoint(second_ids)
+
+
+@pytest.mark.asyncio
+async def test_reindex_does_not_touch_other_files(store: MilvusVectorStore) -> None:
+    partition = "tenant-a"
+    pipeline = build_indexing_pipeline(
+        parser=_FakeParser(n_blocks=2),
+        chunker=_FakeChunker(),
+        embedder=_FakeEmbedder(),
+        vector_store=store,
+    )
+
+    def _row(file_id: str, replace: bool) -> dict:
+        return {
+            "document": Document(id=file_id, filename=f"{file_id}.txt", text="x", partition=partition),
+            "partition": partition,
+            "replace": replace,
+        }
+
+    await pipeline.run(_row("file-a", replace=False))
+    await pipeline.run(_row("file-b", replace=False))
+    # Re-index file-a only; file-b must be untouched.
+    await pipeline.run(_row("file-a", replace=True))
+
+    assert await _count_chunks(store, partition, "file-a") == 2
+    assert await _count_chunks(store, partition, "file-b") == 2

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -678,3 +678,124 @@ async def test_pipeline_breadcrumb_reflects_resolved_named_endpoints(monkeypatch
     assert recorder.debug_bound["contextualization_llm"] == "ctx-llm"
     assert recorder.debug_bound["topic_tagging_llm"] == "topic-llm"
     assert recorder.debug_bound["embedder"] == "embed-fast"
+
+
+class RecordingVectorStore:
+    """Vector store fake that logs call order so tests can assert the re-index
+    insert-before-delete contract (#657)."""
+
+    def __init__(self, existing_ids: list[str] | None = None) -> None:
+        self.existing_ids = list(existing_ids or [])
+        self.events: list[str] = []
+        self.query_filters: list[dict] = []
+        self.deleted: list[list[str]] = []
+        self.collection_exists_result = True
+        self.query_error: Exception | None = None
+        self.delete_error: Exception | None = None
+
+    async def collection_exists(self, name: str) -> bool:
+        return self.collection_exists_result
+
+    async def query_ids_by_filter(self, collection: str, filters: dict) -> list[str]:
+        self.events.append("query")
+        self.query_filters.append(filters)
+        if self.query_error is not None:
+            raise self.query_error
+        return list(self.existing_ids)
+
+    async def upsert(self, chunks: list[Chunk], collection: str = "default", *, indexed_at=None) -> int:
+        self.events.append("upsert")
+        return len(chunks)
+
+    async def ensure_collection(self, name: str, dimension: int, **kwargs) -> None:
+        pass
+
+    async def delete(self, ids: list[str], collection: str = "default") -> int:
+        self.events.append("delete")
+        if self.delete_error is not None:
+            raise self.delete_error
+        self.deleted.append(list(ids))
+        return len(ids)
+
+
+def _reindex_pipeline(vector_store):
+    document = Document(filename="note.txt", text="hi", partition="tenant-a")
+    processed = ProcessedDocument(document_id=document.id, text_blocks=[TextBlock(text="hi")])
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([Chunk(id="c1", text="hi", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=vector_store,
+    )
+    return pipeline, document
+
+
+@pytest.mark.asyncio
+async def test_reindex_deletes_prior_chunks_only_after_storing_new():
+    # #657: replace=True must snapshot the file's existing chunks, store the new
+    # set, then delete exactly the old set — insert-before-delete, so a re-index
+    # never leaves an empty window and never duplicates chunks.
+    vs = RecordingVectorStore(existing_ids=["101", "102"])
+    pipeline, document = _reindex_pipeline(vs)
+
+    await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
+    # Snapshot is scoped to this file + partition only.
+    assert vs.query_filters == [{"partition": "tenant-a", "file_id": document.id}]
+    # Old chunks removed, and strictly after the new insert.
+    assert vs.deleted == [["101", "102"]]
+    assert vs.events == ["query", "upsert", "delete"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_no_delete_when_file_had_no_prior_chunks():
+    vs = RecordingVectorStore(existing_ids=[])
+    pipeline, document = _reindex_pipeline(vs)
+
+    await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
+    assert vs.query_filters == [{"partition": "tenant-a", "file_id": document.id}]
+    assert vs.deleted == []
+    assert "delete" not in vs.events
+
+
+@pytest.mark.asyncio
+async def test_first_time_index_never_queries_or_deletes():
+    # Without replace, the plain insert path is untouched (no snapshot, no delete).
+    vs = RecordingVectorStore(existing_ids=["999"])
+    pipeline, document = _reindex_pipeline(vs)
+
+    await pipeline.run({"document": document, "partition": "tenant-a"})
+
+    assert vs.query_filters == []
+    assert vs.deleted == []
+    assert vs.events == ["upsert"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_snapshot_failure_skips_cleanup_but_still_indexes():
+    # A snapshot lookup failure must not lose the new indexing: duplicates are
+    # recoverable, deleting blindly is not. Indexing completes; cleanup is skipped.
+    vs = RecordingVectorStore(existing_ids=["1"])
+    vs.query_error = RuntimeError("milvus unavailable")
+    pipeline, document = _reindex_pipeline(vs)
+
+    row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
+    assert row["stage"] == "stored"
+    assert "upsert" in vs.events
+    assert vs.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_reindex_delete_failure_is_best_effort():
+    # New chunks are already stored, so a cleanup delete failure must not fail the
+    # re-index (mirrors WorkerDispatcher.delete_file's best-effort cleanup).
+    vs = RecordingVectorStore(existing_ids=["1"])
+    vs.delete_error = RuntimeError("delete failed")
+    pipeline, document = _reindex_pipeline(vs)
+
+    row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
+    assert row["stage"] == "stored"
+    assert vs.events == ["query", "upsert", "delete"]

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -799,3 +799,29 @@ async def test_reindex_delete_failure_is_best_effort():
 
     assert row["stage"] == "stored"
     assert vs.events == ["query", "upsert", "delete"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_with_zero_new_chunks_keeps_old_chunks():
+    # Regression guard: a blank/whitespace-only file, or a parser that extracts
+    # no text, legitimately chunks down to [] without raising (chunk_stage /
+    # BaseChunker.chunk both treat this as success). If the old snapshot were
+    # deleted whenever it was merely non-empty, a re-index that stores zero new
+    # chunks would wipe the file's entire previous chunk set — worse than the
+    # pre-fix duplication bug, and a violation of the "no empty window"
+    # guarantee. The old chunks must survive when nothing new was stored.
+    vs = RecordingVectorStore(existing_ids=["101", "102"])
+    document = Document(filename="blank.txt", text="", partition="tenant-a")
+    processed = ProcessedDocument(document_id=document.id, text_blocks=[])
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([]),
+        embedder=FakeEmbedder([]),
+        vector_store=vs,
+    )
+
+    row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
+    assert row["stored_count"] == 0
+    assert vs.deleted == []
+    assert "delete" not in vs.events


### PR DESCRIPTION
## What

Re-indexing an existing file (`PUT /indexer/partition/{partition}/file/{file_id}`, `replace=True`) no longer duplicates the file's chunks in Milvus. Previously the replace path only rewrote the Postgres catalog row and topic tags, then inserted a fresh full set of chunks — but the Milvus collection is `auto_id`, so a plain insert can never overwrite the old chunks. Every re-index therefore left the previous chunks in place and appended a new copy, compounding on each run: search returned duplicated + stale content and vector storage grew without bound.

This was a regression introduced by the hexagonal / Ray-removal refactor (v2.0.0): the legacy `Indexer.add_file(replace=True)` flow did insert-before-delete; the new worker pipeline dropped the delete step.

## How

`IndexingPipeline.run` (`services/workers/pipeline_builder.py`) is now **insert-before-delete** on `replace=True`:

1. **Snapshot** the file's existing chunk ids *before* the store stage runs — `query_ids_by_filter({"partition": partition, "file_id": file_id})`, scoped strictly to this file in this partition.
2. **Store** the new chunks (unchanged store stage).
3. **Delete** exactly the snapshotted old ids *after* the new chunks are safely stored — `delete(old_ids)`.

This reuses the same `query_ids_by_filter` + `delete` primitives that `WorkerDispatcher.delete_file` already uses in production, so the Milvus mechanics are proven.

### Safety properties

- **No empty window.** Snapshot-before / delete-after means a re-index that fails at or before the store stage leaves the old chunks intact — the file is never left with zero chunks.
- **Snapshot failure is safe.** If the pre-insert lookup fails (e.g. Milvus hiccup), cleanup is skipped and indexing still completes. Leftover duplicates are recoverable; losing the freshly-indexed content is not.
- **Delete failure is best-effort.** The new chunks are already stored, so a cleanup delete failure only leaves recoverable duplicates behind (logged for reconciliation) — mirrors `delete_file`.
- **Scoped.** The snapshot/delete is filtered by `{partition, file_id}`, so a re-index never touches other files or other tenants.

First-time indexing (`replace=False`) is completely untouched — no extra query, no delete.

## Known limitations (flagged, not fixed here)

Milvus has no transactions, so this fix is intentionally scoped to the common case. Both seams below are **strictly better than the pre-fix behaviour** (which duplicated on *every* re-index) and are called out in a code comment on the replace block:

- **Not atomic under concurrency.** Two overlapping re-indexes of the *same* file both snapshot the same old ids and both keep their new set, leaving duplicates. Serializing replace per `(partition, file_id)` (e.g. a Postgres advisory lock) belongs with the durable job/lifecycle work — see #658/#660.
- **No reconciler for the crash window.** A process crash between store and delete orphans the old chunks; the delete is best-effort and logged (same contract as `WorkerDispatcher.delete_file`), but the reconciliation job doesn't exist yet — tracked in #658/#660.

These are deliberately out of scope for a v2.0.1 patch: they need the partition-epoch / reconciliation machinery, not a bigger change to the hot re-index path.

## Tests

- **Unit** (`tests/unit/services/workers/test_pipeline_builder.py`, 5 new): insert-before-delete ordering (`query → upsert → delete`), `{partition, file_id}` scoping, no-delete-when-file-had-no-prior-chunks, first-time index issues no query/delete, snapshot-failure still indexes + skips cleanup, delete-failure is best-effort.
- **Integration vs. real Milvus 2.6** (`tests/integration/test_reindex_no_duplicate_integration.py`, 2 new): drives the actual pipeline — re-indexing a 3-chunk file twice keeps the count at 3 (not 6, then 9) and the survivors are the freshly-stored set; re-indexing one file leaves another file's chunks untouched. Auto-skips when Milvus isn't reachable.

Full unit suite green (1668 passed); ruff + layer-import guard clean.

Fixes #657


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-indexing with `replace=True` no longer creates duplicate chunks.
  * Replacement is correctly scoped to the selected file and partition.
  * Cleanup is safer: prior chunks are removed only after new chunks are successfully stored, avoiding the “empty window” case and using best-effort cleanup if snapshot/query/delete encounters errors.

* **Tests**
  * Added integration tests for repeated re-indexing, partition scoping, and re-indexing a single file.
  * Added unit tests validating insert-before-delete semantics and best-effort behavior when snapshot/query/delete fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->