### PR TITLE
Improve failed job diagnostics

### DIFF
--- a/ui/src/lib/api/jobs.ts
+++ b/ui/src/lib/api/jobs.ts
@@ -35,6 +35,7 @@ export interface TaskDetails {
   partition: string;
   metadata: Record<string, unknown>;
   user_id: number;
+  failed_stage?: string;
 }
 
 /** Row from GET /queue/tasks — note `state` (vs `task_state` in the detail). */

--- a/ui/src/pages/admin/jobs/detail.test.tsx
+++ b/ui/src/pages/admin/jobs/detail.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { getTaskError, getTaskStatus, cancelTask } from "@/lib/api/jobs";
+import { copyToClipboard } from "@/lib/utils";
+import JobDetailPage from "./detail";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/jobs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/jobs")>()),
+  getTaskError: vi.fn(),
+  getTaskStatus: vi.fn(),
+  cancelTask: vi.fn(),
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils")>()),
+  copyToClipboard: vi.fn(),
+}));
+
+const getTaskStatusMock = vi.mocked(getTaskStatus);
+const getTaskErrorMock = vi.mocked(getTaskError);
+const cancelTaskMock = vi.mocked(cancelTask);
+const copyToClipboardMock = vi.mocked(copyToClipboard);
+const toastSuccessMock = vi.mocked(toast.success);
+
+function renderJobDetail(taskId = "task-1") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/jobs/${taskId}`]}>
+        <Routes>
+          <Route path="/jobs/:id" element={<JobDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("JobDetailPage failed diagnostics", () => {
+  beforeEach(() => {
+    getTaskStatusMock.mockResolvedValue({
+      task_id: "task-1",
+      task_state: "FAILED",
+      details: {
+        file_id: "file-1",
+        partition: "docs",
+        metadata: { filename: "failed.pdf", failed_stage: "chunking" },
+        user_id: 1,
+      },
+    });
+    getTaskErrorMock.mockResolvedValue({
+      task_id: "task-1",
+      traceback: [
+        "Traceback (most recent call last):",
+        "  File \"worker.py\", line 10, in run",
+        "ValueError: parser failed",
+      ],
+    });
+    cancelTaskMock.mockResolvedValue({ message: "cancelled" });
+    copyToClipboardMock.mockResolvedValue(true);
+    toastSuccessMock.mockClear();
+  });
+
+  it("shows readable failed-job diagnostics and copies them", async () => {
+    renderJobDetail();
+
+    expect(await screen.findByText("ValueError: parser failed")).not.toBeNull();
+    expect(screen.getByText("chunking")).not.toBeNull();
+    expect(screen.getByText("Raw traceback")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /copy diagnostics/i }));
+
+    await waitFor(() =>
+      expect(copyToClipboardMock).toHaveBeenCalledWith(
+        expect.stringContaining("Task ID: task-1"),
+        expect.any(HTMLButtonElement),
+      ),
+    );
+    expect(copyToClipboardMock.mock.calls[0][0]).toContain("ValueError: parser failed");
+    expect(copyToClipboardMock.mock.calls[0][0]).toContain("Failed stage: chunking");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Diagnostics copied to clipboard");
+  });
+});

--- a/ui/src/pages/admin/jobs/detail.test.tsx
+++ b/ui/src/pages/admin/jobs/detail.test.tsx
@@ -54,13 +54,15 @@ function renderJobDetail(taskId = "task-1") {
 
 describe("JobDetailPage failed diagnostics", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     getTaskStatusMock.mockResolvedValue({
       task_id: "task-1",
       task_state: "FAILED",
       details: {
         file_id: "file-1",
         partition: "docs",
-        metadata: { filename: "failed.pdf", failed_stage: "chunking" },
+        failed_stage: "chunking",
+        metadata: { filename: "failed.pdf" },
         user_id: 1,
       },
     });
@@ -74,7 +76,6 @@ describe("JobDetailPage failed diagnostics", () => {
     });
     cancelTaskMock.mockResolvedValue({ message: "cancelled" });
     copyToClipboardMock.mockResolvedValue(true);
-    toastSuccessMock.mockClear();
   });
 
   it("shows readable failed-job diagnostics and copies them", async () => {
@@ -95,5 +96,31 @@ describe("JobDetailPage failed diagnostics", () => {
     expect(copyToClipboardMock.mock.calls[0][0]).toContain("ValueError: parser failed");
     expect(copyToClipboardMock.mock.calls[0][0]).toContain("Failed stage: chunking");
     expect(toastSuccessMock).toHaveBeenCalledWith("Diagnostics copied to clipboard");
+  });
+
+  it("does not treat user metadata as the failed stage", async () => {
+    getTaskStatusMock.mockResolvedValue({
+      task_id: "task-1",
+      task_state: "FAILED",
+      details: {
+        file_id: "file-1",
+        partition: "docs",
+        metadata: { filename: "failed.pdf", stage: "draft", failed_stage: "user-tag" },
+        user_id: 1,
+      },
+    });
+
+    renderJobDetail();
+
+    expect(await screen.findByText("ValueError: parser failed")).not.toBeNull();
+    expect(screen.queryByText("draft")).toBeNull();
+    expect(screen.queryByText("user-tag")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /copy diagnostics/i }));
+
+    await waitFor(() => expect(copyToClipboardMock).toHaveBeenCalled());
+    expect(copyToClipboardMock.mock.calls[0][0]).not.toContain("Failed stage:");
+    expect(copyToClipboardMock.mock.calls[0][0]).not.toContain("draft");
+    expect(copyToClipboardMock.mock.calls[0][0]).not.toContain("user-tag");
   });
 });

--- a/ui/src/pages/admin/jobs/detail.tsx
+++ b/ui/src/pages/admin/jobs/detail.tsx
@@ -32,10 +32,7 @@ function errorSummary(lines: string[]): string {
 function failedStage(details: unknown): string {
   if (!details || typeof details !== "object") return "";
   const record = details as Record<string, unknown>;
-  const metadata = record.metadata && typeof record.metadata === "object"
-    ? (record.metadata as Record<string, unknown>)
-    : undefined;
-  return str(record.failed_stage ?? record.stage ?? metadata?.failed_stage ?? metadata?.stage);
+  return str(record.failed_stage);
 }
 
 export default function JobDetailPage() {

--- a/ui/src/pages/admin/jobs/detail.tsx
+++ b/ui/src/pages/admin/jobs/detail.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Ban } from "lucide-react";
+import type { MouseEvent } from "react";
+import { ArrowLeft, Ban, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 import { StatusBadge } from "@/components/shared/status-badge";
@@ -20,8 +21,22 @@ import {
   isActiveState,
   isTerminalState,
 } from "@/lib/api/jobs";
+import { copyToClipboard } from "@/lib/utils";
 
 const str = (v: unknown) => (v == null ? "" : String(v));
+
+function errorSummary(lines: string[]): string {
+  return [...lines].reverse().find((line) => line.trim() && !line.trim().startsWith("Traceback"))?.trim() ?? "";
+}
+
+function failedStage(details: unknown): string {
+  if (!details || typeof details !== "object") return "";
+  const record = details as Record<string, unknown>;
+  const metadata = record.metadata && typeof record.metadata === "object"
+    ? (record.metadata as Record<string, unknown>)
+    : undefined;
+  return str(record.failed_stage ?? record.stage ?? metadata?.failed_stage ?? metadata?.stage);
+}
 
 export default function JobDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -79,6 +94,28 @@ export default function JobDetailPage() {
 
   const details = task.details;
   const filename = str(details?.metadata?.filename) || str(details?.file_id) || "—";
+  const traceback = errorQuery.data?.traceback ?? [];
+  const summary = errorSummary(traceback);
+  const stage = failedStage(details);
+  const diagnostics = [
+    `Task ID: ${task.task_id}`,
+    `State: ${task.task_state}`,
+    `File: ${filename}`,
+    `Partition: ${str(details?.partition) || "—"}`,
+    stage ? `Failed stage: ${stage}` : null,
+    summary ? `Reason: ${summary}` : null,
+    traceback.length ? `\nTraceback:\n${traceback.join("\n")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const copyDiagnostics = async (event: MouseEvent<HTMLButtonElement>) => {
+    if (!diagnostics) return;
+    const ok = await copyToClipboard(diagnostics, event.currentTarget);
+    toast[ok ? "success" : "error"](
+      ok ? "Diagnostics copied to clipboard" : "Couldn't copy diagnostics",
+    );
+  };
 
   return (
     <div className="space-y-6">
@@ -173,16 +210,50 @@ export default function JobDetailPage() {
 
       {failed && (
         <Card className="border-destructive/40">
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between gap-4">
             <CardTitle className="text-destructive">Error</CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={copyDiagnostics}
+              disabled={!diagnostics || errorQuery.isLoading}
+            >
+              <Copy className="h-4 w-4" />
+              Copy diagnostics
+            </Button>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             {errorQuery.isLoading ? (
               <p className="text-sm text-muted-foreground">Loading error…</p>
+            ) : errorQuery.isError ? (
+              <p className="text-sm text-destructive">
+                Failed to load error details: {(errorQuery.error as Error).message}
+              </p>
             ) : errorQuery.data?.traceback?.length ? (
-              <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs leading-relaxed text-destructive whitespace-pre-wrap">
-                {errorQuery.data.traceback.join("\n")}
-              </pre>
+              <>
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                  <dl className="grid gap-2 sm:grid-cols-[8rem_1fr]">
+                    <dt className="text-muted-foreground">Reason</dt>
+                    <dd className="font-medium break-words">{summary || "Task failed"}</dd>
+                    {stage && (
+                      <>
+                        <dt className="text-muted-foreground">Failed stage</dt>
+                        <dd className="font-medium">{stage}</dd>
+                      </>
+                    )}
+                    <dt className="text-muted-foreground">Task ID</dt>
+                    <dd className="font-mono text-xs break-all">{task.task_id}</dd>
+                    <dt className="text-muted-foreground">File</dt>
+                    <dd className="break-words">{filename}</dd>
+                  </dl>
+                </div>
+                <details className="rounded-md border bg-muted/40 p-3" open>
+                  <summary className="cursor-pointer text-sm font-medium">Raw traceback</summary>
+                  <pre className="mt-3 max-h-96 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-destructive">
+                    {traceback.join("\n")}
+                  </pre>
+                </details>
+              </>
             ) : (
               <p className="text-sm text-muted-foreground">No error details available.</p>
             )}


### PR DESCRIPTION
## Context

Failed jobs exposed the raw traceback, but it was hard to scan and not easy to copy for debugging.

## Change

Keep the existing Job Detail workflow, but add a readable error summary, optional failed-stage display when the backend provides it, a bounded raw traceback block, and a copy-diagnostics action.

Closes #544.

## Validation

- npm test -- jobs/detail.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Copy diagnostics” option for failed tasks, including task ID, reason, optional failed stage, and traceback.
  * Enhanced the FAILED task error section with a structured summary and an expandable traceback display.
* **Bug Fixes**
  * Ensured only the actual failed stage is shown (not unrelated metadata stage values).
* **Tests**
  * Added coverage for the “failed diagnostics” UI, copy-to-clipboard behavior, and toast feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->