### PR TITLE
Show queue pressure on Jobs page

### DIFF
--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 API_BASE_URL = os.environ.get("OPENRAG_API_URL", "http://localhost:8080")
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
+HTTP_LIMITS = httpx.Limits(max_keepalive_connections=0)
 
 
 def is_auth_enabled():
@@ -26,7 +27,7 @@ def api_client():
     headers = {}
     if is_auth_enabled():
         headers["Authorization"] = f"Bearer {AUTH_TOKEN}"
-    with httpx.Client(base_url=API_BASE_URL, timeout=60.0, headers=headers) as client:
+    with httpx.Client(base_url=API_BASE_URL, timeout=60.0, headers=headers, limits=HTTP_LIMITS) as client:
         yield client
 
 
@@ -59,7 +60,7 @@ def created_user(api_client):
 def user_client(created_user):
     """Create HTTP client authenticated as the created regular user."""
     headers = {"Authorization": f"Bearer {created_user['token']}"}
-    with httpx.Client(base_url=API_BASE_URL, timeout=60.0, headers=headers) as client:
+    with httpx.Client(base_url=API_BASE_URL, timeout=60.0, headers=headers, limits=HTTP_LIMITS) as client:
         yield client
 
 

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listTasks } from "@/lib/api/jobs";
+import { getQueueInfo, listTasks } from "@/lib/api/jobs";
 import JobListPage from "./list";
 
 vi.mock("@/lib/permissions", () => ({
@@ -13,9 +13,11 @@ vi.mock("@/lib/permissions", () => ({
 }));
 
 vi.mock("@/lib/api/jobs", () => ({
+  getQueueInfo: vi.fn(),
   listTasks: vi.fn(),
 }));
 
+const getQueueInfoMock = vi.mocked(getQueueInfo);
 const listTasksMock = vi.mocked(listTasks);
 
 const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string) => ({
@@ -48,6 +50,16 @@ function renderJobs() {
 
 describe("JobListPage filters", () => {
   beforeEach(() => {
+    getQueueInfoMock.mockResolvedValue({
+      workers: { total_slots: 4, pool_size: 2, max_per_actor: 2 },
+      tasks: {
+        active: 1,
+        active_statuses: { QUEUED: 0, SERIALIZING: 0, CHUNKING: 1, INSERTING: 0 },
+        total_completed: 12,
+        total_cancelled: 0,
+        total_failed: 1,
+      },
+    });
     listTasksMock.mockImplementation(async (status?: string) => ({
       tasks:
         status === "FAILED"
@@ -72,5 +84,35 @@ describe("JobListPage filters", () => {
 
     await waitFor(() => expect(search.value).toBe(""));
     expect(await screen.findByText("failed.pdf")).not.toBeNull();
+  });
+
+  it("shows queue and worker pressure from the backend", async () => {
+    getQueueInfoMock.mockResolvedValue({
+      workers: { total_slots: 2, pool_size: 1, max_per_actor: 2 },
+      tasks: {
+        active: 4,
+        active_statuses: { QUEUED: 2, SERIALIZING: 0, CHUNKING: 2, INSERTING: 0 },
+        total_completed: 20,
+        total_cancelled: 0,
+        total_failed: 1,
+      },
+    });
+
+    renderJobs();
+
+    expect(await screen.findByLabelText("Queue pressure")).not.toBeNull();
+    expect(screen.getByText("Saturated")).not.toBeNull();
+    expect(screen.getByText("Queued 2")).not.toBeNull();
+    expect(screen.getByText("Running 2/2")).not.toBeNull();
+    expect(screen.getByText("Workers 1 x 2")).not.toBeNull();
+  });
+
+  it("handles unavailable queue information", async () => {
+    getQueueInfoMock.mockRejectedValue(new Error("queue unavailable"));
+
+    renderJobs();
+
+    expect(await screen.findByText("Queue unavailable")).not.toBeNull();
+    expect(await screen.findByText("completed.pdf")).not.toBeNull();
   });
 });

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -6,9 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getQueueInfo, listTasks } from "@/lib/api/jobs";
 import JobListPage from "./list";
 
+const permissions = vi.hoisted(() => ({ isAdmin: true }));
+
 vi.mock("@/lib/permissions", () => ({
   usePermissions: () => ({
-    isAdmin: true,
+    isAdmin: permissions.isAdmin,
   }),
 }));
 
@@ -50,6 +52,8 @@ function renderJobs() {
 
 describe("JobListPage filters", () => {
   beforeEach(() => {
+    permissions.isAdmin = true;
+    vi.clearAllMocks();
     getQueueInfoMock.mockResolvedValue({
       workers: { total_slots: 4, pool_size: 2, max_per_actor: 2 },
       tasks: {
@@ -114,5 +118,22 @@ describe("JobListPage filters", () => {
 
     expect(await screen.findByText("Queue unavailable")).not.toBeNull();
     expect(await screen.findByText("completed.pdf")).not.toBeNull();
+  });
+
+  it("does not fetch admin-only queue information for non-admin users", async () => {
+    permissions.isAdmin = false;
+
+    renderJobs();
+
+    expect(await screen.findByText("completed.pdf")).not.toBeNull();
+    expect(screen.queryByLabelText("Queue pressure")).toBeNull();
+    expect(screen.queryByText("Queue unavailable")).toBeNull();
+    expect(getQueueInfoMock).not.toHaveBeenCalled();
+
+    const initialTaskRequests = listTasksMock.mock.calls.length;
+    await userEvent.click(screen.getByRole("button", { name: "Refresh jobs" }));
+
+    await waitFor(() => expect(listTasksMock.mock.calls.length).toBeGreaterThan(initialTaskRequests));
+    expect(getQueueInfoMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -8,10 +8,11 @@ import { usePermissions } from "@/lib/permissions";
 import { PageHeader } from "@/components/shared/page-header";
 import { DataTable } from "@/components/shared/data-table";
 import { StatusBadge } from "@/components/shared/status-badge";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { listTasks, type TaskListItem } from "@/lib/api/jobs";
+import { getQueueInfo, listTasks, type QueueInfo, type TaskListItem } from "@/lib/api/jobs";
 
 // OpenRag exposes per-file indexing tasks (TaskStateManager), not batch "jobs".
 const STATUS_TABS = ["ALL", "ACTIVE", "COMPLETED", "FAILED", "CANCELLED"] as const;
@@ -19,6 +20,47 @@ const JOBS_REFETCH_INTERVAL_MS = 5000;
 const JOB_SEARCH_DEBOUNCE_MS = 250;
 
 const str = (v: unknown) => (v == null ? "" : String(v));
+
+function QueuePressureSummary({
+  queueInfo,
+  isLoading,
+  isError,
+}: {
+  queueInfo?: QueueInfo;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Queue: loading...</p>;
+  }
+  if (isError || !queueInfo) {
+    return (
+      <p className="text-sm text-muted-foreground" title="Queue information is currently unavailable">
+        Queue unavailable
+      </p>
+    );
+  }
+
+  const totalSlots = queueInfo.workers.total_slots;
+  const queued = queueInfo.tasks.active_statuses.QUEUED ?? 0;
+  const running = Math.max(0, queueInfo.tasks.active - queued);
+  const saturated = totalSlots > 0 && queued > 0 && running >= totalSlots;
+  const busy = running > 0 || queued > 0;
+  const status = saturated ? "Saturated" : busy ? "Busy" : "Idle";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground" aria-label="Queue pressure">
+      <Badge variant="outline" className={saturated ? "text-destructive" : undefined}>
+        {status}
+      </Badge>
+      <span>Queued {queued}</span>
+      <span>Running {running}/{totalSlots}</span>
+      <span>
+        Workers {queueInfo.workers.pool_size} x {queueInfo.workers.max_per_actor}
+      </span>
+    </div>
+  );
+}
 
 const columns: ColumnDef<TaskListItem, unknown>[] = [
   {
@@ -64,6 +106,11 @@ export default function JobListPage() {
     queryFn: () => listTasks(statusTab === "ALL" ? undefined : statusTab === "ACTIVE" ? "active" : statusTab),
     refetchInterval: JOBS_REFETCH_INTERVAL_MS, // poll — OpenRag has no task SSE
   });
+  const queueInfoQuery = useQuery({
+    queryKey: ["queue-info"],
+    queryFn: getQueueInfo,
+    refetchInterval: JOBS_REFETCH_INTERVAL_MS,
+  });
 
   const tasks = useMemo(() => tasksQuery.data?.tasks ?? [], [tasksQuery.data?.tasks]);
   const filteredTasks = useMemo(() => {
@@ -100,16 +147,23 @@ export default function JobListPage() {
               className="pl-9"
             />
           </div>
-          <div className="ml-auto flex items-center gap-2">
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
             <p className="text-sm text-muted-foreground">
               {filteredTasks.length} job{filteredTasks.length === 1 ? "" : "s"}
             </p>
+            <QueuePressureSummary
+              queueInfo={queueInfoQuery.data}
+              isLoading={queueInfoQuery.isLoading}
+              isError={queueInfoQuery.isError}
+            />
             <Button
               variant="outline"
               size="icon-sm"
               onClick={() => {
                 setManualRefreshing(true);
-                tasksQuery.refetch().finally(() => setManualRefreshing(false));
+                Promise.allSettled([tasksQuery.refetch(), queueInfoQuery.refetch()]).finally(() =>
+                  setManualRefreshing(false),
+                );
               }}
               disabled={manualRefreshing}
               aria-label="Refresh jobs"

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -109,6 +109,7 @@ export default function JobListPage() {
   const queueInfoQuery = useQuery({
     queryKey: ["queue-info"],
     queryFn: getQueueInfo,
+    enabled: isAdmin,
     refetchInterval: JOBS_REFETCH_INTERVAL_MS,
   });
 
@@ -151,19 +152,21 @@ export default function JobListPage() {
             <p className="text-sm text-muted-foreground">
               {filteredTasks.length} job{filteredTasks.length === 1 ? "" : "s"}
             </p>
-            <QueuePressureSummary
-              queueInfo={queueInfoQuery.data}
-              isLoading={queueInfoQuery.isLoading}
-              isError={queueInfoQuery.isError}
-            />
+            {isAdmin && (
+              <QueuePressureSummary
+                queueInfo={queueInfoQuery.data}
+                isLoading={queueInfoQuery.isLoading}
+                isError={queueInfoQuery.isError}
+              />
+            )}
             <Button
               variant="outline"
               size="icon-sm"
               onClick={() => {
                 setManualRefreshing(true);
-                Promise.allSettled([tasksQuery.refetch(), queueInfoQuery.refetch()]).finally(() =>
-                  setManualRefreshing(false),
-                );
+                const refreshes: Promise<unknown>[] = [tasksQuery.refetch()];
+                if (isAdmin) refreshes.push(queueInfoQuery.refetch());
+                Promise.allSettled(refreshes).finally(() => setManualRefreshing(false));
               }}
               disabled={manualRefreshing}
               aria-label="Refresh jobs"


### PR DESCRIPTION
## Context

Admins could not see queue depth or worker pressure from the Jobs page without checking logs or calling the API manually.

## Change

Use the existing /queue/info endpoint to show a compact queue summary in the current Jobs toolbar: idle/busy/saturated, queued count, running tasks versus worker slots, and worker pool shape. The existing refresh button now refreshes both jobs and queue info.

Closes #543.

## Validation

- npm test -- jobs/list.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only “queue pressure” visibility to the jobs admin page, showing **Saturated/Busy/Idle** plus queued/running and worker capacity details.
  * Queue status updates automatically and is also refreshed together with job listings when manually refreshing.

* **Bug Fixes**
  * When queue information can’t be retrieved, the page shows **Queue unavailable** while still displaying jobs.
  * Non-admin users no longer request or see queue-pressure data.

* **Tests**
  * Expanded UI tests to cover queue-pressure states and admin vs non-admin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->