### PR TITLE
fix(indexing): delete vectors before catalog rows

### DIFF
--- a/openrag/core/indexing/dispatcher.py
+++ b/openrag/core/indexing/dispatcher.py
@@ -38,6 +38,7 @@ class IndexingDispatcher(ABC):
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
         require_existing_partition: bool = False,
+        allow_legacy_require_existing_partition_retry: bool = False,
     ) -> str:
         """Queue an (re)indexing job, register its task state, return its id."""
         ...

--- a/openrag/core/indexing/dispatcher.py
+++ b/openrag/core/indexing/dispatcher.py
@@ -37,6 +37,7 @@ class IndexingDispatcher(ABC):
         replace: bool,
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
+        require_existing_partition: bool = False,
     ) -> str:
         """Queue an (re)indexing job, register its task state, return its id."""
         ...

--- a/openrag/core/utils/conts.py
+++ b/openrag/core/utils/conts.py
@@ -8,3 +8,13 @@ IMG_WRAPPER_OPEN = "<image_description>\n\n"
 IMG_WRAPPER_CLOSE = "\n\n</image_description>"
 
 IMAGE_PLACEHOLDER = f"""{IMG_WRAPPER_OPEN}[Image Placeholder]{IMG_WRAPPER_CLOSE}"""
+
+INTERNAL_METADATA_PREFIX = "_openrag"
+
+
+def is_internal_metadata_key(key: object) -> bool:
+    return isinstance(key, str) and key.startswith(INTERNAL_METADATA_PREFIX)
+
+
+def strip_internal_metadata(row: dict) -> dict:
+    return {key: value for key, value in row.items() if not is_internal_metadata_key(key)}

--- a/openrag/core/vector_stores/vector_store.py
+++ b/openrag/core/vector_stores/vector_store.py
@@ -59,6 +59,11 @@ class VectorStore(ABC):
         ...
 
     @abstractmethod
+    async def delete_by_filter(self, filters: dict[str, Any]) -> int:
+        """Delete chunks matching the given filter expression. Returns count."""
+        ...
+
+    @abstractmethod
     async def ensure_collection(self, name: str, dimension: int, **kwargs: Any) -> None:
         """Create collection if it doesn't exist."""
         ...

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -403,6 +403,7 @@ class ServiceContainer:
         """PartitionService — lazily built, cached for the container's lifetime."""
         if self._partition_service is None:
             from services.orchestrators.partition_service import PartitionService
+            from services.workers.bootstrap import get_task_state_manager
 
             settings = self._require_settings()
             self._partition_service = PartitionService(
@@ -413,6 +414,7 @@ class ServiceContainer:
                 user_repo=self.user_repo,
                 collection=settings.vectordb.collection_name,
                 config=settings,
+                task_state_manager_factory=get_task_state_manager,
             )
         return self._partition_service
 

--- a/openrag/services/orchestrators/conversion_service.py
+++ b/openrag/services/orchestrators/conversion_service.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from core.utils.conts import is_internal_metadata_key
 from core.utils.logging import get_logger
 from core.utils.text import sanitize_extracted_text
 
@@ -96,9 +97,5 @@ __all__ = ["ConversionService"]
 
 def _public_chunk_metadata(row: dict) -> dict:
     return {
-        key: value for key, value in row.items() if key not in ("text", "vector") and not _is_internal_metadata_key(key)
+        key: value for key, value in row.items() if key not in ("text", "vector") and not is_internal_metadata_key(key)
     }
-
-
-def _is_internal_metadata_key(key: object) -> bool:
-    return isinstance(key, str) and key.startswith("_openrag")

--- a/openrag/services/orchestrators/conversion_service.py
+++ b/openrag/services/orchestrators/conversion_service.py
@@ -87,8 +87,18 @@ class ConversionService:
         row = rows[0]
         return {
             "page_content": row["text"],
-            "metadata": {k: v for k, v in row.items() if k not in ("text", "vector")},
+            "metadata": _public_chunk_metadata(row),
         }
 
 
 __all__ = ["ConversionService"]
+
+
+def _public_chunk_metadata(row: dict) -> dict:
+    return {
+        key: value for key, value in row.items() if key not in ("text", "vector") and not _is_internal_metadata_key(key)
+    }
+
+
+def _is_internal_metadata_key(key: object) -> bool:
+    return isinstance(key, str) and key.startswith("_openrag")

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -197,6 +197,7 @@ class IndexingService:
             original_filename=original_filename,
         )
         await self._ensure_partition_exists(partition, user)
+        require_existing_partition = bool(self._partition_configs())
         indexation_config, embedder_name = self._resolve_indexation_dispatch_config(partition)
         return await self._dispatcher.dispatch_indexing(
             path=file_path,
@@ -207,6 +208,7 @@ class IndexingService:
             replace=replace,
             indexation_config=indexation_config,
             embedder_name=embedder_name,
+            require_existing_partition=require_existing_partition,
         )
 
     async def delete_file(self, file_id: str, partition: str) -> None:

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -13,6 +13,8 @@ returned via ``HTTPException``.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -117,6 +119,20 @@ class IndexingService:
             return {}
         return getattr(self._config, "partitions", {}) or {}
 
+    @asynccontextmanager
+    async def _partition_admission(self, partition: str) -> AsyncIterator[bool]:
+        if self._partition_service is None:
+            yield False
+            return
+
+        admission = getattr(self._partition_service, "indexing_admission", None)
+        if admission is not None:
+            async with admission(partition) as partition_existed:
+                yield bool(partition_existed)
+            return
+
+        yield await self._partition_service.partition_exists(partition)
+
     async def _ensure_editor_access_after_create_race(self, partition: str, user: dict | None) -> None:
         if user is None:
             return
@@ -196,20 +212,23 @@ class IndexingService:
             sanitized_filename=sanitized_filename,
             original_filename=original_filename,
         )
-        await self._ensure_partition_exists(partition, user)
-        require_existing_partition = bool(self._partition_configs())
-        indexation_config, embedder_name = self._resolve_indexation_dispatch_config(partition)
-        return await self._dispatcher.dispatch_indexing(
-            path=file_path,
-            metadata=full_metadata,
-            partition=partition,
-            user=user,
-            workspace_ids=workspace_ids,
-            replace=replace,
-            indexation_config=indexation_config,
-            embedder_name=embedder_name,
-            require_existing_partition=require_existing_partition,
-        )
+        async with self._partition_admission(partition) as partition_existed_at_admission:
+            await self._ensure_partition_exists(partition, user)
+            require_existing_partition = bool(self._partition_configs()) or partition_existed_at_admission
+            indexation_config, embedder_name = self._resolve_indexation_dispatch_config(partition)
+            legacy_actor_preserves_partition_guard = require_existing_partition and indexation_config is not None
+            return await self._dispatcher.dispatch_indexing(
+                path=file_path,
+                metadata=full_metadata,
+                partition=partition,
+                user=user,
+                workspace_ids=workspace_ids,
+                replace=replace,
+                indexation_config=indexation_config,
+                embedder_name=embedder_name,
+                require_existing_partition=require_existing_partition,
+                allow_legacy_require_existing_partition_retry=legacy_actor_preserves_partition_guard,
+            )
 
     async def delete_file(self, file_id: str, partition: str) -> None:
         await self._dispatcher.delete_file(file_id, partition)

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -251,7 +251,7 @@ class MCPService:
         return {
             "chunk_id": meta.get("_id") or chunk.id,
             "content": chunk.text,
-            "metadata": meta,
+            "metadata": _public_chunk_metadata(meta, exclude=("_id",)),
         }
 
     # ------------------------------------------------------------------
@@ -296,7 +296,7 @@ class MCPService:
             {"partition": partition, "file_id": file_id},
             output_fields=["*"],
         )
-        metadata = {k: v for k, v in rows[0].items() if k not in ("_id", "text", "vector")} if rows else {}
+        metadata = _public_chunk_metadata(rows[0], exclude=("_id", "text", "vector")) if rows else {}
         return {
             "partition": partition,
             "file_id": file_id,
@@ -344,7 +344,7 @@ class MCPService:
                 {
                     "chunk_id": row.get("_id"),
                     "content": row.get("text"),
-                    "metadata": {k: v for k, v in row.items() if k not in ("text", "_id", "vector")},
+                    "metadata": _public_chunk_metadata(row, exclude=("text", "_id", "vector")),
                 }
                 for row in page
             ],
@@ -694,3 +694,11 @@ class MCPService:
 
 
 __all__ = ["MCPService"]
+
+
+def _public_chunk_metadata(row: dict[str, Any], *, exclude: tuple[str, ...]) -> dict[str, Any]:
+    return {key: value for key, value in row.items() if key not in exclude and not _is_internal_metadata_key(key)}
+
+
+def _is_internal_metadata_key(key: Any) -> bool:
+    return isinstance(key, str) and key.startswith("_openrag")

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
+from core.utils.conts import is_internal_metadata_key
 from core.utils.exceptions import ValidationError
 from core.utils.log_tail import collect_task_logs
 from core.utils.logging import get_logger
@@ -697,8 +698,4 @@ __all__ = ["MCPService"]
 
 
 def _public_chunk_metadata(row: dict[str, Any], *, exclude: tuple[str, ...]) -> dict[str, Any]:
-    return {key: value for key, value in row.items() if key not in exclude and not _is_internal_metadata_key(key)}
-
-
-def _is_internal_metadata_key(key: Any) -> bool:
-    return isinstance(key, str) and key.startswith("_openrag")
+    return {key: value for key, value in row.items() if key not in exclude and not is_internal_metadata_key(key)}

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -297,6 +297,7 @@ class PartitionService:
                     partition=partition,
                     error=str(exc),
                 )
+                raise
             else:
                 logger.info(
                     "Deleted race-leftover points from partition",

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -287,7 +287,9 @@ class PartitionService:
                 "No vector collection to clean up before deleting partition",
                 partition=partition,
             )
-        await self._partition_repo.delete_partition(name=partition)
+        deleted = await self._partition_repo.delete_partition(name=partition)
+        if deleted and self._config is not None:
+            self._config.partitions.pop(partition, None)
         if collection_exists:
             try:
                 deleted = await self._vector_store.delete_by_filter({"partition": partition})

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -32,6 +32,7 @@ from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
 from core.indexing.validators import validate_partition_name
 from core.models.preset import PartitionConfig
+from core.utils.conts import is_internal_metadata_key
 from core.utils.exceptions import (
     ConfigError,
     NotFoundError,
@@ -62,7 +63,6 @@ _RESERVED_PARTITION_NAMES = frozenset({"all"})
 # "reset to default"), not the omitted-field sentinel that the None-filter
 # in ``update_partition`` gives every other column.
 _NULLABLE_COLUMNS = frozenset({"chat_llm"})
-_INTERNAL_METADATA_PREFIX = "_openrag"
 
 
 def _validate_limit(limit: int | None) -> None:
@@ -73,10 +73,6 @@ def _validate_limit(limit: int | None) -> None:
     """
     if limit is not None and limit < 0:
         raise ValidationError("`limit` must be greater than or equal to 0.", code="INVALID_LIMIT")
-
-
-def _is_internal_metadata_key(key: Any) -> bool:
-    return isinstance(key, str) and key.startswith(_INTERNAL_METADATA_PREFIX)
 
 
 class PartitionService:
@@ -495,7 +491,7 @@ class PartitionService:
         )
         if len(rows) > limit:
             rows = rows[:limit]
-        return [{k: v for k, v in row.items() if k != "text" and not _is_internal_metadata_key(k)} for row in rows]
+        return [{k: v for k, v in row.items() if k != "text" and not is_internal_metadata_key(k)} for row in rows]
 
     async def list_all_chunks(
         self,
@@ -531,7 +527,7 @@ class PartitionService:
             for k, v in row.items():
                 if k in excluded:
                     continue
-                if _is_internal_metadata_key(k):
+                if is_internal_metadata_key(k):
                     continue
                 if k == "vector":
                     # Legacy surfaced the embedding as a flat string.

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -284,12 +284,20 @@ class PartitionService:
             )
         await self._partition_repo.delete_partition(name=partition)
         if collection_exists:
-            deleted = await self._vector_store.delete_by_filter({"partition": partition})
-            logger.info(
-                "Deleted race-leftover points from partition",
-                partition=partition,
-                count=deleted,
-            )
+            try:
+                deleted = await self._vector_store.delete_by_filter({"partition": partition})
+            except Exception as exc:
+                logger.warning(
+                    "Post-delete vector cleanup failed after partition row removal",
+                    partition=partition,
+                    error=str(exc),
+                )
+            else:
+                logger.info(
+                    "Deleted race-leftover points from partition",
+                    partition=partition,
+                    count=deleted,
+                )
         logger.info("Partition successfully deleted.", partition=partition)
 
     async def update_partition(self, partition: str, **fields: object) -> dict | None:

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -62,6 +62,7 @@ _RESERVED_PARTITION_NAMES = frozenset({"all"})
 # "reset to default"), not the omitted-field sentinel that the None-filter
 # in ``update_partition`` gives every other column.
 _NULLABLE_COLUMNS = frozenset({"chat_llm"})
+_INTERNAL_METADATA_PREFIX = "_openrag"
 
 
 def _validate_limit(limit: int | None) -> None:
@@ -72,6 +73,10 @@ def _validate_limit(limit: int | None) -> None:
     """
     if limit is not None and limit < 0:
         raise ValidationError("`limit` must be greater than or equal to 0.", code="INVALID_LIMIT")
+
+
+def _is_internal_metadata_key(key: Any) -> bool:
+    return isinstance(key, str) and key.startswith(_INTERNAL_METADATA_PREFIX)
 
 
 class PartitionService:
@@ -487,7 +492,7 @@ class PartitionService:
         )
         if len(rows) > limit:
             rows = rows[:limit]
-        return [{k: v for k, v in row.items() if k != "text"} for row in rows]
+        return [{k: v for k, v in row.items() if k != "text" and not _is_internal_metadata_key(k)} for row in rows]
 
     async def list_all_chunks(
         self,
@@ -522,6 +527,8 @@ class PartitionService:
             meta: dict[str, Any] = {}
             for k, v in row.items():
                 if k in excluded:
+                    continue
+                if _is_internal_metadata_key(k):
                     continue
                 if k == "vector":
                     # Legacy surfaced the embedding as a flat string.

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -6,10 +6,9 @@ Phase 7 repositories and the :class:`VectorStore` port directly; it does
 not depend on Ray or pymilvus.
 
 ``delete_partition`` is the one cross-cutting method — it must drop the
-partition's vectors from the store *and* the relational rows. It is
-performed through the clean :class:`VectorStore` port
-(``query_ids_by_filter`` + ``delete``) rather than a Milvus-specific
-filter delete, so PartitionService stays backend-agnostic.
+partition's vectors from the store *and* the relational rows. Vector cleanup
+runs first through :class:`VectorStore.delete_by_filter`, so a failed vector
+delete does not leave catalog rows removed while chunks remain queryable.
 
 Chunk reads return plain dicts (never LangChain ``Document`` objects —
 8H forbids LangChain in orchestrators); the thin router builds the
@@ -245,34 +244,24 @@ class PartitionService:
     async def delete_partition(self, partition: str) -> None:
         """Drop a partition's vectors *and* relational rows (cross-cutting)."""
         await self._ensure_partition(partition)
-        await self._partition_repo.delete_partition(name=partition)
         # The shared Milvus collection is created lazily on the first insert
         # system-wide, so on a fresh stack (nothing ever indexed) it doesn't
-        # exist; querying it would raise (e.g. DescribeCollectionException) and
-        # fail the whole delete *after* the relational rows are already gone.
+        # exist; deleting by filter would raise (e.g. DescribeCollectionException)
+        # even though there are no chunks to clean up.
         # No collection means no chunks to clean up — skip the vector cleanup.
-        if not await self._vector_store.collection_exists(self._collection):
+        if await self._vector_store.collection_exists(self._collection):
+            deleted = await self._vector_store.delete_by_filter({"partition": partition})
             logger.info(
-                "Partition deleted; no vector collection to clean up",
+                "Deleted points from partition",
+                partition=partition,
+                count=deleted,
+            )
+        else:
+            logger.info(
+                "No vector collection to clean up before deleting partition",
                 partition=partition,
             )
-            return
-        ids = await self._vector_store.query_ids_by_filter(
-            self._collection,
-            {"partition": partition},
-        )
-        if ids:
-            try:
-                deleted = await self._vector_store.delete(ids, self._collection)
-                logger.info("Deleted points from partition", partition=partition, count=deleted)
-            except Exception as e:
-                logger.error(
-                    "Failed to delete chunks from vector store after removing partition from database; "
-                    "reconciliation task required",
-                    partition=partition,
-                    chunk_count=len(ids),
-                    error=str(e),
-                )
+        await self._partition_repo.delete_partition(name=partition)
         logger.info("Partition successfully deleted.", partition=partition)
 
     async def update_partition(self, partition: str, **fields: object) -> dict | None:

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -24,6 +24,7 @@ raised). The container supplies both from settings/the catalog store.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -39,6 +40,7 @@ from core.utils.exceptions import (
     ValidationError,
 )
 from core.utils.logging import get_logger
+from services.workers.task_cancellation import cancel_active_indexing_tasks
 
 if TYPE_CHECKING:
     from core.config.root import Settings
@@ -85,6 +87,9 @@ class PartitionService:
         user_repo: UserRepository,
         collection: str,
         config: Settings | None = None,
+        task_state_manager: Any = None,
+        task_state_manager_factory: Callable[[], Any] | None = None,
+        task_cancel_timeout: float = 60.0,
     ) -> None:
         self._partition_repo = partition_repo
         self._membership_repo = membership_repo
@@ -93,6 +98,9 @@ class PartitionService:
         self._user_repo = user_repo
         self._collection = collection
         self._config = config
+        self._task_state_manager = task_state_manager
+        self._task_state_manager_factory = task_state_manager_factory
+        self._task_cancel_timeout = task_cancel_timeout
 
     # ------------------------------------------------------------------
     # Existence guards (mirror the legacy _check_* helpers, core exceptions)
@@ -244,12 +252,25 @@ class PartitionService:
     async def delete_partition(self, partition: str) -> None:
         """Drop a partition's vectors *and* relational rows (cross-cutting)."""
         await self._ensure_partition(partition)
+        task_state_manager = self._task_state_manager
+        if task_state_manager is None and self._task_state_manager_factory is not None:
+            task_state_manager = self._task_state_manager_factory()
+        if task_state_manager is not None:
+            cancelled = await cancel_active_indexing_tasks(
+                task_state_manager,
+                partition=partition,
+                timeout=self._task_cancel_timeout,
+            )
+            if cancelled:
+                logger.info("Cancelled active indexing tasks before deleting partition", partition=partition)
+
         # The shared Milvus collection is created lazily on the first insert
         # system-wide, so on a fresh stack (nothing ever indexed) it doesn't
         # exist; deleting by filter would raise (e.g. DescribeCollectionException)
         # even though there are no chunks to clean up.
         # No collection means no chunks to clean up — skip the vector cleanup.
-        if await self._vector_store.collection_exists(self._collection):
+        collection_exists = await self._vector_store.collection_exists(self._collection)
+        if collection_exists:
             deleted = await self._vector_store.delete_by_filter({"partition": partition})
             logger.info(
                 "Deleted points from partition",
@@ -262,6 +283,13 @@ class PartitionService:
                 partition=partition,
             )
         await self._partition_repo.delete_partition(name=partition)
+        if collection_exists:
+            deleted = await self._vector_store.delete_by_filter({"partition": partition})
+            logger.info(
+                "Deleted race-leftover points from partition",
+                partition=partition,
+                count=deleted,
+            )
         logger.info("Partition successfully deleted.", partition=partition)
 
     async def update_partition(self, partition: str, **fields: object) -> dict | None:

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -24,7 +24,10 @@ raised). The container supplies both from settings/the catalog store.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -63,6 +66,10 @@ _RESERVED_PARTITION_NAMES = frozenset({"all"})
 # "reset to default"), not the omitted-field sentinel that the None-filter
 # in ``update_partition`` gives every other column.
 _NULLABLE_COLUMNS = frozenset({"chat_llm"})
+_ACTIVE_PARTITION_OPERATIONS: ContextVar[dict[str, Any] | None] = ContextVar(
+    "_ACTIVE_PARTITION_OPERATIONS",
+    default=None,
+)
 
 
 def _validate_limit(limit: int | None) -> None:
@@ -102,13 +109,15 @@ class PartitionService:
         self._task_state_manager = task_state_manager
         self._task_state_manager_factory = task_state_manager_factory
         self._task_cancel_timeout = task_cancel_timeout
+        self._partition_locks: dict[str, asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # Existence guards (mirror the legacy _check_* helpers, core exceptions)
     # ------------------------------------------------------------------
 
     async def _ensure_partition(self, partition: str) -> None:
-        if not await self._partition_repo.partition_exists(name=partition):
+        operation = self._active_partition_operation(partition)
+        if not await self._partition_exists_for_operation(partition, operation=operation):
             logger.warning(f"Partition '{partition}' does not exist.")
             raise PartitionNotFoundError(f"Partition '{partition}' does not exist.")
 
@@ -142,10 +151,95 @@ class PartitionService:
 
     async def partition_exists(self, partition: str) -> bool:
         try:
-            return await self._partition_repo.partition_exists(name=partition)
+            operation = self._active_partition_operation(partition)
+            return await self._partition_exists_for_operation(partition, operation=operation)
         except Exception as e:  # pragma: no cover - defensive, matches legacy
             logger.exception("Partition existence check failed.", partition=partition, error=str(e))
             return False
+
+    @asynccontextmanager
+    async def indexing_admission(self, partition: str) -> AsyncIterator[bool]:
+        """Serialize upload admission with partition deletion.
+
+        Yields whether the partition row existed while the admission fence was
+        held. Uploads that observed an existing partition must not auto-create it
+        later if a concurrent delete removes the row before the worker writes the
+        catalog record.
+        """
+        async with self._partition_operation_lock(partition) as operation:
+            active_operations = dict(_ACTIVE_PARTITION_OPERATIONS.get() or {})
+            active_operations[partition] = operation
+            token = _ACTIVE_PARTITION_OPERATIONS.set(active_operations)
+            try:
+                yield await self._partition_exists_for_operation(partition, operation=operation)
+            finally:
+                _ACTIVE_PARTITION_OPERATIONS.reset(token)
+
+    @asynccontextmanager
+    async def _partition_operation_lock(self, partition: str) -> AsyncIterator[Any]:
+        lock_factory = getattr(self._partition_repo, "partition_operation_lock", None)
+        if lock_factory is not None:
+            async with lock_factory(partition) as operation:
+                yield operation
+            return
+
+        lock = self._partition_locks.setdefault(partition, asyncio.Lock())
+        async with lock:
+            yield None
+
+    async def _partition_exists_for_operation(self, partition: str, *, operation: Any = None) -> bool:
+        exists = getattr(operation, "partition_exists", None)
+        if exists is not None:
+            return bool(await exists(partition))
+        return await self._partition_repo.partition_exists(name=partition)
+
+    async def _create_partition_for_operation(
+        self,
+        partition: str,
+        *,
+        user_id: int | None,
+        max_owned: int | None,
+        operation: Any = None,
+    ) -> dict:
+        create_partition = getattr(operation, "create_partition", None)
+        if create_partition is not None:
+            return await create_partition(partition, user_id=user_id, max_owned=max_owned)
+        return await self._partition_repo.create_partition(name=partition, user_id=user_id, max_owned=max_owned)
+
+    async def _delete_partition_for_operation(self, partition: str, *, operation: Any = None) -> bool:
+        delete_partition = getattr(operation, "delete_partition", None)
+        if delete_partition is not None:
+            return bool(await delete_partition(partition))
+        return await self._partition_repo.delete_partition(name=partition)
+
+    async def _update_partition_for_operation(
+        self,
+        partition: str,
+        *,
+        operation: Any = None,
+        **fields: object,
+    ) -> dict | None:
+        update_partition = getattr(operation, "update_partition", None)
+        if update_partition is not None:
+            return await update_partition(partition, **fields)
+        return await self._partition_repo.update_partition(partition, **fields)
+
+    async def _list_partition_rows_for_operation(self, *, operation: Any = None) -> list[dict]:
+        list_partition_rows = getattr(operation, "list_partition_rows", None)
+        if list_partition_rows is not None:
+            return await list_partition_rows()
+        return await self._partition_repo.list_partition_rows()
+
+    def _active_partition_operation(self, partition: str | None = None) -> Any:
+        active_operations = _ACTIVE_PARTITION_OPERATIONS.get() or {}
+        if partition is not None:
+            return active_operations.get(partition)
+        return next((operation for operation in active_operations.values() if operation is not None), None)
+
+    async def _ensure_partition_for_operation(self, partition: str, *, operation: Any = None) -> None:
+        if not await self._partition_exists_for_operation(partition, operation=operation):
+            logger.warning(f"Partition '{partition}' does not exist.")
+            raise PartitionNotFoundError(f"Partition '{partition}' does not exist.")
 
     async def list_partitions(self) -> list[dict]:
         return await self._partition_repo.list_partitions()
@@ -217,7 +311,8 @@ class PartitionService:
                 code="RESERVED_PARTITION_NAME",
             )
         validate_partition_name(partition)
-        if await self._partition_repo.partition_exists(name=partition):
+        operation = self._active_partition_operation(partition)
+        if await self._partition_exists_for_operation(partition, operation=operation):
             raise ValidationError(
                 f"Partition '{partition}' already exists.",
                 status_code=409,
@@ -239,20 +334,29 @@ class PartitionService:
             if chat_llm:
                 self._validate_chat_llm_ref(chat_llm)
 
-        await self._partition_repo.create_partition(name=partition, user_id=user_id, max_owned=max_owned)
+        await self._create_partition_for_operation(
+            partition,
+            user_id=user_id,
+            max_owned=max_owned,
+            operation=operation,
+        )
 
         # Persist the config columns (the insert only sets server defaults)
         # and re-resolve the in-memory cache. Only done in the Phase 14 flow
         # where a config was supplied.
         if self._config is not None:
-            await self._partition_repo.update_partition(partition, **config_fields)
+            await self._update_partition_for_operation(partition, operation=operation, **config_fields)
             await self.load_partitions()
 
         logger.info(f"Partition '{partition}' created by user_id {user_id}.")
 
     async def delete_partition(self, partition: str) -> None:
         """Drop a partition's vectors *and* relational rows (cross-cutting)."""
-        await self._ensure_partition(partition)
+        async with self._partition_operation_lock(partition) as operation:
+            await self._delete_partition_locked(partition, operation=operation)
+
+    async def _delete_partition_locked(self, partition: str, *, operation: Any = None) -> None:
+        await self._ensure_partition_for_operation(partition, operation=operation)
         task_state_manager = self._task_state_manager
         if task_state_manager is None and self._task_state_manager_factory is not None:
             task_state_manager = self._task_state_manager_factory()
@@ -283,7 +387,7 @@ class PartitionService:
                 "No vector collection to clean up before deleting partition",
                 partition=partition,
             )
-        deleted = await self._partition_repo.delete_partition(name=partition)
+        deleted = await self._delete_partition_for_operation(partition, operation=operation)
         if deleted and self._config is not None:
             self._config.partitions.pop(partition, None)
         if collection_exists:
@@ -443,7 +547,7 @@ class PartitionService:
         ``config.partitions`` dict stays valid after the swap.
         """
         cfg = self._require_config()
-        rows = await self._partition_repo.list_partition_rows()
+        rows = await self._list_partition_rows_for_operation(operation=self._active_partition_operation())
         resolved = {row["partition"]: self.resolve_partition_row(row) for row in rows}
 
         cache = cfg.partitions

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -274,6 +274,7 @@ class PgDocumentRepository(DocumentRepository):
         parent_id: str | None = None,
         indexation_config: dict | None = None,
         indexed_at: datetime | None = None,
+        require_existing_partition: bool = False,
     ) -> bool:
         """TODO(phase-9): remove. Mirror of legacy ``add_file_to_partition``.
 
@@ -293,17 +294,26 @@ class PgDocumentRepository(DocumentRepository):
                 if existing:
                     return False
 
-                # Auto-create partition + first-owner membership when missing —
-                # legacy side-effect documented in the phase-7 spec.
-                created = await conn.fetchval(
-                    """
-                    INSERT INTO partitions (partition, created_at)
-                    VALUES ($1, NOW())
-                    ON CONFLICT (partition) DO NOTHING
-                    RETURNING 1
-                    """,
-                    partition,
-                )
+                created = None
+                if require_existing_partition:
+                    partition_exists = await conn.fetchval(
+                        "SELECT 1 FROM partitions WHERE partition = $1",
+                        partition,
+                    )
+                    if not partition_exists:
+                        return False
+                else:
+                    # Auto-create partition + first-owner membership when missing —
+                    # legacy side-effect documented in the phase-7 spec.
+                    created = await conn.fetchval(
+                        """
+                        INSERT INTO partitions (partition, created_at)
+                        VALUES ($1, NOW())
+                        ON CONFLICT (partition) DO NOTHING
+                        RETURNING 1
+                        """,
+                        partition,
+                    )
                 if created and user_id is None:
                     raise ValueError("Cannot auto-create a partition without a user_id")
                 if created and user_id is not None:

--- a/openrag/services/persistence/partition_repo.py
+++ b/openrag/services/persistence/partition_repo.py
@@ -15,7 +15,8 @@ trigger) so the books stay balanced.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from core.ports.partition_repo import PartitionRepository
@@ -33,6 +34,49 @@ _PRESET_COLUMN_TYPES = {
     "indexation_preset": "indexation",
     "retrieval_preset": "retrieval",
 }
+_PARTITION_UPDATE_COLUMNS = frozenset(
+    {
+        "description",
+        "embedder",
+        "indexation_preset",
+        "retrieval_preset",
+        "dimension",
+        "collection_name",
+        "chat_history_depth",
+        "chat_llm",
+    }
+)
+_PARTITION_OPERATION_LOCK_NAMESPACE = 20260720
+
+
+def _partition_updates(fields: dict[str, object]) -> dict[str, object]:
+    return {key: value for key, value in fields.items() if key in _PARTITION_UPDATE_COLUMNS}
+
+
+class _PartitionOperationGuard:
+    def __init__(self, repo: PgPartitionRepository, conn: asyncpg.Connection) -> None:
+        self._repo = repo
+        self._conn = conn
+
+    async def partition_exists(self, name: str) -> bool:
+        return await self._repo._partition_exists_on_conn(self._conn, name)
+
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
+        return await self._repo._create_partition_on_conn(
+            self._conn,
+            name,
+            user_id=user_id,
+            max_owned=max_owned,
+        )
+
+    async def delete_partition(self, name: str) -> bool:
+        return await self._repo._delete_partition_on_conn(self._conn, name)
+
+    async def update_partition(self, name: str, **fields: object) -> dict | None:
+        return await self._repo._update_partition_on_conn(self._conn, name, **fields)
+
+    async def list_partition_rows(self) -> list[dict]:
+        return await self._repo._list_partition_rows_on_conn(self._conn)
 
 
 class PgPartitionRepository(PartitionRepository):
@@ -45,6 +89,24 @@ class PgPartitionRepository(PartitionRepository):
     def pool(self) -> asyncpg.Pool:
         return self._pool_getter()
 
+    @asynccontextmanager
+    async def partition_operation_lock(self, name: str) -> AsyncIterator[_PartitionOperationGuard]:
+        """Hold a cross-process fence for partition deletes and upload admission."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "SELECT pg_advisory_lock($1::integer, hashtext($2)::integer)",
+                _PARTITION_OPERATION_LOCK_NAMESPACE,
+                name,
+            )
+            try:
+                yield _PartitionOperationGuard(self, conn)
+            finally:
+                await conn.execute(
+                    "SELECT pg_advisory_unlock($1::integer, hashtext($2)::integer)",
+                    _PARTITION_OPERATION_LOCK_NAMESPACE,
+                    name,
+                )
+
     # ── PartitionRepository port methods ─────────────────────────────
 
     async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
@@ -55,59 +117,69 @@ class PgPartitionRepository(PartitionRepository):
         for a partition it did not create.
         """
         async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                if user_id is not None and max_owned is not None and max_owned >= 0:
-                    await conn.execute("SELECT pg_advisory_xact_lock($1::bigint)", user_id)
+            return await self._create_partition_on_conn(conn, name, user_id=user_id, max_owned=max_owned)
+
+    async def _create_partition_on_conn(
+        self,
+        conn: asyncpg.Connection,
+        name: str,
+        user_id: int | None = None,
+        *,
+        max_owned: int | None = None,
+    ) -> dict:
+        async with conn.transaction():
+            if user_id is not None and max_owned is not None and max_owned >= 0:
+                await conn.execute("SELECT pg_advisory_xact_lock($1::bigint)", user_id)
+            row = await conn.fetchrow(
+                "SELECT * FROM partitions WHERE partition = $1",
+                name,
+            )
+            if row is not None:
+                raise ValidationError(
+                    f"Partition '{name}' already exists.",
+                    status_code=409,
+                    code="PARTITION_EXISTS",
+                )
+            if user_id is not None and max_owned is not None and max_owned >= 0:
+                owned = await conn.fetchval(
+                    """
+                    SELECT COUNT(*)::int FROM partition_memberships
+                    WHERE user_id = $1 AND role = 'owner'
+                    """,
+                    user_id,
+                )
+                if owned >= max_owned:
+                    raise ValidationError(
+                        f"Partition limit reached ({max_owned}). Contact an administrator.",
+                        status_code=403,
+                        code="PARTITION_LIMIT_EXCEEDED",
+                    )
+            try:
                 row = await conn.fetchrow(
-                    "SELECT * FROM partitions WHERE partition = $1",
+                    """
+                    INSERT INTO partitions (partition, created_at)
+                    VALUES ($1, NOW())
+                    RETURNING *
+                    """,
                     name,
                 )
-                if row is not None:
-                    raise ValidationError(
-                        f"Partition '{name}' already exists.",
-                        status_code=409,
-                        code="PARTITION_EXISTS",
-                    )
-                if user_id is not None and max_owned is not None and max_owned >= 0:
-                    owned = await conn.fetchval(
-                        """
-                        SELECT COUNT(*)::int FROM partition_memberships
-                        WHERE user_id = $1 AND role = 'owner'
-                        """,
-                        user_id,
-                    )
-                    if owned >= max_owned:
-                        raise ValidationError(
-                            f"Partition limit reached ({max_owned}). Contact an administrator.",
-                            status_code=403,
-                            code="PARTITION_LIMIT_EXCEEDED",
-                        )
-                try:
-                    row = await conn.fetchrow(
-                        """
-                        INSERT INTO partitions (partition, created_at)
-                        VALUES ($1, NOW())
-                        RETURNING *
-                        """,
-                        name,
-                    )
-                except asyncpg.UniqueViolationError as exc:
-                    raise ValidationError(
-                        f"Partition '{name}' already exists.",
-                        status_code=409,
-                        code="PARTITION_EXISTS",
-                    ) from exc
-                if user_id is not None:
-                    await conn.execute(
-                        """
-                        INSERT INTO partition_memberships
-                            (partition_name, user_id, role, added_at)
-                        VALUES ($1, $2, 'owner', NOW())
-                        ON CONFLICT (partition_name, user_id) DO NOTHING
-                        """,
-                        name,
-                        user_id,
-                    )
+            except asyncpg.UniqueViolationError as exc:
+                raise ValidationError(
+                    f"Partition '{name}' already exists.",
+                    status_code=409,
+                    code="PARTITION_EXISTS",
+                ) from exc
+            if user_id is not None:
+                await conn.execute(
+                    """
+                    INSERT INTO partition_memberships
+                        (partition_name, user_id, role, added_at)
+                    VALUES ($1, $2, 'owner', NOW())
+                    ON CONFLICT (partition_name, user_id) DO NOTHING
+                    """,
+                    name,
+                    user_id,
+                )
         return self._row_to_dict(row)
 
     async def get_partition(self, name: str) -> dict | None:
@@ -136,40 +208,49 @@ class PgPartitionRepository(PartitionRepository):
         amount (clamped at zero) so quotas stay accurate.
         """
         async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                exists = await conn.fetchval(
-                    "SELECT 1 FROM partitions WHERE partition = $1",
-                    name,
-                )
-                if not exists:
-                    return False
-                uploader_counts = await conn.fetch(
-                    """
-                    SELECT created_by, COUNT(*)::int AS n
-                    FROM files
-                    WHERE partition_name = $1 AND created_by IS NOT NULL
-                    GROUP BY created_by
-                    """,
-                    name,
-                )
+            return await self._delete_partition_on_conn(conn, name)
+
+    async def _delete_partition_on_conn(self, conn: asyncpg.Connection, name: str) -> bool:
+        async with conn.transaction():
+            exists = await conn.fetchval(
+                "SELECT 1 FROM partitions WHERE partition = $1",
+                name,
+            )
+            if not exists:
+                return False
+            uploader_counts = await conn.fetch(
+                """
+                SELECT created_by, COUNT(*)::int AS n
+                FROM files
+                WHERE partition_name = $1 AND created_by IS NOT NULL
+                GROUP BY created_by
+                """,
+                name,
+            )
+            await conn.execute(
+                "DELETE FROM files WHERE partition_name = $1",
+                name,
+            )
+            await conn.execute(
+                "DELETE FROM partitions WHERE partition = $1",
+                name,
+            )
+            for r in uploader_counts:
                 await conn.execute(
-                    "DELETE FROM files WHERE partition_name = $1",
-                    name,
+                    "UPDATE users SET file_count = GREATEST(file_count - $1, 0) WHERE id = $2",
+                    r["n"],
+                    r["created_by"],
                 )
-                await conn.execute(
-                    "DELETE FROM partitions WHERE partition = $1",
-                    name,
-                )
-                for r in uploader_counts:
-                    await conn.execute(
-                        "UPDATE users SET file_count = GREATEST(file_count - $1, 0) WHERE id = $2",
-                        r["n"],
-                        r["created_by"],
-                    )
-                return True
+            return True
 
     async def partition_exists(self, name: str) -> bool:
-        return await self.pool.fetchval(
+        return await self._partition_exists_on_conn(
+            self.pool,
+            name,
+        )
+
+    async def _partition_exists_on_conn(self, conn: asyncpg.Connection | asyncpg.Pool, name: str) -> bool:
+        return await conn.fetchval(
             "SELECT EXISTS (SELECT 1 FROM partitions WHERE partition = $1)",
             name,
         )
@@ -177,14 +258,24 @@ class PgPartitionRepository(PartitionRepository):
     # ── Phase 14 — full config row methods ───────────────────────────
 
     async def get_partition_row(self, name: str) -> dict | None:
-        row = await self.pool.fetchrow(
+        row = await self._get_partition_row_on_conn(
+            self.pool,
+            name,
+        )
+        return row
+
+    async def _get_partition_row_on_conn(self, conn: asyncpg.Connection | asyncpg.Pool, name: str) -> dict | None:
+        row = await conn.fetchrow(
             "SELECT * FROM partitions WHERE partition = $1",
             name,
         )
         return self._row_to_full_dict(row) if row else None
 
     async def list_partition_rows(self) -> list[dict]:
-        rows = await self.pool.fetch(
+        return await self._list_partition_rows_on_conn(self.pool)
+
+    async def _list_partition_rows_on_conn(self, conn: asyncpg.Connection | asyncpg.Pool) -> list[dict]:
+        rows = await conn.fetch(
             "SELECT * FROM partitions ORDER BY created_at",
         )
         return [self._row_to_full_dict(r) for r in rows]
@@ -207,21 +298,23 @@ class PgPartitionRepository(PartitionRepository):
           then the follow-up ``SELECT`` sees the vanished preset and the
           transaction rolls the write back (raising ``PRESET_NOT_FOUND``).
         """
-        _ALLOWED = frozenset(
-            {
-                "description",
-                "embedder",
-                "indexation_preset",
-                "retrieval_preset",
-                "dimension",
-                "collection_name",
-                "chat_history_depth",
-                "chat_llm",
-            }
-        )
-        updates = {k: v for k, v in fields.items() if k in _ALLOWED}
+        updates = _partition_updates(fields)
+        if updates:
+            preset_refs = {col: _PRESET_COLUMN_TYPES[col] for col in updates if col in _PRESET_COLUMN_TYPES}
+            if preset_refs:
+                async with self.pool.acquire() as conn:
+                    return await self._update_partition_on_conn(conn, name, **fields)
+        return await self._update_partition_on_conn(self.pool, name, **fields)
+
+    async def _update_partition_on_conn(
+        self,
+        conn: asyncpg.Connection | asyncpg.Pool,
+        name: str,
+        **fields: object,
+    ) -> dict | None:
+        updates = _partition_updates(fields)
         if not updates:
-            return await self.get_partition_row(name)
+            return await self._get_partition_row_on_conn(conn, name)
 
         params: list = [name]
         sets: list[str] = []
@@ -233,26 +326,28 @@ class PgPartitionRepository(PartitionRepository):
 
         preset_refs = {col: _PRESET_COLUMN_TYPES[col] for col in updates if col in _PRESET_COLUMN_TYPES}
         if not preset_refs:
-            row = await self.pool.fetchrow(sql, *params)
+            row = await conn.fetchrow(sql, *params)
             return self._row_to_full_dict(row) if row else None
 
-        async with self.pool.acquire() as conn:
-            async with conn.transaction():
-                row = await conn.fetchrow(sql, *params)
-                if row is None:
-                    return None
-                for col, preset_type in preset_refs.items():
-                    exists = await conn.fetchval(
-                        "SELECT 1 FROM pipeline_presets WHERE name = $1 AND preset_type = $2",
-                        updates[col],
-                        preset_type,
+        transaction = getattr(conn, "transaction", None)
+        if transaction is None:
+            raise TypeError("preset-reference updates require a connection transaction")
+        async with transaction():
+            row = await conn.fetchrow(sql, *params)
+            if row is None:
+                return None
+            for col, preset_type in preset_refs.items():
+                exists = await conn.fetchval(
+                    "SELECT 1 FROM pipeline_presets WHERE name = $1 AND preset_type = $2",
+                    updates[col],
+                    preset_type,
+                )
+                if not exists:
+                    raise ValidationError(
+                        f"{preset_type.capitalize()} preset '{updates[col]}' does not exist.",
+                        code="PRESET_NOT_FOUND",
                     )
-                    if not exists:
-                        raise ValidationError(
-                            f"{preset_type.capitalize()} preset '{updates[col]}' does not exist.",
-                            code="PRESET_NOT_FOUND",
-                        )
-                return self._row_to_full_dict(row)
+            return self._row_to_full_dict(row)
 
     # ── Legacy method names used by the Phase 7C shim ────────────────
 

--- a/openrag/services/storage/vector_store_searcher.py
+++ b/openrag/services/storage/vector_store_searcher.py
@@ -16,6 +16,8 @@ from core.ports.document_repo import DocumentRepository
 from core.retrieval.searcher import RetrievalSearcher
 from core.vector_stores import VectorStore
 
+_INTERNAL_METADATA_PREFIX = "_openrag"
+
 
 def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
     """Convert a VectorStore result dict to a domain Chunk.
@@ -26,7 +28,7 @@ def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
     raw_id = row.get("id") or row.get("_id")
     chunk_id = str(raw_id) if raw_id is not None else str(uuid.uuid4())
     skip = {"text", "vector", "_id", "id", "score", "file_id", "partition", "page", "chunk_type"}
-    metadata = {k: v for k, v in row.items() if k not in skip}
+    metadata = {k: v for k, v in row.items() if k not in skip and not _is_internal_metadata_key(k)}
     return Chunk(
         id=chunk_id,
         document_id=row.get("file_id", ""),
@@ -36,6 +38,10 @@ def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
         chunk_type=_coerce_chunk_type(row.get("chunk_type", "text")),
         metadata=metadata,
     )
+
+
+def _is_internal_metadata_key(key: Any) -> bool:
+    return isinstance(key, str) and key.startswith(_INTERNAL_METADATA_PREFIX)
 
 
 class VectorStoreSearcher(RetrievalSearcher):

--- a/openrag/services/storage/vector_store_searcher.py
+++ b/openrag/services/storage/vector_store_searcher.py
@@ -14,9 +14,8 @@ from core.embeddings import Embedder
 from core.models.chunk import Chunk, _coerce_chunk_type
 from core.ports.document_repo import DocumentRepository
 from core.retrieval.searcher import RetrievalSearcher
+from core.utils.conts import is_internal_metadata_key
 from core.vector_stores import VectorStore
-
-_INTERNAL_METADATA_PREFIX = "_openrag"
 
 
 def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
@@ -28,7 +27,7 @@ def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
     raw_id = row.get("id") or row.get("_id")
     chunk_id = str(raw_id) if raw_id is not None else str(uuid.uuid4())
     skip = {"text", "vector", "_id", "id", "score", "file_id", "partition", "page", "chunk_type"}
-    metadata = {k: v for k, v in row.items() if k not in skip and not _is_internal_metadata_key(k)}
+    metadata = {k: v for k, v in row.items() if k not in skip and not is_internal_metadata_key(k)}
     return Chunk(
         id=chunk_id,
         document_id=row.get("file_id", ""),
@@ -38,10 +37,6 @@ def _dict_to_chunk(row: dict[str, Any]) -> Chunk:
         chunk_type=_coerce_chunk_type(row.get("chunk_type", "text")),
         metadata=metadata,
     )
-
-
-def _is_internal_metadata_key(key: Any) -> bool:
-    return isinstance(key, str) and key.startswith(_INTERNAL_METADATA_PREFIX)
 
 
 class VectorStoreSearcher(RetrievalSearcher):

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 import uuid
 from typing import Any
 
@@ -91,31 +92,48 @@ class WorkerDispatcher(IndexingDispatcher):
             task_description=f"set_details({task_id})",
         )
 
-        # ``IndexerPool`` is a Ray actor; ``submit`` returns ``[worker_ref]``
-        # (wrapped so Ray doesn't auto-dereference and block on the worker task).
-        # Awaiting the submit call yields that list; element 0 is the worker ref
-        # that ``cancel_task``/``ray.cancel`` must target.
-        submitted = await self._call(
-            self._pool.submit.remote(
-                task_id=task_id,
-                path=path,
-                metadata=metadata,
-                partition=partition,
-                user=user,
-                workspace_ids=workspace_ids,
-                replace=replace,
-                indexation_config=indexation_config,
-                embedder_name=embedder_name,
-            ),
-            task_description=f"submit({task_id})",
-        )
-        task = submitted[0]
+        try:
+            # ``IndexerPool`` is a Ray actor; ``submit`` returns ``[worker_ref]``
+            # (wrapped so Ray doesn't auto-dereference and block on the worker task).
+            # Awaiting the submit call yields that list; element 0 is the worker ref
+            # that ``cancel_task``/``ray.cancel`` must target.
+            submitted = await self._call(
+                self._pool.submit.remote(
+                    task_id=task_id,
+                    path=path,
+                    metadata=metadata,
+                    partition=partition,
+                    user=user,
+                    workspace_ids=workspace_ids,
+                    replace=replace,
+                    indexation_config=indexation_config,
+                    embedder_name=embedder_name,
+                ),
+                task_description=f"submit({task_id})",
+            )
+            task = submitted[0]
 
-        await self._call(
-            self._tsm.set_object_ref.remote(task_id, {"ref": task}),
-            task_description=f"set_object_ref({task_id})",
-        )
+            await self._call(
+                self._tsm.set_object_ref.remote(task_id, {"ref": task}),
+                task_description=f"set_object_ref({task_id})",
+            )
+        except Exception:
+            await self._mark_submit_failed(task_id, traceback.format_exc())
+            raise
         return task_id
+
+    async def _mark_submit_failed(self, task_id: str, tb: str) -> None:
+        set_failed = getattr(self._tsm, "set_failed_if_not_cancelled", None)
+        if set_failed is not None:
+            await self._call(
+                set_failed.remote(task_id, tb),
+                task_description=f"set_failed_if_not_cancelled({task_id})",
+            )
+            return
+        await self._call(
+            self._tsm.set_state.remote(task_id, "FAILED"),
+            task_description=f"set_state({task_id}, FAILED)",
+        )
 
     async def delete_file(self, file_id: str, partition: str) -> None:
         cancelled = await cancel_active_indexing_tasks(

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -14,6 +14,7 @@ from services.workers.task_cancellation import cancel_active_indexing_tasks
 logger = get_logger()
 
 DEFAULT_TIMEOUT = 60.0
+_REQUIRE_EXISTING_PARTITION_KWARG = "require_existing_partition"
 
 
 class WorkerDispatcher(IndexingDispatcher):
@@ -98,26 +99,24 @@ class WorkerDispatcher(IndexingDispatcher):
 
         task: Any | None = None
         try:
-            # ``IndexerPool`` is a Ray actor; ``submit`` returns ``[worker_ref]``
-            # (wrapped so Ray doesn't auto-dereference and block on the worker task).
-            # Awaiting the submit call yields that list; element 0 is the worker ref
-            # that ``cancel_task``/``ray.cancel`` must target.
-            submitted = await self._call(
-                self._pool.submit.remote(
-                    task_id=task_id,
-                    path=path,
-                    metadata=metadata,
-                    partition=partition,
-                    user=user,
-                    workspace_ids=workspace_ids,
-                    replace=replace,
-                    indexation_config=indexation_config,
-                    embedder_name=embedder_name,
-                    require_existing_partition=require_existing_partition,
-                ),
-                task_description=f"submit({task_id})",
+            submit_kwargs: dict[str, Any] = {
+                "task_id": task_id,
+                "path": path,
+                "metadata": metadata,
+                "partition": partition,
+                "user": user,
+                "workspace_ids": workspace_ids,
+                "replace": replace,
+                "indexation_config": indexation_config,
+                "embedder_name": embedder_name,
+            }
+            if require_existing_partition:
+                submit_kwargs[_REQUIRE_EXISTING_PARTITION_KWARG] = True
+            task = await self._submit_indexing_task(
+                task_id,
+                submit_kwargs,
+                allow_legacy_retry=require_existing_partition,
             )
-            task = submitted[0]
 
             registered = await self._call(
                 self._tsm.set_object_ref.remote(task_id, {"ref": task}),
@@ -133,6 +132,37 @@ class WorkerDispatcher(IndexingDispatcher):
                 await self._mark_submit_failed(task_id, traceback.format_exc())
             raise
         return task_id
+
+    async def _submit_indexing_task(
+        self,
+        task_id: str,
+        submit_kwargs: dict[str, Any],
+        *,
+        allow_legacy_retry: bool,
+    ) -> Any:
+        try:
+            return await self._submit_indexing_task_once(task_id, submit_kwargs)
+        except Exception as exc:
+            if not allow_legacy_retry or not _is_legacy_require_existing_partition_rejection(exc):
+                raise
+            logger.warning(
+                "Indexer actor rejected require_existing_partition; retrying without it for rolling-deploy compatibility",
+                task_id=task_id,
+            )
+            legacy_kwargs = dict(submit_kwargs)
+            legacy_kwargs.pop(_REQUIRE_EXISTING_PARTITION_KWARG, None)
+            return await self._submit_indexing_task_once(task_id, legacy_kwargs)
+
+    async def _submit_indexing_task_once(self, task_id: str, submit_kwargs: dict[str, Any]) -> Any:
+        # ``IndexerPool`` is a Ray actor; ``submit`` returns ``[worker_ref]``
+        # (wrapped so Ray doesn't auto-dereference and block on the worker task).
+        # Awaiting the submit call yields that list; element 0 is the worker ref
+        # that ``cancel_task``/``ray.cancel`` must target.
+        submitted = await self._call(
+            self._pool.submit.remote(**submit_kwargs),
+            task_description=f"submit({task_id})",
+        )
+        return submitted[0]
 
     async def _mark_submit_failed(self, task_id: str, tb: str) -> None:
         set_failed = getattr(self._tsm, "set_failed_if_not_cancelled", None)
@@ -353,6 +383,23 @@ def from_ray_namespace(
         collection=collection,
         timeout=timeout,
     )
+
+
+def _is_legacy_require_existing_partition_rejection(exc: BaseException) -> bool:
+    for current in _exception_chain(exc):
+        message = f"{type(current).__name__}: {current}"
+        if _REQUIRE_EXISTING_PARTITION_KWARG in message and "unexpected keyword" in message:
+            return True
+    return False
+
+
+def _exception_chain(exc: BaseException):
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
 
 
 __all__ = ["WorkerDispatcher", "from_ray_namespace"]

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -117,24 +117,10 @@ class WorkerDispatcher(IndexingDispatcher):
         return task_id
 
     async def delete_file(self, file_id: str, partition: str) -> None:
+        if await self._vector_store.collection_exists(self._collection):
+            await self._vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
         await self._workspace_repo.remove_file_from_all_workspaces(file_id, partition)
         await self._document_repo.remove_file_from_partition(file_id=file_id, partition=partition)
-        ids = await self._vector_store.query_ids_by_filter(
-            self._collection,
-            {"partition": partition, "file_id": file_id},
-        )
-        if ids:
-            try:
-                await self._vector_store.delete(ids, self._collection)
-            except Exception as e:
-                logger.error(
-                    "Failed to delete chunks from vector store after removing from database; "
-                    "reconciliation task required",
-                    file_id=file_id,
-                    partition=partition,
-                    chunk_count=len(ids),
-                    error=str(e),
-                )
 
     async def update_file_metadata(
         self,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -74,10 +74,10 @@ class WorkerDispatcher(IndexingDispatcher):
         partition: str,
         metadata: dict[str, Any],
         user_id: int | None,
-    ) -> None:
+    ) -> bool:
         remote = _remote_actor_method(self._tsm, "set_queued_details")
         if remote is not None:
-            await self._call(
+            accepted = await self._call(
                 remote(
                     task_id,
                     file_id=file_id,
@@ -87,7 +87,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 ),
                 task_description=f"set_queued_details({task_id})",
             )
-            return
+            return accepted is not False
 
         await self._call(
             self._tsm.set_state.remote(task_id, "QUEUED"),
@@ -102,6 +102,25 @@ class WorkerDispatcher(IndexingDispatcher):
                 user_id=user_id,
             ),
             task_description=f"set_details({task_id})",
+        )
+        return True
+
+    async def _begin_file_delete_fence(self, *, file_id: str, partition: str) -> None:
+        remote = _remote_actor_method(self._tsm, "begin_file_delete")
+        if remote is None:
+            raise RuntimeError("TaskStateManager does not expose file delete fencing for delete cleanup")
+        await self._call(
+            remote(partition=partition, file_id=file_id),
+            task_description=f"begin_file_delete({partition}, {file_id})",
+        )
+
+    async def _end_file_delete_fence(self, *, file_id: str, partition: str) -> None:
+        remote = _remote_actor_method(self._tsm, "end_file_delete")
+        if remote is None:
+            raise RuntimeError("TaskStateManager does not expose file delete fencing for delete cleanup")
+        await self._call(
+            remote(partition=partition, file_id=file_id),
+            task_description=f"end_file_delete({partition}, {file_id})",
         )
 
     async def dispatch_indexing(
@@ -121,13 +140,18 @@ class WorkerDispatcher(IndexingDispatcher):
         task_id = uuid.uuid4().hex
 
         user_metadata = {key: value for key, value in metadata.items() if key not in {"file_id", "source"}}
-        await self._set_queued_details(
+        accepted = await self._set_queued_details(
             task_id,
             file_id=metadata.get("file_id"),
             partition=partition,
             metadata=user_metadata,
             user_id=user.get("id") if user else None,
         )
+        if not accepted:
+            raise RuntimeError(
+                f"Task {task_id} was rejected because file {metadata.get('file_id')!r} "
+                f"in partition {partition!r} is being deleted"
+            )
 
         task: Any | None = None
         try:
@@ -275,6 +299,27 @@ class WorkerDispatcher(IndexingDispatcher):
         return False
 
     async def delete_file(self, file_id: str, partition: str) -> None:
+        await self._begin_file_delete_fence(file_id=file_id, partition=partition)
+        delete_failed = False
+        try:
+            await self._delete_file_with_fence(file_id=file_id, partition=partition)
+        except Exception:
+            delete_failed = True
+            raise
+        finally:
+            try:
+                await self._end_file_delete_fence(file_id=file_id, partition=partition)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to release file delete fence",
+                    file_id=file_id,
+                    partition=partition,
+                    error=str(exc),
+                )
+                if not delete_failed:
+                    raise
+
+    async def _delete_file_with_fence(self, *, file_id: str, partition: str) -> None:
         cancelled = await cancel_active_indexing_tasks(
             self._tsm,
             partition=partition,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -9,6 +9,7 @@ from core.utils.conts import is_internal_metadata_key, strip_internal_metadata
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout
+from services.workers.stages.store import INDEXING_TASK_ID_METADATA_KEY
 from services.workers.task_cancellation import cancel_active_indexing_tasks
 
 logger = get_logger()
@@ -65,6 +66,44 @@ class WorkerDispatcher(IndexingDispatcher):
             task_description=task_description,
         )
 
+    async def _set_queued_details(
+        self,
+        task_id: str,
+        *,
+        file_id: str | None,
+        partition: str,
+        metadata: dict[str, Any],
+        user_id: int | None,
+    ) -> None:
+        remote = _remote_actor_method(self._tsm, "set_queued_details")
+        if remote is not None:
+            await self._call(
+                remote(
+                    task_id,
+                    file_id=file_id,
+                    partition=partition,
+                    metadata=metadata,
+                    user_id=user_id,
+                ),
+                task_description=f"set_queued_details({task_id})",
+            )
+            return
+
+        await self._call(
+            self._tsm.set_state.remote(task_id, "QUEUED"),
+            task_description=f"set_state({task_id})",
+        )
+        await self._call(
+            self._tsm.set_details.remote(
+                task_id,
+                file_id=file_id,
+                partition=partition,
+                metadata=metadata,
+                user_id=user_id,
+            ),
+            task_description=f"set_details({task_id})",
+        )
+
     async def dispatch_indexing(
         self,
         *,
@@ -77,24 +116,17 @@ class WorkerDispatcher(IndexingDispatcher):
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
         require_existing_partition: bool = False,
+        allow_legacy_require_existing_partition_retry: bool = False,
     ) -> str:
         task_id = uuid.uuid4().hex
 
-        await self._call(
-            self._tsm.set_state.remote(task_id, "QUEUED"),
-            task_description=f"set_state({task_id})",
-        )
-
         user_metadata = {key: value for key, value in metadata.items() if key not in {"file_id", "source"}}
-        await self._call(
-            self._tsm.set_details.remote(
-                task_id,
-                file_id=metadata.get("file_id"),
-                partition=partition,
-                metadata=user_metadata,
-                user_id=user.get("id") if user else None,
-            ),
-            task_description=f"set_details({task_id})",
+        await self._set_queued_details(
+            task_id,
+            file_id=metadata.get("file_id"),
+            partition=partition,
+            metadata=user_metadata,
+            user_id=user.get("id") if user else None,
         )
 
         task: Any | None = None
@@ -115,7 +147,7 @@ class WorkerDispatcher(IndexingDispatcher):
             task = await self._submit_indexing_task(
                 task_id,
                 submit_kwargs,
-                allow_legacy_retry=require_existing_partition,
+                allow_legacy_retry=allow_legacy_require_existing_partition_retry,
             )
 
             registered = await self._call(
@@ -128,10 +160,34 @@ class WorkerDispatcher(IndexingDispatcher):
             mark_submit_failed = True
             if task is not None:
                 mark_submit_failed = await self._cancel_submitted_task(task_id, task)
+                if mark_submit_failed:
+                    await self._cleanup_submitted_vectors(task_id, metadata=metadata, partition=partition)
             if mark_submit_failed:
                 await self._mark_submit_failed(task_id, traceback.format_exc())
             raise
         return task_id
+
+    async def _cleanup_submitted_vectors(self, task_id: str, *, metadata: dict, partition: str) -> None:
+        file_id = metadata.get("file_id")
+        if not file_id:
+            return
+        try:
+            if await self._vector_store.collection_exists(self._collection):
+                await self._vector_store.delete_by_filter(
+                    {
+                        "partition": partition,
+                        "file_id": file_id,
+                        INDEXING_TASK_ID_METADATA_KEY: str(task_id),
+                    }
+                )
+        except Exception as exc:
+            logger.warning(
+                "Failed to clean task-marked vectors after indexing dispatch failure",
+                task_id=task_id,
+                file_id=file_id,
+                partition=partition,
+                error=str(exc),
+            )
 
     async def _submit_indexing_task(
         self,
@@ -408,6 +464,14 @@ def _exception_chain(exc: BaseException):
         seen.add(id(current))
         yield current
         current = current.__cause__ or current.__context__
+
+
+def _remote_actor_method(actor: Any, name: str) -> Any | None:
+    method_names = getattr(actor, "_ray_actor_method_names", None)
+    if isinstance(method_names, (frozenset, list, set, tuple)) and name not in method_names:
+        return None
+    method = getattr(actor, name, None)
+    return getattr(method, "remote", None)
 
 
 __all__ = ["WorkerDispatcher", "from_ray_namespace"]

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -124,9 +124,11 @@ class WorkerDispatcher(IndexingDispatcher):
             if registered is False:
                 raise RuntimeError(f"Task {task_id} was cancelled before worker ref registration")
         except Exception:
+            mark_submit_failed = True
             if task is not None:
-                await self._cancel_submitted_task(task_id, task)
-            await self._mark_submit_failed(task_id, traceback.format_exc())
+                mark_submit_failed = await self._cancel_submitted_task(task_id, task)
+            if mark_submit_failed:
+                await self._mark_submit_failed(task_id, traceback.format_exc())
             raise
         return task_id
 
@@ -143,7 +145,7 @@ class WorkerDispatcher(IndexingDispatcher):
             task_description=f"set_state({task_id}, FAILED)",
         )
 
-    async def _cancel_submitted_task(self, task_id: str, task: Any) -> None:
+    async def _cancel_submitted_task(self, task_id: str, task: Any) -> bool:
         import ray
 
         try:
@@ -154,7 +156,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 task_id=task_id,
                 error=str(exc),
             )
-            return
+            raise RuntimeError(f"Failed to cancel submitted indexing task {task_id}") from exc
         try:
             await call_ray_actor_with_timeout(
                 future=task,
@@ -162,18 +164,27 @@ class WorkerDispatcher(IndexingDispatcher):
                 task_description=f"cancel_submitted_task({task_id})",
             )
         except TaskCancelledError:
-            return
-        except TimeoutError:
+            return True
+        except TimeoutError as exc:
             logger.warning(
                 "Timed out waiting for submitted indexing task to settle after dispatch failure",
                 task_id=task_id,
             )
+            raise TimeoutError(
+                f"Timed out waiting for submitted indexing task {task_id} to settle after dispatch failure"
+            ) from exc
         except Exception as exc:
             logger.info(
                 "Submitted indexing task settled after dispatch failure cancellation request",
                 task_id=task_id,
                 error=str(exc),
             )
+            return False
+        logger.info(
+            "Submitted indexing task completed before dispatch failure cancellation took effect",
+            task_id=task_id,
+        )
+        return False
 
     async def delete_file(self, file_id: str, partition: str) -> None:
         cancelled = await cancel_active_indexing_tasks(

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
+from core.utils.conts import is_internal_metadata_key, strip_internal_metadata
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout
@@ -34,7 +35,6 @@ class WorkerDispatcher(IndexingDispatcher):
             "next_section_id",
         }
     )
-    _INTERNAL_METADATA_PREFIX = "_openrag"
 
     def __init__(
         self,
@@ -75,6 +75,7 @@ class WorkerDispatcher(IndexingDispatcher):
         replace: bool,
         indexation_config: dict | None = None,
         embedder_name: str | None = None,
+        require_existing_partition: bool = False,
     ) -> str:
         task_id = uuid.uuid4().hex
 
@@ -112,6 +113,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     replace=replace,
                     indexation_config=indexation_config,
                     embedder_name=embedder_name,
+                    require_existing_partition=require_existing_partition,
                 ),
                 task_description=f"submit({task_id})",
             )
@@ -228,10 +230,10 @@ class WorkerDispatcher(IndexingDispatcher):
         if not rows:
             return
 
-        public_metadata = self._strip_internal_metadata(metadata)
+        public_metadata = strip_internal_metadata(metadata)
         entities = []
         for row in rows:
-            internal_metadata = {k: v for k, v in row.items() if self._is_internal_metadata_key(k)}
+            internal_metadata = {k: v for k, v in row.items() if is_internal_metadata_key(k)}
             entity = dict(row)
             entity.update(public_metadata)
             entity.update(internal_metadata)
@@ -258,10 +260,10 @@ class WorkerDispatcher(IndexingDispatcher):
         if not rows:
             return
 
-        public_metadata = self._strip_internal_metadata(metadata)
+        public_metadata = strip_internal_metadata(metadata)
         entities = []
         for row in rows:
-            entity = self._strip_internal_metadata(row)
+            entity = strip_internal_metadata(row)
             entity.pop("_id", None)
             entity.update(public_metadata)
             entities.append(entity)
@@ -297,16 +299,8 @@ class WorkerDispatcher(IndexingDispatcher):
         return {
             k: v
             for k, v in chunk.items()
-            if k not in self._FILE_METADATA_EXCLUDED_KEYS and not self._is_internal_metadata_key(k)
+            if k not in self._FILE_METADATA_EXCLUDED_KEYS and not is_internal_metadata_key(k)
         }
-
-    @classmethod
-    def _strip_internal_metadata(cls, row: dict[str, Any]) -> dict[str, Any]:
-        return {k: v for k, v in row.items() if not cls._is_internal_metadata_key(k)}
-
-    @classmethod
-    def _is_internal_metadata_key(cls, key: Any) -> bool:
-        return isinstance(key, str) and key.startswith(cls._INTERNAL_METADATA_PREFIX)
 
     async def get_task_state(self, task_id: str) -> str | None:
         return await self._call(

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
 from core.utils.logging import get_logger
+from services.workers.task_cancellation import cancel_active_indexing_tasks
 
 logger = get_logger()
 
@@ -117,10 +118,22 @@ class WorkerDispatcher(IndexingDispatcher):
         return task_id
 
     async def delete_file(self, file_id: str, partition: str) -> None:
-        if await self._vector_store.collection_exists(self._collection):
+        cancelled = await cancel_active_indexing_tasks(
+            self._tsm,
+            partition=partition,
+            file_id=file_id,
+            timeout=self._timeout,
+        )
+        if cancelled:
+            logger.info("Cancelled active indexing tasks before deleting file", file_id=file_id, partition=partition)
+
+        collection_exists = await self._vector_store.collection_exists(self._collection)
+        if collection_exists:
             await self._vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
         await self._workspace_repo.remove_file_from_all_workspaces(file_id, partition)
         await self._document_repo.remove_file_from_partition(file_id=file_id, partition=partition)
+        if collection_exists:
+            await self._vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
 
     async def update_file_metadata(
         self,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -200,6 +200,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     partition=partition,
                     error=str(exc),
                 )
+                raise
 
     async def update_file_metadata(
         self,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -228,16 +228,19 @@ class WorkerDispatcher(IndexingDispatcher):
         if not rows:
             return
 
+        public_metadata = self._strip_internal_metadata(metadata)
         entities = []
         for row in rows:
-            entity = self._strip_internal_metadata(row)
-            entity.update(metadata)
+            internal_metadata = {k: v for k, v in row.items() if self._is_internal_metadata_key(k)}
+            entity = dict(row)
+            entity.update(public_metadata)
+            entity.update(internal_metadata)
             entities.append(entity)
 
         await self._upsert_entities(entities)
 
         file_metadata = self._file_metadata_from_chunk(rows[0])
-        file_metadata.update(metadata)
+        file_metadata.update(public_metadata)
         await self._document_repo.update_file_metadata_in_db(file_id, partition, file_metadata)
 
     async def copy_file(
@@ -255,11 +258,12 @@ class WorkerDispatcher(IndexingDispatcher):
         if not rows:
             return
 
+        public_metadata = self._strip_internal_metadata(metadata)
         entities = []
         for row in rows:
             entity = self._strip_internal_metadata(row)
             entity.pop("_id", None)
-            entity.update(metadata)
+            entity.update(public_metadata)
             entities.append(entity)
 
         await self._insert_entities(entities)
@@ -267,7 +271,7 @@ class WorkerDispatcher(IndexingDispatcher):
         target_file_id = metadata.get("file_id", file_id)
         target_partition = metadata.get("partition", partition)
         file_metadata = self._file_metadata_from_chunk(rows[0])
-        file_metadata.update(metadata)
+        file_metadata.update(public_metadata)
         await self._document_repo.add_file_to_partition(
             file_id=target_file_id,
             partition=target_partition,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -133,7 +133,15 @@ class WorkerDispatcher(IndexingDispatcher):
         await self._workspace_repo.remove_file_from_all_workspaces(file_id, partition)
         await self._document_repo.remove_file_from_partition(file_id=file_id, partition=partition)
         if collection_exists:
-            await self._vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
+            try:
+                await self._vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
+            except Exception as exc:
+                logger.warning(
+                    "Post-delete vector cleanup failed after file catalog removal",
+                    file_id=file_id,
+                    partition=partition,
+                    error=str(exc),
+                )
 
     async def update_file_metadata(
         self,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
 from core.utils.logging import get_logger
+from ray.exceptions import TaskCancelledError
+from services.workers.ray_utils import call_ray_actor_with_timeout
 from services.workers.task_cancellation import cancel_active_indexing_tasks
 
 logger = get_logger()
@@ -32,6 +34,7 @@ class WorkerDispatcher(IndexingDispatcher):
             "next_section_id",
         }
     )
+    _INTERNAL_METADATA_PREFIX = "_openrag"
 
     def __init__(
         self,
@@ -92,6 +95,7 @@ class WorkerDispatcher(IndexingDispatcher):
             task_description=f"set_details({task_id})",
         )
 
+        task: Any | None = None
         try:
             # ``IndexerPool`` is a Ray actor; ``submit`` returns ``[worker_ref]``
             # (wrapped so Ray doesn't auto-dereference and block on the worker task).
@@ -113,11 +117,15 @@ class WorkerDispatcher(IndexingDispatcher):
             )
             task = submitted[0]
 
-            await self._call(
+            registered = await self._call(
                 self._tsm.set_object_ref.remote(task_id, {"ref": task}),
                 task_description=f"set_object_ref({task_id})",
             )
+            if registered is False:
+                raise RuntimeError(f"Task {task_id} was cancelled before worker ref registration")
         except Exception:
+            if task is not None:
+                await self._cancel_submitted_task(task_id, task)
             await self._mark_submit_failed(task_id, traceback.format_exc())
             raise
         return task_id
@@ -134,6 +142,38 @@ class WorkerDispatcher(IndexingDispatcher):
             self._tsm.set_state.remote(task_id, "FAILED"),
             task_description=f"set_state({task_id}, FAILED)",
         )
+
+    async def _cancel_submitted_task(self, task_id: str, task: Any) -> None:
+        import ray
+
+        try:
+            ray.cancel(task, recursive=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel submitted indexing task after dispatch failure",
+                task_id=task_id,
+                error=str(exc),
+            )
+            return
+        try:
+            await call_ray_actor_with_timeout(
+                future=task,
+                timeout=self._timeout,
+                task_description=f"cancel_submitted_task({task_id})",
+            )
+        except TaskCancelledError:
+            return
+        except TimeoutError:
+            logger.warning(
+                "Timed out waiting for submitted indexing task to settle after dispatch failure",
+                task_id=task_id,
+            )
+        except Exception as exc:
+            logger.info(
+                "Submitted indexing task settled after dispatch failure cancellation request",
+                task_id=task_id,
+                error=str(exc),
+            )
 
     async def delete_file(self, file_id: str, partition: str) -> None:
         cancelled = await cancel_active_indexing_tasks(
@@ -178,7 +218,7 @@ class WorkerDispatcher(IndexingDispatcher):
 
         entities = []
         for row in rows:
-            entity = dict(row)
+            entity = self._strip_internal_metadata(row)
             entity.update(metadata)
             entities.append(entity)
 
@@ -205,7 +245,7 @@ class WorkerDispatcher(IndexingDispatcher):
 
         entities = []
         for row in rows:
-            entity = dict(row)
+            entity = self._strip_internal_metadata(row)
             entity.pop("_id", None)
             entity.update(metadata)
             entities.append(entity)
@@ -238,7 +278,19 @@ class WorkerDispatcher(IndexingDispatcher):
         await insert_entities(entities, self._collection)
 
     def _file_metadata_from_chunk(self, chunk: dict[str, Any]) -> dict[str, Any]:
-        return {k: v for k, v in chunk.items() if k not in self._FILE_METADATA_EXCLUDED_KEYS}
+        return {
+            k: v
+            for k, v in chunk.items()
+            if k not in self._FILE_METADATA_EXCLUDED_KEYS and not self._is_internal_metadata_key(k)
+        }
+
+    @classmethod
+    def _strip_internal_metadata(cls, row: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in row.items() if not cls._is_internal_metadata_key(k)}
+
+    @classmethod
+    def _is_internal_metadata_key(cls, key: Any) -> bool:
+        return isinstance(key, str) and key.startswith(cls._INTERNAL_METADATA_PREFIX)
 
     async def get_task_state(self, task_id: str) -> str | None:
         return await self._call(

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -34,11 +34,15 @@ class IndexerWorker:
         task_state_manager: Any,
         document_repo: Any = None,
         topic_tag_repo: Any = None,
+        vector_store: Any = None,
+        collection: str = "default",
     ) -> None:
         self._pipeline = pipeline
         self._tsm = task_state_manager
         self._document_repo = document_repo
         self._topic_tag_repo = topic_tag_repo
+        self._vector_store = vector_store
+        self._collection = collection
 
     async def process_file(
         self,
@@ -60,6 +64,8 @@ class IndexerWorker:
         is re-raised so the Ray task is marked as errored.
         """
         await self._tsm.set_state.remote(task_id, "SERIALIZING")
+        row: dict[str, Any] | None = None
+        catalog_written = False
         try:
             document = await _load_document(path, metadata, partition)
             # One indexation timestamp for this file, shared by the Milvus chunks
@@ -80,7 +86,7 @@ class IndexerWorker:
             indexed_at = row.get("indexed_at")
 
             if self._document_repo is not None:
-                await _write_catalog_record(
+                wrote_catalog = await _write_catalog_record(
                     doc_repo=self._document_repo,
                     metadata=metadata,
                     partition=partition,
@@ -89,6 +95,9 @@ class IndexerWorker:
                     indexation_config=indexation_config,
                     indexed_at=indexed_at,
                 )
+                if not wrote_catalog:
+                    raise RuntimeError("Catalog row was not written after vector indexing")
+                catalog_written = True
             if self._topic_tag_repo is not None:
                 await _replace_topic_tags_if_needed(
                     topic_tag_repo=self._topic_tag_repo,
@@ -100,6 +109,13 @@ class IndexerWorker:
             await self._tsm.set_state.remote(task_id, "COMPLETED")
             return {"stored_count": row.get("stored_count", 0), "stage": row.get("stage", "")}
         except Exception:
+            if not catalog_written and row is not None and row.get("stored_count", 0) > 0:
+                await _cleanup_indexed_vectors(
+                    vector_store=self._vector_store,
+                    collection=self._collection,
+                    metadata=metadata,
+                    partition=partition,
+                )
             tb = traceback.format_exc()
             await self._tsm.set_failed_if_not_cancelled.remote(task_id, tb)
             raise
@@ -118,12 +134,12 @@ async def _write_catalog_record(
     replace: bool,
     indexation_config: dict[str, Any] | None,
     indexed_at: datetime | None = None,
-) -> None:
+) -> bool:
     file_id = metadata.get("file_id", "")
     file_metadata = {key: value for key, value in metadata.items() if key != "page"}
     config_kwargs = {"indexation_config": indexation_config} if indexation_config is not None else {}
     if replace:
-        await doc_repo.update_file_in_partition(
+        return await doc_repo.update_file_in_partition(
             file_id=file_id,
             partition=partition,
             file_metadata=file_metadata,
@@ -132,9 +148,8 @@ async def _write_catalog_record(
             indexed_at=indexed_at,
             **config_kwargs,
         )
-        return
 
-    await doc_repo.add_file_to_partition(
+    return await doc_repo.add_file_to_partition(
         file_id=file_id,
         partition=partition,
         file_metadata=file_metadata,
@@ -142,8 +157,28 @@ async def _write_catalog_record(
         relationship_id=metadata.get("relationship_id"),
         parent_id=metadata.get("parent_id"),
         indexed_at=indexed_at,
+        require_existing_partition=True,
         **config_kwargs,
     )
+
+
+async def _cleanup_indexed_vectors(
+    *,
+    vector_store: Any,
+    collection: str,
+    metadata: dict[str, Any],
+    partition: str,
+) -> None:
+    file_id = metadata.get("file_id")
+    if vector_store is None or not file_id:
+        return
+    try:
+        if await vector_store.collection_exists(collection):
+            await vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
+    except Exception:
+        # Preserve the original indexing failure; cleanup errors are logged by
+        # the caller's failed task state and can be retried through delete.
+        return
 
 
 async def _replace_topic_tags_if_needed(

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -159,7 +159,7 @@ async def _write_catalog_record(
         relationship_id=metadata.get("relationship_id"),
         parent_id=metadata.get("parent_id"),
         indexed_at=indexed_at,
-        require_existing_partition=True,
+        require_existing_partition=indexation_config is not None,
         **config_kwargs,
     )
 

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from core.models.document import Document
 from services.workers.pipeline_builder import IndexingPipeline
+from services.workers.stages.store import INDEXING_TASK_ID_METADATA_KEY
 
 
 class IndexerWorker:
@@ -115,6 +116,7 @@ class IndexerWorker:
                     collection=self._collection,
                     metadata=metadata,
                     partition=partition,
+                    task_id=task_id,
                 )
             tb = traceback.format_exc()
             await self._tsm.set_failed_if_not_cancelled.remote(task_id, tb)
@@ -168,16 +170,23 @@ async def _cleanup_indexed_vectors(
     collection: str,
     metadata: dict[str, Any],
     partition: str,
+    task_id: str,
 ) -> None:
     file_id = metadata.get("file_id")
-    if vector_store is None or not file_id:
+    if vector_store is None or not file_id or not task_id:
         return
     try:
         if await vector_store.collection_exists(collection):
-            await vector_store.delete_by_filter({"partition": partition, "file_id": file_id})
+            await vector_store.delete_by_filter(
+                {
+                    "partition": partition,
+                    "file_id": file_id,
+                    INDEXING_TASK_ID_METADATA_KEY: str(task_id),
+                }
+            )
     except Exception:
-        # Preserve the original indexing failure; cleanup errors are logged by
-        # the caller's failed task state and can be retried through delete.
+        # Preserve the original indexing failure. A later file delete still runs
+        # the broader partition/file cleanup path if this best-effort sweep fails.
         return
 
 

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -7,8 +7,16 @@ from pathlib import Path
 from typing import Any
 
 from core.models.document import Document
-from services.workers.pipeline_builder import IndexingPipeline
+from core.utils.logging import get_logger
+from services.workers.pipeline_builder import (
+    REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY,
+    REPLACE_OLD_CHUNK_IDS_ROW_KEY,
+    IndexingPipeline,
+)
+from services.workers.stages._common import run_with_optional_timeout
 from services.workers.stages.store import INDEXING_TASK_ID_METADATA_KEY
+
+logger = get_logger()
 
 
 class IndexerWorker:
@@ -99,6 +107,11 @@ class IndexerWorker:
                 if not wrote_catalog:
                     raise RuntimeError("Catalog row was not written after vector indexing")
                 catalog_written = True
+                await _delete_replaced_chunks_after_catalog(
+                    vector_store=self._vector_store or getattr(self._pipeline, "vector_store", None),
+                    row=row,
+                    timeout=getattr(getattr(self._pipeline, "timeouts", None), "store", None),
+                )
             if self._topic_tag_repo is not None:
                 await _replace_topic_tags_if_needed(
                     topic_tag_repo=self._topic_tag_repo,
@@ -110,9 +123,12 @@ class IndexerWorker:
             await self._tsm.set_state.remote(task_id, "COMPLETED")
             return {"stored_count": row.get("stored_count", 0), "stage": row.get("stage", "")}
         except Exception:
-            if not catalog_written and row is not None and row.get("stored_count", 0) > 0:
+            should_cleanup_vectors = row is not None and (
+                row.get("stored_count", 0) > 0 or row.get("stage") == "store_failed"
+            )
+            if not catalog_written and should_cleanup_vectors:
                 await _cleanup_indexed_vectors(
-                    vector_store=self._vector_store,
+                    vector_store=self._vector_store or getattr(self._pipeline, "vector_store", None),
                     collection=self._collection,
                     metadata=metadata,
                     partition=partition,
@@ -188,6 +204,26 @@ async def _cleanup_indexed_vectors(
         # Preserve the original indexing failure. A later file delete still runs
         # the broader partition/file cleanup path if this best-effort sweep fails.
         return
+
+
+async def _delete_replaced_chunks_after_catalog(
+    *,
+    vector_store: Any,
+    row: dict[str, Any],
+    timeout: float | None,
+) -> None:
+    ids = row.get(REPLACE_OLD_CHUNK_IDS_ROW_KEY)
+    if vector_store is None or not isinstance(ids, list) or not ids:
+        return
+    collection = row.get(REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY) or "default"
+    try:
+        deleted = await run_with_optional_timeout(lambda: vector_store.delete(ids, collection), timeout)
+        logger.bind(task_id=row.get("task_id")).debug(f"re-index: removed {deleted} stale chunk(s) after replace")
+    except Exception as exc:  # noqa: BLE001 - cleanup is best-effort after catalog commit
+        logger.bind(task_id=row.get("task_id")).error(
+            f"re-index: catalog was updated but failed to delete {len(ids)} stale chunk(s); "
+            f"duplicates remain until reconciliation: {exc}"
+        )
 
 
 async def _replace_topic_tags_if_needed(

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -65,6 +65,7 @@ class IndexerWorker:
         replace: bool = False,
         indexation_config: dict[str, Any] | None = None,
         embedder_name: str | None = None,
+        require_existing_partition: bool = False,
     ) -> dict[str, Any]:
         """Run one file through the indexing pipeline.
 
@@ -103,6 +104,7 @@ class IndexerWorker:
                     replace=replace,
                     indexation_config=indexation_config,
                     indexed_at=indexed_at,
+                    require_existing_partition=require_existing_partition,
                 )
                 if not wrote_catalog:
                     raise RuntimeError("Catalog row was not written after vector indexing")
@@ -152,6 +154,7 @@ async def _write_catalog_record(
     replace: bool,
     indexation_config: dict[str, Any] | None,
     indexed_at: datetime | None = None,
+    require_existing_partition: bool = False,
 ) -> bool:
     file_id = metadata.get("file_id", "")
     file_metadata = {key: value for key, value in metadata.items() if key != "page"}
@@ -175,7 +178,7 @@ async def _write_catalog_record(
         relationship_id=metadata.get("relationship_id"),
         parent_id=metadata.get("parent_id"),
         indexed_at=indexed_at,
-        require_existing_partition=indexation_config is not None,
+        require_existing_partition=require_existing_partition,
         **config_kwargs,
     )
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -211,6 +211,7 @@ class IndexerWorkerActor:
         replace: bool = False,
         indexation_config: dict[str, Any] | None = None,
         embedder_name: str | None = None,
+        require_existing_partition: bool = False,
     ) -> dict[str, Any]:
         try:
             await self._ensure_catalog()
@@ -225,6 +226,7 @@ class IndexerWorkerActor:
                 replace=replace,
                 indexation_config=indexation_config,
                 embedder_name=embedder_name,
+                require_existing_partition=require_existing_partition,
             )
             file_id = metadata.get("file_id", "")
             if workspace_ids and not replace and file_id:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -112,6 +112,8 @@ class IndexerWorkerActor:
             task_state_manager=task_state_manager,
             document_repo=self._catalog_store.document_repo,
             topic_tag_repo=self._catalog_store.topic_tag_repo,
+            vector_store=self._vector_store,
+            collection=cfg.vectordb.collection_name,
         )
         # When False (e.g. Twake, which keeps its own copy), the raw upload is
         # purged from ``paths.data_dir`` once indexing settles. Enforced at this

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -75,6 +75,7 @@ class IndexerWorkerActor:
             vlm_factory=vlm_factory,
             contextualizer_factory=contextualizer_factory,
             topic_tagger_factory=topic_tagger_factory,
+            defer_replace_cleanup=True,
         )
         rdb_cfg = cfg.rdb.model_copy(update={"database": f"partitions_for_collection_{cfg.vectordb.collection_name}"})
         self._catalog_store = PostgresStore(rdb_cfg, run_migrations=False)

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -169,9 +169,8 @@ class IndexingPipeline:
             #     set, leaving duplicates. Serializing replace per (partition,
             #     file_id) belongs with the durable job/lifecycle work (#658/#660).
             #   * A crash between store and delete orphans the old chunks with no
-            #     reconciler yet (the delete below logs for reconciliation, same
-            #     best-effort contract as WorkerDispatcher.delete_file) — the
-            #     reconciliation job is tracked in #658/#660.
+            #     reconciler yet (the delete below logs for reconciliation) —
+            #     the reconciliation job is tracked in #658/#660.
             replace = bool(row.get("replace"))
             old_chunk_ids = await self._existing_chunk_ids(row) if replace else []
             await _timed(
@@ -238,7 +237,7 @@ class IndexingPipeline:
 
         Best-effort: the new chunks are already safely inserted, so a delete
         failure only leaves recoverable duplicates behind (logged for
-        reconciliation), mirroring ``WorkerDispatcher.delete_file``.
+        reconciliation).
         """
         try:
             # Bound by the store budget: the new chunks are already stored, so a

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -26,6 +26,9 @@ from services.workers.stages.topic_tag import topic_tag_stage
 
 logger = get_logger()
 
+REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY = "_replace_old_chunk_collection"
+REPLACE_OLD_CHUNK_IDS_ROW_KEY = "_replace_old_chunk_ids"
+
 
 @dataclass(slots=True, frozen=True)
 class PipelineTimeouts:
@@ -155,7 +158,8 @@ class IndexingPipeline:
             )
             # Re-index (``replace=True``) is insert-before-delete: snapshot the
             # file's existing chunk ids *before* the store stage inserts the new
-            # set, then delete exactly that old set *after* a successful insert.
+            # set, then let the worker delete exactly that old set *after* the
+            # catalog row is successfully written.
             # The Milvus collection is ``auto_id``, so a plain insert can never
             # overwrite the previous chunks — without this cleanup every re-index
             # duplicates the whole file (#657). Insert-before-delete also means a
@@ -168,9 +172,11 @@ class IndexingPipeline:
             #     *same* file snapshot the same old ids and both keep their new
             #     set, leaving duplicates. Serializing replace per (partition,
             #     file_id) belongs with the durable job/lifecycle work (#658/#660).
-            #   * A crash between store and delete orphans the old chunks with no
-            #     reconciler yet (the delete below logs for reconciliation) —
-            #     the reconciliation job is tracked in #658/#660.
+            #   * A crash between store and the worker's post-catalog cleanup
+            #     can orphan the old chunks with no reconciler yet — the
+            #     reconciliation job is tracked in #658/#660.
+            row.pop(REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY, None)
+            row.pop(REPLACE_OLD_CHUNK_IDS_ROW_KEY, None)
             replace = bool(row.get("replace"))
             old_chunk_ids = await self._existing_chunk_ids(row) if replace else []
             await _timed(
@@ -191,10 +197,11 @@ class IndexingPipeline:
             # and leave the file with zero chunks in Milvus — worse than the
             # pre-fix duplication bug, and a violation of the "no empty window"
             # guarantee this whole insert-before-delete design is built on.
-            # Gating on ``stored_count`` ensures cleanup only runs once we know
-            # the new set actually replaced the old one.
+            # Gating on ``stored_count`` ensures cleanup is only scheduled once
+            # we know the new set actually replaced the old one.
             if replace and old_chunk_ids and row.get("stored_count"):
-                await self._delete_replaced_chunks(row, old_chunk_ids)
+                row[REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY] = "default"
+                row[REPLACE_OLD_CHUNK_IDS_ROW_KEY] = old_chunk_ids
             return row
         finally:
             logger.bind(
@@ -231,26 +238,6 @@ class IndexingPipeline:
                 f"re-index: could not snapshot existing chunks; skipping stale-chunk cleanup: {exc}"
             )
             return []
-
-    async def _delete_replaced_chunks(self, row: MutableMapping[str, Any], ids: list[str]) -> None:
-        """Delete the pre-re-index chunk set after the new chunks are stored.
-
-        Best-effort: the new chunks are already safely inserted, so a delete
-        failure only leaves recoverable duplicates behind (logged for
-        reconciliation).
-        """
-        try:
-            # Bound by the store budget: the new chunks are already stored, so a
-            # stalled delete must not hang the task — it degrades to duplicates.
-            deleted = await run_with_optional_timeout(
-                lambda: self.vector_store.delete(ids, "default"), self.timeouts.store
-            )
-            logger.bind(task_id=row.get("task_id")).debug(f"re-index: removed {deleted} stale chunk(s) after replace")
-        except Exception as exc:  # noqa: BLE001 - new chunks are stored; cleanup is best-effort
-            logger.bind(task_id=row.get("task_id")).error(
-                f"re-index: stored new chunks but failed to delete {len(ids)} stale chunk(s); "
-                f"duplicates remain until reconciliation: {exc}"
-            )
 
     def _effective_indexation_config(self, row: MutableMapping[str, Any]) -> IndexationPipelineConfig | None:
         raw_config = row.get("indexation_config", self.indexation_config)

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -66,6 +66,7 @@ class IndexingPipeline:
     vlm_factory: Callable[[str], VLM] | None = None
     contextualizer_factory: Callable[[str], ChunkContextualizer] | None = None
     topic_tagger_factory: Callable[[str], TopicTagger] | None = None
+    defer_replace_cleanup: bool = False
 
     async def run(self, row: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         """Run a single row through parse, optional enrichments, embed, and store.
@@ -158,8 +159,9 @@ class IndexingPipeline:
             )
             # Re-index (``replace=True``) is insert-before-delete: snapshot the
             # file's existing chunk ids *before* the store stage inserts the new
-            # set, then let the worker delete exactly that old set *after* the
-            # catalog row is successfully written.
+            # set, then delete exactly that old set after a successful insert.
+            # Worker pipelines defer that delete until after the catalog row is
+            # successfully written; direct pipeline callers clean it up here.
             # The Milvus collection is ``auto_id``, so a plain insert can never
             # overwrite the previous chunks — without this cleanup every re-index
             # duplicates the whole file (#657). Insert-before-delete also means a
@@ -172,9 +174,9 @@ class IndexingPipeline:
             #     *same* file snapshot the same old ids and both keep their new
             #     set, leaving duplicates. Serializing replace per (partition,
             #     file_id) belongs with the durable job/lifecycle work (#658/#660).
-            #   * A crash between store and the worker's post-catalog cleanup
-            #     can orphan the old chunks with no reconciler yet — the
-            #     reconciliation job is tracked in #658/#660.
+            #   * A crash after store but before cleanup can orphan the old
+            #     chunks with no reconciler yet — the reconciliation job is
+            #     tracked in #658/#660.
             row.pop(REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY, None)
             row.pop(REPLACE_OLD_CHUNK_IDS_ROW_KEY, None)
             replace = bool(row.get("replace"))
@@ -197,11 +199,14 @@ class IndexingPipeline:
             # and leave the file with zero chunks in Milvus — worse than the
             # pre-fix duplication bug, and a violation of the "no empty window"
             # guarantee this whole insert-before-delete design is built on.
-            # Gating on ``stored_count`` ensures cleanup is only scheduled once
-            # we know the new set actually replaced the old one.
+            # Gating on ``stored_count`` ensures cleanup only runs once we know
+            # the new set actually replaced the old one.
             if replace and old_chunk_ids and row.get("stored_count"):
-                row[REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY] = "default"
-                row[REPLACE_OLD_CHUNK_IDS_ROW_KEY] = old_chunk_ids
+                if self.defer_replace_cleanup:
+                    row[REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY] = "default"
+                    row[REPLACE_OLD_CHUNK_IDS_ROW_KEY] = old_chunk_ids
+                else:
+                    await self._delete_replaced_chunks(row, old_chunk_ids)
             return row
         finally:
             logger.bind(
@@ -238,6 +243,19 @@ class IndexingPipeline:
                 f"re-index: could not snapshot existing chunks; skipping stale-chunk cleanup: {exc}"
             )
             return []
+
+    async def _delete_replaced_chunks(self, row: MutableMapping[str, Any], ids: list[str]) -> None:
+        """Delete the pre-re-index chunk set after the new chunks are stored."""
+        try:
+            deleted = await run_with_optional_timeout(
+                lambda: self.vector_store.delete(ids, "default"), self.timeouts.store
+            )
+            logger.bind(task_id=row.get("task_id")).debug(f"re-index: removed {deleted} stale chunk(s) after replace")
+        except Exception as exc:  # noqa: BLE001 - new chunks are stored; cleanup is best-effort
+            logger.bind(task_id=row.get("task_id")).error(
+                f"re-index: stored new chunks but failed to delete {len(ids)} stale chunk(s); "
+                f"duplicates remain until reconciliation: {exc}"
+            )
 
     def _effective_indexation_config(self, row: MutableMapping[str, Any]) -> IndexationPipelineConfig | None:
         raw_config = row.get("indexation_config", self.indexation_config)
@@ -362,6 +380,7 @@ def build_indexing_pipeline(
     vlm_factory: Callable[[str], VLM] | None = None,
     contextualizer_factory: Callable[[str], ChunkContextualizer] | None = None,
     topic_tagger_factory: Callable[[str], TopicTagger] | None = None,
+    defer_replace_cleanup: bool = False,
 ) -> IndexingPipeline:
     """Build the default sequential indexing pipeline."""
 
@@ -381,6 +400,7 @@ def build_indexing_pipeline(
         vlm_factory=vlm_factory,
         contextualizer_factory=contextualizer_factory,
         topic_tagger_factory=topic_tagger_factory,
+        defer_replace_cleanup=defer_replace_cleanup,
     )
 
 

--- a/openrag/services/workers/stages/store.py
+++ b/openrag/services/workers/stages/store.py
@@ -8,6 +8,8 @@ from core.models.chunk import Chunk
 from core.vector_stores.vector_store import VectorStore
 from services.workers.stages._common import run_with_optional_timeout, scrub_credentials, stage_timeout
 
+INDEXING_TASK_ID_METADATA_KEY = "_openrag_indexing_task_id"
+
 
 async def store_stage(
     row: MutableMapping[str, Any],
@@ -31,6 +33,10 @@ async def store_stage(
             if embedding is None:
                 raise ValueError("store_stage received chunks without embeddings")
             await vector_store.ensure_collection("default", len(embedding))
+            task_id = row.get("task_id")
+            if task_id:
+                for chunk in chunks:
+                    chunk.metadata[INDEXING_TASK_ID_METADATA_KEY] = str(task_id)
 
         effective_timeout = stage_timeout(timeout, len(chunks), per_item_timeout=per_chunk_timeout)
         # One indexation timestamp shared by the Milvus chunks (via the upsert

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from time import monotonic
 from typing import Any
 
 import ray
@@ -7,6 +9,8 @@ from core.utils.logging import get_logger
 from services.workers.ray_utils import call_ray_actor_with_timeout
 
 logger = get_logger()
+
+_REF_WAIT_INTERVAL = 0.05
 
 
 async def cancel_active_indexing_tasks(
@@ -27,28 +31,64 @@ async def cancel_active_indexing_tasks(
         )
         return 0
 
-    matches = await call_ray_actor_with_timeout(
-        future=remote(partition=partition, file_id=file_id),
-        timeout=timeout,
-        task_description=f"get_matching_active_task_refs({partition}, {file_id})",
-    )
+    deadline = monotonic() + timeout
     cancelled = 0
-    for task_id, object_ref in matches.items():
-        ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
-        if ref is not None:
+    while True:
+        remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
+        matches = await call_ray_actor_with_timeout(
+            future=remote(partition=partition, file_id=file_id),
+            timeout=remaining,
+            task_description=f"get_matching_active_task_refs({partition}, {file_id})",
+        )
+        pending_without_ref: list[str] = []
+        for task_id, object_ref in matches.items():
+            ref = _task_ref(object_ref)
+            if ref is None:
+                pending_without_ref.append(task_id)
+                continue
             try:
                 ray.cancel(ref, recursive=True)
-            except Exception:
+            except Exception as exc:
                 logger.warning(
                     "Failed to cancel active indexing task",
                     task_id=task_id,
                     partition=partition,
                     file_id=file_id,
+                    error=str(exc),
                 )
-        await call_ray_actor_with_timeout(
-            future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
-            timeout=timeout,
-            task_description=f"set_state({task_id}, CANCELLED)",
+                raise RuntimeError(f"Failed to cancel active indexing task {task_id}") from exc
+            remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
+            await call_ray_actor_with_timeout(
+                future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
+                timeout=remaining,
+                task_description=f"set_state({task_id}, CANCELLED)",
+            )
+            cancelled += 1
+        if not pending_without_ref:
+            return cancelled
+        logger.info(
+            "Waiting for active indexing tasks to expose object refs before delete cleanup",
+            partition=partition,
+            file_id=file_id,
+            task_ids=pending_without_ref,
         )
-        cancelled += 1
-    return cancelled
+        await asyncio.sleep(
+            min(
+                _REF_WAIT_INTERVAL,
+                _remaining_timeout(deadline, partition=partition, file_id=file_id),
+            )
+        )
+
+
+def _task_ref(object_ref: Any) -> Any | None:
+    return object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+
+
+def _remaining_timeout(deadline: float, *, partition: str, file_id: str | None) -> float:
+    remaining = deadline - monotonic()
+    if remaining <= 0:
+        raise TimeoutError(
+            "Timed out waiting for active indexing tasks to become cancellable "
+            f"before deleting partition={partition!r}, file_id={file_id!r}"
+        )
+    return remaining

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -12,6 +12,10 @@ from services.workers.ray_utils import call_ray_actor_with_timeout
 logger = get_logger()
 
 _REF_WAIT_INTERVAL = 0.05
+_STATE_UPDATE_TIMEOUT = 5.0
+_STALE_REFLESS_TASK_ERROR = (
+    "Indexing task never exposed a cancellable worker ref before delete cleanup; marking it failed as stale."
+)
 
 
 async def cancel_active_indexing_tasks(
@@ -80,12 +84,18 @@ async def cancel_active_indexing_tasks(
             file_id=file_id,
             task_ids=pending_without_ref,
         )
-        await asyncio.sleep(
-            min(
-                _REF_WAIT_INTERVAL,
-                _remaining_timeout(deadline, partition=partition, file_id=file_id),
+        remaining = deadline - monotonic()
+        if remaining <= _REF_WAIT_INTERVAL:
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            await _mark_ref_less_tasks_failed(
+                task_state_manager,
+                pending_without_ref,
+                partition=partition,
+                file_id=file_id,
             )
-        )
+            return cancelled
+        await asyncio.sleep(_REF_WAIT_INTERVAL)
 
 
 def _task_ref(object_ref: Any) -> Any | None:
@@ -122,6 +132,42 @@ async def _wait_for_task_to_settle(
             result="failed",
             error=str(exc),
         )
+
+
+async def _mark_ref_less_tasks_failed(
+    task_state_manager: Any,
+    task_ids: list[str],
+    *,
+    partition: str,
+    file_id: str | None,
+) -> None:
+    set_failed = getattr(task_state_manager, "set_failed_if_not_cancelled", None)
+    if set_failed is not None:
+        for task_id in task_ids:
+            await call_ray_actor_with_timeout(
+                future=set_failed.remote(task_id, _STALE_REFLESS_TASK_ERROR),
+                timeout=_STATE_UPDATE_TIMEOUT,
+                task_description=f"set_failed_if_not_cancelled({task_id})",
+            )
+        logger.warning(
+            "Marked stale ref-less indexing tasks as failed before delete cleanup",
+            partition=partition,
+            file_id=file_id,
+            task_ids=task_ids,
+        )
+        return
+    for task_id in task_ids:
+        await call_ray_actor_with_timeout(
+            future=task_state_manager.set_state.remote(task_id, "FAILED"),
+            timeout=_STATE_UPDATE_TIMEOUT,
+            task_description=f"set_state({task_id}, FAILED)",
+        )
+    logger.warning(
+        "Marked stale ref-less indexing tasks as failed before delete cleanup",
+        partition=partition,
+        file_id=file_id,
+        task_ids=task_ids,
+    )
 
 
 def _remaining_timeout(deadline: float, *, partition: str, file_id: str | None) -> float:

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import ray
 from core.utils.logging import get_logger
+from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout
 
 logger = get_logger()
@@ -57,6 +58,13 @@ async def cancel_active_indexing_tasks(
                     error=str(exc),
                 )
                 raise RuntimeError(f"Failed to cancel active indexing task {task_id}") from exc
+            await _wait_for_task_to_settle(
+                ref,
+                task_id=task_id,
+                deadline=deadline,
+                partition=partition,
+                file_id=file_id,
+            )
             remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
             await call_ray_actor_with_timeout(
                 future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
@@ -82,6 +90,38 @@ async def cancel_active_indexing_tasks(
 
 def _task_ref(object_ref: Any) -> Any | None:
     return object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+
+
+async def _wait_for_task_to_settle(
+    ref: Any,
+    *,
+    task_id: str,
+    deadline: float,
+    partition: str,
+    file_id: str | None,
+) -> None:
+    try:
+        await call_ray_actor_with_timeout(
+            future=ref,
+            timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+            task_description=f"wait_for_cancelled_indexing_task({task_id})",
+        )
+    except TaskCancelledError:
+        return
+    except TimeoutError as exc:
+        raise TimeoutError(
+            "Timed out waiting for active indexing task to settle after cancellation request "
+            f"before deleting partition={partition!r}, file_id={file_id!r}, task_id={task_id!r}"
+        ) from exc
+    except Exception as exc:
+        logger.info(
+            "Active indexing task settled after cancellation request",
+            task_id=task_id,
+            partition=partition,
+            file_id=file_id,
+            result="failed",
+            error=str(exc),
+        )
 
 
 def _remaining_timeout(deadline: float, *, partition: str, file_id: str | None) -> float:

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -11,8 +11,8 @@ from services.workers.ray_utils import call_ray_actor_with_timeout
 
 logger = get_logger()
 
+_ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"})
 _REF_WAIT_INTERVAL = 0.05
-_STATE_UPDATE_TIMEOUT = 5.0
 _STALE_REFLESS_TASK_ERROR = (
     "Indexing task never exposed a cancellable worker ref before delete cleanup; marking it failed as stale."
 )
@@ -26,24 +26,14 @@ async def cancel_active_indexing_tasks(
     timeout: float = 60.0,
 ) -> int:
     """Cancel queued/running indexing tasks matching a partition or file."""
-    try:
-        remote = task_state_manager.get_matching_active_task_refs.remote
-    except AttributeError:
-        logger.warning(
-            "TaskStateManager does not expose active-task lookup; refusing delete cleanup",
-            partition=partition,
-            file_id=file_id,
-        )
-        raise RuntimeError("TaskStateManager does not expose active-task lookup for delete cleanup")
-
     deadline = monotonic() + timeout
     cancelled = 0
     while True:
-        remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
-        matches = await call_ray_actor_with_timeout(
-            future=remote(partition=partition, file_id=file_id),
-            timeout=remaining,
-            task_description=f"get_matching_active_task_refs({partition}, {file_id})",
+        matches = await _get_matching_active_task_refs(
+            task_state_manager,
+            deadline=deadline,
+            partition=partition,
+            file_id=file_id,
         )
         cancelled_now, pending_without_ref = await _cancel_refs(
             task_state_manager,
@@ -63,18 +53,17 @@ async def cancel_active_indexing_tasks(
         )
         remaining = deadline - monotonic()
         if remaining <= _REF_WAIT_INTERVAL:
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-            final_matches = await call_ray_actor_with_timeout(
-                future=remote(partition=partition, file_id=file_id),
-                timeout=_STATE_UPDATE_TIMEOUT,
-                task_description=f"get_matching_active_task_refs({partition}, {file_id}) final",
+            final_matches = await _get_matching_active_task_refs(
+                task_state_manager,
+                deadline=deadline,
+                partition=partition,
+                file_id=file_id,
+                final=True,
             )
-            final_deadline = monotonic() + _STATE_UPDATE_TIMEOUT
             cancelled_now, pending_without_ref = await _cancel_refs(
                 task_state_manager,
                 final_matches,
-                deadline=final_deadline,
+                deadline=deadline,
                 partition=partition,
                 file_id=file_id,
             )
@@ -84,11 +73,91 @@ async def cancel_active_indexing_tasks(
             await _mark_ref_less_tasks_failed(
                 task_state_manager,
                 pending_without_ref,
+                deadline=deadline,
                 partition=partition,
                 file_id=file_id,
             )
             return cancelled
         await asyncio.sleep(_REF_WAIT_INTERVAL)
+
+
+async def _get_matching_active_task_refs(
+    task_state_manager: Any,
+    *,
+    deadline: float,
+    partition: str,
+    file_id: str | None,
+    final: bool = False,
+) -> dict[str, Any]:
+    get_matching = getattr(task_state_manager, "get_matching_active_task_refs", None)
+    remote = getattr(get_matching, "remote", None)
+    suffix = " final" if final else ""
+    if remote is not None:
+        return await call_ray_actor_with_timeout(
+            future=remote(partition=partition, file_id=file_id),
+            timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+            task_description=f"get_matching_active_task_refs({partition}, {file_id}){suffix}",
+        )
+    return await _get_matching_active_task_refs_legacy(
+        task_state_manager,
+        deadline=deadline,
+        partition=partition,
+        file_id=file_id,
+        final=final,
+    )
+
+
+async def _get_matching_active_task_refs_legacy(
+    task_state_manager: Any,
+    *,
+    deadline: float,
+    partition: str,
+    file_id: str | None,
+    final: bool,
+) -> dict[str, Any]:
+    get_all_info = getattr(task_state_manager, "get_all_info", None)
+    get_all_info_remote = getattr(get_all_info, "remote", None)
+    if get_all_info_remote is None:
+        logger.warning(
+            "TaskStateManager does not expose active-task lookup; refusing delete cleanup",
+            partition=partition,
+            file_id=file_id,
+        )
+        raise RuntimeError("TaskStateManager does not expose active-task lookup for delete cleanup")
+
+    suffix = " final" if final else ""
+    all_info = await call_ray_actor_with_timeout(
+        future=get_all_info_remote(),
+        timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+        task_description=f"get_all_info_for_active_task_refs({partition}, {file_id}){suffix}",
+    )
+    if not isinstance(all_info, dict):
+        raise RuntimeError("TaskStateManager returned invalid task info for delete cleanup")
+
+    get_object_ref = getattr(task_state_manager, "get_object_ref", None)
+    get_object_ref_remote = getattr(get_object_ref, "remote", None)
+    matches: dict[str, Any] = {}
+    for task_id, info in all_info.items():
+        if not isinstance(info, dict):
+            continue
+        if info.get("state") not in _ACTIVE_INDEXING_STATES:
+            continue
+        details = info.get("details") or {}
+        if not isinstance(details, dict):
+            continue
+        if details.get("partition") != partition:
+            continue
+        if file_id is not None and details.get("file_id") != file_id:
+            continue
+        object_ref = None
+        if get_object_ref_remote is not None:
+            object_ref = await call_ray_actor_with_timeout(
+                future=get_object_ref_remote(task_id),
+                timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+                task_description=f"get_object_ref({task_id}) for delete cleanup",
+            )
+        matches[task_id] = object_ref
+    return matches
 
 
 async def _cancel_refs(
@@ -174,6 +243,7 @@ async def _mark_ref_less_tasks_failed(
     task_state_manager: Any,
     task_ids: list[str],
     *,
+    deadline: float,
     partition: str,
     file_id: str | None,
 ) -> None:
@@ -182,7 +252,7 @@ async def _mark_ref_less_tasks_failed(
         for task_id in task_ids:
             await call_ray_actor_with_timeout(
                 future=set_failed.remote(task_id, _STALE_REFLESS_TASK_ERROR),
-                timeout=_STATE_UPDATE_TIMEOUT,
+                timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
                 task_description=f"set_failed_if_not_cancelled({task_id})",
             )
         logger.warning(
@@ -195,7 +265,7 @@ async def _mark_ref_less_tasks_failed(
     for task_id in task_ids:
         await call_ray_actor_with_timeout(
             future=task_state_manager.set_state.remote(task_id, "FAILED"),
-            timeout=_STATE_UPDATE_TIMEOUT,
+            timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
             task_description=f"set_state({task_id}, FAILED)",
         )
     logger.warning(

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -145,6 +145,16 @@ async def _get_matching_active_task_refs_legacy(
         details = info.get("details") or {}
         if not isinstance(details, dict):
             continue
+        if not details:
+            object_ref = None
+            if get_object_ref_remote is not None:
+                object_ref = await call_ray_actor_with_timeout(
+                    future=get_object_ref_remote(task_id),
+                    timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+                    task_description=f"get_object_ref({task_id}) for delete cleanup",
+                )
+            matches[task_id] = object_ref
+            continue
         if details.get("partition") != partition:
             continue
         if file_id is not None and details.get("file_id") != file_id:

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+import ray
+from core.utils.logging import get_logger
+from services.workers.ray_utils import call_ray_actor_with_timeout
+
+logger = get_logger()
+
+
+async def cancel_active_indexing_tasks(
+    task_state_manager: Any,
+    *,
+    partition: str,
+    file_id: str | None = None,
+    timeout: float = 60.0,
+) -> int:
+    """Cancel queued/running indexing tasks matching a partition or file."""
+    try:
+        remote = task_state_manager.get_matching_active_task_refs.remote
+    except AttributeError:
+        logger.warning(
+            "TaskStateManager does not expose active-task lookup; delete will continue without task cancellation",
+            partition=partition,
+            file_id=file_id,
+        )
+        return 0
+
+    matches = await call_ray_actor_with_timeout(
+        future=remote(partition=partition, file_id=file_id),
+        timeout=timeout,
+        task_description=f"get_matching_active_task_refs({partition}, {file_id})",
+    )
+    cancelled = 0
+    for task_id, object_ref in matches.items():
+        ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+        if ref is not None:
+            try:
+                ray.cancel(ref, recursive=True)
+            except Exception:
+                logger.warning(
+                    "Failed to cancel active indexing task",
+                    task_id=task_id,
+                    partition=partition,
+                    file_id=file_id,
+                )
+        await call_ray_actor_with_timeout(
+            future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
+            timeout=timeout,
+            task_description=f"set_state({task_id}, CANCELLED)",
+        )
+        cancelled += 1
+    return cancelled

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -8,6 +8,7 @@ import ray
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout
+from services.workers.task_state import PENDING_TASK_DETAILS
 
 logger = get_logger()
 
@@ -35,7 +36,7 @@ async def cancel_active_indexing_tasks(
             partition=partition,
             file_id=file_id,
         )
-        cancelled_now, pending_without_ref = await _cancel_refs(
+        cancelled_now, pending_without_ref, pending_details = await _cancel_refs(
             task_state_manager,
             matches,
             deadline=deadline,
@@ -43,13 +44,14 @@ async def cancel_active_indexing_tasks(
             file_id=file_id,
         )
         cancelled += cancelled_now
-        if not pending_without_ref:
+        if not pending_without_ref and not pending_details:
             return cancelled
         logger.info(
-            "Waiting for active indexing tasks to expose object refs before delete cleanup",
+            "Waiting for active indexing tasks to finish registration before delete cleanup",
             partition=partition,
             file_id=file_id,
-            task_ids=pending_without_ref,
+            pending_without_ref=pending_without_ref,
+            pending_details=pending_details,
         )
         remaining = deadline - monotonic()
         if remaining <= _REF_WAIT_INTERVAL:
@@ -60,7 +62,7 @@ async def cancel_active_indexing_tasks(
                 file_id=file_id,
                 final=True,
             )
-            cancelled_now, pending_without_ref = await _cancel_refs(
+            cancelled_now, pending_without_ref, pending_details = await _cancel_refs(
                 task_state_manager,
                 final_matches,
                 deadline=deadline,
@@ -68,6 +70,8 @@ async def cancel_active_indexing_tasks(
                 file_id=file_id,
             )
             cancelled += cancelled_now
+            if pending_details:
+                _raise_pending_details_timeout(pending_details, partition=partition, file_id=file_id)
             if not pending_without_ref:
                 return cancelled
             await _mark_ref_less_tasks_failed(
@@ -89,14 +93,13 @@ async def _get_matching_active_task_refs(
     file_id: str | None,
     final: bool = False,
 ) -> dict[str, Any]:
-    get_matching = getattr(task_state_manager, "get_matching_active_task_refs", None)
-    remote = getattr(get_matching, "remote", None)
+    remote = _remote_actor_method(task_state_manager, "get_matching_active_task_refs_v2")
     suffix = " final" if final else ""
     if remote is not None:
         return await call_ray_actor_with_timeout(
             future=remote(partition=partition, file_id=file_id),
             timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
-            task_description=f"get_matching_active_task_refs({partition}, {file_id}){suffix}",
+            task_description=f"get_matching_active_task_refs_v2({partition}, {file_id}){suffix}",
         )
     return await _get_matching_active_task_refs_legacy(
         task_state_manager,
@@ -115,8 +118,7 @@ async def _get_matching_active_task_refs_legacy(
     file_id: str | None,
     final: bool,
 ) -> dict[str, Any]:
-    get_all_info = getattr(task_state_manager, "get_all_info", None)
-    get_all_info_remote = getattr(get_all_info, "remote", None)
+    get_all_info_remote = _remote_actor_method(task_state_manager, "get_all_info")
     if get_all_info_remote is None:
         logger.warning(
             "TaskStateManager does not expose active-task lookup; refusing delete cleanup",
@@ -134,8 +136,7 @@ async def _get_matching_active_task_refs_legacy(
     if not isinstance(all_info, dict):
         raise RuntimeError("TaskStateManager returned invalid task info for delete cleanup")
 
-    get_object_ref = getattr(task_state_manager, "get_object_ref", None)
-    get_object_ref_remote = getattr(get_object_ref, "remote", None)
+    get_object_ref_remote = _remote_actor_method(task_state_manager, "get_object_ref")
     matches: dict[str, Any] = {}
     for task_id, info in all_info.items():
         if not isinstance(info, dict):
@@ -146,14 +147,7 @@ async def _get_matching_active_task_refs_legacy(
         if not isinstance(details, dict):
             continue
         if not details:
-            object_ref = None
-            if get_object_ref_remote is not None:
-                object_ref = await call_ray_actor_with_timeout(
-                    future=get_object_ref_remote(task_id),
-                    timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
-                    task_description=f"get_object_ref({task_id}) for delete cleanup",
-                )
-            matches[task_id] = object_ref
+            matches[task_id] = PENDING_TASK_DETAILS
             continue
         if details.get("partition") != partition:
             continue
@@ -177,10 +171,14 @@ async def _cancel_refs(
     deadline: float,
     partition: str,
     file_id: str | None,
-) -> tuple[int, list[str]]:
+) -> tuple[int, list[str], list[str]]:
     cancelled = 0
     pending_without_ref: list[str] = []
+    pending_details: list[str] = []
     for task_id, object_ref in matches.items():
+        if _task_details_pending(object_ref):
+            pending_details.append(task_id)
+            continue
         ref = _task_ref(object_ref)
         if ref is None:
             pending_without_ref.append(task_id)
@@ -210,11 +208,23 @@ async def _cancel_refs(
             task_description=f"set_state({task_id}, CANCELLED)",
         )
         cancelled += 1
-    return cancelled, pending_without_ref
+    return cancelled, pending_without_ref, pending_details
+
+
+def _task_details_pending(object_ref: Any) -> bool:
+    return object_ref == PENDING_TASK_DETAILS
 
 
 def _task_ref(object_ref: Any) -> Any | None:
     return object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+
+
+def _remote_actor_method(actor: Any, name: str) -> Any | None:
+    method_names = getattr(actor, "_ray_actor_method_names", None)
+    if isinstance(method_names, (frozenset, list, set, tuple)) and name not in method_names:
+        return None
+    method = getattr(actor, name, None)
+    return getattr(method, "remote", None)
 
 
 async def _wait_for_task_to_settle(
@@ -294,3 +304,10 @@ def _remaining_timeout(deadline: float, *, partition: str, file_id: str | None) 
             f"before deleting partition={partition!r}, file_id={file_id!r}"
         )
     return remaining
+
+
+def _raise_pending_details_timeout(task_ids: list[str], *, partition: str, file_id: str | None) -> None:
+    raise TimeoutError(
+        "Timed out waiting for active indexing tasks to record routing details "
+        f"before deleting partition={partition!r}, file_id={file_id!r}, task_ids={task_ids!r}"
+    )

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -30,11 +30,11 @@ async def cancel_active_indexing_tasks(
         remote = task_state_manager.get_matching_active_task_refs.remote
     except AttributeError:
         logger.warning(
-            "TaskStateManager does not expose active-task lookup; delete will continue without task cancellation",
+            "TaskStateManager does not expose active-task lookup; refusing delete cleanup",
             partition=partition,
             file_id=file_id,
         )
-        return 0
+        raise RuntimeError("TaskStateManager does not expose active-task lookup for delete cleanup")
 
     deadline = monotonic() + timeout
     cancelled = 0
@@ -45,37 +45,14 @@ async def cancel_active_indexing_tasks(
             timeout=remaining,
             task_description=f"get_matching_active_task_refs({partition}, {file_id})",
         )
-        pending_without_ref: list[str] = []
-        for task_id, object_ref in matches.items():
-            ref = _task_ref(object_ref)
-            if ref is None:
-                pending_without_ref.append(task_id)
-                continue
-            try:
-                ray.cancel(ref, recursive=True)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to cancel active indexing task",
-                    task_id=task_id,
-                    partition=partition,
-                    file_id=file_id,
-                    error=str(exc),
-                )
-                raise RuntimeError(f"Failed to cancel active indexing task {task_id}") from exc
-            await _wait_for_task_to_settle(
-                ref,
-                task_id=task_id,
-                deadline=deadline,
-                partition=partition,
-                file_id=file_id,
-            )
-            remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
-            await call_ray_actor_with_timeout(
-                future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
-                timeout=remaining,
-                task_description=f"set_state({task_id}, CANCELLED)",
-            )
-            cancelled += 1
+        cancelled_now, pending_without_ref = await _cancel_refs(
+            task_state_manager,
+            matches,
+            deadline=deadline,
+            partition=partition,
+            file_id=file_id,
+        )
+        cancelled += cancelled_now
         if not pending_without_ref:
             return cancelled
         logger.info(
@@ -88,6 +65,22 @@ async def cancel_active_indexing_tasks(
         if remaining <= _REF_WAIT_INTERVAL:
             if remaining > 0:
                 await asyncio.sleep(remaining)
+            final_matches = await call_ray_actor_with_timeout(
+                future=remote(partition=partition, file_id=file_id),
+                timeout=_STATE_UPDATE_TIMEOUT,
+                task_description=f"get_matching_active_task_refs({partition}, {file_id}) final",
+            )
+            final_deadline = monotonic() + _STATE_UPDATE_TIMEOUT
+            cancelled_now, pending_without_ref = await _cancel_refs(
+                task_state_manager,
+                final_matches,
+                deadline=final_deadline,
+                partition=partition,
+                file_id=file_id,
+            )
+            cancelled += cancelled_now
+            if not pending_without_ref:
+                return cancelled
             await _mark_ref_less_tasks_failed(
                 task_state_manager,
                 pending_without_ref,
@@ -96,6 +89,49 @@ async def cancel_active_indexing_tasks(
             )
             return cancelled
         await asyncio.sleep(_REF_WAIT_INTERVAL)
+
+
+async def _cancel_refs(
+    task_state_manager: Any,
+    matches: dict[str, Any],
+    *,
+    deadline: float,
+    partition: str,
+    file_id: str | None,
+) -> tuple[int, list[str]]:
+    cancelled = 0
+    pending_without_ref: list[str] = []
+    for task_id, object_ref in matches.items():
+        ref = _task_ref(object_ref)
+        if ref is None:
+            pending_without_ref.append(task_id)
+            continue
+        try:
+            ray.cancel(ref, recursive=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to cancel active indexing task",
+                task_id=task_id,
+                partition=partition,
+                file_id=file_id,
+                error=str(exc),
+            )
+            raise RuntimeError(f"Failed to cancel active indexing task {task_id}") from exc
+        await _wait_for_task_to_settle(
+            ref,
+            task_id=task_id,
+            deadline=deadline,
+            partition=partition,
+            file_id=file_id,
+        )
+        remaining = _remaining_timeout(deadline, partition=partition, file_id=file_id)
+        await call_ray_actor_with_timeout(
+            future=task_state_manager.set_state.remote(task_id, "CANCELLED"),
+            timeout=remaining,
+            task_description=f"set_state({task_id}, CANCELLED)",
+        )
+        cancelled += 1
+    return cancelled, pending_without_ref
 
 
 def _task_ref(object_ref: Any) -> Any | None:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -9,6 +9,7 @@ from core.models.catalog import TERMINAL_TASK_STATES, DocumentStatus
 
 ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"})
 TERMINAL_INDEXING_STATES = frozenset({"COMPLETED", "FAILED"})
+PENDING_TASK_DETAILS = "__openrag_pending_task_details__"
 
 try:
     from core.config import load_config as _load_config
@@ -38,13 +39,31 @@ class TaskInfo:
 class TaskStateManager:
     def __init__(self) -> None:
         self.tasks: dict[str, TaskInfo] = {}
-        self.user_index: dict[int, set[str]] = {}
+        self.user_index: dict[int | None, set[str]] = {}
         self.lock = asyncio.Lock()
 
     async def _ensure_task(self, task_id: str) -> TaskInfo:
         if task_id not in self.tasks:
             self.tasks[task_id] = TaskInfo()
         return self.tasks[task_id]
+
+    def _record_details(
+        self,
+        task_id: str,
+        info: TaskInfo,
+        *,
+        file_id: str | None,
+        partition: str,
+        metadata: dict[str, Any],
+        user_id: int | None,
+    ) -> None:
+        info.details = {
+            "file_id": file_id,
+            "partition": partition,
+            "metadata": metadata,
+            "user_id": user_id,
+        }
+        self.user_index.setdefault(user_id, set()).add(task_id)
 
     @ray.method(concurrency_group="set")
     async def set_state(self, task_id: str, state: str) -> None:
@@ -85,20 +104,45 @@ class TaskStateManager:
         self,
         task_id: str,
         *,
-        file_id: str,
-        partition: int,
-        metadata: dict,
-        user_id: int,
+        file_id: str | None,
+        partition: str,
+        metadata: dict[str, Any],
+        user_id: int | None,
     ) -> None:
         async with self.lock:
             info = await self._ensure_task(task_id)
-            info.details = {
-                "file_id": file_id,
-                "partition": partition,
-                "metadata": metadata,
-                "user_id": user_id,
-            }
-            self.user_index.setdefault(user_id, set()).add(task_id)
+            self._record_details(
+                task_id,
+                info,
+                file_id=file_id,
+                partition=partition,
+                metadata=metadata,
+                user_id=user_id,
+            )
+
+    @ray.method(concurrency_group="set")
+    async def set_queued_details(
+        self,
+        task_id: str,
+        *,
+        file_id: str | None,
+        partition: str,
+        metadata: dict[str, Any],
+        user_id: int | None,
+    ) -> None:
+        async with self.lock:
+            info = await self._ensure_task(task_id)
+            if info.state == DocumentStatus.CANCELLED:
+                return
+            info.state = "QUEUED"
+            self._record_details(
+                task_id,
+                info,
+                file_id=file_id,
+                partition=partition,
+                metadata=metadata,
+                user_id=user_id,
+            )
 
     @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
@@ -137,22 +181,40 @@ class TaskStateManager:
         *,
         partition: str,
         file_id: str | None = None,
-    ) -> dict[str, ray.ObjectRef | None]:
+    ) -> dict[str, ray.ObjectRef | None | str]:
         async with self.lock:
-            matches = {}
-            for task_id, info in self.tasks.items():
-                if info.state not in ACTIVE_INDEXING_STATES:
-                    continue
-                details = info.details or {}
-                if not details:
-                    matches[task_id] = info.object_ref
-                    continue
-                if details.get("partition") != partition:
-                    continue
-                if file_id is not None and details.get("file_id") != file_id:
-                    continue
-                matches[task_id] = info.object_ref
-            return matches
+            return self._matching_active_task_refs_locked(partition=partition, file_id=file_id)
+
+    @ray.method(concurrency_group="get")
+    async def get_matching_active_task_refs_v2(
+        self,
+        *,
+        partition: str,
+        file_id: str | None = None,
+    ) -> dict[str, ray.ObjectRef | None | str]:
+        async with self.lock:
+            return self._matching_active_task_refs_locked(partition=partition, file_id=file_id)
+
+    def _matching_active_task_refs_locked(
+        self,
+        *,
+        partition: str,
+        file_id: str | None = None,
+    ) -> dict[str, ray.ObjectRef | None | str]:
+        matches = {}
+        for task_id, info in self.tasks.items():
+            if info.state not in ACTIVE_INDEXING_STATES:
+                continue
+            details = info.details or {}
+            if not details:
+                matches[task_id] = PENDING_TASK_DETAILS
+                continue
+            if details.get("partition") != partition:
+                continue
+            if file_id is not None and details.get("file_id") != file_id:
+                continue
+            matches[task_id] = info.object_ref
+        return matches
 
     @ray.method(concurrency_group="queue_info")
     async def get_all_states(self) -> dict[str, str | None]:
@@ -200,4 +262,10 @@ class TaskStateManager:
             return sum(1 for tid in task_ids if (info := self.tasks.get(tid)) and info.state in ACTIVE_INDEXING_STATES)
 
 
-__all__ = ["ACTIVE_INDEXING_STATES", "TERMINAL_INDEXING_STATES", "TaskInfo", "TaskStateManager"]
+__all__ = [
+    "ACTIVE_INDEXING_STATES",
+    "PENDING_TASK_DETAILS",
+    "TERMINAL_INDEXING_STATES",
+    "TaskInfo",
+    "TaskStateManager",
+]

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -88,10 +88,11 @@ class TaskStateManager:
             self.user_index.setdefault(user_id, set()).add(task_id)
 
     @ray.method(concurrency_group="set")
-    async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> None:
+    async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         async with self.lock:
             info = await self._ensure_task(task_id)
             info.object_ref = object_ref
+            return info.state in ACTIVE_INDEXING_STATES
 
     @ray.method(concurrency_group="get")
     async def get_state(self, task_id: str) -> str | None:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import ray
 
+ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"})
+
 try:
     from core.config import load_config as _load_config
 
@@ -115,6 +117,26 @@ class TaskStateManager:
             info = self.tasks.get(task_id)
             return info.object_ref if info else None
 
+    @ray.method(concurrency_group="get")
+    async def get_matching_active_task_refs(
+        self,
+        *,
+        partition: str,
+        file_id: str | None = None,
+    ) -> dict[str, ray.ObjectRef | None]:
+        async with self.lock:
+            matches = {}
+            for task_id, info in self.tasks.items():
+                if info.state not in ACTIVE_INDEXING_STATES:
+                    continue
+                details = info.details or {}
+                if details.get("partition") != partition:
+                    continue
+                if file_id is not None and details.get("file_id") != file_id:
+                    continue
+                matches[task_id] = info.object_ref
+            return matches
+
     @ray.method(concurrency_group="queue_info")
     async def get_all_states(self) -> dict[str, str | None]:
         async with self.lock:
@@ -158,8 +180,7 @@ class TaskStateManager:
     async def get_user_pending_task_count(self, user_id: int) -> int:
         async with self.lock:
             task_ids = self.user_index.get(user_id, set())
-            pending_states = {"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"}
-            return sum(1 for tid in task_ids if (info := self.tasks.get(tid)) and info.state in pending_states)
+            return sum(1 for tid in task_ids if (info := self.tasks.get(tid)) and info.state in ACTIVE_INDEXING_STATES)
 
 
-__all__ = ["TaskInfo", "TaskStateManager"]
+__all__ = ["ACTIVE_INDEXING_STATES", "TaskInfo", "TaskStateManager"]

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -132,6 +132,9 @@ class TaskStateManager:
                 if info.state not in ACTIVE_INDEXING_STATES:
                     continue
                 details = info.details or {}
+                if not details:
+                    matches[task_id] = info.object_ref
+                    continue
                 if details.get("partition") != partition:
                     continue
                 if file_id is not None and details.get("file_id") != file_id:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -7,6 +7,7 @@ from typing import Any
 import ray
 
 ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"})
+TERMINAL_INDEXING_STATES = frozenset({"COMPLETED", "FAILED"})
 
 try:
     from core.config import load_config as _load_config
@@ -92,7 +93,7 @@ class TaskStateManager:
         async with self.lock:
             info = await self._ensure_task(task_id)
             info.object_ref = object_ref
-            return info.state in ACTIVE_INDEXING_STATES
+            return info.state in ACTIVE_INDEXING_STATES or info.state in TERMINAL_INDEXING_STATES
 
     @ray.method(concurrency_group="get")
     async def get_state(self, task_id: str) -> str | None:
@@ -184,4 +185,4 @@ class TaskStateManager:
             return sum(1 for tid in task_ids if (info := self.tasks.get(tid)) and info.state in ACTIVE_INDEXING_STATES)
 
 
-__all__ = ["ACTIVE_INDEXING_STATES", "TaskInfo", "TaskStateManager"]
+__all__ = ["ACTIVE_INDEXING_STATES", "TERMINAL_INDEXING_STATES", "TaskInfo", "TaskStateManager"]

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -40,6 +40,7 @@ class TaskStateManager:
     def __init__(self) -> None:
         self.tasks: dict[str, TaskInfo] = {}
         self.user_index: dict[int | None, set[str]] = {}
+        self.file_delete_fences: dict[tuple[str, str], int] = {}
         self.lock = asyncio.Lock()
 
     async def _ensure_task(self, task_id: str) -> TaskInfo:
@@ -64,6 +65,27 @@ class TaskStateManager:
             "user_id": user_id,
         }
         self.user_index.setdefault(user_id, set()).add(task_id)
+
+    def _file_delete_fenced(self, *, partition: str | None, file_id: str | None) -> bool:
+        if partition is None or file_id is None:
+            return False
+        return self.file_delete_fences.get((partition, file_id), 0) > 0
+
+    @ray.method(concurrency_group="set")
+    async def begin_file_delete(self, *, partition: str, file_id: str) -> None:
+        async with self.lock:
+            key = (partition, file_id)
+            self.file_delete_fences[key] = self.file_delete_fences.get(key, 0) + 1
+
+    @ray.method(concurrency_group="set")
+    async def end_file_delete(self, *, partition: str, file_id: str) -> None:
+        async with self.lock:
+            key = (partition, file_id)
+            remaining = self.file_delete_fences.get(key, 0) - 1
+            if remaining > 0:
+                self.file_delete_fences[key] = remaining
+            else:
+                self.file_delete_fences.pop(key, None)
 
     @ray.method(concurrency_group="set")
     async def set_state(self, task_id: str, state: str) -> None:
@@ -129,12 +151,11 @@ class TaskStateManager:
         partition: str,
         metadata: dict[str, Any],
         user_id: int | None,
-    ) -> None:
+    ) -> bool:
         async with self.lock:
             info = await self._ensure_task(task_id)
             if info.state == DocumentStatus.CANCELLED:
-                return
-            info.state = "QUEUED"
+                return False
             self._record_details(
                 task_id,
                 info,
@@ -143,12 +164,21 @@ class TaskStateManager:
                 metadata=metadata,
                 user_id=user_id,
             )
+            if self._file_delete_fenced(partition=partition, file_id=file_id):
+                info.state = "CANCELLED"
+                return False
+            info.state = "QUEUED"
+            return True
 
     @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         async with self.lock:
             info = await self._ensure_task(task_id)
             info.object_ref = object_ref
+            details = info.details or {}
+            if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
+                info.state = "CANCELLED"
+                return False
             return info.state in ACTIVE_INDEXING_STATES or info.state in TERMINAL_INDEXING_STATES
 
     @ray.method(concurrency_group="get")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -76,6 +76,15 @@ class MockVectorStore(VectorStore):
                 removed += 1
         return removed
 
+    async def delete_by_filter(self, filters: dict[str, Any]) -> int:
+        removed = 0
+        for collection in self.collections.values():
+            for cid, chunk in list(collection.items()):
+                if all(getattr(chunk, key, None) == value for key, value in filters.items()):
+                    collection.pop(cid, None)
+                    removed += 1
+        return removed
+
     async def ensure_collection(self, name: str, dimension: int, **kwargs: Any) -> None:
         self.collections.setdefault(name, {})
 

--- a/tests/unit/services/orchestrators/test_conversion_service.py
+++ b/tests/unit/services/orchestrators/test_conversion_service.py
@@ -55,7 +55,17 @@ async def test_serialize_file_merges_metadata_and_sanitizes():
 
 @pytest.mark.asyncio
 async def test_get_chunk_returns_page_content_and_metadata():
-    store = FakeVectorStore(rows=[{"text": "chunk body", "vector": [0.1], "partition": "p1", "file_id": "f1"}])
+    store = FakeVectorStore(
+        rows=[
+            {
+                "text": "chunk body",
+                "vector": [0.1],
+                "partition": "p1",
+                "file_id": "f1",
+                "_openrag_indexing_task_id": "t1",
+            }
+        ]
+    )
     svc = _service(store=store)
 
     chunk = await svc.get_chunk("42")

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -49,6 +49,7 @@ class FakeDispatcher:
         replace,
         indexation_config=None,
         embedder_name=None,
+        require_existing_partition=False,
     ):
         self.dispatched.append(
             {
@@ -60,6 +61,7 @@ class FakeDispatcher:
                 "replace": replace,
                 "indexation_config": indexation_config,
                 "embedder_name": embedder_name,
+                "require_existing_partition": require_existing_partition,
             }
         )
         return "task-abc"
@@ -218,6 +220,7 @@ async def test_add_file_builds_metadata_and_dispatches(tmp_path):
     assert sent["partition"] == "p1"
     assert sent["workspace_ids"] == ["w1"]
     assert sent["replace"] is False
+    assert sent["require_existing_partition"] is False
     md = sent["metadata"]
     assert md["author"] == "alice"
     assert md["source"] == str(f)
@@ -269,6 +272,7 @@ async def test_add_file_dispatches_partition_indexation_config_and_embedder(tmp_
     assert sent["indexation_config"]["enable_image_captioning"] is False
     assert sent["indexation_config"]["enable_contextualization"] is True
     assert sent["indexation_config"]["contextualization_llm"] == "llm-context"
+    assert sent["require_existing_partition"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.config.retrieval_pipeline import RetrievalPipelineConfig
@@ -50,6 +52,7 @@ class FakeDispatcher:
         indexation_config=None,
         embedder_name=None,
         require_existing_partition=False,
+        allow_legacy_require_existing_partition_retry=False,
     ):
         self.dispatched.append(
             {
@@ -62,6 +65,7 @@ class FakeDispatcher:
                 "indexation_config": indexation_config,
                 "embedder_name": embedder_name,
                 "require_existing_partition": require_existing_partition,
+                "allow_legacy_require_existing_partition_retry": allow_legacy_require_existing_partition_retry,
             }
         )
         return "task-abc"
@@ -118,6 +122,8 @@ class FakePartitionService:
         self.created: list[tuple[str, int]] = []
         self.create_kwargs: list[dict] = []
         self.loaded = 0
+        self.admissions: list[str] = []
+        self.admission_depth = 0
 
     def _cfg(self, partition: str) -> PartitionConfig:
         return PartitionConfig(
@@ -129,6 +135,15 @@ class FakePartitionService:
 
     async def partition_exists(self, partition: str) -> bool:
         return partition in self._db
+
+    @asynccontextmanager
+    async def indexing_admission(self, partition: str):
+        self.admissions.append(partition)
+        self.admission_depth += 1
+        try:
+            yield await self.partition_exists(partition)
+        finally:
+            self.admission_depth -= 1
 
     async def create_partition(self, partition: str, *, user_id: int, **_) -> None:
         self.created.append((partition, user_id))
@@ -231,6 +246,83 @@ async def test_add_file_builds_metadata_and_dispatches(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_add_file_holds_partition_admission_fence_until_dispatch(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    config = type("Config", (), {"partitions": {}})()
+    psvc = FakePartitionService(config, db_partitions={"tenant-a"})
+
+    class CheckingDispatcher(FakeDispatcher):
+        async def dispatch_indexing(self, **kwargs):
+            assert psvc.admission_depth == 1
+            return await super().dispatch_indexing(**kwargs)
+
+    disp = CheckingDispatcher()
+    svc = _service(disp=disp, config=config, partition_service=psvc)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="tenant-a",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+    )
+
+    assert psvc.admissions == ["tenant-a"]
+    assert psvc.admission_depth == 0
+
+
+@pytest.mark.asyncio
+async def test_add_file_requires_existing_partition_when_configless_partition_existed_at_admission(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    disp = FakeDispatcher()
+    config = type("Config", (), {"partitions": {}})()
+    psvc = FakePartitionService(config, db_partitions={"tenant-a"})
+    svc = _service(disp=disp, config=config, partition_service=psvc)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="tenant-a",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+    )
+
+    assert psvc.created == []
+    assert disp.dispatched[0]["require_existing_partition"] is True
+    assert disp.dispatched[0]["allow_legacy_require_existing_partition_retry"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_file_keeps_legacy_auto_create_for_new_configless_partition(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("x")
+    disp = FakeDispatcher()
+    config = type("Config", (), {"partitions": {}})()
+    psvc = FakePartitionService(config)
+    svc = _service(disp=disp, config=config, partition_service=psvc)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="tenant-new",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+    )
+
+    assert psvc.created == []
+    assert disp.dispatched[0]["require_existing_partition"] is False
+    assert disp.dispatched[0]["allow_legacy_require_existing_partition_retry"] is False
+
+
+@pytest.mark.asyncio
 async def test_replace_sets_replace_flag(tmp_path):
     f = tmp_path / "doc.txt"
     f.write_text("x")
@@ -273,6 +365,7 @@ async def test_add_file_dispatches_partition_indexation_config_and_embedder(tmp_
     assert sent["indexation_config"]["enable_contextualization"] is True
     assert sent["indexation_config"]["contextualization_llm"] == "llm-context"
     assert sent["require_existing_partition"] is True
+    assert sent["allow_legacy_require_existing_partition_retry"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -265,7 +265,7 @@ async def test_search_rejects_file_id_with_slash():
 
 @pytest.mark.asyncio
 async def test_search_shapes_chunks():
-    chunks = [FakeChunk(_id=11, text="body", metadata={"file_id": "f1"})]
+    chunks = [FakeChunk(_id=11, text="body", metadata={"file_id": "f1", "_openrag_indexing_task_id": "t1"})]
     out = await _service(retrieval=FakeRetrieval(chunks=chunks)).search_documents(
         query="hi", partitions=["a"], top_k=3, allowed_partitions=["a"]
     )
@@ -274,6 +274,7 @@ async def test_search_shapes_chunks():
     assert doc["chunk_id"] == 11
     assert doc["content"] == "body"
     assert doc["metadata"]["file_id"] == "f1"
+    assert "_openrag_indexing_task_id" not in doc["metadata"]
 
 
 # ---------------------------------------------------------------------------
@@ -311,11 +312,20 @@ async def test_get_file_info_not_found():
 
 @pytest.mark.asyncio
 async def test_get_file_info_strips_id_text_vector_from_metadata():
-    rows = [{"_id": 1, "file_id": "f1", "page": 2, "text": "body", "vector": [0.1, 0.2]}]
+    rows = [
+        {
+            "_id": 1,
+            "file_id": "f1",
+            "page": 2,
+            "text": "body",
+            "vector": [0.1, 0.2],
+            "_openrag_indexing_task_id": "t1",
+        }
+    ]
     svc = _service(partitions=FakePartitions(exists=True), vector_store=FakeVectorStore(rows=rows))
     out = await svc.get_file_info(partition="a", file_id="f1", allowed_partitions=["a"])
     assert out["chunk_count"] == 1
-    assert {"_id", "text", "vector"}.isdisjoint(out["metadata"])
+    assert {"_id", "text", "vector", "_openrag_indexing_task_id"}.isdisjoint(out["metadata"])
     assert out["metadata"]["file_id"] == "f1"
 
 
@@ -330,7 +340,10 @@ async def test_get_file_info_count_not_capped():
 
 @pytest.mark.asyncio
 async def test_get_file_chunks_paginates_with_content():
-    rows = [{"_id": i, "text": f"c{i}", "file_id": "f1", "partition": "a"} for i in range(5)]
+    rows = [
+        {"_id": i, "text": f"c{i}", "file_id": "f1", "partition": "a", "_openrag_indexing_task_id": "t1"}
+        for i in range(5)
+    ]
     svc = _service(vector_store=FakeVectorStore(rows=rows))
     out = await svc.get_file_chunks(partition="a", file_id="f1", allowed_partitions=["a"], offset=1, limit=2)
     assert out["total_chunks"] == 5
@@ -338,6 +351,7 @@ async def test_get_file_chunks_paginates_with_content():
     assert [c["chunk_id"] for c in out["chunks"]] == [1, 2]
     assert out["chunks"][0]["content"] == "c1"
     assert "text" not in out["chunks"][0]["metadata"]
+    assert "_openrag_indexing_task_id" not in out["chunks"][0]["metadata"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_preset_resolution.py
+++ b/tests/unit/services/orchestrators/test_partition_preset_resolution.py
@@ -71,6 +71,11 @@ class _FakePartitionRepo:
         return dict(self._counts)
 
 
+class _FakeVectorStore:
+    async def collection_exists(self, name: str) -> bool:
+        return False
+
+
 def _settings(idx=None, ret=None):
     from core.config.root import Settings
 
@@ -89,7 +94,7 @@ def _make_service(repo=None, rows=None, settings=None):
         partition_repo=repo or _FakePartitionRepo(rows),
         membership_repo=object(),
         document_repo=object(),
-        vector_store=object(),
+        vector_store=_FakeVectorStore(),
         user_repo=object(),
         collection="vdb",
         config=settings if settings is not None else _settings(),
@@ -234,6 +239,19 @@ async def test_create_partition_persists_config_and_reloads():
     assert any(c[0] == "update_partition" for c in repo.calls)
     assert "p1" in settings.partitions
     assert settings.partitions["p1"].description == "docs"
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_removes_deleted_partition_from_cache():
+    settings = _settings()
+    repo = _FakePartitionRepo(rows=[_full_row("p1"), _full_row("keep")])
+    svc = _make_service(repo, settings=settings)
+    await svc.load_partitions()
+
+    await svc.delete_partition("p1")
+
+    assert "p1" not in settings.partitions
+    assert "keep" in settings.partitions
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -100,6 +100,7 @@ class FakeVectorStore:
         self._rows = rows or []
         self._exists = exists
         self.deleted_ids: list[str] = []
+        self.deleted_filters: list[dict] = []
         self.last_chunk_filters: dict | None = None
 
     async def collection_exists(self, name) -> bool:
@@ -112,9 +113,15 @@ class FakeVectorStore:
         self.deleted_ids.extend(ids)
         return len(ids)
 
+    async def delete_by_filter(self, filters) -> int:
+        self.deleted_filters.append(dict(filters))
+        before = len(self._rows)
+        self._rows = [row for row in self._rows if not all(row.get(key) == value for key, value in filters.items())]
+        return len(self._ids) or before - len(self._rows)
+
     async def query_chunks_by_filter(self, collection, filters, output_fields=None):
         self.last_chunk_filters = dict(filters)
-        return list(self._rows)
+        return [row for row in self._rows if all(key not in row or row[key] == value for key, value in filters.items())]
 
 
 class FakeUserRepo:
@@ -230,12 +237,7 @@ async def test_delete_partition_missing_raises_404():
 
 
 @pytest.mark.asyncio
-async def test_delete_partition_deletes_rows_before_vectors():
-    """Regression for #379: partition deletion from database happens first.
-
-    If database cleanup succeeds but vector store delete fails, the data model remains
-    consistent (partition is gone from database, orphaned chunks logged for reconciliation).
-    """
+async def test_delete_partition_deletes_vectors_before_rows():
     prepo = FakePartitionRepo(existing={"p1"})
     vstore = FakeVectorStore(ids=["c1", "c2"])
     call_order = []
@@ -247,18 +249,19 @@ async def test_delete_partition_deletes_rows_before_vectors():
         return await prepo_delete_orig(*args, **kwargs)
 
     prepo.delete_partition = tracked_prepo_delete
-    vstore_delete_orig = vstore.delete
+    vstore_delete_orig = vstore.delete_by_filter
 
     async def tracked_vstore_delete(*args, **kwargs):
-        call_order.append("vstore_delete")
+        call_order.append("vstore_delete_by_filter")
         return await vstore_delete_orig(*args, **kwargs)
 
-    vstore.delete = tracked_vstore_delete
+    vstore.delete_by_filter = tracked_vstore_delete
 
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
 
-    assert call_order == ["prepo_delete", "vstore_delete"]
-    assert vstore.deleted_ids == ["c1", "c2"]
+    assert call_order == ["vstore_delete_by_filter", "prepo_delete"]
+    assert vstore.deleted_filters == [{"partition": "p1"}]
+    assert vstore.deleted_ids == []
     assert prepo.deleted == ["p1"]
 
 
@@ -267,8 +270,28 @@ async def test_delete_partition_no_vectors_still_deletes_rows():
     prepo = FakePartitionRepo(existing={"p1"})
     vstore = FakeVectorStore(ids=[])
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    assert vstore.deleted_filters == [{"partition": "p1"}]
     assert vstore.deleted_ids == []
     assert prepo.deleted == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_cleans_vectors_before_partition_name_reuse():
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore(
+        rows=[
+            {"partition": "p1", "file_id": "old-file", "text": "old tenant data"},
+            {"partition": "other", "file_id": "keep-file", "text": "other data"},
+        ]
+    )
+
+    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    await _svc(prepo=prepo, vstore=vstore).create_partition("p1", user_id=42)
+
+    assert await vstore.query_chunks_by_filter("vdb", {"partition": "p1"}) == []
+    assert await vstore.query_chunks_by_filter("vdb", {"partition": "other"}) == [
+        {"partition": "other", "file_id": "keep-file", "text": "other data"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -291,6 +314,10 @@ async def test_delete_partition_skips_vectors_when_collection_absent():
             self.delete_called = True
             raise AssertionError("must not delete vectors when collection doesn't exist")
 
+        async def delete_by_filter(self, filters) -> int:
+            self.delete_called = True
+            raise AssertionError("must not delete vectors when collection doesn't exist")
+
     vstore = ExplodingVectorStore(exists=False)
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
     assert prepo.deleted == ["p1"]
@@ -299,25 +326,19 @@ async def test_delete_partition_skips_vectors_when_collection_absent():
 
 
 @pytest.mark.asyncio
-async def test_delete_partition_logs_error_if_vector_store_delete_fails():
-    """Regression for #379: if vector store delete fails after database cleanup,
-    log an error for reconciliation but don't raise (data model is consistent)."""
+async def test_delete_partition_keeps_rows_if_vector_store_delete_fails():
     prepo = FakePartitionRepo(existing={"p1"})
 
     class FailingVectorStore(FakeVectorStore):
-        async def delete(self, ids, collection="default") -> int:
+        async def delete_by_filter(self, filters) -> int:
             raise Exception("Milvus connection failed")
 
     vstore = FailingVectorStore(ids=["c1", "c2"])
 
-    with pytest.importorskip("unittest.mock").patch("services.orchestrators.partition_service.logger") as mock_logger:
+    with pytest.raises(Exception, match="Milvus connection failed"):
         await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
 
-        mock_logger.error.assert_called_once()
-        call_args = mock_logger.error.call_args
-        assert "reconciliation task required" in call_args[0][0]
-        assert call_args[1]["partition"] == "p1"
-        assert call_args[1]["chunk_count"] == 2
+    assert prepo.deleted == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -375,7 +375,7 @@ async def test_delete_partition_does_not_cleanup_when_cancelled_task_does_not_se
 
 
 @pytest.mark.asyncio
-async def test_delete_partition_does_not_cleanup_when_matching_task_has_no_ref():
+async def test_delete_partition_marks_stale_ref_less_task_failed_before_cleanup():
     from unittest.mock import AsyncMock, MagicMock, patch
 
     prepo = FakePartitionRepo(existing={"p1"})
@@ -383,16 +383,19 @@ async def test_delete_partition_does_not_cleanup_when_matching_task_has_no_ref()
     tsm = MagicMock()
     tsm.get_matching_active_task_refs = MagicMock()
     tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    tsm.set_failed_if_not_cancelled = MagicMock()
+    tsm.set_failed_if_not_cancelled.remote = AsyncMock(return_value=True)
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
 
-    with pytest.raises(TimeoutError, match="become cancellable"), patch("ray.cancel") as cancel:
+    with patch("ray.cancel") as cancel:
         await _svc(prepo=prepo, vstore=vstore, tsm=tsm, task_cancel_timeout=0.01).delete_partition("p1")
 
     cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
     tsm.set_state.remote.assert_not_called()
-    assert vstore.deleted_filters == []
-    assert prepo.deleted == []
+    assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
+    assert prepo.deleted == ["p1"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -140,6 +140,7 @@ def _svc(
     vstore=None,
     urepo=None,
     collection="vdb",
+    tsm=None,
 ) -> PartitionService:
     return PartitionService(
         partition_repo=prepo or FakePartitionRepo(),
@@ -148,6 +149,7 @@ def _svc(
         vector_store=vstore or FakeVectorStore(),
         user_repo=urepo or FakeUserRepo(),
         collection=collection,
+        task_state_manager=tsm,
     )
 
 
@@ -259,8 +261,8 @@ async def test_delete_partition_deletes_vectors_before_rows():
 
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
 
-    assert call_order == ["vstore_delete_by_filter", "prepo_delete"]
-    assert vstore.deleted_filters == [{"partition": "p1"}]
+    assert call_order == ["vstore_delete_by_filter", "prepo_delete", "vstore_delete_by_filter"]
+    assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
     assert vstore.deleted_ids == []
     assert prepo.deleted == ["p1"]
 
@@ -270,7 +272,7 @@ async def test_delete_partition_no_vectors_still_deletes_rows():
     prepo = FakePartitionRepo(existing={"p1"})
     vstore = FakeVectorStore(ids=[])
     await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
-    assert vstore.deleted_filters == [{"partition": "p1"}]
+    assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
     assert vstore.deleted_ids == []
     assert prepo.deleted == ["p1"]
 
@@ -323,6 +325,26 @@ async def test_delete_partition_skips_vectors_when_collection_absent():
     assert prepo.deleted == ["p1"]
     assert vstore.deleted_ids == []
     assert vstore.delete_called is False
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    prepo = FakePartitionRepo(existing={"p1"})
+    ref = object()
+    tsm = MagicMock()
+    tsm.get_matching_active_task_refs = MagicMock()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    tsm.set_state = MagicMock()
+    tsm.set_state.remote = AsyncMock(return_value=None)
+
+    with patch("ray.cancel") as cancel:
+        await _svc(prepo=prepo, tsm=tsm).delete_partition("p1")
+
+    tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="p1", file_id=None)
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from core.utils.exceptions import NotFoundError, PartitionNotFoundError, UserNotFoundError, ValidationError
 from services.orchestrators.partition_service import PartitionService
@@ -334,7 +336,8 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     from unittest.mock import AsyncMock, MagicMock, patch
 
     prepo = FakePartitionRepo(existing={"p1"})
-    ref = object()
+    ref = asyncio.get_running_loop().create_future()
+    ref.set_result(None)
     tsm = MagicMock()
     tsm.get_matching_active_task_refs = MagicMock()
     tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
@@ -347,6 +350,28 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="p1", file_id=None)
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_does_not_cleanup_when_cancelled_task_does_not_settle():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore()
+    ref = asyncio.get_running_loop().create_future()
+    tsm = MagicMock()
+    tsm.get_matching_active_task_refs = MagicMock()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    tsm.set_state = MagicMock()
+    tsm.set_state.remote = AsyncMock(return_value=None)
+
+    with pytest.raises(TimeoutError, match="settle after cancellation request"), patch("ray.cancel") as cancel:
+        await _svc(prepo=prepo, vstore=vstore, tsm=tsm, task_cancel_timeout=0.01).delete_partition("p1")
+
+    assert cancel.call_count >= 1
+    tsm.set_state.remote.assert_not_called()
+    assert vstore.deleted_filters == []
+    assert prepo.deleted == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -363,6 +363,25 @@ async def test_delete_partition_keeps_rows_if_vector_store_delete_fails():
     assert prepo.deleted == []
 
 
+@pytest.mark.asyncio
+async def test_delete_partition_keeps_success_when_post_delete_cleanup_fails():
+    prepo = FakePartitionRepo(existing={"p1"})
+
+    class FailingSecondSweepVectorStore(FakeVectorStore):
+        async def delete_by_filter(self, filters) -> int:
+            self.deleted_filters.append(dict(filters))
+            if len(self.deleted_filters) == 2:
+                raise Exception("Milvus connection failed")
+            return 1
+
+    vstore = FailingSecondSweepVectorStore()
+
+    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+
+    assert prepo.deleted == ["p1"]
+    assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
+
+
 # --------------------------------------------------------------------------- #
 # file / chunk reads
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -415,7 +415,7 @@ async def test_delete_partition_keeps_rows_if_vector_store_delete_fails():
 
 
 @pytest.mark.asyncio
-async def test_delete_partition_keeps_success_when_post_delete_cleanup_fails():
+async def test_delete_partition_reports_failure_when_post_delete_cleanup_fails():
     prepo = FakePartitionRepo(existing={"p1"})
 
     class FailingSecondSweepVectorStore(FakeVectorStore):
@@ -427,7 +427,8 @@ async def test_delete_partition_keeps_success_when_post_delete_cleanup_fails():
 
     vstore = FailingSecondSweepVectorStore()
 
-    await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
+    with pytest.raises(Exception, match="Milvus connection failed"):
+        await _svc(prepo=prepo, vstore=vstore).delete_partition("p1")
 
     assert prepo.deleted == ["p1"]
     assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 from core.utils.exceptions import NotFoundError, PartitionNotFoundError, UserNotFoundError, ValidationError
@@ -37,6 +39,89 @@ class FakePartitionRepo:
         self.deleted.append(name)
         self._existing.discard(name)
         return True
+
+
+class LockingPartitionRepo(FakePartitionRepo):
+    def __init__(self, existing: set[str] | None = None, *, events: list[tuple[str, str]]):
+        super().__init__(existing)
+        self.events = events
+        self.locked = False
+
+    @asynccontextmanager
+    async def partition_operation_lock(self, name: str):
+        self.events.append(("lock_enter", name))
+        self.locked = True
+        try:
+            yield
+        finally:
+            self.locked = False
+            self.events.append(("lock_exit", name))
+
+    async def delete_partition(self, name: str) -> bool:
+        assert self.locked is True
+        self.events.append(("repo_delete", name))
+        return await super().delete_partition(name)
+
+
+class _GuardedPartitionOperation:
+    def __init__(self, repo: GuardedPartitionRepo, name: str) -> None:
+        self._repo = repo
+        self._name = name
+
+    async def partition_exists(self, name: str) -> bool:
+        assert name == self._name
+        self._repo.events.append(("guard_exists", name))
+        return name in self._repo._existing
+
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
+        assert name == self._name
+        self._repo.events.append(("guard_create", name))
+        return await FakePartitionRepo.create_partition(self._repo, name, user_id=user_id, max_owned=max_owned)
+
+    async def delete_partition(self, name: str) -> bool:
+        assert name == self._name
+        self._repo.events.append(("guard_delete", name))
+        return await FakePartitionRepo.delete_partition(self._repo, name)
+
+    async def update_partition(self, name: str, **fields: object) -> dict:
+        assert name == self._name
+        self._repo.events.append(("guard_update", name))
+        self._repo.updated.append((name, fields))
+        return {"partition": name, **fields}
+
+    async def list_partition_rows(self) -> list[dict]:
+        self._repo.events.append(("guard_list", self._name))
+        return [{"partition": name} for name in sorted(self._repo._existing)]
+
+
+class GuardedPartitionRepo(FakePartitionRepo):
+    def __init__(self, existing: set[str] | None = None, *, events: list[tuple[str, str]]):
+        super().__init__(existing)
+        self.events = events
+        self.updated: list[tuple[str, dict[str, object]]] = []
+
+    @asynccontextmanager
+    async def partition_operation_lock(self, name: str):
+        self.events.append(("lock_enter", name))
+        try:
+            yield _GuardedPartitionOperation(self, name)
+        finally:
+            self.events.append(("lock_exit", name))
+
+    async def partition_exists(self, name: str) -> bool:
+        raise AssertionError("locked operations must use the operation guard")
+
+    async def create_partition(self, name: str, user_id: int | None = None, *, max_owned: int | None = None) -> dict:
+        raise AssertionError("locked operations must create through the operation guard")
+
+    async def delete_partition(self, name: str) -> bool:
+        raise AssertionError("locked operations must delete through the operation guard")
+
+    async def update_partition(self, name: str, **fields: object) -> dict | None:
+        raise AssertionError("locked operations must update through the operation guard")
+
+    async def list_partition_rows(self) -> list[dict]:
+        raise AssertionError("locked operations must list through the operation guard")
 
 
 class FakeMembershipRepo:
@@ -144,6 +229,7 @@ def _svc(
     collection="vdb",
     tsm=None,
     task_cancel_timeout=60.0,
+    config=None,
 ) -> PartitionService:
     return PartitionService(
         partition_repo=prepo or FakePartitionRepo(),
@@ -154,6 +240,7 @@ def _svc(
         collection=collection,
         task_state_manager=tsm,
         task_cancel_timeout=task_cancel_timeout,
+        config=config,
     )
 
 
@@ -272,6 +359,146 @@ async def test_delete_partition_deletes_vectors_before_rows():
 
 
 @pytest.mark.asyncio
+async def test_indexing_admission_reports_existing_partition_under_operation_lock():
+    events: list[tuple[str, str]] = []
+    prepo = LockingPartitionRepo(existing={"p1"}, events=events)
+    svc = _svc(prepo=prepo)
+
+    async with svc.indexing_admission("p1") as existed:
+        assert existed is True
+        assert prepo.locked is True
+
+    assert prepo.locked is False
+    assert events == [("lock_enter", "p1"), ("lock_exit", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_indexing_admission_uses_operation_guard_for_existence_check():
+    events: list[tuple[str, str]] = []
+    prepo = GuardedPartitionRepo(existing={"p1"}, events=events)
+    svc = _svc(prepo=prepo)
+
+    async with svc.indexing_admission("p1") as existed:
+        assert existed is True
+
+    assert events == [("lock_enter", "p1"), ("guard_exists", "p1"), ("lock_exit", "p1")]
+
+
+@pytest.mark.asyncio
+async def test_partition_exists_inside_indexing_admission_uses_operation_guard():
+    events: list[tuple[str, str]] = []
+    prepo = GuardedPartitionRepo(existing={"p1"}, events=events)
+    svc = _svc(prepo=prepo)
+
+    async with svc.indexing_admission("p1"):
+        assert await svc.partition_exists("p1") is True
+
+    assert events == [
+        ("lock_enter", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_exists", "p1"),
+        ("lock_exit", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_partition_inside_indexing_admission_uses_operation_guard():
+    events: list[tuple[str, str]] = []
+    prepo = GuardedPartitionRepo(existing=set(), events=events)
+    svc = _svc(prepo=prepo)
+
+    async with svc.indexing_admission("p1") as existed:
+        assert existed is False
+        await svc.create_partition("p1", user_id=7)
+
+    assert prepo.created == [("p1", 7)]
+    assert events == [
+        ("lock_enter", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_create", "p1"),
+        ("lock_exit", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_partition_with_config_inside_indexing_admission_keeps_db_work_on_operation_guard():
+    events: list[tuple[str, str]] = []
+    prepo = GuardedPartitionRepo(existing=set(), events=events)
+    config = SimpleNamespace(partitions={})
+    svc = _svc(prepo=prepo, config=config)
+    svc._validate_preset_refs = lambda row: None
+    svc.resolve_partition_row = lambda row: f"resolved-{row['partition']}"
+
+    async with svc.indexing_admission("p1") as existed:
+        assert existed is False
+        await svc.create_partition("p1", user_id=7)
+
+    assert prepo.created == [("p1", 7)]
+    assert prepo.updated == [
+        (
+            "p1",
+            {
+                "description": "",
+                "embedder": "default",
+                "indexation_preset": "default",
+                "retrieval_preset": "default",
+                "chat_history_depth": 0,
+                "chat_llm": None,
+            },
+        )
+    ]
+    assert config.partitions == {"p1": "resolved-p1"}
+    assert events == [
+        ("lock_enter", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_create", "p1"),
+        ("guard_update", "p1"),
+        ("guard_list", "p1"),
+        ("lock_exit", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_holds_operation_lock_through_vector_and_row_cleanup():
+    events: list[tuple[str, str]] = []
+    prepo = LockingPartitionRepo(existing={"p1"}, events=events)
+
+    class LockAssertingVectorStore(FakeVectorStore):
+        async def delete_by_filter(self, filters) -> int:
+            assert prepo.locked is True
+            events.append(("vector_delete", filters["partition"]))
+            return await super().delete_by_filter(filters)
+
+    await _svc(prepo=prepo, vstore=LockAssertingVectorStore()).delete_partition("p1")
+
+    assert events == [
+        ("lock_enter", "p1"),
+        ("vector_delete", "p1"),
+        ("repo_delete", "p1"),
+        ("vector_delete", "p1"),
+        ("lock_exit", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_uses_operation_guard_for_existence_and_row_delete():
+    events: list[tuple[str, str]] = []
+    prepo = GuardedPartitionRepo(existing={"p1"}, events=events)
+
+    await _svc(prepo=prepo).delete_partition("p1")
+
+    assert prepo.deleted == ["p1"]
+    assert events == [
+        ("lock_enter", "p1"),
+        ("guard_exists", "p1"),
+        ("guard_delete", "p1"),
+        ("lock_exit", "p1"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_delete_partition_no_vectors_still_deletes_rows():
     prepo = FakePartitionRepo(existing={"p1"})
     vstore = FakeVectorStore(ids=[])
@@ -339,15 +566,15 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     ref = asyncio.get_running_loop().create_future()
     ref.set_result(None)
     tsm = MagicMock()
-    tsm.get_matching_active_task_refs = MagicMock()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2 = MagicMock()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
 
     with patch("ray.cancel") as cancel:
         await _svc(prepo=prepo, tsm=tsm).delete_partition("p1")
 
-    tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="p1", file_id=None)
+    tsm.get_matching_active_task_refs_v2.remote.assert_called_once_with(partition="p1", file_id=None)
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
 
@@ -361,7 +588,7 @@ async def test_delete_partition_uses_legacy_task_state_lookup_when_matching_api_
     ref = asyncio.get_running_loop().create_future()
     ref.set_result(None)
     tsm = MagicMock()
-    del tsm.get_matching_active_task_refs
+    del tsm.get_matching_active_task_refs_v2
     tsm.get_all_info = MagicMock()
     tsm.get_all_info.remote = AsyncMock(
         return_value={
@@ -399,8 +626,8 @@ async def test_delete_partition_does_not_cleanup_when_cancelled_task_does_not_se
     vstore = FakeVectorStore()
     ref = asyncio.get_running_loop().create_future()
     tsm = MagicMock()
-    tsm.get_matching_active_task_refs = MagicMock()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2 = MagicMock()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
 
@@ -420,8 +647,8 @@ async def test_delete_partition_marks_stale_ref_less_task_failed_before_cleanup(
     prepo = FakePartitionRepo(existing={"p1"})
     vstore = FakeVectorStore()
     tsm = MagicMock()
-    tsm.get_matching_active_task_refs = MagicMock()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    tsm.get_matching_active_task_refs_v2 = MagicMock()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": None}})
     tsm.set_failed_if_not_cancelled = MagicMock()
     tsm.set_failed_if_not_cancelled.remote = AsyncMock(return_value=True)
     tsm.set_state = MagicMock()

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -353,6 +353,45 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
 
 
 @pytest.mark.asyncio
+async def test_delete_partition_uses_legacy_task_state_lookup_when_matching_api_missing():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore()
+    ref = asyncio.get_running_loop().create_future()
+    ref.set_result(None)
+    tsm = MagicMock()
+    del tsm.get_matching_active_task_refs
+    tsm.get_all_info = MagicMock()
+    tsm.get_all_info.remote = AsyncMock(
+        return_value={
+            "task-1": {
+                "state": "SERIALIZING",
+                "details": {"partition": "p1", "file_id": "f1"},
+            },
+            "other": {
+                "state": "SERIALIZING",
+                "details": {"partition": "p2", "file_id": "f2"},
+            },
+        }
+    )
+    tsm.get_object_ref = MagicMock()
+    tsm.get_object_ref.remote = AsyncMock(return_value={"ref": ref})
+    tsm.set_state = MagicMock()
+    tsm.set_state.remote = AsyncMock(return_value=None)
+
+    with patch("ray.cancel") as cancel:
+        await _svc(prepo=prepo, vstore=vstore, tsm=tsm).delete_partition("p1")
+
+    tsm.get_all_info.remote.assert_called_once_with()
+    tsm.get_object_ref.remote.assert_called_once_with("task-1")
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
+    assert prepo.deleted == ["p1"]
+
+
+@pytest.mark.asyncio
 async def test_delete_partition_does_not_cleanup_when_cancelled_task_does_not_settle():
     from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -141,6 +141,7 @@ def _svc(
     urepo=None,
     collection="vdb",
     tsm=None,
+    task_cancel_timeout=60.0,
 ) -> PartitionService:
     return PartitionService(
         partition_repo=prepo or FakePartitionRepo(),
@@ -150,6 +151,7 @@ def _svc(
         user_repo=urepo or FakeUserRepo(),
         collection=collection,
         task_state_manager=tsm,
+        task_cancel_timeout=task_cancel_timeout,
     )
 
 
@@ -345,6 +347,27 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="p1", file_id=None)
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+
+
+@pytest.mark.asyncio
+async def test_delete_partition_does_not_cleanup_when_matching_task_has_no_ref():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    prepo = FakePartitionRepo(existing={"p1"})
+    vstore = FakeVectorStore()
+    tsm = MagicMock()
+    tsm.get_matching_active_task_refs = MagicMock()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    tsm.set_state = MagicMock()
+    tsm.set_state.remote = AsyncMock(return_value=None)
+
+    with pytest.raises(TimeoutError, match="become cancellable"), patch("ray.cancel") as cancel:
+        await _svc(prepo=prepo, vstore=vstore, tsm=tsm, task_cancel_timeout=0.01).delete_partition("p1")
+
+    cancel.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    assert vstore.deleted_filters == []
+    assert prepo.deleted == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -460,7 +460,17 @@ async def test_get_file_chunks_missing_file_404():
 
 @pytest.mark.asyncio
 async def test_get_file_chunks_strips_text_keeps_id_and_caps_limit():
-    rows = [{"_id": str(i), "text": "body", "page": i, "partition": "p", "file_id": "f"} for i in range(5)]
+    rows = [
+        {
+            "_id": str(i),
+            "text": "body",
+            "page": i,
+            "partition": "p",
+            "file_id": "f",
+            "_openrag_indexing_task_id": "task-1",
+        }
+        for i in range(5)
+    ]
     svc = _svc(
         drepo=FakeDocumentRepo(files={("f", "p")}),
         vstore=FakeVectorStore(rows=rows),
@@ -469,16 +479,26 @@ async def test_get_file_chunks_strips_text_keeps_id_and_caps_limit():
     assert len(out) == 3
     assert all("text" not in r for r in out)
     assert all("_id" in r for r in out)
+    assert all("_openrag_indexing_task_id" not in r for r in out)
 
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_excludes_vector_when_no_embedding():
-    rows = [{"text": "t", "_id": "1", "partition": "p", "vector": [0.1, 0.2]}]
+    rows = [
+        {
+            "text": "t",
+            "_id": "1",
+            "partition": "p",
+            "vector": [0.1, 0.2],
+            "_openrag_indexing_task_id": "task-1",
+        }
+    ]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     out = await svc.list_all_chunks("p", include_embedding=False)
     assert out[0]["content"] == "t"
     assert "vector" not in out[0]["metadata"]
     assert "text" not in out[0]["metadata"]
+    assert "_openrag_indexing_task_id" not in out[0]["metadata"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -397,7 +397,6 @@ async def test_list_all_chunks_stringifies_vector_when_included():
     assert isinstance(out[0]["metadata"]["vector"], str)
 
 
-@pytest.mark.asyncio
 async def test_list_all_chunks_without_file_id_filters_partition_only():
     vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1", "partition": "p"}])
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=vstore)
@@ -414,7 +413,6 @@ async def test_list_all_chunks_scopes_to_file_id_when_given():
     assert vstore.last_chunk_filters == {"partition": "p", "file_id": "f-123"}
 
 
-@pytest.mark.asyncio
 async def test_list_all_chunks_applies_limit():
     rows = [{"text": str(i), "_id": str(i), "partition": "p"} for i in range(5)]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
@@ -422,7 +420,6 @@ async def test_list_all_chunks_applies_limit():
     assert len(out) == 2
 
 
-@pytest.mark.asyncio
 async def test_list_all_chunks_rejects_negative_limit():
     rows = [{"text": str(i), "_id": str(i), "partition": "p"} for i in range(5)]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -121,7 +121,7 @@ class FakeVectorStore:
 
     async def query_chunks_by_filter(self, collection, filters, output_fields=None):
         self.last_chunk_filters = dict(filters)
-        return [row for row in self._rows if all(key not in row or row[key] == value for key, value in filters.items())]
+        return [row for row in self._rows if all(row.get(key) == value for key, value in filters.items())]
 
 
 class FakeUserRepo:
@@ -368,7 +368,7 @@ async def test_get_file_chunks_missing_file_404():
 
 @pytest.mark.asyncio
 async def test_get_file_chunks_strips_text_keeps_id_and_caps_limit():
-    rows = [{"_id": str(i), "text": "body", "page": i} for i in range(5)]
+    rows = [{"_id": str(i), "text": "body", "page": i, "partition": "p", "file_id": "f"} for i in range(5)]
     svc = _svc(
         drepo=FakeDocumentRepo(files={("f", "p")}),
         vstore=FakeVectorStore(rows=rows),
@@ -381,7 +381,7 @@ async def test_get_file_chunks_strips_text_keeps_id_and_caps_limit():
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_excludes_vector_when_no_embedding():
-    rows = [{"text": "t", "_id": "1", "vector": [0.1, 0.2]}]
+    rows = [{"text": "t", "_id": "1", "partition": "p", "vector": [0.1, 0.2]}]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     out = await svc.list_all_chunks("p", include_embedding=False)
     assert out[0]["content"] == "t"
@@ -391,7 +391,7 @@ async def test_list_all_chunks_excludes_vector_when_no_embedding():
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_stringifies_vector_when_included():
-    rows = [{"text": "t", "_id": "1", "vector": [0.1, 0.2]}]
+    rows = [{"text": "t", "_id": "1", "partition": "p", "vector": [0.1, 0.2]}]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     out = await svc.list_all_chunks("p", include_embedding=True)
     assert isinstance(out[0]["metadata"]["vector"], str)
@@ -399,7 +399,7 @@ async def test_list_all_chunks_stringifies_vector_when_included():
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_without_file_id_filters_partition_only():
-    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1"}])
+    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1", "partition": "p"}])
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=vstore)
     await svc.list_all_chunks("p", include_embedding=False)
     assert vstore.last_chunk_filters == {"partition": "p"}
@@ -408,7 +408,7 @@ async def test_list_all_chunks_without_file_id_filters_partition_only():
 @pytest.mark.asyncio
 async def test_list_all_chunks_scopes_to_file_id_when_given():
     """file_id is pushed down to the vector store so the detail view is O(file)."""
-    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1"}])
+    vstore = FakeVectorStore(rows=[{"text": "t", "_id": "1", "partition": "p", "file_id": "f-123"}])
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=vstore)
     await svc.list_all_chunks("p", include_embedding=False, file_id="f-123")
     assert vstore.last_chunk_filters == {"partition": "p", "file_id": "f-123"}
@@ -416,7 +416,7 @@ async def test_list_all_chunks_scopes_to_file_id_when_given():
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_applies_limit():
-    rows = [{"text": str(i), "_id": str(i)} for i in range(5)]
+    rows = [{"text": str(i), "_id": str(i), "partition": "p"} for i in range(5)]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     out = await svc.list_all_chunks("p", include_embedding=False, limit=2)
     assert len(out) == 2
@@ -424,7 +424,7 @@ async def test_list_all_chunks_applies_limit():
 
 @pytest.mark.asyncio
 async def test_list_all_chunks_rejects_negative_limit():
-    rows = [{"text": str(i), "_id": str(i)} for i in range(5)]
+    rows = [{"text": str(i), "_id": str(i), "partition": "p"} for i in range(5)]
     svc = _svc(prepo=FakePartitionRepo({"p"}), vstore=FakeVectorStore(rows=rows))
     with pytest.raises(ValidationError) as ei:
         await svc.list_all_chunks("p", include_embedding=False, limit=-1)
@@ -433,7 +433,7 @@ async def test_list_all_chunks_rejects_negative_limit():
 
 @pytest.mark.asyncio
 async def test_get_file_chunks_rejects_negative_limit():
-    rows = [{"_id": str(i), "text": "body"} for i in range(5)]
+    rows = [{"_id": str(i), "text": "body", "partition": "p", "file_id": "f"} for i in range(5)]
     svc = _svc(
         drepo=FakeDocumentRepo(files={("f", "p")}),
         vstore=FakeVectorStore(rows=rows),

--- a/tests/unit/services/persistence/test_add_file_to_partition_user_id.py
+++ b/tests/unit/services/persistence/test_add_file_to_partition_user_id.py
@@ -15,8 +15,9 @@ class _AsyncContext:
 
 
 class _FakeConn:
-    def __init__(self):
+    def __init__(self, *, partition_exists: bool = False):
         self.executed: list[tuple[str, tuple]] = []
+        self.partition_exists = partition_exists
 
     def transaction(self):
         return _AsyncContext(self)
@@ -24,6 +25,8 @@ class _FakeConn:
     async def fetchval(self, query: str, *params):
         if "SELECT 1 FROM files" in query:
             return None
+        if "SELECT 1 FROM partitions" in query:
+            return 1 if self.partition_exists else None
         if "RETURNING 1" in query:
             return 1
         return None
@@ -34,8 +37,8 @@ class _FakeConn:
 
 
 class _FakePool:
-    def __init__(self):
-        self.conn = _FakeConn()
+    def __init__(self, *, partition_exists: bool = False):
+        self.conn = _FakeConn(partition_exists=partition_exists)
 
     def acquire(self):
         return _AsyncContext(self.conn)
@@ -96,6 +99,46 @@ async def test_add_file_to_partition_persists_indexation_config_column():
     )
     assert "indexation_config" in insert_query
     assert snapshot in insert_params
+
+
+@pytest.mark.asyncio
+async def test_require_existing_partition_does_not_auto_create_missing_partition():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _FakePool(partition_exists=False)
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert (
+        await repo.add_file_to_partition(
+            file_id="f1",
+            partition="deleted-part",
+            user_id=42,
+            require_existing_partition=True,
+        )
+        is False
+    )
+    assert not any("INSERT INTO partitions" in query for query, _ in pool.conn.executed)
+    assert not any("INSERT INTO files" in query for query, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_require_existing_partition_inserts_when_partition_exists():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _FakePool(partition_exists=True)
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert (
+        await repo.add_file_to_partition(
+            file_id="f1",
+            partition="tenant-a",
+            user_id=42,
+            require_existing_partition=True,
+        )
+        is True
+    )
+    assert not any("INSERT INTO partitions" in query for query, _ in pool.conn.executed)
+    assert any("INSERT INTO files" in query for query, _ in pool.conn.executed)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_partition_repo.py
+++ b/tests/unit/services/persistence/test_partition_repo.py
@@ -41,6 +41,8 @@ class _FakeConn:
 
     async def fetchval(self, query: str, *params):
         self.operations.append((query, params))
+        if "SELECT EXISTS (SELECT 1 FROM partitions" in query:
+            return self.existing_partition
         if "COUNT(*)::int FROM partition_memberships" in query:
             return self.owned_count
         return None
@@ -53,8 +55,10 @@ class _FakeConn:
 class _FakePool:
     def __init__(self, conn: _FakeConn):
         self.conn = conn
+        self.acquire_count = 0
 
     def acquire(self):
+        self.acquire_count += 1
         return _AsyncContext(self.conn)
 
 
@@ -105,6 +109,48 @@ async def test_create_partition_existing_row_raises_conflict():
     assert exc.value.status_code == 409
     assert exc.value.code == "PARTITION_EXISTS"
     assert conn.inserted_partition is False
+
+
+@pytest.mark.asyncio
+async def test_partition_operation_lock_uses_session_advisory_lock_and_unlocks_on_error():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _FakeConn()
+    pool = _FakePool(conn)
+    repo = PgPartitionRepository(pool_getter=lambda: pool)
+
+    with pytest.raises(RuntimeError, match="inside fence"):
+        async with repo.partition_operation_lock("tenant-a"):
+            raise RuntimeError("inside fence")
+
+    operations = [(query, params) for query, params in conn.operations if "pg_advisory_" in query]
+    assert [query for query, _ in operations] == [
+        "SELECT pg_advisory_lock($1::integer, hashtext($2)::integer)",
+        "SELECT pg_advisory_unlock($1::integer, hashtext($2)::integer)",
+    ]
+    assert operations[0][1] == operations[1][1]
+    assert operations[0][1][1] == "tenant-a"
+    assert pool.acquire_count == 1
+
+
+@pytest.mark.asyncio
+async def test_partition_operation_guard_checks_existence_on_lock_connection():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _FakeConn(existing_partition=True)
+    pool = _FakePool(conn)
+    repo = PgPartitionRepository(pool_getter=lambda: pool)
+
+    async with repo.partition_operation_lock("tenant-a") as operation:
+        assert await operation.partition_exists("tenant-a") is True
+
+    operations = [query for query, _params in conn.operations]
+    assert operations == [
+        "SELECT pg_advisory_lock($1::integer, hashtext($2)::integer)",
+        "SELECT EXISTS (SELECT 1 FROM partitions WHERE partition = $1)",
+        "SELECT pg_advisory_unlock($1::integer, hashtext($2)::integer)",
+    ]
+    assert pool.acquire_count == 1
 
 
 # ── update_partition preset-assignment race guard ────────────────────

--- a/tests/unit/services/storage/test_vector_store_searcher.py
+++ b/tests/unit/services/storage/test_vector_store_searcher.py
@@ -67,9 +67,18 @@ def test_dict_to_chunk_uses_underscore_id_as_fallback():
 
 
 def test_dict_to_chunk_metadata_excludes_reserved_keys():
-    row = {"id": "x", "text": "t", "partition": "p", "file_id": "f", "score": 0.9, "extra_key": "val"}
+    row = {
+        "id": "x",
+        "text": "t",
+        "partition": "p",
+        "file_id": "f",
+        "score": 0.9,
+        "extra_key": "val",
+        "_openrag_indexing_task_id": "task-1",
+    }
     c = _dict_to_chunk(row)
     assert "score" not in c.metadata
+    assert "_openrag_indexing_task_id" not in c.metadata
     assert "extra_key" in c.metadata
 
 

--- a/tests/unit/services/workers/stages/test_pipeline_stages.py
+++ b/tests/unit/services/workers/stages/test_pipeline_stages.py
@@ -324,6 +324,17 @@ async def test_store_stage_upserts_to_default_collection_with_chunk_partitions()
 
 
 @pytest.mark.asyncio
+async def test_store_stage_stamps_task_id_on_chunks_for_precise_cleanup():
+    chunks = [Chunk(id="c1", text="alpha", embedding=[1.0])]
+    store = FakeVectorStore(count=1)
+    row = {"task_id": "task-1", "chunks": chunks}
+
+    await store_stage(row, store)
+
+    assert chunks[0].metadata["_openrag_indexing_task_id"] == "task-1"
+
+
+@pytest.mark.asyncio
 async def test_store_stage_rejects_chunks_without_embeddings():
     chunks = [Chunk(id="c1", text="alpha")]
     store = FakeVectorStore(count=0)

--- a/tests/unit/services/workers/stages/test_pipeline_stages.py
+++ b/tests/unit/services/workers/stages/test_pipeline_stages.py
@@ -113,6 +113,9 @@ class FakeVectorStore(VectorStore):
     async def delete(self, ids: list[str], collection: str = "default") -> int:
         return 0
 
+    async def delete_by_filter(self, filters: dict) -> int:
+        return 0
+
     async def ensure_collection(self, name: str, dimension: int, **kwargs) -> None:
         self.ensure_calls.append((name, dimension))
         return None

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -88,7 +88,9 @@ def _task_state_manager() -> MagicMock:
     tsm.get_matching_active_task_refs_v2 = _remote_mock({})
     tsm.get_matching_active_task_refs = _remote_mock({})
     tsm.get_all_info = None
-    tsm.set_queued_details = _remote_mock()
+    tsm.set_queued_details = _remote_mock(True)
+    tsm.begin_file_delete = _remote_mock()
+    tsm.end_file_delete = _remote_mock()
     return tsm
 
 
@@ -171,6 +173,39 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         require_existing_partition=True,
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_rejects_task_when_file_delete_fence_is_active() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    pool = _pool_with_ref(object())
+    tsm = _task_state_manager()
+    tsm.set_queued_details.remote = AsyncMock(return_value=False)
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="is being deleted"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt", "filename": "report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=["ws-1"],
+                replace=True,
+            )
+
+    pool.submit.remote.assert_not_called()
+    tsm.set_object_ref.remote.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -720,6 +755,96 @@ async def test_delete_file_cleans_vector_store_before_database() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_file_holds_file_delete_fence_around_cleanup() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    call_order = []
+    tsm = _task_state_manager()
+    tsm.begin_file_delete.remote = AsyncMock(side_effect=lambda **kwargs: call_order.append("begin"))
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(
+        side_effect=lambda **kwargs: call_order.append("lookup") or {}
+    )
+    tsm.end_file_delete.remote = AsyncMock(side_effect=lambda **kwargs: call_order.append("end"))
+    vector_store = _vector_store()
+    vector_store.collection_exists = AsyncMock(side_effect=lambda collection: call_order.append("exists") or True)
+    vector_store.delete_by_filter = AsyncMock(side_effect=lambda *args, **kwargs: call_order.append("delete") or 2)
+    workspace_repo = _workspace_repo()
+    workspace_repo.remove_file_from_all_workspaces = AsyncMock(
+        side_effect=lambda *args, **kwargs: call_order.append("workspace")
+    )
+    document_repo = _document_repo()
+    document_repo.remove_file_from_partition = AsyncMock(
+        side_effect=lambda *args, **kwargs: call_order.append("document")
+    )
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert call_order == ["begin", "lookup", "exists", "delete", "workspace", "document", "delete", "end"]
+    tsm.begin_file_delete.remote.assert_awaited_once_with(partition="tenant-a", file_id="file-1")
+    tsm.end_file_delete.remote.assert_awaited_once_with(partition="tenant-a", file_id="file-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_file_releases_file_delete_fence_when_cleanup_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    vector_store = _vector_store()
+    vector_store.delete_by_filter = AsyncMock(side_effect=Exception("Milvus connection failed"))
+    workspace_repo = _workspace_repo()
+    document_repo = _document_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    with pytest.raises(Exception, match="Milvus connection failed"):
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    tsm.end_file_delete.remote.assert_awaited_once_with(partition="tenant-a", file_id="file-1")
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_fails_closed_when_file_delete_fence_is_missing() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    del tsm.begin_file_delete
+    vector_store = _vector_store()
+    workspace_repo = _workspace_repo()
+    document_repo = _document_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    with pytest.raises(RuntimeError, match="file delete fencing"):
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
@@ -1009,6 +1134,8 @@ async def test_delete_file_ignores_unsafe_legacy_matching_api_when_v2_missing() 
     ref = _settled_ref()
     tsm = _task_state_manager()
     tsm._ray_actor_method_names = {
+        "begin_file_delete",
+        "end_file_delete",
         "get_matching_active_task_refs",
         "get_all_info",
         "get_object_ref",

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -141,6 +141,7 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
             replace=True,
             indexation_config={"parsing_strategy": "pymupdf"},
             embedder_name="embed-fast",
+            require_existing_partition=True,
         )
 
     assert task_id == "task-1"
@@ -162,6 +163,7 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         replace=True,
         indexation_config={"parsing_strategy": "pymupdf"},
         embedder_name="embed-fast",
+        require_existing_partition=True,
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -422,7 +422,12 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     )
 
     await dispatcher.delete_file("file-1", "tenant-a")
-    await dispatcher.update_file_metadata("file-1", {"title": "new"}, "tenant-a", user={"id": 7})
+    await dispatcher.update_file_metadata(
+        "file-1",
+        {"title": "new", "_openrag_indexing_task_id": "from-user-metadata"},
+        "tenant-a",
+        user={"id": 7},
+    )
     await dispatcher.copy_file("file-1", {"file_id": "copy-1", "partition": "tenant-b"}, "tenant-b", user=None)
 
     assert [call.args for call in vector_store.delete_by_filter.call_args_list] == [
@@ -447,7 +452,7 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     )
     vector_store.upsert_entities.assert_awaited_once()
     vector_store.insert_entities.assert_awaited_once()
-    assert "_openrag_indexing_task_id" not in vector_store.upsert_entities.await_args.args[0][0]
+    assert vector_store.upsert_entities.await_args.args[0][0]["_openrag_indexing_task_id"] == "task-1"
     assert "_openrag_indexing_task_id" not in vector_store.insert_entities.await_args.args[0][0]
 
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -757,6 +757,45 @@ async def test_delete_file_uses_legacy_task_state_lookup_when_matching_api_missi
 
 
 @pytest.mark.asyncio
+async def test_delete_file_legacy_lookup_blocks_detail_less_active_task() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    tsm = _task_state_manager()
+    del tsm.get_matching_active_task_refs
+    tsm.get_all_info = _remote_mock(
+        {
+            "task-1": {
+                "state": "QUEUED",
+                "details": {},
+            },
+            "other-partition": {
+                "state": "SERIALIZING",
+                "details": {"partition": "tenant-b", "file_id": "file-1"},
+            },
+        }
+    )
+    tsm.get_object_ref = _remote_mock({"ref": ref})
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    tsm.get_object_ref.remote.assert_called_once_with("task-1")
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_delete_file_does_not_cleanup_when_cancelled_task_does_not_settle() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +20,12 @@ def _pool_with_ref(ref: object) -> MagicMock:
     # awaits the call and takes element 0).
     pool.submit = _remote_mock([ref])
     return pool
+
+
+def _settled_ref() -> asyncio.Future[None]:
+    ref = asyncio.get_running_loop().create_future()
+    ref.set_result(None)
+    return ref
 
 
 def _vector_store() -> MagicMock:
@@ -276,7 +283,7 @@ async def test_delete_file_cleans_vector_store_before_database() -> None:
 async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
-    ref = object()
+    ref = _settled_ref()
     tsm = _task_state_manager()
     tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
     dispatcher = WorkerDispatcher(
@@ -300,7 +307,7 @@ async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup(
 async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
-    ref = object()
+    ref = _settled_ref()
     tsm = _task_state_manager()
     tsm.get_matching_active_task_refs.remote = AsyncMock(
         side_effect=[
@@ -325,6 +332,66 @@ async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
     assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_waits_for_cancelled_task_to_settle_before_cleanup() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    settled = asyncio.Event()
+    ref = asyncio.create_task(settled.wait())
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("ray.cancel") as cancel:
+        delete_task = asyncio.create_task(dispatcher.delete_file("file-1", "tenant-a"))
+        await asyncio.sleep(0)
+        assert vector_store.delete_by_filter.await_count == 0
+        settled.set()
+        await delete_task
+
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_does_not_cleanup_when_cancelled_task_does_not_settle() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = asyncio.get_running_loop().create_future()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="settle after cancellation request"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert cancel.call_count >= 1
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -360,7 +427,7 @@ async def test_delete_file_does_not_cleanup_when_matching_task_has_no_ref() -> N
 async def test_delete_file_does_not_cleanup_when_matching_task_cancel_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
-    ref = object()
+    ref = _settled_ref()
     tsm = _task_state_manager()
     tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
     vector_store = _vector_store()

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -320,3 +320,28 @@ async def test_delete_file_does_not_remove_database_row_if_vector_store_delete_f
 
     workspace_repo.remove_file_from_all_workspaces.assert_not_called()
     document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_keeps_success_when_post_delete_cleanup_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=_task_state_manager(),
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    vector_store.delete_by_filter = AsyncMock(side_effect=[2, Exception("Milvus connection failed")])
+
+    await dispatcher.delete_file("file-1", "tenant-a")
+
+    workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
+    document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -68,6 +68,7 @@ def _task_state_manager() -> MagicMock:
     tsm.get_state = _remote_mock("SERIALIZING")
     tsm.get_error = _remote_mock("traceback")
     tsm.get_object_ref = _remote_mock({"ref": object()})
+    tsm.get_matching_active_task_refs = _remote_mock({})
     return tsm
 
 
@@ -169,7 +170,10 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     await dispatcher.update_file_metadata("file-1", {"title": "new"}, "tenant-a", user={"id": 7})
     await dispatcher.copy_file("file-1", {"file_id": "copy-1", "partition": "tenant-b"}, "tenant-b", user=None)
 
-    vector_store.delete_by_filter.assert_called_once_with({"partition": "tenant-a", "file_id": "file-1"})
+    assert [call.args for call in vector_store.delete_by_filter.call_args_list] == [
+        ({"partition": "tenant-a", "file_id": "file-1"},),
+        ({"partition": "tenant-a", "file_id": "file-1"},),
+    ]
     vector_store.delete.assert_not_called()
     workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
     document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")
@@ -265,7 +269,31 @@ async def test_delete_file_cleans_vector_store_before_database() -> None:
 
     await dispatcher.delete_file("file-1", "tenant-a")
 
-    assert call_order == ["delete_by_filter", "workspace", "document"]
+    assert call_order == ["delete_by_filter", "workspace", "document", "delete_by_filter"]
+
+
+@pytest.mark.asyncio
+async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="tenant-a", file_id="file-1")
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from ray.exceptions import TaskCancelledError
 
 
 def _remote_mock(return_value: Any = None) -> MagicMock:
@@ -25,6 +26,12 @@ def _pool_with_ref(ref: object) -> MagicMock:
 def _settled_ref() -> asyncio.Future[None]:
     ref = asyncio.get_running_loop().create_future()
     ref.set_result(None)
+    return ref
+
+
+def _cancelled_ref() -> asyncio.Future[None]:
+    ref = asyncio.get_running_loop().create_future()
+    ref.set_exception(TaskCancelledError())
     return ref
 
 
@@ -77,6 +84,7 @@ def _task_state_manager() -> MagicMock:
     tsm.get_error = _remote_mock("traceback")
     tsm.get_object_ref = _remote_mock({"ref": object()})
     tsm.get_matching_active_task_refs = _remote_mock({})
+    tsm.get_all_info = None
     return tsm
 
 
@@ -198,7 +206,7 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
 async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
-    ref = _settled_ref()
+    ref = _cancelled_ref()
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
@@ -227,6 +235,107 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() ->
     tsm.set_failed_if_not_cancelled.remote.assert_called_once()
     assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
     assert "ref registration failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_already_settled() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="ref registration failed"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_cancel_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with (
+        patch("services.workers.dispatcher.uuid") as mock_uuid,
+        patch("ray.cancel", side_effect=RuntimeError("cancel failed")),
+    ):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="Failed to cancel submitted indexing task"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_cancel_times_out() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = asyncio.get_running_loop().create_future()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        timeout=0.01,
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel"):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(TimeoutError, match="submitted indexing task task-1"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -266,7 +375,7 @@ async def test_dispatch_indexing_keeps_fast_finished_task_when_ref_registration_
 async def test_dispatch_indexing_cancels_worker_when_ref_registration_is_rejected() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
-    ref = _settled_ref()
+    ref = _cancelled_ref()
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(return_value=False)
@@ -509,6 +618,40 @@ async def test_delete_file_rechecks_ref_less_task_before_marking_stale() -> None
 
 
 @pytest.mark.asyncio
+async def test_delete_file_final_ref_recheck_stays_within_delete_timeout() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        timeout=0.5,
+    )
+    timeouts: list[tuple[str, float]] = []
+
+    async def bounded_call(*, future: Any, timeout: float, task_description: str) -> Any:
+        timeouts.append((task_description, timeout))
+        return await future
+
+    with (
+        patch("services.workers.task_cancellation._REF_WAIT_INTERVAL", 999),
+        patch("services.workers.task_cancellation.call_ray_actor_with_timeout", side_effect=bounded_call),
+    ):
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert all(0 < timeout <= 0.5 for _, timeout in timeouts)
+    assert any("final" in description for description, _ in timeouts)
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_delete_file_waits_for_cancelled_task_to_settle_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
@@ -562,6 +705,50 @@ async def test_delete_file_fails_closed_when_active_task_lookup_missing() -> Non
     vector_store.delete_by_filter.assert_not_called()
     workspace_repo.remove_file_from_all_workspaces.assert_not_called()
     document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_uses_legacy_task_state_lookup_when_matching_api_missing() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    tsm = _task_state_manager()
+    del tsm.get_matching_active_task_refs
+    tsm.get_all_info = _remote_mock(
+        {
+            "task-1": {
+                "state": "SERIALIZING",
+                "details": {"partition": "tenant-a", "file_id": "file-1"},
+            },
+            "other-partition": {
+                "state": "SERIALIZING",
+                "details": {"partition": "tenant-b", "file_id": "file-1"},
+            },
+            "completed": {
+                "state": "COMPLETED",
+                "details": {"partition": "tenant-a", "file_id": "file-1"},
+            },
+        }
+    )
+    tsm.get_object_ref = _remote_mock({"ref": ref})
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    tsm.get_all_info.remote.assert_called_once_with()
+    tsm.get_object_ref.remote.assert_called_once_with("task-1")
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vector_store.delete_by_filter.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -679,7 +679,7 @@ async def test_delete_file_does_not_remove_database_row_if_vector_store_delete_f
 
 
 @pytest.mark.asyncio
-async def test_delete_file_keeps_success_when_post_delete_cleanup_fails() -> None:
+async def test_delete_file_reports_failure_when_post_delete_cleanup_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     vector_store = _vector_store()
@@ -697,7 +697,9 @@ async def test_delete_file_keeps_success_when_post_delete_cleanup_fails() -> Non
 
     vector_store.delete_by_filter = AsyncMock(side_effect=[2, Exception("Milvus connection failed")])
 
-    await dispatcher.delete_file("file-1", "tenant-a")
+    with pytest.raises(Exception, match="Milvus connection failed"):
+        await dispatcher.delete_file("file-1", "tenant-a")
 
     workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
     document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")
+    assert vector_store.delete_by_filter.await_count == 2

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -70,6 +70,7 @@ def _workspace_repo() -> MagicMock:
 def _task_state_manager() -> MagicMock:
     tsm = MagicMock()
     tsm.set_state = _remote_mock()
+    tsm.set_failed_if_not_cancelled = _remote_mock()
     tsm.set_details = _remote_mock()
     tsm.set_object_ref = _remote_mock()
     tsm.get_state = _remote_mock("SERIALIZING")
@@ -155,6 +156,42 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         embedder_name="embed-fast",
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=RuntimeError("submit failed"))
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="submit failed"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.set_details.remote.assert_called_once()
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
+    assert "submit failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
+    tsm.set_object_ref.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -395,7 +432,7 @@ async def test_delete_file_does_not_cleanup_when_cancelled_task_does_not_settle(
 
 
 @pytest.mark.asyncio
-async def test_delete_file_does_not_cleanup_when_matching_task_has_no_ref() -> None:
+async def test_delete_file_marks_stale_ref_less_task_failed_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     tsm = _task_state_manager()
@@ -413,14 +450,15 @@ async def test_delete_file_does_not_cleanup_when_matching_task_has_no_ref() -> N
         timeout=0.01,
     )
 
-    with pytest.raises(TimeoutError, match="become cancellable"), patch("ray.cancel") as cancel:
+    with patch("ray.cancel") as cancel:
         await dispatcher.delete_file("file-1", "tenant-a")
 
     cancel.assert_not_called()
-    tsm.set_state.remote.assert_not_called()
-    vector_store.delete_by_filter.assert_not_called()
-    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
-    document_repo.remove_file_from_partition.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
+    assert vector_store.delete_by_filter.await_count == 2
+    workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
+    document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -169,6 +169,79 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
 
 
 @pytest.mark.asyncio
+async def test_dispatch_indexing_omits_false_require_existing_partition_for_legacy_actors() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        task_id = await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "source": "/data/report.txt"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+            require_existing_partition=False,
+        )
+
+    assert task_id == "task-1"
+    assert "require_existing_partition" not in pool.submit.remote.call_args.kwargs
+    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_retries_without_require_existing_partition_for_legacy_actor() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    legacy_error = RuntimeError("submit(task-1) failed")
+    legacy_error.__cause__ = TypeError("process_file() got an unexpected keyword argument 'require_existing_partition'")
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=[legacy_error, [ref]])
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        task_id = await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "source": "/data/report.txt"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+            require_existing_partition=True,
+        )
+
+    assert task_id == "task-1"
+    first_call, second_call = pool.submit.remote.call_args_list
+    assert first_call.kwargs["require_existing_partition"] is True
+    assert "require_existing_partition" not in second_call.kwargs
+    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ray.exceptions import TaskCancelledError
+from services.workers.task_state import PENDING_TASK_DETAILS
 
 
 def _remote_mock(return_value: Any = None) -> MagicMock:
@@ -84,8 +85,10 @@ def _task_state_manager() -> MagicMock:
     tsm.get_state = _remote_mock("SERIALIZING")
     tsm.get_error = _remote_mock("traceback")
     tsm.get_object_ref = _remote_mock({"ref": object()})
+    tsm.get_matching_active_task_refs_v2 = _remote_mock({})
     tsm.get_matching_active_task_refs = _remote_mock({})
     tsm.get_all_info = None
+    tsm.set_queued_details = _remote_mock()
     return tsm
 
 
@@ -146,14 +149,15 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         )
 
     assert task_id == "task-1"
-    tsm.set_state.remote.assert_called_once_with("task-1", "QUEUED")
-    tsm.set_details.remote.assert_called_once_with(
+    tsm.set_queued_details.remote.assert_called_once_with(
         "task-1",
         file_id="file-1",
         partition="tenant-a",
         metadata={"filename": "report.txt"},
         user_id=42,
     )
+    tsm.set_state.remote.assert_not_called()
+    tsm.set_details.remote.assert_not_called()
     pool.submit.remote.assert_called_once_with(
         task_id="task-1",
         path="/data/report.txt",
@@ -165,6 +169,48 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         indexation_config={"parsing_strategy": "pymupdf"},
         embedder_name="embed-fast",
         require_existing_partition=True,
+    )
+    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_uses_split_queue_registration_for_legacy_task_state_actor() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm._ray_actor_method_names = {"set_state", "set_details", "set_object_ref"}
+    del tsm.set_queued_details
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        task_id = await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "source": "/data/report.txt", "filename": "report.txt"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=["ws-1"],
+            replace=True,
+            require_existing_partition=True,
+        )
+
+    assert task_id == "task-1"
+    tsm.set_state.remote.assert_called_once_with("task-1", "QUEUED")
+    tsm.set_details.remote.assert_called_once_with(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"filename": "report.txt"},
+        user_id=42,
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
 
@@ -232,6 +278,7 @@ async def test_dispatch_indexing_retries_without_require_existing_partition_for_
             workspace_ids=None,
             replace=False,
             require_existing_partition=True,
+            allow_legacy_require_existing_partition_retry=True,
         )
 
     assert task_id == "task-1"
@@ -240,6 +287,44 @@ async def test_dispatch_indexing_retries_without_require_existing_partition_for_
     assert "require_existing_partition" not in second_call.kwargs
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_drop_required_partition_guard_for_legacy_actor() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    legacy_error = RuntimeError("submit(task-1) failed")
+    legacy_error.__cause__ = TypeError("process_file() got an unexpected keyword argument 'require_existing_partition'")
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=legacy_error)
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="submit"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+                require_existing_partition=True,
+            )
+
+    pool.submit.remote.assert_called_once()
+    assert pool.submit.remote.call_args.kwargs["require_existing_partition"] is True
+    tsm.set_object_ref.remote.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -271,7 +356,9 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
                 replace=False,
             )
 
-    tsm.set_details.remote.assert_called_once()
+    tsm.set_queued_details.remote.assert_called_once()
+    tsm.set_state.remote.assert_not_called()
+    tsm.set_details.remote.assert_not_called()
     tsm.set_failed_if_not_cancelled.remote.assert_called_once()
     assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
     assert "submit failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
@@ -286,10 +373,11 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() ->
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
+    vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
-        vector_store=_vector_store(),
+        vector_store=vector_store,
         document_repo=_document_repo(),
         workspace_repo=_workspace_repo(),
         collection="default",
@@ -311,6 +399,13 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() ->
     tsm.set_failed_if_not_cancelled.remote.assert_called_once()
     assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
     assert "ref registration failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
+    vector_store.delete_by_filter.assert_awaited_once_with(
+        {
+            "partition": "tenant-a",
+            "file_id": "file-1",
+            "_openrag_indexing_task_id": "task-1",
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -321,10 +416,11 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_alre
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
+    vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
-        vector_store=_vector_store(),
+        vector_store=vector_store,
         document_repo=_document_repo(),
         workspace_repo=_workspace_repo(),
         collection="default",
@@ -344,6 +440,7 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_alre
 
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -354,10 +451,11 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_canc
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
-        vector_store=_vector_store(),
+        vector_store=vector_store,
         document_repo=_document_repo(),
         workspace_repo=_workspace_repo(),
         collection="default",
@@ -379,6 +477,7 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_canc
             )
 
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -389,10 +488,11 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_canc
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
-        vector_store=_vector_store(),
+        vector_store=vector_store,
         document_repo=_document_repo(),
         workspace_repo=_workspace_repo(),
         collection="default",
@@ -412,6 +512,7 @@ async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_canc
             )
 
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -455,10 +556,11 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_is_rejecte
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
     tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
-        vector_store=_vector_store(),
+        vector_store=vector_store,
         document_repo=_document_repo(),
         workspace_repo=_workspace_repo(),
         collection="default",
@@ -478,6 +580,13 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_is_rejecte
 
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    vector_store.delete_by_filter.assert_awaited_once_with(
+        {
+            "partition": "tenant-a",
+            "file_id": "file-1",
+            "_openrag_indexing_task_id": "task-1",
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -616,7 +725,7 @@ async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup(
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2 = _remote_mock({"task-1": {"ref": ref}})
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -629,7 +738,7 @@ async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup(
     with patch("ray.cancel") as cancel:
         await dispatcher.delete_file("file-1", "tenant-a")
 
-    tsm.get_matching_active_task_refs.remote.assert_called_once_with(partition="tenant-a", file_id="file-1")
+    tsm.get_matching_active_task_refs_v2.remote.assert_called_once_with(partition="tenant-a", file_id="file-1")
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
 
@@ -640,7 +749,7 @@ async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(
         side_effect=[
             {"task-1": {"ref": None}},
             {"task-1": {"ref": ref}},
@@ -659,7 +768,7 @@ async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
     with patch("services.workers.task_cancellation._REF_WAIT_INTERVAL", 0), patch("ray.cancel") as cancel:
         await dispatcher.delete_file("file-1", "tenant-a")
 
-    assert tsm.get_matching_active_task_refs.remote.call_count == 2
+    assert tsm.get_matching_active_task_refs_v2.remote.call_count == 2
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
     assert vector_store.delete_by_filter.await_count == 2
@@ -671,7 +780,7 @@ async def test_delete_file_rechecks_ref_less_task_before_marking_stale() -> None
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(
         side_effect=[
             {"task-1": {"ref": None}},
             {"task-1": {"ref": ref}},
@@ -691,7 +800,7 @@ async def test_delete_file_rechecks_ref_less_task_before_marking_stale() -> None
     with patch("ray.cancel") as cancel:
         await dispatcher.delete_file("file-1", "tenant-a")
 
-    assert tsm.get_matching_active_task_refs.remote.call_count == 2
+    assert tsm.get_matching_active_task_refs_v2.remote.call_count == 2
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
@@ -699,11 +808,72 @@ async def test_delete_file_rechecks_ref_less_task_before_marking_stale() -> None
 
 
 @pytest.mark.asyncio
+async def test_delete_file_rechecks_pending_task_details_before_cleanup() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(
+        side_effect=[
+            {"task-1": PENDING_TASK_DETAILS},
+            {},
+        ]
+    )
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.task_cancellation._REF_WAIT_INTERVAL", 0), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert tsm.get_matching_active_task_refs_v2.remote.call_count == 2
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_fails_closed_when_pending_task_details_do_not_settle() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": PENDING_TASK_DETAILS})
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="routing details"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_delete_file_final_ref_recheck_stays_within_delete_timeout() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": None}})
     vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
@@ -739,7 +909,7 @@ async def test_delete_file_waits_for_cancelled_task_to_settle_before_cleanup() -
     settled = asyncio.Event()
     ref = asyncio.create_task(settled.wait())
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2 = _remote_mock({"task-1": {"ref": ref}})
     vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
@@ -767,7 +937,7 @@ async def test_delete_file_fails_closed_when_active_task_lookup_missing() -> Non
     from services.workers.dispatcher import WorkerDispatcher
 
     tsm = _task_state_manager()
-    del tsm.get_matching_active_task_refs
+    del tsm.get_matching_active_task_refs_v2
     vector_store = _vector_store()
     document_repo = _document_repo()
     workspace_repo = _workspace_repo()
@@ -794,7 +964,7 @@ async def test_delete_file_uses_legacy_task_state_lookup_when_matching_api_missi
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    del tsm.get_matching_active_task_refs
+    del tsm.get_matching_active_task_refs_v2
     tsm.get_all_info = _remote_mock(
         {
             "task-1": {
@@ -833,25 +1003,19 @@ async def test_delete_file_uses_legacy_task_state_lookup_when_matching_api_missi
 
 
 @pytest.mark.asyncio
-async def test_delete_file_legacy_lookup_blocks_detail_less_active_task() -> None:
+async def test_delete_file_ignores_unsafe_legacy_matching_api_when_v2_missing() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    del tsm.get_matching_active_task_refs
-    tsm.get_all_info = _remote_mock(
-        {
-            "task-1": {
-                "state": "QUEUED",
-                "details": {},
-            },
-            "other-partition": {
-                "state": "SERIALIZING",
-                "details": {"partition": "tenant-b", "file_id": "file-1"},
-            },
-        }
-    )
-    tsm.get_object_ref = _remote_mock({"ref": ref})
+    tsm._ray_actor_method_names = {
+        "get_matching_active_task_refs",
+        "get_all_info",
+        "get_object_ref",
+        "set_state",
+    }
+    tsm.get_matching_active_task_refs = _remote_mock({"unsafe-task": {"ref": ref}})
+    tsm.get_all_info = _remote_mock({})
     vector_store = _vector_store()
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
@@ -865,10 +1029,50 @@ async def test_delete_file_legacy_lookup_blocks_detail_less_active_task() -> Non
     with patch("ray.cancel") as cancel:
         await dispatcher.delete_file("file-1", "tenant-a")
 
-    tsm.get_object_ref.remote.assert_called_once_with("task-1")
-    cancel.assert_called_once_with(ref, recursive=True)
-    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    tsm.get_matching_active_task_refs.remote.assert_not_called()
+    tsm.get_all_info.remote.assert_called_once_with()
+    cancel.assert_not_called()
     assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_legacy_lookup_blocks_detail_less_active_task() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    del tsm.get_matching_active_task_refs_v2
+    tsm.get_all_info = _remote_mock(
+        {
+            "task-1": {
+                "state": "QUEUED",
+                "details": {},
+            },
+            "other-partition": {
+                "state": "SERIALIZING",
+                "details": {"partition": "tenant-b", "file_id": "file-1"},
+            },
+        }
+    )
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="routing details"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert tsm.get_all_info.remote.call_count == 2
+    tsm.get_object_ref.remote.assert_not_called()
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -877,7 +1081,7 @@ async def test_delete_file_does_not_cleanup_when_cancelled_task_does_not_settle(
 
     ref = asyncio.get_running_loop().create_future()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs = _remote_mock({"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2 = _remote_mock({"task-1": {"ref": ref}})
     vector_store = _vector_store()
     document_repo = _document_repo()
     workspace_repo = _workspace_repo()
@@ -906,7 +1110,7 @@ async def test_delete_file_marks_stale_ref_less_task_failed_before_cleanup() -> 
     from services.workers.dispatcher import WorkerDispatcher
 
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": None}})
     vector_store = _vector_store()
     document_repo = _document_repo()
     workspace_repo = _workspace_repo()
@@ -937,7 +1141,7 @@ async def test_delete_file_does_not_cleanup_when_matching_task_cancel_fails() ->
 
     ref = _settled_ref()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
     vector_store = _vector_store()
     document_repo = _document_repo()
     workspace_repo = _workspace_repo()

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -39,6 +39,8 @@ def _vector_store() -> MagicMock:
         ]
     )
     store.delete = AsyncMock()
+    store.delete_by_filter = AsyncMock(return_value=2)
+    store.collection_exists = AsyncMock(return_value=True)
     store.upsert_entities = AsyncMock()
     store.insert_entities = AsyncMock()
     return store
@@ -167,8 +169,8 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     await dispatcher.update_file_metadata("file-1", {"title": "new"}, "tenant-a", user={"id": 7})
     await dispatcher.copy_file("file-1", {"file_id": "copy-1", "partition": "tenant-b"}, "tenant-b", user=None)
 
-    vector_store.query_ids_by_filter.assert_called_once_with("default", {"partition": "tenant-a", "file_id": "file-1"})
-    vector_store.delete.assert_called_once_with(["1", "2"], "default")
+    vector_store.delete_by_filter.assert_called_once_with({"partition": "tenant-a", "file_id": "file-1"})
+    vector_store.delete.assert_not_called()
     workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
     document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")
     document_repo.update_file_metadata_in_db.assert_called_once_with(
@@ -238,12 +240,7 @@ async def test_cancel_task_marks_cancelled_even_if_worker_finished_first() -> No
 
 
 @pytest.mark.asyncio
-async def test_delete_file_cleans_database_before_vector_store() -> None:
-    """Regression for #378: database cleanup happens first, vector store cleanup after.
-
-    If database cleanup succeeds but vector store delete fails, the data model remains
-    consistent (file is gone from database, orphaned chunks logged for reconciliation).
-    """
+async def test_delete_file_cleans_vector_store_before_database() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     vector_store = _vector_store()
@@ -264,20 +261,15 @@ async def test_delete_file_cleans_database_before_vector_store() -> None:
         side_effect=lambda *a, **k: call_order.append("workspace")
     )
     document_repo.remove_file_from_partition = AsyncMock(side_effect=lambda *a, **k: call_order.append("document"))
-    vector_store.query_ids_by_filter = AsyncMock(
-        return_value=["1", "2"], side_effect=lambda *a, **k: call_order.append("query") or ["1", "2"]
-    )
-    vector_store.delete = AsyncMock(side_effect=lambda *a, **k: call_order.append("delete") or None)
+    vector_store.delete_by_filter = AsyncMock(side_effect=lambda *a, **k: call_order.append("delete_by_filter") or 2)
 
     await dispatcher.delete_file("file-1", "tenant-a")
 
-    assert call_order == ["workspace", "document", "query", "delete"]
+    assert call_order == ["delete_by_filter", "workspace", "document"]
 
 
 @pytest.mark.asyncio
-async def test_delete_file_logs_error_if_vector_store_delete_fails() -> None:
-    """Regression for #378: if vector store delete fails after database cleanup,
-    log an error for reconciliation but don't raise (data model is consistent)."""
+async def test_delete_file_does_not_remove_database_row_if_vector_store_delete_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     vector_store = _vector_store()
@@ -293,15 +285,10 @@ async def test_delete_file_logs_error_if_vector_store_delete_fails() -> None:
         collection="default",
     )
 
-    vector_store.query_ids_by_filter = AsyncMock(return_value=["1", "2"])
-    vector_store.delete = AsyncMock(side_effect=Exception("Milvus connection failed"))
+    vector_store.delete_by_filter = AsyncMock(side_effect=Exception("Milvus connection failed"))
 
-    with patch("services.workers.dispatcher.logger") as mock_logger:
+    with pytest.raises(Exception, match="Milvus connection failed"):
         await dispatcher.delete_file("file-1", "tenant-a")
 
-        mock_logger.error.assert_called_once()
-        call_args = mock_logger.error.call_args
-        assert "reconciliation task required" in call_args[0][0]
-        assert call_args[1]["file_id"] == "file-1"
-        assert call_args[1]["partition"] == "tenant-a"
-        assert call_args[1]["chunk_count"] == 2
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -230,6 +230,72 @@ async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() ->
 
 
 @pytest.mark.asyncio
+async def test_dispatch_indexing_keeps_fast_finished_task_when_ref_registration_is_settled() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(return_value=True)
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        task_id = await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "source": "/data/report.txt"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert task_id == "task-1"
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_cancels_worker_when_ref_registration_is_rejected() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(return_value=False)
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -195,10 +195,46 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    pool = _pool_with_ref(ref)
+    tsm = _task_state_manager()
+    tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="ref registration failed"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
+    assert "ref registration failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
+
+
+@pytest.mark.asyncio
 async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     vector_store = _vector_store()
+    vector_store.query_chunks_by_filter.return_value[0]["_openrag_indexing_task_id"] = "task-1"
     document_repo = _document_repo()
     workspace_repo = _workspace_repo()
     dispatcher = WorkerDispatcher(
@@ -236,6 +272,8 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
     )
     vector_store.upsert_entities.assert_awaited_once()
     vector_store.insert_entities.assert_awaited_once()
+    assert "_openrag_indexing_task_id" not in vector_store.upsert_entities.await_args.args[0][0]
+    assert "_openrag_indexing_task_id" not in vector_store.insert_entities.await_args.args[0][0]
 
 
 @pytest.mark.asyncio
@@ -372,6 +410,39 @@ async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delete_file_rechecks_ref_less_task_before_marking_stale() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = _settled_ref()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(
+        side_effect=[
+            {"task-1": {"ref": None}},
+            {"task-1": {"ref": ref}},
+        ]
+    )
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        timeout=0.01,
+    )
+
+    with patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert tsm.get_matching_active_task_refs.remote.call_count == 2
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_delete_file_waits_for_cancelled_task_to_settle_before_cleanup() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
@@ -399,6 +470,32 @@ async def test_delete_file_waits_for_cancelled_task_to_settle_before_cleanup() -
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
     assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_fails_closed_when_active_task_lookup_missing() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    del tsm.get_matching_active_task_refs
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    with pytest.raises(RuntimeError, match="active-task lookup"):
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -297,6 +297,94 @@ async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_delete_file_waits_for_matching_task_ref_before_cleanup() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(
+        side_effect=[
+            {"task-1": {"ref": None}},
+            {"task-1": {"ref": ref}},
+        ]
+    )
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.task_cancellation._REF_WAIT_INTERVAL", 0), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    assert tsm.get_matching_active_task_refs.remote.call_count == 2
+    cancel.assert_called_once_with(ref, recursive=True)
+    tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_file_does_not_cleanup_when_matching_task_has_no_ref() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": None}})
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="become cancellable"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    cancel.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_does_not_cleanup_when_matching_task_cancel_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    ref = object()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to cancel"), patch("ray.cancel", side_effect=RuntimeError("boom")):
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_delete_file_does_not_remove_database_row_if_vector_store_delete_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -354,7 +354,7 @@ async def test_process_file_creates_catalog_record_after_successful_pipeline(tmp
         "user_id": 42,
         "relationship_id": "rel",
         "parent_id": "parent",
-        "require_existing_partition": True,
+        "require_existing_partition": False,
     }
     assert repo.update_calls == []
 
@@ -408,6 +408,7 @@ async def test_process_file_stores_indexation_config_snapshot_on_new_file(tmp_pa
     )
 
     assert repo.add_calls[0]["indexation_config"] == indexation_config
+    assert repo.add_calls[0]["require_existing_partition"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -533,7 +533,7 @@ async def test_process_file_cleans_vectors_when_catalog_write_loses_delete_race(
             partition="p",
         )
 
-    assert vector_store.deleted_filters == [{"partition": "p", "file_id": "f1"}]
+    assert vector_store.deleted_filters == [{"partition": "p", "file_id": "f1", "_openrag_indexing_task_id": "t-race"}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -9,7 +9,11 @@ import pytest
 from core.models.chunk import Chunk
 from core.models.document import Document, DocumentType, ProcessedDocument, TextBlock
 from services.workers.indexer_actor import IndexerWorker, _load_document
-from services.workers.pipeline_builder import build_indexing_pipeline
+from services.workers.pipeline_builder import (
+    REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY,
+    REPLACE_OLD_CHUNK_IDS_ROW_KEY,
+    build_indexing_pipeline,
+)
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -51,6 +55,7 @@ class FakeVectorStore:
         self.calls: list[tuple] = []
         self.ensure_calls: list[tuple[str, int]] = []
         self.deleted_filters: list[dict[str, Any]] = []
+        self.deleted_ids: list[tuple[list[str], str]] = []
 
     async def upsert(self, chunks: list[Chunk], collection: str = "default", *, indexed_at=None) -> int:
         self.calls.append((chunks, collection, indexed_at))
@@ -65,6 +70,10 @@ class FakeVectorStore:
     async def delete_by_filter(self, filters: dict[str, Any]) -> int:
         self.deleted_filters.append(dict(filters))
         return 1
+
+    async def delete(self, ids: list[str], collection: str = "default") -> int:
+        self.deleted_ids.append((list(ids), collection))
+        return len(ids)
 
 
 def _fake_tsm() -> MagicMock:
@@ -446,6 +455,81 @@ async def test_process_file_updates_catalog_record_on_replace(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_process_file_deletes_replaced_chunks_after_catalog_update(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+
+    class ReplacePipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            row["stored_count"] = 1
+            row["stage"] = "stored"
+            row[REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY] = "default"
+            row[REPLACE_OLD_CHUNK_IDS_ROW_KEY] = ["old-1", "old-2"]
+            return row
+
+    repo = FakeDocumentRepo()
+    vector_store = FakeVectorStore()
+    worker = IndexerWorker(
+        pipeline=ReplacePipeline(),
+        task_state_manager=_fake_tsm(),
+        document_repo=repo,
+        vector_store=vector_store,
+    )
+
+    await worker.process_file(
+        task_id="t-replace",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="p",
+        replace=True,
+    )
+
+    assert len(repo.update_calls) == 1
+    assert vector_store.deleted_ids == [(["old-1", "old-2"], "default")]
+    assert vector_store.deleted_filters == []
+
+
+@pytest.mark.asyncio
+async def test_process_file_keeps_old_replace_chunks_when_catalog_update_fails(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+
+    class ReplacePipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            row["stored_count"] = 1
+            row["stage"] = "stored"
+            row[REPLACE_OLD_CHUNK_COLLECTION_ROW_KEY] = "default"
+            row[REPLACE_OLD_CHUNK_IDS_ROW_KEY] = ["old-1"]
+            return row
+
+    class MissingCatalogRepo:
+        async def update_file_in_partition(self, **kwargs: Any) -> bool:
+            return False
+
+    vector_store = FakeVectorStore()
+    worker = IndexerWorker(
+        pipeline=ReplacePipeline(),
+        task_state_manager=_fake_tsm(),
+        document_repo=MissingCatalogRepo(),
+        vector_store=vector_store,
+    )
+
+    with pytest.raises(RuntimeError, match="Catalog row was not written"):
+        await worker.process_file(
+            task_id="t-replace",
+            path=str(path),
+            metadata={"file_id": "f1"},
+            partition="p",
+            replace=True,
+        )
+
+    assert vector_store.deleted_ids == []
+    assert vector_store.deleted_filters == [
+        {"partition": "p", "file_id": "f1", "_openrag_indexing_task_id": "t-replace"}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_process_file_stores_indexation_config_snapshot_on_replace(tmp_path: Path) -> None:
     path = tmp_path / "doc.txt"
     path.write_bytes(b"content")
@@ -535,6 +619,35 @@ async def test_process_file_cleans_vectors_when_catalog_write_loses_delete_race(
         )
 
     assert vector_store.deleted_filters == [{"partition": "p", "file_id": "f1", "_openrag_indexing_task_id": "t-race"}]
+
+
+@pytest.mark.asyncio
+async def test_process_file_cleans_task_marked_vectors_when_store_stage_fails(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+
+    class BrokenStorePipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            row["stage"] = "store_failed"
+            raise RuntimeError("milvus write timed out")
+
+    vector_store = FakeVectorStore()
+    worker = IndexerWorker(
+        pipeline=BrokenStorePipeline(),
+        task_state_manager=_fake_tsm(),
+        vector_store=vector_store,
+        collection="vdb",
+    )
+
+    with pytest.raises(RuntimeError, match="milvus write timed out"):
+        await worker.process_file(
+            task_id="t-store",
+            path=str(path),
+            metadata={"file_id": "f1"},
+            partition="p",
+        )
+
+    assert vector_store.deleted_filters == [{"partition": "p", "file_id": "f1", "_openrag_indexing_task_id": "t-store"}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -414,10 +414,38 @@ async def test_process_file_stores_indexation_config_snapshot_on_new_file(tmp_pa
         partition="p",
         user={"id": 42},
         indexation_config=indexation_config,
+        require_existing_partition=True,
     )
 
     assert repo.add_calls[0]["indexation_config"] == indexation_config
     assert repo.add_calls[0]["require_existing_partition"] is True
+
+
+@pytest.mark.asyncio
+async def test_process_file_does_not_use_indexation_config_as_partition_policy(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    processed = ProcessedDocument(document_id="d1", text_blocks=[TextBlock(text="content")])
+    chunks = [Chunk(id="c1", text="content", partition="p")]
+    repo = FakeDocumentRepo()
+    worker = IndexerWorker(
+        pipeline=_make_pipeline(processed, chunks),
+        task_state_manager=_fake_tsm(),
+        document_repo=repo,
+    )
+    indexation_config = {"parsing_strategy": "pymupdf"}
+
+    await worker.process_file(
+        task_id="t-new",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="p",
+        user={"id": 42},
+        indexation_config=indexation_config,
+    )
+
+    assert repo.add_calls[0]["indexation_config"] == indexation_config
+    assert repo.add_calls[0]["require_existing_partition"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -50,6 +50,7 @@ class FakeVectorStore:
     def __init__(self) -> None:
         self.calls: list[tuple] = []
         self.ensure_calls: list[tuple[str, int]] = []
+        self.deleted_filters: list[dict[str, Any]] = []
 
     async def upsert(self, chunks: list[Chunk], collection: str = "default", *, indexed_at=None) -> int:
         self.calls.append((chunks, collection, indexed_at))
@@ -57,6 +58,13 @@ class FakeVectorStore:
 
     async def ensure_collection(self, name: str, dimension: int, **kwargs: Any) -> None:
         self.ensure_calls.append((name, dimension))
+
+    async def collection_exists(self, name: str) -> bool:
+        return True
+
+    async def delete_by_filter(self, filters: dict[str, Any]) -> int:
+        self.deleted_filters.append(dict(filters))
+        return 1
 
 
 def _fake_tsm() -> MagicMock:
@@ -346,6 +354,7 @@ async def test_process_file_creates_catalog_record_after_successful_pipeline(tmp
         "user_id": 42,
         "relationship_id": "rel",
         "parent_id": "parent",
+        "require_existing_partition": True,
     }
     assert repo.update_calls == []
 
@@ -493,6 +502,41 @@ async def test_process_file_catalog_failure_sets_failed_state(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_process_file_cleans_vectors_when_catalog_write_loses_delete_race(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+
+    class StoredPipeline:
+        async def run(self, row: dict[str, Any]) -> dict[str, Any]:
+            row["stored_count"] = 1
+            row["stage"] = "stored"
+            return row
+
+    class MissingCatalogRepo:
+        async def add_file_to_partition(self, **kwargs: Any) -> bool:
+            return False
+
+    vector_store = FakeVectorStore()
+    worker = IndexerWorker(
+        pipeline=StoredPipeline(),
+        task_state_manager=_fake_tsm(),
+        document_repo=MissingCatalogRepo(),
+        vector_store=vector_store,
+        collection="vdb",
+    )
+
+    with pytest.raises(RuntimeError, match="Catalog row was not written"):
+        await worker.process_file(
+            task_id="t-race",
+            path=str(path),
+            metadata={"file_id": "f1"},
+            partition="p",
+        )
+
+    assert vector_store.deleted_filters == [{"partition": "p", "file_id": "f1"}]
+
+
+@pytest.mark.asyncio
 async def test_process_file_replaces_topic_tags_after_successful_pipeline(tmp_path: Path) -> None:
     path = tmp_path / "doc.txt"
     path.write_bytes(b"content")
@@ -571,10 +615,14 @@ async def test_process_file_rejects_malformed_topic_tags_before_delete(tmp_path:
             return row
 
     repo = FakeTopicTagRepo()
+    document_repo = FakeDocumentRepo()
+    vector_store = FakeVectorStore()
     worker = IndexerWorker(
         pipeline=BrokenTaggingPipeline(),
         task_state_manager=tsm,
+        document_repo=document_repo,
         topic_tag_repo=repo,
+        vector_store=vector_store,
     )
 
     with pytest.raises(TypeError, match="topic_tags"):
@@ -587,4 +635,6 @@ async def test_process_file_rejects_malformed_topic_tags_before_delete(tmp_path:
 
     assert repo.deleted == []
     assert repo.inserted == []
+    assert len(document_repo.add_calls) == 1
+    assert vector_store.deleted_filters == []
     tsm.set_failed_if_not_cancelled.remote.assert_called_once()

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -720,7 +720,7 @@ class RecordingVectorStore:
         return len(ids)
 
 
-def _reindex_pipeline(vector_store):
+def _reindex_pipeline(vector_store, *, defer_replace_cleanup: bool = False):
     document = Document(filename="note.txt", text="hi", partition="tenant-a")
     processed = ProcessedDocument(document_id=document.id, text_blocks=[TextBlock(text="hi")])
     pipeline = build_indexing_pipeline(
@@ -728,21 +728,37 @@ def _reindex_pipeline(vector_store):
         chunker=FakeChunker([Chunk(id="c1", text="hi", partition="tenant-a")]),
         embedder=FakeEmbedder([[1.0]]),
         vector_store=vector_store,
+        defer_replace_cleanup=defer_replace_cleanup,
     )
     return pipeline, document
 
 
 @pytest.mark.asyncio
-async def test_reindex_defers_prior_chunk_cleanup_until_catalog_commit():
+async def test_reindex_direct_pipeline_deletes_prior_chunks_after_store():
     # #657: replace=True must snapshot the file's existing chunks, store the new
-    # set, then expose exactly that old set for the worker to delete after the
-    # catalog write succeeds.
+    # set, then delete exactly that old set for direct pipeline callers.
     vs = RecordingVectorStore(existing_ids=["101", "102"])
     pipeline, document = _reindex_pipeline(vs)
 
     row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
 
     # Snapshot is scoped to this file + partition only.
+    assert vs.query_filters == [{"partition": "tenant-a", "file_id": document.id}]
+    assert "_replace_old_chunk_collection" not in row
+    assert "_replace_old_chunk_ids" not in row
+    assert vs.deleted == [["101", "102"]]
+    assert vs.events == ["query", "upsert", "delete"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_deferred_pipeline_exposes_prior_chunks_for_worker_cleanup():
+    # Worker indexing updates the catalog after storing vectors. In that path,
+    # cleanup is deferred so a catalog failure cannot remove the old chunk set.
+    vs = RecordingVectorStore(existing_ids=["101", "102"])
+    pipeline, document = _reindex_pipeline(vs, defer_replace_cleanup=True)
+
+    row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+
     assert vs.query_filters == [{"partition": "tenant-a", "file_id": document.id}]
     assert row["_replace_old_chunk_collection"] == "default"
     assert row["_replace_old_chunk_ids"] == ["101", "102"]
@@ -797,7 +813,7 @@ async def test_reindex_defers_cleanup_delete_to_worker():
     # with neither the old nor the new vector set.
     vs = RecordingVectorStore(existing_ids=["1"])
     vs.delete_error = RuntimeError("delete failed")
-    pipeline, document = _reindex_pipeline(vs)
+    pipeline, document = _reindex_pipeline(vs, defer_replace_cleanup=True)
 
     row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
 

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -733,20 +733,21 @@ def _reindex_pipeline(vector_store):
 
 
 @pytest.mark.asyncio
-async def test_reindex_deletes_prior_chunks_only_after_storing_new():
+async def test_reindex_defers_prior_chunk_cleanup_until_catalog_commit():
     # #657: replace=True must snapshot the file's existing chunks, store the new
-    # set, then delete exactly the old set — insert-before-delete, so a re-index
-    # never leaves an empty window and never duplicates chunks.
+    # set, then expose exactly that old set for the worker to delete after the
+    # catalog write succeeds.
     vs = RecordingVectorStore(existing_ids=["101", "102"])
     pipeline, document = _reindex_pipeline(vs)
 
-    await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
+    row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
 
     # Snapshot is scoped to this file + partition only.
     assert vs.query_filters == [{"partition": "tenant-a", "file_id": document.id}]
-    # Old chunks removed, and strictly after the new insert.
-    assert vs.deleted == [["101", "102"]]
-    assert vs.events == ["query", "upsert", "delete"]
+    assert row["_replace_old_chunk_collection"] == "default"
+    assert row["_replace_old_chunk_ids"] == ["101", "102"]
+    assert vs.deleted == []
+    assert vs.events == ["query", "upsert"]
 
 
 @pytest.mark.asyncio
@@ -790,9 +791,10 @@ async def test_reindex_snapshot_failure_skips_cleanup_but_still_indexes():
 
 
 @pytest.mark.asyncio
-async def test_reindex_delete_failure_is_best_effort():
-    # New chunks are already stored, so a cleanup delete failure must not fail the
-    # re-index (mirrors WorkerDispatcher.delete_file's best-effort cleanup).
+async def test_reindex_defers_cleanup_delete_to_worker():
+    # The pipeline must not delete stale chunks itself. The worker does that
+    # after the catalog write, so a later catalog failure cannot leave the file
+    # with neither the old nor the new vector set.
     vs = RecordingVectorStore(existing_ids=["1"])
     vs.delete_error = RuntimeError("delete failed")
     pipeline, document = _reindex_pipeline(vs)
@@ -800,7 +802,8 @@ async def test_reindex_delete_failure_is_best_effort():
     row = await pipeline.run({"document": document, "partition": "tenant-a", "replace": True})
 
     assert row["stage"] == "stored"
-    assert vs.events == ["query", "upsert", "delete"]
+    assert row["_replace_old_chunk_ids"] == ["1"]
+    assert vs.events == ["query", "upsert"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -44,7 +44,7 @@ async def test_set_object_ref_accepts_terminal_states_without_reopening_task() -
 async def test_set_queued_details_records_active_state_and_routing_together() -> None:
     manager = _task_state_manager()
 
-    await manager.set_queued_details(
+    accepted = await manager.set_queued_details(
         "task-1",
         file_id="file-1",
         partition="tenant-a",
@@ -52,6 +52,7 @@ async def test_set_queued_details_records_active_state_and_routing_together() ->
         user_id=42,
     )
 
+    assert accepted is True
     assert await manager.get_state("task-1") == "QUEUED"
     assert await manager.get_details("task-1") == {
         "file_id": "file-1",
@@ -83,3 +84,101 @@ async def test_matching_active_task_refs_treat_detail_less_queued_tasks_as_pendi
 
     assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == expected
     assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
+
+
+@pytest.mark.asyncio
+async def test_file_delete_fence_rejects_matching_queued_details() -> None:
+    manager = _task_state_manager()
+
+    await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+    accepted = await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"filename": "report.txt"},
+        user_id=42,
+    )
+
+    assert accepted is False
+    assert await manager.get_state("task-1") == "CANCELLED"
+    assert await manager.get_details("task-1") == {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"filename": "report.txt"},
+        "user_id": 42,
+    }
+
+
+@pytest.mark.asyncio
+async def test_file_delete_fence_rejects_late_object_ref_registration() -> None:
+    manager = _task_state_manager()
+
+    assert await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=None,
+    )
+    await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+
+    assert await manager.set_object_ref("task-1", {"ref": object()}) is False
+    assert await manager.get_state("task-1") == "CANCELLED"
+
+
+@pytest.mark.asyncio
+async def test_file_delete_fence_only_blocks_same_partition_and_file() -> None:
+    manager = _task_state_manager()
+
+    await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+
+    assert await manager.set_queued_details(
+        "other-file",
+        file_id="file-2",
+        partition="tenant-a",
+        metadata={},
+        user_id=None,
+    )
+    assert await manager.set_queued_details(
+        "other-partition",
+        file_id="file-1",
+        partition="tenant-b",
+        metadata={},
+        user_id=None,
+    )
+
+    assert await manager.get_state("other-file") == "QUEUED"
+    assert await manager.get_state("other-partition") == "QUEUED"
+
+
+@pytest.mark.asyncio
+async def test_file_delete_fence_is_counted_for_overlapping_deletes() -> None:
+    manager = _task_state_manager()
+
+    await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+    await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+    await manager.end_file_delete(partition="tenant-a", file_id="file-1")
+
+    assert (
+        await manager.set_queued_details(
+            "task-1",
+            file_id="file-1",
+            partition="tenant-a",
+            metadata={},
+            user_id=None,
+        )
+        is False
+    )
+
+    await manager.end_file_delete(partition="tenant-a", file_id="file-1")
+
+    assert (
+        await manager.set_queued_details(
+            "task-2",
+            file_id="file-1",
+            partition="tenant-a",
+            metadata={},
+            user_id=None,
+        )
+        is True
+    )

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_object_ref_accepts_terminal_states_without_reopening_task() -> None:
+    from services.workers.task_state import TaskStateManager
+
+    manager = TaskStateManager.__ray_metadata__.modified_class()
+
+    await manager.set_state("completed-task", "COMPLETED")
+    await manager.set_state("failed-task", "FAILED")
+    await manager.set_state("cancelled-task", "CANCELLED")
+
+    assert await manager.set_object_ref("completed-task", {"ref": object()}) is True
+    assert await manager.set_object_ref("failed-task", {"ref": object()}) is True
+    assert await manager.set_object_ref("cancelled-task", {"ref": object()}) is False
+
+    assert await manager.get_state("completed-task") == "COMPLETED"
+    assert await manager.get_state("failed-task") == "FAILED"
+    assert await manager.get_state("cancelled-task") == "CANCELLED"

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from services.workers.task_state import TaskStateManager
+from services.workers.task_state import PENDING_TASK_DETAILS, TaskStateManager
 
 
 def _task_state_manager() -> Any:
@@ -41,7 +41,29 @@ async def test_set_object_ref_accepts_terminal_states_without_reopening_task() -
 
 
 @pytest.mark.asyncio
-async def test_matching_active_task_refs_include_detail_less_queued_tasks() -> None:
+async def test_set_queued_details_records_active_state_and_routing_together() -> None:
+    manager = _task_state_manager()
+
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"filename": "report.txt"},
+        user_id=42,
+    )
+
+    assert await manager.get_state("task-1") == "QUEUED"
+    assert await manager.get_details("task-1") == {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"filename": "report.txt"},
+        "user_id": 42,
+    }
+    assert "task-1" in await manager.get_all_user_info(42)
+
+
+@pytest.mark.asyncio
+async def test_matching_active_task_refs_treat_detail_less_queued_tasks_as_pending_registration() -> None:
     manager = _task_state_manager()
     ref = object()
 
@@ -57,6 +79,7 @@ async def test_matching_active_task_refs_include_detail_less_queued_tasks() -> N
         user_id=1,
     )
 
-    assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == {
-        "queued-without-details": {"ref": ref}
-    }
+    expected = {"queued-without-details": PENDING_TASK_DETAILS}
+
+    assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == expected
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -20,3 +20,27 @@ async def test_set_object_ref_accepts_terminal_states_without_reopening_task() -
     assert await manager.get_state("completed-task") == "COMPLETED"
     assert await manager.get_state("failed-task") == "FAILED"
     assert await manager.get_state("cancelled-task") == "CANCELLED"
+
+
+@pytest.mark.asyncio
+async def test_matching_active_task_refs_include_detail_less_queued_tasks() -> None:
+    from services.workers.task_state import TaskStateManager
+
+    manager = TaskStateManager.__ray_metadata__.modified_class()
+    ref = object()
+
+    await manager.set_state("queued-without-details", "QUEUED")
+    await manager.set_object_ref("queued-without-details", {"ref": ref})
+    await manager.set_state("completed-without-details", "COMPLETED")
+    await manager.set_state("other-partition", "QUEUED")
+    await manager.set_details(
+        "other-partition",
+        file_id="file-2",
+        partition="tenant-b",
+        metadata={},
+        user_id=1,
+    )
+
+    assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == {
+        "queued-without-details": {"ref": ref}
+    }


### PR DESCRIPTION
## Summary

Fixes the delete failure mode described in #658. File and partition deletes now clean the vector store before removing the catalog rows, so a Milvus cleanup failure does not leave users with a deleted catalog entry whose chunks are still queryable.

## Why

The previous flow removed Postgres rows first and treated Milvus cleanup as best effort. If that cleanup failed, deleted content could remain searchable, and a reused partition name could expose stale chunks.

## Validation

- Full unit suite: 1664 passed
- Focused service/storage tests: passed
- Ruff check and format check: passed

Closes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filter-based deletion for vector-store chunks, enabling more targeted cleanup during file and partition removal.
  * Chunks are now stamped with an indexing task identifier to support precise downstream cleanup.
  * Added an option to prevent auto-creating missing partitions when adding a file to a partition.

* **Bug Fixes**
  * Improved deletion ordering so matching vector chunks are removed before database records.
  * Active indexing tasks are cancelled prior to cleanup, with safer wait/timeout behavior.
  * Internal metadata is no longer exposed in returned chunk metadata (including searches/listing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->