### PR TITLE
fix(admin-ui): link queued uploads to jobs

### DIFF
--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -1,10 +1,20 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { deleteFile } from "@/lib/api/indexing";
+import { toast } from "sonner";
+import type { Action } from "sonner";
+import { deleteFile, uploadFile } from "@/lib/api/indexing";
 import DocumentListPage from "./list";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/permissions", () => ({
   usePermissions: () => ({
@@ -54,6 +64,13 @@ vi.mock("@/lib/api/indexing", () => ({
 }));
 
 const deleteFileMock = vi.mocked(deleteFile);
+const uploadFileMock = vi.mocked(uploadFile);
+const toastSuccessMock = vi.mocked(toast.success);
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}</output>;
+}
 
 function renderDocuments() {
   const queryClient = new QueryClient({
@@ -67,14 +84,17 @@ function renderDocuments() {
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
         <DocumentListPage />
+        <LocationProbe />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
-describe("DocumentListPage bulk actions", () => {
+describe("DocumentListPage", () => {
   beforeEach(() => {
     deleteFileMock.mockClear();
+    uploadFileMock.mockReset();
+    toastSuccessMock.mockClear();
   });
 
   it("selects all documents from the table header and deletes the selected files", async () => {
@@ -92,5 +112,34 @@ describe("DocumentListPage bulk actions", () => {
 
     await waitFor(() => expect(deleteFileMock).toHaveBeenCalledWith("docs", "file-a"));
     expect(deleteFileMock).toHaveBeenCalledWith("docs", "file-b");
+  });
+
+  it("summarizes queued files and links directly to the jobs view", async () => {
+    uploadFileMock.mockResolvedValue({ task_status_url: "/queue/task-1" });
+    renderDocuments();
+
+    await screen.findByText("a.pdf");
+    await userEvent.click(screen.getByRole("button", { name: "Upload" }));
+
+    const files = [
+      new File(["first"], "first.txt", { type: "text/plain" }),
+      new File(["second"], "second.txt", { type: "text/plain" }),
+    ];
+    await userEvent.upload(screen.getByLabelText("Files"), files);
+    await userEvent.click(screen.getByRole("button", { name: "Upload" }));
+
+    await waitFor(() => expect(uploadFileMock).toHaveBeenCalledTimes(2));
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "2 file(s) queued for indexing.",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "View Jobs" }),
+      }),
+    );
+
+    const options = toastSuccessMock.mock.calls[0][1];
+    const action = options?.action as unknown as Action;
+    act(() => action.onClick({} as ReactMouseEvent<HTMLButtonElement>));
+
+    expect(screen.getByTestId("location").textContent).toBe("/jobs");
   });
 });

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef, OnChangeFn, RowSelectionState } from "@tanstack/react-table";
 import { Plus, Eye, Trash2, RefreshCw } from "lucide-react";
@@ -40,6 +40,7 @@ const fileLabel = (f: PartitionFile) => (f.filename as string) || f.file_id;
 
 export default function DocumentListPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { canWrite } = usePermissions();
 
   // OpenRag has no flat/cross-partition file list — files live inside a
@@ -198,7 +199,14 @@ export default function DocumentListPage() {
       return { ok, errors };
     },
     onSuccess: ({ ok, errors }) => {
-      if (ok) toast.success(`${ok} file(s) queued for indexing — track progress in Jobs.`);
+      if (ok) {
+        toast.success(`${ok} file(s) queued for indexing.`, {
+          action: {
+            label: "View Jobs",
+            onClick: () => navigate("/jobs"),
+          },
+        });
+      }
       if (errors.length) toast.error(`${errors.length} upload(s) failed: ${errors[0]}`);
       setUploadOpen(false);
       setFiles([]);


### PR DESCRIPTION
## Summary

- keep the queued-file count in the successful upload notification
- add a `View Jobs` action that navigates directly to the indexing jobs page
- cover the multi-file upload summary and action navigation in the document list test

## Tests

- `cd ui && npm test -- src/pages/admin/documents/list.test.tsx`
- `cd ui && npx eslint src/pages/admin/documents/list.tsx src/pages/admin/documents/list.test.tsx`
- `cd ui && npm run build`

Fixes #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “View Jobs” action to the file upload confirmation message.
  * Users can now navigate directly to the jobs view after files are queued for indexing.

* **Tests**
  * Added coverage for upload confirmations, queued file counts, and navigation to the jobs view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->