### PR TITLE
Add filtered CSV exports for Jobs and Documents

### DIFF
--- a/ui/src/lib/csv.test.ts
+++ b/ui/src/lib/csv.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { toCsv } from "./csv";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadCsv, toCsv, toExcelCsv } from "./csv";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
 
 describe("toCsv", () => {
   it("sanitizes formula-leading cells", () => {
@@ -27,6 +34,36 @@ describe("toCsv", () => {
       "\"'\r=cmd\"",
       "\"'\n=cmd\"",
       "safe.pdf",
-    ].join("\n"));
+    ].join("\r\n"));
+  });
+
+  it("adds Excel encoding and delimiter hints to downloads", () => {
+    const csv = toExcelCsv(
+      [{ header: "filename", value: (row: { filename: string }) => row.filename }],
+      [{ filename: "Rapport_priv\u00e9.pdf" }],
+    );
+
+    expect(csv).toBe("\uFEFFsep=,\r\nfilename\r\nRapport_priv\u00e9.pdf");
+  });
+
+  it("keeps the object URL alive until the browser handles the click", () => {
+    vi.useFakeTimers();
+    const createObjectURL = vi.fn(() => "blob:csv");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    downloadCsv("report.csv", [{ header: "name", value: (row: { name: string }) => row.name }], [
+      { name: "report" },
+    ]);
+
+    expect(document.querySelector('a[download="report.csv"]')).not.toBeNull();
+    expect(click).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(document.querySelector('a[download="report.csv"]')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:csv");
   });
 });

--- a/ui/src/lib/csv.test.ts
+++ b/ui/src/lib/csv.test.ts
@@ -10,17 +10,23 @@ describe("toCsv", () => {
         { filename: "+sum(1,2)" },
         { filename: "-10" },
         { filename: "@admin" },
+        { filename: "\t=cmd" },
+        { filename: "\r=cmd" },
+        { filename: "\n=cmd" },
         { filename: "safe.pdf" },
       ],
     );
 
-    expect(csv.split("\n")).toEqual([
+    expect(csv).toBe([
       "filename",
       "'=cmd|' /C calc'!A0",
       "\"'+sum(1,2)\"",
       "'-10",
       "'@admin",
+      "'\t=cmd",
+      "\"'\r=cmd\"",
+      "\"'\n=cmd\"",
       "safe.pdf",
-    ]);
+    ].join("\n"));
   });
 });

--- a/ui/src/lib/csv.test.ts
+++ b/ui/src/lib/csv.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { toCsv } from "./csv";
+
+describe("toCsv", () => {
+  it("sanitizes formula-leading cells", () => {
+    const csv = toCsv(
+      [{ header: "filename", value: (row: { filename: string }) => row.filename }],
+      [
+        { filename: "=cmd|' /C calc'!A0" },
+        { filename: "+sum(1,2)" },
+        { filename: "-10" },
+        { filename: "@admin" },
+        { filename: "safe.pdf" },
+      ],
+    );
+
+    expect(csv.split("\n")).toEqual([
+      "filename",
+      "'=cmd|' /C calc'!A0",
+      "\"'+sum(1,2)\"",
+      "'-10",
+      "'@admin",
+      "safe.pdf",
+    ]);
+  });
+});

--- a/ui/src/lib/csv.ts
+++ b/ui/src/lib/csv.ts
@@ -3,8 +3,11 @@ type CsvColumn<T> = {
   value: (row: T) => unknown;
 };
 
+const FORMULA_PREFIX = /^[=+\-@]/;
+
 function csvCell(value: unknown): string {
-  const text = value == null ? "" : String(value);
+  const raw = value == null ? "" : String(value);
+  const text = FORMULA_PREFIX.test(raw) ? `'${raw}` : raw;
   return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 

--- a/ui/src/lib/csv.ts
+++ b/ui/src/lib/csv.ts
@@ -4,6 +4,9 @@ type CsvColumn<T> = {
 };
 
 const FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
+const CSV_DELIMITER = ",";
+const CSV_LINE_BREAK = "\r\n";
+const UTF8_BOM = "\uFEFF";
 
 function csvCell(value: unknown): string {
   const raw = value == null ? "" : String(value);
@@ -13,17 +16,30 @@ function csvCell(value: unknown): string {
 
 export function toCsv<T>(columns: CsvColumn<T>[], rows: T[]): string {
   return [
-    columns.map((column) => csvCell(column.header)).join(","),
-    ...rows.map((row) => columns.map((column) => csvCell(column.value(row))).join(",")),
-  ].join("\n");
+    columns.map((column) => csvCell(column.header)).join(CSV_DELIMITER),
+    ...rows.map((row) => columns.map((column) => csvCell(column.value(row))).join(CSV_DELIMITER)),
+  ].join(CSV_LINE_BREAK);
+}
+
+export function toExcelCsv<T>(columns: CsvColumn<T>[], rows: T[]): string {
+  return `${UTF8_BOM}sep=${CSV_DELIMITER}${CSV_LINE_BREAK}${toCsv(columns, rows)}`;
 }
 
 export function downloadCsv<T>(filename: string, columns: CsvColumn<T>[], rows: T[]) {
-  const blob = new Blob([toCsv(columns, rows)], { type: "text/csv;charset=utf-8" });
+  const blob = new Blob([toExcelCsv(columns, rows)], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
   link.download = filename;
-  link.click();
-  URL.revokeObjectURL(url);
+  link.style.display = "none";
+
+  try {
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    window.setTimeout(() => {
+      link.remove();
+      URL.revokeObjectURL(url);
+    }, 0);
+  }
 }

--- a/ui/src/lib/csv.ts
+++ b/ui/src/lib/csv.ts
@@ -3,7 +3,7 @@ type CsvColumn<T> = {
   value: (row: T) => unknown;
 };
 
-const FORMULA_PREFIX = /^[=+\-@]/;
+const FORMULA_PREFIX = /^[=+\-@\t\r\n]/;
 
 function csvCell(value: unknown): string {
   const raw = value == null ? "" : String(value);

--- a/ui/src/lib/csv.ts
+++ b/ui/src/lib/csv.ts
@@ -1,0 +1,26 @@
+type CsvColumn<T> = {
+  header: string;
+  value: (row: T) => unknown;
+};
+
+function csvCell(value: unknown): string {
+  const text = value == null ? "" : String(value);
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export function toCsv<T>(columns: CsvColumn<T>[], rows: T[]): string {
+  return [
+    columns.map((column) => csvCell(column.header)).join(","),
+    ...rows.map((row) => columns.map((column) => csvCell(column.value(row))).join(",")),
+  ].join("\n");
+}
+
+export function downloadCsv<T>(filename: string, columns: CsvColumn<T>[], rows: T[]) {
+  const blob = new Blob([toCsv(columns, rows)], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -123,7 +123,7 @@ describe("DocumentListPage", () => {
     renderDocuments();
 
     expect(await screen.findByText("a.pdf")).not.toBeNull();
-    await userEvent.type(screen.getByPlaceholderText("Search files..."), "b");
+    await userEvent.type(screen.getByLabelText("Search files"), "b");
     await userEvent.type(screen.getByLabelText("Indexed since"), "2026-01-02");
 
     expect(screen.queryByText("a.pdf")).toBeNull();

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import type { Action } from "sonner";
 import { deleteFile, uploadFile } from "@/lib/api/indexing";
+import { downloadCsv } from "@/lib/csv";
 import DocumentListPage from "./list";
 
 vi.mock("sonner", () => ({
@@ -63,8 +64,13 @@ vi.mock("@/lib/api/indexing", () => ({
   newFileId: vi.fn(() => "new-file-id"),
 }));
 
+vi.mock("@/lib/csv", () => ({
+  downloadCsv: vi.fn(),
+}));
+
 const deleteFileMock = vi.mocked(deleteFile);
 const uploadFileMock = vi.mocked(uploadFile);
+const downloadCsvMock = vi.mocked(downloadCsv);
 const toastSuccessMock = vi.mocked(toast.success);
 
 function LocationProbe() {
@@ -94,6 +100,7 @@ describe("DocumentListPage", () => {
   beforeEach(() => {
     deleteFileMock.mockClear();
     uploadFileMock.mockReset();
+    downloadCsvMock.mockClear();
     toastSuccessMock.mockClear();
   });
 
@@ -110,6 +117,26 @@ describe("DocumentListPage", () => {
     const fileLink = await screen.findByRole("link", { name: "a.pdf" });
     expect(fileLink.getAttribute("title")).toBe("a.pdf");
     expect(fileLink.className).toContain("truncate");
+  });
+
+  it("filters documents by file name and indexed date before exporting", async () => {
+    renderDocuments();
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    await userEvent.type(screen.getByPlaceholderText("Search files..."), "b");
+    await userEvent.type(screen.getByLabelText("Indexed since"), "2026-01-02");
+
+    expect(screen.queryByText("a.pdf")).toBeNull();
+    expect(screen.getByText("b.pdf")).not.toBeNull();
+    expect(screen.getByText("1 of 2 file(s)")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(downloadCsvMock).toHaveBeenCalledWith(
+      "openrag-documents-docs.csv",
+      expect.any(Array),
+      [expect.objectContaining({ file_id: "file-b" })],
+    );
   });
 
   it("selects all documents from the table header and deletes the selected files", async () => {

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -55,7 +55,7 @@ vi.mock("@/lib/api/documents", () => ({
         partition: "docs",
         filename: "b.pdf",
         mimetype: "application/pdf",
-        indexed_at: "2026-01-02T00:00:00Z",
+        indexed_at: new Date(2026, 0, 2, 0, 30).toISOString(),
       },
     ],
   }),
@@ -147,6 +147,18 @@ describe("DocumentListPage", () => {
       expect.any(Array),
       [expect.objectContaining({ file_id: "file-b" })],
     );
+  });
+
+  it("reports CSV download failures", async () => {
+    downloadCsvMock.mockImplementationOnce(() => {
+      throw new Error("downloads unavailable");
+    });
+    renderDocuments();
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(toast.error).toHaveBeenCalledWith("CSV export failed: downloads unavailable");
   });
 
   it("opens the upload dialog for a partition upload link", async () => {

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -149,15 +149,16 @@ export default function DocumentListPage() {
   const fileRows = useMemo(() => filesQuery.data?.files ?? [], [filesQuery.data?.files]);
   const filteredFileRows = useMemo(() => {
     const q = fileSearch.trim().toLowerCase();
+    const indexedSinceTime = indexedSince ? new Date(`${indexedSince}T00:00:00`).getTime() : null;
     return fileRows.filter((file) => {
       const filename = fileLabel(file);
-      const fileDate = str(file.indexed_at ?? file.created_at).slice(0, 10);
+      const fileTime = Date.parse(str(file.indexed_at ?? file.created_at));
       const matchesSearch =
         !q ||
         [filename, file.file_id, file.mimetype].some((value) =>
           str(value).toLowerCase().includes(q),
         );
-      const matchesDate = !indexedSince || (fileDate && fileDate >= indexedSince);
+      const matchesDate = indexedSinceTime === null || (Number.isFinite(fileTime) && fileTime >= indexedSinceTime);
       return matchesSearch && matchesDate;
     });
   }, [fileRows, fileSearch, indexedSince]);
@@ -181,18 +182,22 @@ export default function DocumentListPage() {
   );
 
   const exportDocuments = () => {
-    downloadCsv(
-      `openrag-documents-${selected || "partition"}.csv`,
-      [
-        { header: "partition", value: () => selected },
-        { header: "file_id", value: (file) => file.file_id },
-        { header: "filename", value: (file) => fileLabel(file) },
-        { header: "mimetype", value: (file) => file.mimetype },
-        { header: "indexed_at", value: (file) => file.indexed_at },
-        { header: "created_at", value: (file) => file.created_at },
-      ],
-      filteredFileRows,
-    );
+    try {
+      downloadCsv(
+        `openrag-documents-${selected || "partition"}.csv`,
+        [
+          { header: "partition", value: () => selected },
+          { header: "file_id", value: (file) => file.file_id },
+          { header: "filename", value: (file) => fileLabel(file) },
+          { header: "mimetype", value: (file) => file.mimetype },
+          { header: "indexed_at", value: (file) => file.indexed_at },
+          { header: "created_at", value: (file) => file.created_at },
+        ],
+        filteredFileRows,
+      );
+    } catch (error) {
+      toast.error(`CSV export failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
   };
 
   useEffect(() => {

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -389,6 +389,7 @@ export default function DocumentListPage() {
             value={fileSearch}
             onChange={(e) => setFileSearch(e.target.value)}
             className="pl-9"
+            aria-label="Search files"
           />
         </div>
         <Input

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef, OnChangeFn, RowSelectionState } from "@tanstack/react-table";
-import { Plus, Eye, Trash2, RefreshCw } from "lucide-react";
+import { Download, Plus, Eye, Trash2, RefreshCw, Search } from "lucide-react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/shared/page-header";
@@ -32,11 +32,13 @@ import { listPartitionFiles, type PartitionFile } from "@/lib/api/documents";
 import { uploadFile, deleteFile, newFileId } from "@/lib/api/indexing";
 import { listPartitions } from "@/lib/api/partitions";
 import { usePermissions } from "@/lib/permissions";
+import { downloadCsv } from "@/lib/csv";
 import { resolveDocumentsPartition } from "./partition-selection";
 
 const fileHref = (partition: string, fileId: string) =>
   `/documents/${encodeURIComponent(partition)}/${encodeURIComponent(fileId)}`;
 const fileLabel = (f: PartitionFile) => (f.filename as string) || f.file_id;
+const str = (v: unknown) => (v == null ? "" : String(v));
 
 export default function DocumentListPage() {
   const queryClient = useQueryClient();
@@ -54,6 +56,8 @@ export default function DocumentListPage() {
   const [uploadOpen, setUploadOpen] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [fileSearch, setFileSearch] = useState("");
+  const [indexedSince, setIndexedSince] = useState("");
   const [fileSelection, setFileSelection] = useState<{
     partition: string;
     rows: RowSelectionState;
@@ -120,6 +124,20 @@ export default function DocumentListPage() {
     refetchInterval: 5000,
   });
   const fileRows = useMemo(() => filesQuery.data?.files ?? [], [filesQuery.data?.files]);
+  const filteredFileRows = useMemo(() => {
+    const q = fileSearch.trim().toLowerCase();
+    return fileRows.filter((file) => {
+      const filename = fileLabel(file);
+      const fileDate = str(file.indexed_at ?? file.created_at).slice(0, 10);
+      const matchesSearch =
+        !q ||
+        [filename, file.file_id, file.mimetype].some((value) =>
+          str(value).toLowerCase().includes(q),
+        );
+      const matchesDate = !indexedSince || (fileDate && fileDate >= indexedSince);
+      return matchesSearch && matchesDate;
+    });
+  }, [fileRows, fileSearch, indexedSince]);
   const fileRowSelection = useMemo(
     () => (fileSelection.partition === selected ? fileSelection.rows : {}),
     [fileSelection.partition, fileSelection.rows, selected],
@@ -135,9 +153,24 @@ export default function DocumentListPage() {
     [selected],
   );
   const selectedFiles = useMemo(
-    () => fileRows.filter((file) => fileRowSelection[file.file_id]),
-    [fileRows, fileRowSelection],
+    () => filteredFileRows.filter((file) => fileRowSelection[file.file_id]),
+    [filteredFileRows, fileRowSelection],
   );
+
+  const exportDocuments = () => {
+    downloadCsv(
+      `openrag-documents-${selected || "partition"}.csv`,
+      [
+        { header: "partition", value: () => selected },
+        { header: "file_id", value: (file) => file.file_id },
+        { header: "filename", value: (file) => fileLabel(file) },
+        { header: "mimetype", value: (file) => file.mimetype },
+        { header: "indexed_at", value: (file) => file.indexed_at },
+        { header: "created_at", value: (file) => file.created_at },
+      ],
+      filteredFileRows,
+    );
+  };
 
   useEffect(() => {
     if (!writable && Object.keys(fileRowSelection).length > 0) {
@@ -335,7 +368,7 @@ export default function DocumentListPage() {
         }
       />
 
-      <div className="flex items-center gap-2 mb-4">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
         <Label className="text-sm font-medium">Partition</Label>
         <Select value={selected} onValueChange={selectPartition}>
           <SelectTrigger className="w-[220px]">
@@ -349,6 +382,22 @@ export default function DocumentListPage() {
             ))}
           </SelectContent>
         </Select>
+        <div className="relative max-w-xs">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search files..."
+            value={fileSearch}
+            onChange={(e) => setFileSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Input
+          type="date"
+          value={indexedSince}
+          onChange={(e) => setIndexedSince(e.target.value)}
+          className="w-[150px]"
+          aria-label="Indexed since"
+        />
         {writable && selectedFiles.length > 0 && (
           <>
             <ConfirmDialog
@@ -377,10 +426,23 @@ export default function DocumentListPage() {
             </p>
           </>
         )}
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           {filesQuery.data && (
-            <p className="text-sm text-muted-foreground">{fileRows.length} file(s)</p>
+            <p className="text-sm text-muted-foreground">
+              {filteredFileRows.length}
+              {(fileSearch || indexedSince) && ` of ${fileRows.length}`} file(s)
+            </p>
           )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={exportDocuments}
+            disabled={!filteredFileRows.length}
+            title="Export filtered documents"
+          >
+            <Download className="h-4 w-4" />
+            Export CSV
+          </Button>
           <Button
             variant="outline"
             size="icon-sm"
@@ -425,7 +487,7 @@ export default function DocumentListPage() {
       ) : (
         <DataTable
           columns={columns}
-          data={fileRows}
+          data={filteredFileRows}
           initialSorting={[{ id: "indexed_at", desc: true }]}
           enableSelection={writable}
           getRowId={(f) => f.file_id}

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -178,6 +178,7 @@ describe("JobListPage filters", () => {
       tasks: [
         task("docs-task", "COMPLETED", "docs.pdf", "docs"),
         task("archive-task", "FAILED", "archive.pdf", "archive"),
+        task("all-named-task", "COMPLETED", "all-named.pdf", "__all__"),
       ],
     });
 
@@ -196,6 +197,21 @@ describe("JobListPage filters", () => {
       "openrag-jobs.csv",
       expect.any(Array),
       [expect.objectContaining({ task_id: "archive-task" })],
+    );
+
+    await userEvent.click(screen.getByRole("combobox", { name: /filter jobs by partition/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "__all__" }));
+
+    expect(screen.queryByText("docs.pdf")).toBeNull();
+    expect(screen.queryByText("archive.pdf")).toBeNull();
+    expect(screen.getByText("all-named.pdf")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(downloadCsvMock).toHaveBeenLastCalledWith(
+      "openrag-jobs.csv",
+      expect.any(Array),
+      [expect.objectContaining({ task_id: "all-named-task" })],
     );
 
     await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -197,5 +197,8 @@ describe("JobListPage filters", () => {
       expect.any(Array),
       [expect.objectContaining({ task_id: "archive-task" })],
     );
+
+    await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));
+    await waitFor(() => expect(screen.getByText("docs.pdf")).not.toBeNull());
   });
 });

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -2,8 +2,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getQueueInfo, listTasks } from "@/lib/api/jobs";
+import { downloadCsv } from "@/lib/csv";
 import JobListPage from "./list";
 
 const permissions = vi.hoisted(() => ({ isAdmin: true }));
@@ -19,8 +20,28 @@ vi.mock("@/lib/api/jobs", () => ({
   listTasks: vi.fn(),
 }));
 
+vi.mock("@/lib/csv", () => ({
+  downloadCsv: vi.fn(),
+}));
+
 const getQueueInfoMock = vi.mocked(getQueueInfo);
 const listTasksMock = vi.mocked(listTasks);
+const downloadCsvMock = vi.mocked(downloadCsv);
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
 
 const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string, partition = "docs") => ({
   task_id,
@@ -150,5 +171,31 @@ describe("JobListPage filters", () => {
 
     await waitFor(() => expect(listTasksMock.mock.calls.length).toBeGreaterThan(initialTaskRequests));
     expect(getQueueInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("filters jobs by partition and exports the filtered rows", async () => {
+    listTasksMock.mockResolvedValue({
+      tasks: [
+        task("docs-task", "COMPLETED", "docs.pdf", "docs"),
+        task("archive-task", "FAILED", "archive.pdf", "archive"),
+      ],
+    });
+
+    renderJobs();
+
+    expect(await screen.findByText("docs.pdf")).not.toBeNull();
+    await userEvent.click(screen.getByRole("combobox", { name: /filter jobs by partition/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "archive" }));
+
+    expect(screen.queryByText("docs.pdf")).toBeNull();
+    expect(screen.getByText("archive.pdf")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(downloadCsvMock).toHaveBeenCalledWith(
+      "openrag-jobs.csv",
+      expect.any(Array),
+      [expect.objectContaining({ task_id: "archive-task" })],
+    );
   });
 });

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -202,7 +202,10 @@ describe("JobListPage filters", () => {
     listTasksMock.mockResolvedValue({
       tasks: [
         task("docs-task", "COMPLETED", "docs.pdf", "docs"),
-        task("archive-task", "FAILED", "archive.pdf", "archive"),
+        task("archive-task", "FAILED", "archive.pdf", "archive", {
+          created_at: "2026-07-20T08:00:00Z",
+          duration_ms: 65_000,
+        }),
         task("all-named-task", "COMPLETED", "all-named.pdf", "__all__"),
       ],
     });
@@ -220,7 +223,10 @@ describe("JobListPage filters", () => {
 
     expect(downloadCsvMock).toHaveBeenCalledWith(
       "openrag-jobs.csv",
-      expect.any(Array),
+      expect.arrayContaining([
+        expect.objectContaining({ header: "created_at" }),
+        expect.objectContaining({ header: "duration_ms" }),
+      ]),
       [expect.objectContaining({ task_id: "archive-task" })],
     );
 
@@ -241,6 +247,18 @@ describe("JobListPage filters", () => {
 
     await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));
     await waitFor(() => expect(screen.getByText("docs.pdf")).not.toBeNull());
+  });
+
+  it("reports CSV download failures", async () => {
+    downloadCsvMock.mockImplementationOnce(() => {
+      throw new Error("downloads unavailable");
+    });
+    renderJobs();
+
+    expect(await screen.findByText("completed.pdf")).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(toastErrorMock).toHaveBeenCalledWith("CSV export failed: downloads unavailable");
   });
 
   it("keeps long job values constrained while exposing full names", async () => {

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -182,6 +182,7 @@ export default function JobListPage() {
     setStatusTab(value);
     setSearch("");
     setDebouncedSearch("");
+    setPartitionFilter("__all__");
   };
 
   return (

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
-import { RefreshCw, Search } from "lucide-react";
+import { Download, RefreshCw, Search } from "lucide-react";
 import { usePermissions } from "@/lib/permissions";
 
 import { PageHeader } from "@/components/shared/page-header";
@@ -11,8 +11,16 @@ import { StatusBadge } from "@/components/shared/status-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { getQueueInfo, listTasks, type QueueInfo, type TaskListItem } from "@/lib/api/jobs";
+import { downloadCsv } from "@/lib/csv";
 
 // OpenRag exposes per-file indexing tasks (TaskStateManager), not batch "jobs".
 const STATUS_TABS = ["ALL", "ACTIVE", "COMPLETED", "FAILED", "CANCELLED"] as const;
@@ -114,6 +122,7 @@ export default function JobListPage() {
   const [statusTab, setStatusTab] = useState<string>("ALL");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [partitionFilter, setPartitionFilter] = useState("__all__");
   const [manualRefreshing, setManualRefreshing] = useState(false);
 
   useEffect(() => {
@@ -134,18 +143,40 @@ export default function JobListPage() {
   });
 
   const tasks = useMemo(() => tasksQuery.data?.tasks ?? [], [tasksQuery.data?.tasks]);
+  const partitionOptions = useMemo(
+    () =>
+      Array.from(new Set(tasks.map((task) => str(task.details?.partition)).filter(Boolean))).sort(),
+    [tasks],
+  );
   const filteredTasks = useMemo(() => {
     const q = debouncedSearch.trim().toLowerCase();
-    if (!q) return tasks;
     return tasks.filter((task) => {
       const filename = str(task.details?.metadata?.filename);
       const fileId = str(task.details?.file_id);
       const partition = str(task.details?.partition);
-      return [task.task_id, task.state, filename, fileId, partition].some((value) =>
-        str(value).toLowerCase().includes(q),
-      );
+      const matchesSearch =
+        !q ||
+        [task.task_id, task.state, filename, fileId, partition].some((value) =>
+          str(value).toLowerCase().includes(q),
+        );
+      const matchesPartition = partitionFilter === "__all__" || partition === partitionFilter;
+      return matchesSearch && matchesPartition;
     });
-  }, [tasks, debouncedSearch]);
+  }, [tasks, debouncedSearch, partitionFilter]);
+
+  const exportJobs = () => {
+    downloadCsv(
+      "openrag-jobs.csv",
+      [
+        { header: "task_id", value: (task) => task.task_id },
+        { header: "state", value: (task) => task.state },
+        { header: "filename", value: (task) => str(task.details?.metadata?.filename) },
+        { header: "file_id", value: (task) => str(task.details?.file_id) },
+        { header: "partition", value: (task) => str(task.details?.partition) },
+      ],
+      filteredTasks,
+    );
+  };
 
   const handleStatusTabChange = (value: string) => {
     setStatusTab(value);
@@ -158,7 +189,7 @@ export default function JobListPage() {
       <PageHeader title="Jobs" description={isAdmin ? "Monitor indexing tasks" : "Monitor your indexing tasks"} />
 
       <Tabs value={statusTab} onValueChange={handleStatusTabChange}>
-        <div className="mb-4 mt-0 flex items-center gap-2">
+        <div className="mb-4 mt-0 flex flex-wrap items-center gap-2">
           <div className="relative max-w-sm">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -168,6 +199,19 @@ export default function JobListPage() {
               className="pl-9"
             />
           </div>
+          <Select value={partitionFilter} onValueChange={setPartitionFilter}>
+            <SelectTrigger className="w-[180px]" aria-label="Filter jobs by partition">
+              <SelectValue placeholder="All partitions" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">All partitions</SelectItem>
+              {partitionOptions.map((partition) => (
+                <SelectItem key={partition} value={partition}>
+                  {partition}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
             <p className="text-sm text-muted-foreground">
               {filteredTasks.length} job{filteredTasks.length === 1 ? "" : "s"}
@@ -179,6 +223,16 @@ export default function JobListPage() {
                 isError={queueInfoQuery.isError}
               />
             )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={exportJobs}
+              disabled={!filteredTasks.length}
+              title="Export filtered jobs"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
+            </Button>
             <Button
               variant="outline"
               size="icon-sm"

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -228,17 +228,23 @@ export default function JobListPage() {
   });
 
   const exportJobs = () => {
-    downloadCsv(
-      "openrag-jobs.csv",
-      [
-        { header: "task_id", value: (task) => task.task_id },
-        { header: "state", value: (task) => task.state },
-        { header: "filename", value: (task) => str(task.details?.metadata?.filename) },
-        { header: "file_id", value: (task) => str(task.details?.file_id) },
-        { header: "partition", value: (task) => str(task.details?.partition) },
-      ],
-      filteredTasks,
-    );
+    try {
+      downloadCsv(
+        "openrag-jobs.csv",
+        [
+          { header: "task_id", value: (task) => task.task_id },
+          { header: "state", value: (task) => task.state },
+          { header: "filename", value: (task) => str(task.details?.metadata?.filename) },
+          { header: "file_id", value: (task) => str(task.details?.file_id) },
+          { header: "partition", value: (task) => str(task.details?.partition) },
+          { header: "created_at", value: (task) => task.created_at },
+          { header: "duration_ms", value: (task) => task.duration_ms },
+        ],
+        filteredTasks,
+      );
+    } catch (error) {
+      toast.error(`CSV export failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
   };
 
   const handleStatusTabChange = (value: string) => {

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -26,6 +26,7 @@ import { downloadCsv } from "@/lib/csv";
 const STATUS_TABS = ["ALL", "ACTIVE", "COMPLETED", "FAILED", "CANCELLED"] as const;
 const JOBS_REFETCH_INTERVAL_MS = 5000;
 const JOB_SEARCH_DEBOUNCE_MS = 250;
+const ALL_PARTITIONS_FILTER = "__openrag/all_partitions__";
 
 const str = (v: unknown) => (v == null ? "" : String(v));
 
@@ -122,7 +123,7 @@ export default function JobListPage() {
   const [statusTab, setStatusTab] = useState<string>("ALL");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [partitionFilter, setPartitionFilter] = useState("__all__");
+  const [partitionFilter, setPartitionFilter] = useState(ALL_PARTITIONS_FILTER);
   const [manualRefreshing, setManualRefreshing] = useState(false);
 
   useEffect(() => {
@@ -159,7 +160,7 @@ export default function JobListPage() {
         [task.task_id, task.state, filename, fileId, partition].some((value) =>
           str(value).toLowerCase().includes(q),
         );
-      const matchesPartition = partitionFilter === "__all__" || partition === partitionFilter;
+      const matchesPartition = partitionFilter === ALL_PARTITIONS_FILTER || partition === partitionFilter;
       return matchesSearch && matchesPartition;
     });
   }, [tasks, debouncedSearch, partitionFilter]);
@@ -182,7 +183,7 @@ export default function JobListPage() {
     setStatusTab(value);
     setSearch("");
     setDebouncedSearch("");
-    setPartitionFilter("__all__");
+    setPartitionFilter(ALL_PARTITIONS_FILTER);
   };
 
   return (
@@ -205,7 +206,7 @@ export default function JobListPage() {
               <SelectValue placeholder="All partitions" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="__all__">All partitions</SelectItem>
+              <SelectItem value={ALL_PARTITIONS_FILTER}>All partitions</SelectItem>
               {partitionOptions.map((partition) => (
                 <SelectItem key={partition} value={partition}>
                   {partition}


### PR DESCRIPTION
## Context

Investigating benchmark runs or failed files currently requires paging through the Admin UI or falling back to scripts.

## Change

Extend the existing Jobs and Documents controls without changing the table layout:

- Jobs: add a partition filter and CSV export for the currently filtered loaded rows.
- Documents: add filename search, indexed-since filtering, filtered result count, and CSV export for the current partition's filtered rows.
- CSV output includes identifiers, state, filename, partition, and timestamps where already exposed. It does not include tracebacks or secrets.

Partially addresses #546.

## Limitation

Job date filtering remains outside this PR. Job creation time and duration are available and included in the CSV export, but adding another UI filter should be scoped separately.

## Validation

- npm test -- jobs/list.test.tsx documents/list.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added client-side filtering and an “Export CSV” option on the documents admin list (filename/text search and “indexed since” date), exporting only the filtered rows.
  - Added partition-based filtering and “Export CSV” on the jobs admin list, exporting only tasks from the selected partition/status/search view.
- **Bug Fixes**
  - Improved CSV export by escaping/quoting values and neutralizing spreadsheet formula-like cell contents (including whitespace-prefixed variants); Excel-friendly CSV formatting is used for downloads.
- **Tests**
  - Expanded CSV and admin list test coverage, including export success/failure and browser download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->