### PR TITLE
Fix accessible names for icon-only Admin UI actions

### DIFF
--- a/ui/src/components/shared/data-table.test.tsx
+++ b/ui/src/components/shared/data-table.test.tsx
@@ -13,14 +13,18 @@ const columns: ColumnDef<Row, unknown>[] = [
 
 const makeRows = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ id: i + 1 }));
 
-// The pager renders only a prev + next icon button (no text), so "next" is the
-// last button on screen.
 const clickNextPage = () => {
-  const buttons = screen.getAllByRole("button");
-  fireEvent.click(buttons[buttons.length - 1]);
+  fireEvent.click(screen.getByRole("button", { name: /next page/i }));
 };
 
 describe("DataTable pagination", () => {
+  it("labels pagination icon buttons", () => {
+    render(<DataTable columns={columns} data={makeRows(25)} />);
+
+    expect(screen.getByRole("button", { name: /previous page/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /next page/i })).toBeTruthy();
+  });
+
   it("keeps the user on the current page when a row is deleted underneath them", () => {
     const { rerender } = render(<DataTable columns={columns} data={makeRows(25)} />);
     expect(screen.getByText("Page 1 of 3")).toBeTruthy();

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -186,6 +186,8 @@ export function DataTable<TData, TValue>({
               size="sm"
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
+              aria-label="Previous page"
+              title="Previous page"
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -194,6 +196,8 @@ export function DataTable<TData, TValue>({
               size="sm"
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
+              aria-label="Next page"
+              title="Next page"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -97,6 +97,13 @@ describe("DocumentListPage", () => {
     toastSuccessMock.mockClear();
   });
 
+  it("labels row icon actions", async () => {
+    renderDocuments();
+
+    expect(await screen.findByRole("link", { name: /view a\.pdf/i })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /delete a\.pdf/i })).not.toBeNull();
+  });
+
   it("selects all documents from the table header and deletes the selected files", async () => {
     renderDocuments();
 

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -247,7 +247,11 @@ export default function DocumentListPage() {
       cell: ({ row }) => (
         <div className="flex items-center gap-1">
           <Button variant="ghost" size="icon-xs" asChild>
-            <Link to={fileHref(selected, row.original.file_id)}>
+            <Link
+              to={fileHref(selected, row.original.file_id)}
+              aria-label={`View ${fileLabel(row.original)}`}
+              title={`View ${fileLabel(row.original)}`}
+            >
               <Eye className="h-3.5 w-3.5" />
             </Link>
           </Button>
@@ -257,7 +261,12 @@ export default function DocumentListPage() {
               description={`Delete "${fileLabel(row.original)}"? This cannot be undone.`}
               onConfirm={() => deleteMutation.mutate(row.original.file_id)}
             >
-              <Button variant="ghost" size="icon-xs">
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`Delete ${fileLabel(row.original)}`}
+                title={`Delete ${fileLabel(row.original)}`}
+              >
                 <Trash2 className="h-3.5 w-3.5 text-destructive" />
               </Button>
             </ConfirmDialog>

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -87,6 +87,14 @@ describe("PartitionListPage bulk actions", () => {
     });
   });
 
+  it("labels row icon actions", async () => {
+    permissions.canManagePartitions = true;
+    renderPartitions();
+
+    expect(await screen.findByRole("link", { name: /edit owned-a/i })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /delete owned-a/i })).not.toBeNull();
+  });
+
   it("selects all deletable partitions and deletes only those partitions", async () => {
     renderPartitions();
 

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -81,7 +81,11 @@ function RowActions({
     <div className="flex items-center gap-1">
       {showEdit && (
         <Button variant="ghost" size="sm" asChild>
-          <Link to={partitionDetailPath(partition.name)}>
+          <Link
+            to={partitionDetailPath(partition.name)}
+            aria-label={`Edit ${partition.name}`}
+            title={`Edit ${partition.name}`}
+          >
             <Pencil className="h-3 w-3" />
           </Link>
         </Button>
@@ -92,7 +96,13 @@ function RowActions({
           description={`Delete "${partition.name}"? This cannot be undone.`}
           onConfirm={() => deleteMutation.mutate()}
         >
-          <Button variant="ghost" size="sm" disabled={deleteMutation.isPending}>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={deleteMutation.isPending}
+            aria-label={`Delete ${partition.name}`}
+            title={`Delete ${partition.name}`}
+          >
             <Trash2 className="h-3 w-3 text-destructive" />
           </Button>
         </ConfirmDialog>

--- a/ui/src/pages/admin/system.tsx
+++ b/ui/src/pages/admin/system.tsx
@@ -160,7 +160,7 @@ function ActorsTab() {
                     className="h-7 w-7 flex-shrink-0"
                     disabled={restartMut.isPending}
                     aria-label={`Restart ${a.name}`}
-                    title="Restart actor"
+                    title={`Restart ${a.name}`}
                   >
                     <RotateCcw className="h-3.5 w-3.5" />
                   </Button>

--- a/ui/src/pages/admin/system.tsx
+++ b/ui/src/pages/admin/system.tsx
@@ -159,6 +159,7 @@ function ActorsTab() {
                     size="icon"
                     className="h-7 w-7 flex-shrink-0"
                     disabled={restartMut.isPending}
+                    aria-label={`Restart ${a.name}`}
                     title="Restart actor"
                   >
                     <RotateCcw className="h-3.5 w-3.5" />

--- a/ui/src/pages/admin/users/detail.tsx
+++ b/ui/src/pages/admin/users/detail.tsx
@@ -543,7 +543,7 @@ function ApiTokenTab({ userId }: { userId: number }) {
             </p>
             <div className="flex gap-2">
               <Input value={token} readOnly className="font-mono text-xs" />
-              <Button size="icon" variant="outline" onClick={copyToken}>
+              <Button size="icon" variant="outline" onClick={copyToken} aria-label="Copy API token" title="Copy API token">
                 <Copy className="h-4 w-4" />
               </Button>
             </div>

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -241,7 +241,7 @@ function PreProvisionDialog({
               <Label>API token</Label>
               <div className="flex gap-2">
                 <Input value={created.token} readOnly className="font-mono text-xs" />
-                <Button size="icon" variant="outline" onClick={copyToken}>
+                <Button size="icon" variant="outline" onClick={copyToken} aria-label="Copy API token" title="Copy API token">
                   <Copy className="h-4 w-4" />
                 </Button>
               </div>

--- a/ui/src/pages/app/settings.tsx
+++ b/ui/src/pages/app/settings.tsx
@@ -78,7 +78,7 @@ export default function SettingsPage() {
                 </p>
                 <div className="flex gap-2">
                   <Input value={token} readOnly className="font-mono text-xs" />
-                  <Button size="icon" variant="outline" onClick={copyToken}>
+                  <Button size="icon" variant="outline" onClick={copyToken} aria-label="Copy API token" title="Copy API token">
                     <Copy className="h-4 w-4" />
                   </Button>
                 </div>


### PR DESCRIPTION
## Context

Some icon-only actions in the Admin UI did not expose a clear accessible name, so screen-reader users and role/name tests could not reliably find them.

## Change

Add focused accessible labels and matching titles to the affected pagination, table action, copy-token, and restart buttons without changing their layout or behavior.

Closes #539.

## Validation

- npm test -- data-table.test.tsx list.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added descriptive labels and tooltips to pagination, document, partition, system, and API token action buttons.
  - Improved screen-reader identification for view, edit, delete, restart, copy, and navigation controls.

- **Tests**
  - Added coverage confirming accessible labels for table pagination and administrative row actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->