### PR TITLE
Fix Settings auth copy for token sessions

### DIFF
--- a/ui/src/lib/api/account.ts
+++ b/ui/src/lib/api/account.ts
@@ -17,9 +17,21 @@ export interface MyInfo {
   external_user_id?: string | null;
 }
 
+export interface CurrentAuthInfo {
+  user_id: number | null;
+  email?: string | null;
+  auth_method: "token" | "oidc" | string;
+  session_expires_at?: string | null;
+}
+
 /** Current authenticated user (from the bearer token / session). */
 export function getMyInfo() {
   return request<MyInfo>("/users/info");
+}
+
+/** Current authentication method resolved by the backend middleware. */
+export function getCurrentAuthInfo() {
+  return request<CurrentAuthInfo>("/auth/me");
 }
 
 /**

--- a/ui/src/pages/app/settings.test.tsx
+++ b/ui/src/pages/app/settings.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentAuthInfo, regenerateMyToken } from "@/lib/api/account";
+import SettingsPage from "./settings";
+
+vi.mock("@/lib/api/account", () => ({
+  getCurrentAuthInfo: vi.fn(),
+  regenerateMyToken: vi.fn(),
+}));
+
+const getCurrentAuthInfoMock = vi.mocked(getCurrentAuthInfo);
+const regenerateMyTokenMock = vi.mocked(regenerateMyToken);
+
+function renderSettings() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SettingsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SettingsPage authentication copy", () => {
+  beforeEach(() => {
+    getCurrentAuthInfoMock.mockReset();
+    regenerateMyTokenMock.mockReset();
+    regenerateMyTokenMock.mockResolvedValue({ token: "or-new-token" });
+  });
+
+  it("explains bearer token authentication in token mode", async () => {
+    getCurrentAuthInfoMock.mockResolvedValue({
+      user_id: 1,
+      email: "admin@example.com",
+      auth_method: "token",
+      session_expires_at: null,
+    });
+
+    renderSettings();
+
+    expect(await screen.findByText(/Authentication uses your OpenRAG bearer token/i)).toBeTruthy();
+    expect(screen.queryByText(/organization's SSO/i)).toBeNull();
+  });
+
+  it("keeps the SSO explanation in OIDC mode", async () => {
+    getCurrentAuthInfoMock.mockResolvedValue({
+      user_id: 1,
+      email: "admin@example.com",
+      auth_method: "oidc",
+      session_expires_at: "2026-07-16T10:00:00Z",
+    });
+
+    renderSettings();
+
+    expect(await screen.findByText(/organization's SSO/i)).toBeTruthy();
+    expect(screen.queryByText(/Authentication uses your OpenRAG bearer token/i)).toBeNull();
+  });
+});

--- a/ui/src/pages/app/settings.tsx
+++ b/ui/src/pages/app/settings.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Copy, KeyRound, ShieldCheck } from "lucide-react";
-import { regenerateMyToken } from "@/lib/api/account";
+import { getCurrentAuthInfo, regenerateMyToken } from "@/lib/api/account";
 import { PageHeader } from "@/components/shared/page-header";
 import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,13 @@ import { copyToClipboard } from "@/lib/utils";
 
 export default function SettingsPage() {
   const [token, setToken] = useState<string | null>(null);
+  const { data: authInfo } = useQuery({
+    queryKey: ["current-auth-info"],
+    queryFn: getCurrentAuthInfo,
+    staleTime: 60_000,
+  });
+  const isOidc = authInfo?.auth_method === "oidc";
+  const isToken = authInfo?.auth_method === "token";
 
   const regenerateMut = useMutation({
     mutationFn: regenerateMyToken,
@@ -36,15 +43,18 @@ export default function SettingsPage() {
       <PageHeader title="Account Settings" description="Manage your API access and authentication." />
 
       <div className="mt-4 grid gap-4 max-w-2xl">
-        {/* Sign-in is handled by the IdP — nothing to manage here. */}
+        {/* Sign-in is handled by the configured auth mode — nothing to manage here. */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">
               <ShieldCheck className="h-4 w-4 text-primary" /> Sign-in
             </CardTitle>
             <CardDescription>
-              Authentication is managed through your organization's SSO. OpenRAG does not manage
-              passwords.
+              {isOidc
+                ? "Authentication is managed through your organization's SSO. OpenRAG does not manage passwords."
+                : isToken
+                  ? "Authentication uses your OpenRAG bearer token. Regenerate it below if the current token needs to be rotated."
+                  : "Authentication is managed by the active OpenRAG deployment configuration."}
             </CardDescription>
           </CardHeader>
         </Card>


### PR DESCRIPTION
## Context

The Settings page always described sign-in as SSO, even when the current session was authenticated with a bearer token. That made token-mode deployments look misconfigured.

## Change

Use the existing protected auth endpoint to detect whether the current session is token-based or OIDC-based, then keep the existing Settings layout while swapping only the sign-in explanation.

Closes #538.

## Validation

- npm test -- settings.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now displays authentication-specific sign-in guidance for SSO, bearer-token, and deployment-managed authentication.
  * Added support for retrieving the current authentication method and optional session expiration.

* **Tests**
  * Added coverage to verify the correct sign-in guidance appears for SSO and bearer-token authentication modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->