### PR TITLE
fix(marker): kill and rebuild the worker pool on parse timeout (reclaim wedged slot)

### DIFF
--- a/openrag/services/workers/parsers/marker_workers.py
+++ b/openrag/services/workers/parsers/marker_workers.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import re
+import threading
 import time
 
 import pypdfium2
@@ -22,6 +23,36 @@ from marker.converters.pdf import PdfConverter
 from ..ray_utils import call_ray_actor_with_timeout, retry_with_backoff
 
 logger = get_logger()
+
+
+def _force_kill_executor(executor, log) -> None:
+    """SIGKILL an executor's worker processes, then shut it down.
+
+    ``ProcessPoolExecutor.shutdown()`` only asks workers to exit *after* their
+    current task finishes. A worker wedged on a pathological PDF never finishes,
+    so a plain shutdown leaves it running — holding its pool slot and the GPU
+    indefinitely (#659). Killing the OS processes directly is the only way to
+    reclaim a wedged worker; the whole pool is recycled because
+    ``ProcessPoolExecutor`` doesn't expose which worker ran a given task.
+    """
+    if executor is None:
+        return
+    # Snapshot before shutdown(): the shutdown machinery clears ``_processes``.
+    procs = list(getattr(executor, "_processes", {}).values())
+    for proc in procs:
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001 - one unkillable proc must not block the rest
+            log.warning("Failed to kill Marker worker process", exc_info=True)
+    try:
+        executor.shutdown(wait=False, cancel_futures=True)
+    except Exception:  # noqa: BLE001 - teardown is best-effort; a fresh pool follows
+        log.warning("Failed to shut down Marker executor", exc_info=True)
+    for proc in procs:
+        try:
+            proc.join(timeout=5)
+        except Exception:  # noqa: BLE001 - a stuck join must not block the rebuild
+            pass
 
 
 def _marker_num_gpus(config) -> float:
@@ -72,6 +103,9 @@ class MarkerWorker:
         os.environ["RAY_ADDRESS"] = "auto"
 
         self.executor = None
+        # Serializes executor submit vs. teardown/rebuild: a parse timeout can
+        # reset the pool from a worker thread while other threads are submitting.
+        self._executor_lock = threading.Lock()
         self.init_resources()
 
     def init_resources(self):
@@ -97,27 +131,30 @@ class MarkerWorker:
 
         import torch.multiprocessing as mp
 
-        if self.executor:
-            self.logger.warning("Resetting ProcessPoolExecutor")
-            self.executor.shutdown(wait=False, cancel_futures=True)
-            self.executor = None
+        with self._executor_lock:
+            if self.executor is not None:
+                # Force-kill: a wedged worker won't exit on a plain shutdown, so
+                # it would keep holding its slot and the GPU (#659).
+                self.logger.warning("Resetting ProcessPoolExecutor (killing worker processes)")
+                _force_kill_executor(self.executor, self.logger)
+                self.executor = None
 
-        # Ensure spawn method for CUDA compatibility
-        try:
-            if mp.get_start_method(allow_none=True) != "spawn":
-                mp.set_start_method("spawn", force=True)
-        except RuntimeError:
-            self.logger.warning("Process start method already set, using existing method")
+            # Ensure spawn method for CUDA compatibility
+            try:
+                if mp.get_start_method(allow_none=True) != "spawn":
+                    mp.set_start_method("spawn", force=True)
+            except RuntimeError:
+                self.logger.warning("Process start method already set, using existing method")
 
-        self.logger.info(f"Initializing MarkerWorker with {self._workers} workers")
-        self.executor = ProcessPoolExecutor(
-            max_workers=self._workers,
-            initializer=self._worker_init,
-            initargs=(self.model_dict,),
-            mp_context=mp.get_context("spawn"),
-            max_tasks_per_child=self.config.loader.marker_max_tasks_per_child,
-        )
-        self.logger.info("MarkerWorker initialized with ProcessPoolExecutor")
+            self.logger.info(f"Initializing MarkerWorker with {self._workers} workers")
+            self.executor = ProcessPoolExecutor(
+                max_workers=self._workers,
+                initializer=self._worker_init,
+                initargs=(self.model_dict,),
+                mp_context=mp.get_context("spawn"),
+                max_tasks_per_child=self.config.loader.marker_max_tasks_per_child,
+            )
+            self.logger.info("MarkerWorker initialized with ProcessPoolExecutor")
 
     @staticmethod
     def _worker_init(model_dict):
@@ -163,12 +200,21 @@ class MarkerWorker:
         timeout = self.config.loader.marker_timeout
 
         def run_with_timeout():
-            future = self.executor.submit(self._process_pdf, file_path, converter_config)
+            with self._executor_lock:
+                future = self.executor.submit(self._process_pdf, file_path, converter_config)
             try:
                 result = future.result(timeout=timeout)
                 return result
             except FuturesTimeoutError:
-                self.logger.exception("MarkerWorker child process timed out", path=file_path)
+                # The child is still computing on the GPU and won't stop on its
+                # own; recycle the pool to reclaim the wedged worker's slot so it
+                # isn't lost forever (#659). Sibling parses in this worker are
+                # recycled too and retried by MarkerPool.
+                self.logger.exception(
+                    "MarkerWorker child process timed out; recycling the pool to reclaim the slot",
+                    path=file_path,
+                )
+                self.setup_mp()
                 raise
             except Exception:
                 self.logger.exception("Error processing with MarkerWorker", path=file_path)
@@ -184,11 +230,15 @@ class MarkerWorker:
         return self.executor is None or bool(getattr(self.executor, "_broken", False))
 
     def __del__(self):
-        """Clean up ProcessPoolExecutor on actor destruction"""
+        """Clean up ProcessPoolExecutor on actor destruction.
+
+        Force-kill so a worker still wedged on a parse doesn't outlive the actor
+        and keep holding the GPU (#659).
+        """
         executor = getattr(self, "executor", None)
         if executor:
             try:
-                executor.shutdown(wait=False, cancel_futures=True)
+                _force_kill_executor(executor, self.logger)
             except Exception:
                 pass  # Best effort cleanup
 

--- a/openrag/services/workers/parsers/marker_workers.py
+++ b/openrag/services/workers/parsers/marker_workers.py
@@ -118,20 +118,30 @@ class MarkerWorker:
 
         self.setup_mp()
 
-    def setup_mp(self):
-        """Initialize ProcessPoolExecutor for PDF processing.
+    def setup_mp(self, old_executor=None):
+        """Initialize (or rebuild) the ProcessPoolExecutor for PDF processing.
 
         We use ProcessPoolExecutor instead of multiprocessing.Pool because:
         - Ray actors run as daemon processes
         - Pool workers are daemonic by default and cannot spawn children
         - The pdftext library (used by Marker) internally spawns processes
         - ProcessPoolExecutor workers are non-daemon, allowing nested process creation
+
+        ``old_executor`` guards against concurrent timeouts cascading: a timeout
+        handler passes the executor it timed out on, and if another handler has
+        already recycled the pool since then (``self.executor`` has moved on), we
+        skip — otherwise the second handler would force-kill the fresh pool the
+        first just built. ``None`` (init / explicit pool reset) always rebuilds.
         """
         from concurrent.futures import ProcessPoolExecutor
 
         import torch.multiprocessing as mp
 
         with self._executor_lock:
+            if old_executor is not None and self.executor is not old_executor:
+                # Another timeout already recycled the pool; nothing wedged to reclaim.
+                return
+
             if self.executor is not None:
                 # Force-kill: a wedged worker won't exit on a plain shutdown, so
                 # it would keep holding its slot and the GPU (#659).
@@ -201,7 +211,8 @@ class MarkerWorker:
 
         def run_with_timeout():
             with self._executor_lock:
-                future = self.executor.submit(self._process_pdf, file_path, converter_config)
+                current_executor = self.executor
+                future = current_executor.submit(self._process_pdf, file_path, converter_config)
             try:
                 result = future.result(timeout=timeout)
                 return result
@@ -209,12 +220,14 @@ class MarkerWorker:
                 # The child is still computing on the GPU and won't stop on its
                 # own; recycle the pool to reclaim the wedged worker's slot so it
                 # isn't lost forever (#659). Sibling parses in this worker are
-                # recycled too and retried by MarkerPool.
+                # recycled too and retried by MarkerPool. Pass the executor we
+                # timed out on so a concurrent timeout can't kill a pool that was
+                # already rebuilt in the meantime.
                 self.logger.exception(
                     "MarkerWorker child process timed out; recycling the pool to reclaim the slot",
                     path=file_path,
                 )
-                self.setup_mp()
+                self.setup_mp(old_executor=current_executor)
                 raise
             except Exception:
                 self.logger.exception("Error processing with MarkerWorker", path=file_path)

--- a/tests/unit/services/workers/parsers/test_marker_workers.py
+++ b/tests/unit/services/workers/parsers/test_marker_workers.py
@@ -16,3 +16,67 @@ def test_marker_num_gpus_uses_ray_cluster_resources_when_cuda_is_hidden(monkeypa
     monkeypatch.setattr(marker_workers.ray, "cluster_resources", lambda: {"GPU": 1.0})
 
     assert marker_workers._marker_num_gpus(_config()) == 0.25
+
+
+# ---------------------------------------------------------------------------
+# _force_kill_executor — reclaiming a wedged Marker worker (#659)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, kill_error: Exception | None = None) -> None:
+        self.kill_error = kill_error
+        self.killed = False
+        self.joined = False
+
+    def kill(self) -> None:
+        if self.kill_error is not None:
+            raise self.kill_error
+        self.killed = True
+
+    def join(self, timeout: float | None = None) -> None:
+        self.joined = True
+
+
+class _FakeExecutor:
+    def __init__(self, procs: list[_FakeProc]) -> None:
+        self._processes = dict(enumerate(procs))
+        self.shutdown_kwargs: dict | None = None
+
+    def shutdown(self, wait: bool = True, cancel_futures: bool = False) -> None:
+        self.shutdown_kwargs = {"wait": wait, "cancel_futures": cancel_futures}
+
+
+class _NullLogger:
+    def warning(self, *args, **kwargs) -> None:
+        pass
+
+
+def test_force_kill_executor_kills_every_worker_then_shuts_down():
+    procs = [_FakeProc(), _FakeProc(), _FakeProc()]
+    executor = _FakeExecutor(procs)
+
+    marker_workers._force_kill_executor(executor, _NullLogger())
+
+    # Every worker is SIGKILLed (reclaims the wedged one) and joined...
+    assert all(p.killed for p in procs)
+    assert all(p.joined for p in procs)
+    # ...and the executor is torn down without blocking on the wedged task.
+    assert executor.shutdown_kwargs == {"wait": False, "cancel_futures": True}
+
+
+def test_force_kill_executor_is_noop_for_none():
+    # Must not raise when there is no executor yet (e.g. first init).
+    marker_workers._force_kill_executor(None, _NullLogger())
+
+
+def test_force_kill_executor_survives_a_kill_error():
+    # One unkillable worker must not prevent killing the others or the shutdown.
+    boom = _FakeProc(kill_error=OSError("no such process"))
+    ok = _FakeProc()
+    executor = _FakeExecutor([boom, ok])
+
+    marker_workers._force_kill_executor(executor, _NullLogger())
+
+    assert ok.killed
+    assert executor.shutdown_kwargs == {"wait": False, "cancel_futures": True}

--- a/tests/unit/services/workers/parsers/test_marker_workers.py
+++ b/tests/unit/services/workers/parsers/test_marker_workers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 
 from services.workers.parsers import marker_workers
@@ -51,6 +52,9 @@ class _NullLogger:
     def warning(self, *args, **kwargs) -> None:
         pass
 
+    def info(self, *args, **kwargs) -> None:
+        pass
+
 
 def test_force_kill_executor_kills_every_worker_then_shuts_down():
     procs = [_FakeProc(), _FakeProc(), _FakeProc()]
@@ -80,3 +84,76 @@ def test_force_kill_executor_survives_a_kill_error():
 
     assert ok.killed
     assert executor.shutdown_kwargs == {"wait": False, "cancel_futures": True}
+
+
+# ---------------------------------------------------------------------------
+# MarkerWorker.setup_mp(old_executor=...) — concurrent-timeout guard (#674)
+# ---------------------------------------------------------------------------
+
+
+def _bare_marker_worker():
+    """A MarkerWorker instance with __init__ skipped (no real models/pool)."""
+    actor_class = marker_workers.MarkerWorker.__ray_metadata__.modified_class
+    worker = actor_class.__new__(actor_class)
+    worker.logger = _NullLogger()
+    worker._executor_lock = threading.Lock()
+    worker._workers = 1
+    worker.model_dict = {}
+    worker.config = SimpleNamespace(loader=SimpleNamespace(marker_max_tasks_per_child=1))
+    return worker
+
+
+def test_setup_mp_skips_rebuild_when_pool_already_recycled(monkeypatch):
+    """If another timeout handler already recycled the pool, a second handler
+    racing on the same stale executor must not force-kill the fresh one."""
+    worker = _bare_marker_worker()
+    stale_executor = _FakeExecutor([_FakeProc()])
+    fresh_executor = _FakeExecutor([_FakeProc()])
+    worker.executor = fresh_executor  # already rebuilt by the "winning" handler
+
+    monkeypatch.setattr("torch.multiprocessing.get_start_method", lambda allow_none=False: "spawn")
+    built = []
+    monkeypatch.setattr(
+        "concurrent.futures.ProcessPoolExecutor",
+        lambda *a, **k: built.append(1) or _FakeExecutor([]),
+    )
+
+    worker.setup_mp(old_executor=stale_executor)
+
+    assert worker.executor is fresh_executor  # left untouched
+    assert fresh_executor.shutdown_kwargs is None  # never force-killed
+    assert not built  # no pool was rebuilt
+
+
+def test_setup_mp_rebuilds_when_old_executor_is_still_current(monkeypatch):
+    """A timeout handler racing against nothing else must still reclaim the
+    wedged worker: kill the current pool and build a fresh one."""
+    worker = _bare_marker_worker()
+    current_executor = _FakeExecutor([_FakeProc()])
+    worker.executor = current_executor
+
+    monkeypatch.setattr("torch.multiprocessing.get_start_method", lambda allow_none=False: "spawn")
+    new_executor = _FakeExecutor([])
+    monkeypatch.setattr("concurrent.futures.ProcessPoolExecutor", lambda *a, **k: new_executor)
+
+    worker.setup_mp(old_executor=current_executor)
+
+    assert current_executor.shutdown_kwargs == {"wait": False, "cancel_futures": True}
+    assert worker.executor is new_executor
+
+
+def test_setup_mp_always_rebuilds_when_old_executor_is_none(monkeypatch):
+    """Explicit resets (init, MarkerPool health-check) always rebuild,
+    regardless of what's currently installed."""
+    worker = _bare_marker_worker()
+    current_executor = _FakeExecutor([_FakeProc()])
+    worker.executor = current_executor
+
+    monkeypatch.setattr("torch.multiprocessing.get_start_method", lambda allow_none=False: "spawn")
+    new_executor = _FakeExecutor([])
+    monkeypatch.setattr("concurrent.futures.ProcessPoolExecutor", lambda *a, **k: new_executor)
+
+    worker.setup_mp()
+
+    assert current_executor.shutdown_kwargs == {"wait": False, "cancel_futures": True}
+    assert worker.executor is new_executor


### PR DESCRIPTION
## What

When a Marker PDF parse exceeds `marker_timeout`, the worker used to re-raise the timeout but leave the child process running — it kept computing on the GPU and holding its `ProcessPoolExecutor` slot forever. `is_pool_broken()` can't see a busy-but-alive worker, and `shutdown()` only asks workers to exit *after* their current task finishes (a wedged one never does). Enough pathological PDFs could occupy every slot and stall all subsequent PDF indexing until the actor restarted.

Now a parse timeout **force-kills the worker processes and rebuilds the pool**, reclaiming the slot.

## How

- New `_force_kill_executor(executor, log)` — SIGKILLs the executor's worker processes (snapshotting `_processes` before `shutdown()`, since shutdown clears it), then `shutdown(wait=False, cancel_futures=True)` and joins. This is the only way to reclaim a wedged worker; the whole pool is recycled because `ProcessPoolExecutor` doesn't expose which worker ran a given task.
- `MarkerWorker.process_pdf`: on `FuturesTimeoutError`, call `setup_mp()` to force-kill + rebuild, then re-raise so `MarkerPool`'s existing retry (`retry_with_backoff`) re-attempts on a healthy worker.
- `setup_mp()` teardown now force-kills instead of a plain `shutdown()`, and the submit/teardown/rebuild are serialized by a new `self._executor_lock` (a timeout can reset the pool from a worker thread while other threads submit).
- `__del__` also force-kills so a wedged worker can't outlive the actor.

**Cost is proportionate:** `_worker_init` attaches an already-`share_memory()`'d model dict, so rebuilding the pool respawns processes attached to the shared models — it does **not** reload models from disk. And it only happens on a timeout (rare / pathological input); the prior behaviour was a *permanent* GPU-occupied stall.

**Blast radius:** recycling the pool also fails any sibling parses in flight on that worker; they surface as `BrokenProcessPool` and are retried by `MarkerPool`. Acceptable, since `ProcessPoolExecutor` can't target a single worker and the alternative is a stuck pool.

## Tests

- Unit (`tests/unit/services/workers/parsers/test_marker_workers.py`, 3 new): `_force_kill_executor` kills every worker + joins + `shutdown(wait=False, cancel_futures=True)`; is a no-op for `None`; and survives one worker whose `kill()` raises (still kills the rest, still shuts down).
- Full unit suite green (1666); ruff + layer-import guard clean.

## Verification boundary (honest)

The reclaim *logic* is unit-tested. The full end-to-end path — a real PDF wedging a Marker GPU worker past `marker_timeout`, then the slot being reclaimed — needs a GPU + a pathological input and isn't reproducible in CI/dev here (the existing Marker tests are pure-function only for the same reason). Worth a smoke test on the GPU stack before the v2.0.1 cut: set a low `MARKER_TIMEOUT`, feed a large/slow PDF, confirm the pool recovers and subsequent PDFs still index.

Fixes #659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when PDF processing workers become stuck or hit timeouts by force-recycling the stalled executor.
  * Prevented executor race conditions during timeout handling by serializing teardown/rebuild vs. new submissions.
  * Enhanced worker shutdown cleanup to reliably terminate stuck executor processes and reclaim stalled slots.
* **Tests**
  * Added unit tests covering forced executor termination (including no-op and kill-error scenarios).
  * Added unit tests for executor rebuild behavior in timeout/recovery and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->