### PR TITLE
Fix Create Partition dialog height on small screens

### DIFF
--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -87,6 +87,22 @@ describe("PartitionListPage bulk actions", () => {
     });
   });
 
+  it("keeps the create dialog actions reachable with a scrollable form body", async () => {
+    renderPartitions();
+
+    await userEvent.click(screen.getByRole("button", { name: /create personal partition/i }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("max-h-[calc(100vh-2rem)]");
+    expect(dialog.className).toContain("overflow-hidden");
+
+    const form = dialog.querySelector("form");
+    expect(form?.className).toContain("min-h-0");
+    expect(form?.firstElementChild?.className).toContain("overflow-y-auto");
+    expect(screen.getByRole("button", { name: "Cancel" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Create" })).not.toBeNull();
+  });
+
   it("selects all deletable partitions and deletes only those partitions", async () => {
     renderPartitions();
 

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -613,117 +613,119 @@ export default function PartitionListPage() {
       )}
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
+        <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col overflow-hidden sm:max-w-lg">
+          <DialogHeader className="shrink-0">
             <DialogTitle>{createPartitionLabel}</DialogTitle>
             <DialogDescription>
               {createPartitionDescription}
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label>Name *</Label>
-              <Input
-                placeholder="my-partition"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Description</Label>
-              <Textarea
-                placeholder="Optional description..."
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-              />
-            </div>
-            {canManagePartitions && (
-              <>
-                <div className="space-y-2">
-                  <Label>Embedder *</Label>
-                  <Select value={embedder} onValueChange={setEmbedder}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select embedder..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {(embedderEndpoints ?? []).map((ep) => (
-                        <SelectItem key={ep.name} value={ep.name}>
-                          {ep.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="-mx-1 min-h-0 flex-1 space-y-4 overflow-y-auto px-1 pb-1">
+              <div className="space-y-2">
+                <Label>Name *</Label>
+                <Input
+                  placeholder="my-partition"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Description</Label>
+                <Textarea
+                  placeholder="Optional description..."
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </div>
+              {canManagePartitions && (
+                <>
                   <div className="space-y-2">
-                    <Label>Indexation Preset</Label>
-                    <Select value={indexationPreset} onValueChange={setIndexationPreset}>
+                    <Label>Embedder *</Label>
+                    <Select value={embedder} onValueChange={setEmbedder}>
                       <SelectTrigger>
-                        <SelectValue placeholder="Select preset" />
+                        <SelectValue placeholder="Select embedder..." />
                       </SelectTrigger>
                       <SelectContent>
-                        {indexationPresets.map((p) => (
-                          <SelectItem key={p.name} value={p.name}>
-                            {p.name}
+                        {(embedderEndpoints ?? []).map((ep) => (
+                          <SelectItem key={ep.name} value={ep.name}>
+                            {ep.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label>Indexation Preset</Label>
+                      <Select value={indexationPreset} onValueChange={setIndexationPreset}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select preset" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {indexationPresets.map((p) => (
+                            <SelectItem key={p.name} value={p.name}>
+                              {p.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Retrieval Preset</Label>
+                      <Select value={retrievalPreset} onValueChange={setRetrievalPreset}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select preset" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {retrievalPresets.map((p) => (
+                            <SelectItem key={p.name} value={p.name}>
+                              {p.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label className="flex items-center gap-1.5">
+                      Chat LLM
+                      {llmValidating && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+                      {!llmValidating && llmValidated === true && chatLlm !== "__default__" && (
+                        <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+                      )}
+                      {!llmValidating && llmValidated === false && (
+                        <XCircle className="h-3.5 w-3.5 text-destructive" />
+                      )}
+                    </Label>
+                    <Select value={chatLlm} onValueChange={handleChatLlmChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select LLM" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__default__">Default (from retrieval config)</SelectItem>
+                        {llmEndpoints?.map((ep) => (
+                          <SelectItem key={ep.name} value={ep.name}>
+                            {ep.name}
                           </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
                   <div className="space-y-2">
-                    <Label>Retrieval Preset</Label>
-                    <Select value={retrievalPreset} onValueChange={setRetrievalPreset}>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select preset" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {retrievalPresets.map((p) => (
-                          <SelectItem key={p.name} value={p.name}>
-                            {p.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <Label>Chat History Depth</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={chatHistoryDepth}
+                      onChange={(e) => setChatHistoryDepth(e.target.value)}
+                    />
                   </div>
-                </div>
-                <div className="space-y-2">
-                  <Label className="flex items-center gap-1.5">
-                    Chat LLM
-                    {llmValidating && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
-                    {!llmValidating && llmValidated === true && chatLlm !== "__default__" && (
-                      <CheckCircle className="h-3.5 w-3.5 text-green-500" />
-                    )}
-                    {!llmValidating && llmValidated === false && (
-                      <XCircle className="h-3.5 w-3.5 text-destructive" />
-                    )}
-                  </Label>
-                  <Select value={chatLlm} onValueChange={handleChatLlmChange}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select LLM" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__default__">Default (from retrieval config)</SelectItem>
-                      {llmEndpoints?.map((ep) => (
-                        <SelectItem key={ep.name} value={ep.name}>
-                          {ep.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label>Chat History Depth</Label>
-                  <Input
-                    type="number"
-                    min={0}
-                    value={chatHistoryDepth}
-                    onChange={(e) => setChatHistoryDepth(e.target.value)}
-                  />
-                </div>
-              </>
-            )}
-            <DialogFooter>
+                </>
+              )}
+            </div>
+            <DialogFooter className="shrink-0 pt-4">
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
                 Cancel
               </Button>


### PR DESCRIPTION
## Context

The Create Partition dialog could become awkward on shorter screens because the actions moved with the full dialog content.

## Change

Keep the existing form and layout, but constrain this dialog to the viewport and make only the form body scroll so the title and Cancel/Create actions remain reachable.

Closes #541.

## Validation

- npm test -- partitions/list.test.tsx
- npm run lint
- npm run build