### PR TITLE
Fix long Admin UI table values

### DIFF
--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -104,6 +104,14 @@ describe("DocumentListPage", () => {
     expect(screen.getByRole("button", { name: /delete a\.pdf/i })).not.toBeNull();
   });
 
+  it("keeps filenames constrained while exposing the full name", async () => {
+    renderDocuments();
+
+    const fileLink = await screen.findByRole("link", { name: "a.pdf" });
+    expect(fileLink.getAttribute("title")).toBe("a.pdf");
+    expect(fileLink.className).toContain("truncate");
+  });
+
   it("selects all documents from the table header and deletes the selected files", async () => {
     renderDocuments();
 

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -223,7 +223,11 @@ export default function DocumentListPage() {
       accessorFn: (f) => fileLabel(f).toLowerCase(),
       header: ({ column }) => <SortableHeader column={column} title="Filename" />,
       cell: ({ row }) => (
-        <Link to={fileHref(selected, row.original.file_id)} className="text-primary hover:underline font-medium">
+        <Link
+          to={fileHref(selected, row.original.file_id)}
+          className="block max-w-[280px] truncate font-medium text-primary hover:underline sm:max-w-[360px] lg:max-w-[480px]"
+          title={fileLabel(row.original)}
+        >
           {fileLabel(row.original)}
         </Link>
       ),

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -22,12 +22,12 @@ vi.mock("@/lib/api/jobs", () => ({
 const getQueueInfoMock = vi.mocked(getQueueInfo);
 const listTasksMock = vi.mocked(listTasks);
 
-const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string) => ({
+const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string, partition = "docs") => ({
   task_id,
   state,
   details: {
     file_id: task_id,
-    partition: "docs",
+    partition,
     metadata: { filename },
     user_id: 1,
   },
@@ -88,6 +88,21 @@ describe("JobListPage filters", () => {
 
     await waitFor(() => expect(search.value).toBe(""));
     expect(await screen.findByText("failed.pdf")).not.toBeNull();
+  });
+
+  it("keeps long job values constrained while exposing full names", async () => {
+    const longTaskId = "task-" + "1234567890".repeat(5);
+    const longFilename = "benchmark-run-with-a-very-long-document-name-that-should-not-stretch-the-table.pdf";
+    const longPartition = "benchmark-partition-with-a-very-long-name-for-regression-testing";
+    listTasksMock.mockResolvedValue({
+      tasks: [task(longTaskId, "COMPLETED", longFilename, longPartition)],
+    });
+
+    renderJobs();
+
+    expect(await screen.findByTitle(longTaskId)).not.toBeNull();
+    expect(screen.getByTitle(longFilename).className).toContain("truncate");
+    expect(screen.getByTitle(longPartition).className).toContain("truncate");
   });
 
   it("shows queue and worker pressure from the backend", async () => {

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -62,12 +62,25 @@ function QueuePressureSummary({
   );
 }
 
+function TruncatedValue({ value, className = "max-w-[320px]" }: { value: string; className?: string }) {
+  if (!value) return "—";
+  return (
+    <span className={`block truncate ${className}`} title={value}>
+      {value}
+    </span>
+  );
+}
+
 const columns: ColumnDef<TaskListItem, unknown>[] = [
   {
     accessorKey: "task_id",
     header: "Task",
     cell: ({ row }) => (
-      <Link to={`/jobs/${row.original.task_id}`} className="text-primary hover:underline font-mono text-sm">
+      <Link
+        to={`/jobs/${row.original.task_id}`}
+        className="text-primary hover:underline font-mono text-sm"
+        title={row.original.task_id}
+      >
         {row.original.task_id.slice(0, 8)}
       </Link>
     ),
@@ -80,12 +93,19 @@ const columns: ColumnDef<TaskListItem, unknown>[] = [
   {
     id: "file",
     header: "File",
-    cell: ({ row }) => str(row.original.details?.metadata?.filename) || str(row.original.details?.file_id) || "—",
+    cell: ({ row }) => (
+      <TruncatedValue
+        value={str(row.original.details?.metadata?.filename) || str(row.original.details?.file_id)}
+        className="max-w-[280px] sm:max-w-[360px] lg:max-w-[440px]"
+      />
+    ),
   },
   {
     id: "partition",
     header: "Partition",
-    cell: ({ row }) => str(row.original.details?.partition) || "—",
+    cell: ({ row }) => (
+      <TruncatedValue value={str(row.original.details?.partition)} className="max-w-[180px] sm:max-w-[240px]" />
+    ),
   },
 ];
 

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -111,6 +111,19 @@ describe("PartitionListPage bulk actions", () => {
     expect(screen.getByRole("button", { name: /delete owned-a/i })).not.toBeNull();
   });
 
+  it("keeps long partition names constrained while exposing the full name", async () => {
+    const longName = "partition-with-a-very-long-benchmark-name-that-should-not-stretch-the-table";
+    listPartitionsMock.mockResolvedValue({
+      partitions: [makePartition(longName)],
+    });
+
+    renderPartitions();
+
+    const partitionLink = await screen.findByRole("link", { name: longName });
+    expect(partitionLink.getAttribute("title")).toBe(longName);
+    expect(partitionLink.className).toContain("truncate");
+  });
+
   it("selects all deletable partitions and deletes only those partitions", async () => {
     renderPartitions();
 

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -526,10 +526,11 @@ export default function PartitionListPage() {
                       </TableCell>
                     )}
                     <TableCell>
-                      <div className="flex items-center gap-2">
+                      <div className="flex min-w-0 items-center gap-2">
                         <Link
                           to={partitionDetailPath(p.name)}
-                          className="font-medium text-primary hover:underline"
+                          className="block max-w-[220px] truncate font-medium text-primary hover:underline"
+                          title={p.name}
                         >
                           {p.name}
                         </Link>
@@ -554,11 +555,25 @@ export default function PartitionListPage() {
                     <TableCell>{p.document_count}</TableCell>
                     {canManagePartitions && (
                       <TableCell className="text-sm">
-                        {resolveEmbedderName(p.embedder, embedderEndpoints)}
+                        <span className="block max-w-[180px] truncate" title={resolveEmbedderName(p.embedder, embedderEndpoints)}>
+                          {resolveEmbedderName(p.embedder, embedderEndpoints)}
+                        </span>
                       </TableCell>
                     )}
-                    {canManagePartitions && <TableCell>{p.indexation_preset}</TableCell>}
-                    {canManagePartitions && <TableCell>{p.retrieval_preset}</TableCell>}
+                    {canManagePartitions && (
+                      <TableCell>
+                        <span className="block max-w-[180px] truncate" title={p.indexation_preset}>
+                          {p.indexation_preset}
+                        </span>
+                      </TableCell>
+                    )}
+                    {canManagePartitions && (
+                      <TableCell>
+                        <span className="block max-w-[180px] truncate" title={p.retrieval_preset}>
+                          {p.retrieval_preset}
+                        </span>
+                      </TableCell>
+                    )}
                     <TableCell className="text-sm text-muted-foreground">
                       {p.created_at
                         ? new Date(p.created_at).toLocaleDateString()


### PR DESCRIPTION
## Context

Long benchmark names and document filenames could stretch the existing Admin UI tables and make scanning harder.

## Change

Keep the current table structure, but constrain long filename, task, partition, model, and preset values with the existing truncation/title pattern so the full value is still available on hover.

Closes #540.

## Validation

- npm test -- jobs/list.test.tsx documents/list.test.tsx partitions/list.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved admin tables for documents, jobs, and partitions to better handle long filenames, task details, and partition names using truncation styling.
  * Added/standardized hover tooltips via `title` attributes so full values remain accessible.
  * Configuration fields in the partitions table now show truncated values with tooltips, and empty fields display a consistent placeholder.
* **Tests**
  * Added and updated coverage to verify truncation styling and tooltip `title` behavior for long values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->