### PR TITLE
fix(indexing): stop IMAGE_CAPTIONING env var from silently overriding partition presets

### DIFF
--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -34,12 +34,14 @@ _VALID_PRESET_TYPES = frozenset({"indexation", "retrieval"})
 _RESERVED_PRESET_NAME = "default"
 
 _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
-    # ``enable_contextualization`` and ``parsing_strategy`` are intentionally
-    # omitted from the ``default`` indexation preset below. The former is injected
-    # at seed time from the global ``chunker.contextual_retrieval``
-    # (``CONTEXTUAL_RETRIEVAL``) toggle in _finalize_seed; the latter stays unset
-    # so the default preset inherits the global ``file_loaders.pdf`` (``PDFLOADER``)
-    # backend at parse time. Named presets (legal/finance) keep their explicit choice.
+    # ``enable_contextualization``, ``enable_image_captioning``, and
+    # ``parsing_strategy`` are intentionally omitted from the ``default``
+    # indexation preset below. The first two are injected at seed time from
+    # the global ``chunker.contextual_retrieval`` (``CONTEXTUAL_RETRIEVAL``)
+    # and ``loader.image_captioning`` (``IMAGE_CAPTIONING``) toggles in
+    # _finalize_seed; the last stays unset so the default preset inherits the
+    # global ``file_loaders.pdf`` (``PDFLOADER``) backend at parse time.
+    # Named presets (legal/finance) keep their explicit choice.
     "indexation": {
         "default": {
             "chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 0.2},
@@ -49,7 +51,6 @@ _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
             # value here would override the operator's global choice and lazily
             # spin up that backend's Ray pool — e.g. forcing marker on a
             # pymupdf-configured deployment. Named presets below opt in explicitly.
-            "enable_image_captioning": True,
             "enable_entity_extraction": True,
             "enable_topic_tagging": True,
         },
@@ -127,21 +128,32 @@ class PresetService:
     def _finalize_seed(self, name: str, preset_type: str, config: dict[str, Any]) -> dict[str, Any]:
         """Overlay env-derived global toggles onto a static default seed.
 
-        Two top-level kill-switches are folded into the seeded presets so a
+        Top-level kill-switches are folded into the seeded presets so a
         fresh deployment honours the env flags without admin action:
 
         * every retrieval preset inherits ``reranker.enabled`` (``enable_reranker``)
           so a deployment without a reranker never builds one against a
           missing/unreachable endpoint;
         * the ``default`` indexation preset inherits ``chunker.contextual_retrieval``
-          (``CONTEXTUAL_RETRIEVAL``) as ``enable_contextualization`` so the global
-          toggle still drives contextualization. Named presets keep the explicit
-          value carried in the seed.
+          (``CONTEXTUAL_RETRIEVAL``) as ``enable_contextualization`` and
+          ``loader.image_captioning`` (``IMAGE_CAPTIONING``) as
+          ``enable_image_captioning``, so the global toggles still drive
+          these enrichments on a fresh deployment. Named presets keep the
+          explicit value carried in the seed.
+
+        This is a one-time seed-time default, not a live runtime gate: once a
+        preset row exists, it is the sole source of truth (an admin can flip
+        ``enable_image_captioning`` per partition regardless of the current
+        ``IMAGE_CAPTIONING`` env value) — see ``IndexingPipeline._should_caption``.
         """
         if preset_type == "retrieval":
             return {**config, "enable_reranker": self._config.reranker.enabled}
         if preset_type == "indexation" and name == "default":
-            return {**config, "enable_contextualization": self._config.chunker.contextual_retrieval}
+            return {
+                **config,
+                "enable_contextualization": self._config.chunker.contextual_retrieval,
+                "enable_image_captioning": self._config.loader.image_captioning,
+            }
         return config
 
     async def load_all(self) -> None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -68,7 +68,6 @@ class IndexerWorkerActor:
             embedder=embedder,
             vector_store=self._vector_store,
             vlm=vlm,
-            image_captioning=cfg.loader.image_captioning,
             timeouts=_build_pipeline_timeouts(cfg),
             chunker_factory=_build_chunker_from_config,
             parser_factory=parser_factory,

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -53,10 +53,6 @@ class IndexingPipeline:
     embedder: Embedder
     vector_store: VectorStore
     vlm: VLM | None = None
-    # Global gate for captioning images *embedded* in other documents
-    # (mirrors ``config.loader.image_captioning``). Standalone image files are
-    # always captioned when a VLM is available, regardless of this flag.
-    image_captioning: bool = True
     contextualizer: ChunkContextualizer | None = None
     topic_tagger: TopicTagger | None = None
     timeouts: PipelineTimeouts = PipelineTimeouts()
@@ -312,14 +308,17 @@ class IndexingPipeline:
 
         A standalone image file's caption is its only text content, so it is
         always captioned when a VLM is available (legacy ``ImageLoader``
-        parity). Images embedded in other documents are gated by the global
-        ``image_captioning`` flag and the per-partition setting.
+        parity). Images embedded in other documents are gated solely by the
+        per-partition ``enable_image_captioning`` setting — the deployment's
+        ``IMAGE_CAPTIONING`` env flag only seeds that setting's default on the
+        ``default`` preset at first boot (see ``PresetService._finalize_seed``);
+        it is not re-checked here, so a preset can enable/disable captioning
+        independent of the current env value.
         """
         document = row.get("document")
         if isinstance(document, Document) and document.content_type is DocumentType.IMAGE:
             return True
-        per_partition = config.enable_image_captioning if config is not None else True
-        return self.image_captioning and per_partition
+        return config.enable_image_captioning if config is not None else True
 
     def _select_contextualizer(
         self, config: IndexationPipelineConfig | None
@@ -367,7 +366,6 @@ def build_indexing_pipeline(
     embedder: Embedder,
     vector_store: VectorStore,
     vlm: VLM | None = None,
-    image_captioning: bool = True,
     contextualizer: ChunkContextualizer | None = None,
     topic_tagger: TopicTagger | None = None,
     timeouts: PipelineTimeouts | None = None,
@@ -387,7 +385,6 @@ def build_indexing_pipeline(
         embedder=embedder,
         vector_store=vector_store,
         vlm=vlm,
-        image_captioning=image_captioning,
         contextualizer=contextualizer,
         topic_tagger=topic_tagger,
         timeouts=timeouts or PipelineTimeouts(),

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -213,6 +213,34 @@ async def test_seed_defaults_default_indexation_inherits_contextual_retrieval_en
 
 
 @pytest.mark.asyncio
+async def test_seed_defaults_default_indexation_inherits_image_captioning_disabled():
+    from core.config.root import Settings
+
+    settings = Settings(loader={"image_captioning": False})
+    repo = _FakePresetRepo()
+    svc = _make_service(repo, settings=settings)
+    await svc.seed_defaults()
+
+    default_idx = repo._store[("default", "indexation")]["config"]
+    assert default_idx["enable_image_captioning"] is False
+    # Named presets keep their explicit seed value regardless of the global flag.
+    assert repo._store[("legal", "indexation")]["config"]["enable_image_captioning"] is True
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_default_indexation_inherits_image_captioning_enabled():
+    from core.config.root import Settings
+
+    settings = Settings(loader={"image_captioning": True})
+    repo = _FakePresetRepo()
+    svc = _make_service(repo, settings=settings)
+    await svc.seed_defaults()
+
+    default_idx = repo._store[("default", "indexation")]["config"]
+    assert default_idx["enable_image_captioning"] is True
+
+
+@pytest.mark.asyncio
 async def test_seed_defaults_preserves_existing_default_indexation_admin_choice():
     from core.config.root import Settings
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1002,7 +1002,7 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
             batch_size=32,
             embed_concurrency=2,
         ),
-        loader=SimpleNamespace(image_captioning=True, parse_timeout=3600, save_uploaded_files=True),
+        loader=SimpleNamespace(parse_timeout=3600, save_uploaded_files=True),
         vectordb=SimpleNamespace(collection_name="vdb_test"),
         rdb=RDBConfig(),
     )

--- a/tests/unit/services/workers/test_model_endpoint_registry_e2e.py
+++ b/tests/unit/services/workers/test_model_endpoint_registry_e2e.py
@@ -192,7 +192,6 @@ async def _run_pipeline(
         embedder=embedder,
         vector_store=_FakeVectorStore(),
         vlm=vlm,
-        image_captioning=True,
         embedder_factory=embedder_factory or _build_embedder_factory(settings),
         vlm_factory=vlm_factory or _build_vlm_factory(settings),
     )

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -483,9 +483,10 @@ async def test_pipeline_propagates_non_keyerror_contextualizer_factory_error():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_always_captions_standalone_image_even_when_globally_off():
+async def test_pipeline_always_captions_standalone_image_even_when_partition_disables_it():
     # A standalone image file's caption is its only text content, so it is
-    # captioned even when global image captioning is off (legacy parity).
+    # captioned even when the partition's enable_image_captioning is off
+    # (legacy parity).
     document = Document(filename="logo.png", content_type=DocumentType.IMAGE, raw_bytes=b"img")
     processed = ProcessedDocument(
         document_id=document.id,
@@ -499,7 +500,7 @@ async def test_pipeline_always_captions_standalone_image_even_when_globally_off(
         embedder=FakeEmbedder([[1.0]]),
         vector_store=FakeVectorStore(),
         vlm=vlm,
-        image_captioning=False,
+        indexation_config=IndexationPipelineConfig(enable_image_captioning=False),
     )
     row = {"document": document, "partition": "tenant-a", "filename": "logo.png"}
 
@@ -509,8 +510,9 @@ async def test_pipeline_always_captions_standalone_image_even_when_globally_off(
 
 
 @pytest.mark.asyncio
-async def test_pipeline_skips_embedded_image_caption_when_globally_off():
-    # Images embedded in a non-image document stay gated by the global flag.
+async def test_pipeline_skips_embedded_image_caption_when_partition_disables_it():
+    # Images embedded in a non-image document stay gated by the per-partition
+    # (preset) enable_image_captioning setting.
     document = Document(filename="note.txt", text="hello", partition="tenant-a")
     processed = ProcessedDocument(
         document_id=document.id,
@@ -524,7 +526,7 @@ async def test_pipeline_skips_embedded_image_caption_when_globally_off():
         embedder=FakeEmbedder([[1.0]]),
         vector_store=FakeVectorStore(),
         vlm=vlm,
-        image_captioning=False,
+        indexation_config=IndexationPipelineConfig(enable_image_captioning=False),
     )
     row = {"document": document, "partition": "tenant-a", "filename": "note.txt"}
 


### PR DESCRIPTION
## Summary

- `IndexingPipeline._should_caption` re-ANDed the live `IMAGE_CAPTIONING` env flag against each partition's preset on every indexing run, so a deployment-wide `IMAGE_CAPTIONING=false` silently disabled captioning for every partition — even ones whose preset explicitly set `enable_image_captioning: true` — with no visibility into why.
- This was inconsistent with `enable_contextualization`/`enable_reranker`, which fold their env toggle into the `default` preset once at first-boot seed time (`PresetService._finalize_seed`), after which the preset alone is authoritative.
- Fixes it by folding `IMAGE_CAPTIONING` into the `default` indexation preset's `enable_image_captioning` at seed time the same way, and making `_should_caption` trust the preset alone at runtime (standalone image files still always caption, unchanged).
  - **Breaking change / upgrade note:** `IMAGE_CAPTIONING` is now only consulted once, at first-boot seed time, to initialize the `default` preset's `enable_image_captioning`. After that, the preset alone controls captioning — the env var is no longer re-checked at runtime. If you have an existing deployment that currently relies on `IMAGE_CAPTIONING=false` to keep embedded-image captioning off, set `enable_image_captioning` to `false` on the affected preset(s) via the admin UI after upgrading; otherwise captioning will resume on the next indexing run. No automatic migration is provided, since all known major deployments run with image captioning enabled.

Fixes #672

## Test plan

- [x] `uv run pytest tests/unit/` — 1665 passed
- [x] `uv run ruff check` / `ruff format` — clean
- [x] Added `test_seed_defaults_default_indexation_inherits_image_captioning_{disabled,enabled}` mirroring the existing contextualization seed tests
- [x] Updated the two pipeline_builder tests that exercised the old pipeline-level global flag to instead exercise `IndexationPipelineConfig(enable_image_captioning=False)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Behavior Changes**
  * Image captioning is now governed per indexing preset (per partition) rather than a single global pipeline flag.
  * The `default` preset now inherits the global loader image-captioning setting at seeding time; the `legal` preset keeps its explicit value.
  * Standalone images captioning follows the selected preset setting; embedded-image captioning is gated by the partition’s configuration.
* **Tests**
  * Added and updated unit tests to cover default vs. legal presets and partition-specific captioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
