### PR TITLE
Add bulk cancellation for active jobs

### DIFF
--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -557,5 +557,11 @@ async def cancel_task(
 ):
     cancelled = await service.cancel_task(task_id)
     if not cancelled:
+        task_state = await service.get_task_state(task_id)
+        if task_state in {"COMPLETED", "FAILED", "CANCELLED"}:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                f"Task {task_id} is already {task_state.lower()} and cannot be cancelled",
+            )
         raise HTTPException(404, f"No ObjectRef stored for task {task_id}")
     return {"message": f"Cancellation signal sent for task {task_id}"}

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -30,6 +30,7 @@ from api.dependencies.files import (
     validate_metadata,
 )
 from api.routers.admin.task_logs import collect_task_logs
+from core.models.catalog import TERMINAL_TASK_STATES
 from core.utils.exceptions import OpenRAGError
 from core.utils.filename import sanitize_filename
 from core.utils.log_tail import app_log_file
@@ -558,7 +559,7 @@ async def cancel_task(
     cancelled = await service.cancel_task(task_id)
     if not cancelled:
         task_state = await service.get_task_state(task_id)
-        if task_state in {"COMPLETED", "FAILED", "CANCELLED"}:
+        if task_state in TERMINAL_TASK_STATES:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Task {task_id} is already {task_state.lower()} and cannot be cancelled",

--- a/openrag/core/indexing/dispatcher.py
+++ b/openrag/core/indexing/dispatcher.py
@@ -82,8 +82,7 @@ class IndexingDispatcher(ABC):
     async def cancel_task(self, task_id: str) -> bool:
         """Cancel a running/queued task.
 
-        Returns ``False`` when no object ref is stored for ``task_id``
-        (the caller maps that to a 404), ``True`` once the cancel signal
-        has been sent.
+        Returns ``False`` when the task cannot be cancelled, ``True`` once
+        the cancel signal has been sent.
         """
         ...

--- a/openrag/core/models/__init__.py
+++ b/openrag/core/models/__init__.py
@@ -1,6 +1,6 @@
 """Domain models — pure Pydantic, no infrastructure imports."""
 
-from .catalog import DocumentRecord, DocumentStatus, IndexationJob, JobStatus
+from .catalog import TERMINAL_TASK_STATES, DocumentRecord, DocumentStatus, IndexationJob, JobStatus
 from .chunk import Chunk, ChunkType
 from .contextualization import ContextualizedQuery
 from .conversation import Conversation, Message
@@ -13,6 +13,7 @@ from .user import ApiKey, OIDCSession, PartitionRole, TokenPayload, User, UserPa
 from .workspace import Workspace
 
 __all__ = [
+    "TERMINAL_TASK_STATES",
     "ApiKey",
     "Chunk",
     "ChunkType",

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -20,6 +20,13 @@ class DocumentStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+# States a task/document cannot leave once reached. Single source of truth for
+# the cancellation guard shared by the indexing route, dispatcher, and
+# TaskStateManager — keep those in sync via this constant rather than
+# re-declaring the set.
+TERMINAL_TASK_STATES = frozenset({DocumentStatus.COMPLETED, DocumentStatus.FAILED, DocumentStatus.CANCELLED})
+
+
 class JobStatus(str, Enum):
     QUEUED = "QUEUED"
     RUNNING = "RUNNING"

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -4,7 +4,6 @@ import uuid
 from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
-from core.models.catalog import TERMINAL_TASK_STATES
 from core.utils.logging import get_logger
 
 logger = get_logger()
@@ -238,21 +237,20 @@ class WorkerDispatcher(IndexingDispatcher):
         if obj_ref is None:
             return False
 
-        # Re-checked atomically in set_cancelled_if_active below; this early
-        # check just avoids an unnecessary ray.cancel() call on a task that
-        # has already reached a terminal state.
-        state = await self._call(
-            self._tsm.get_state.remote(task_id),
-            task_description=f"get_state({task_id})",
-        )
-        if state in TERMINAL_TASK_STATES:
-            return False
-
-        ray.cancel(obj_ref["ref"], recursive=True)
-        return await self._call(
+        # Atomically claim the cancellation first: if ray.cancel() ran before
+        # this and the RPC then failed, a killed worker could never report
+        # back and the task would be stuck active forever (a zombie).
+        # Claiming first means a failed ray.cancel() just leaves a task
+        # marked CANCELLED that later self-corrects to COMPLETED/FAILED.
+        cancelled = await self._call(
             self._tsm.set_cancelled_if_active.remote(task_id),
             task_description=f"set_cancelled_if_active({task_id})",
         )
+        if not cancelled:
+            return False
+
+        ray.cancel(obj_ref["ref"], recursive=True)
+        return True
 
 
 def from_ray_namespace(

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -240,8 +240,8 @@ class WorkerDispatcher(IndexingDispatcher):
         # Atomically claim the cancellation first: if ray.cancel() ran before
         # this and the RPC then failed, a killed worker could never report
         # back and the task would be stuck active forever (a zombie).
-        # Claiming first means a failed ray.cancel() just leaves a task
-        # marked CANCELLED that later self-corrects to COMPLETED/FAILED.
+        # TaskStateManager keeps CANCELLED sticky, so a worker that starts in
+        # this small window cannot report active/success after the cancel claim.
         cancelled = await self._call(
             self._tsm.set_cancelled_if_active.remote(task_id),
             task_description=f"set_cancelled_if_active({task_id})",

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -30,6 +30,7 @@ class WorkerDispatcher(IndexingDispatcher):
             "next_section_id",
         }
     )
+    _TERMINAL_STATES = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
 
     def __init__(
         self,
@@ -230,6 +231,13 @@ class WorkerDispatcher(IndexingDispatcher):
     async def cancel_task(self, task_id: str) -> bool:
         import ray
 
+        state = await self._call(
+            self._tsm.get_state.remote(task_id),
+            task_description=f"get_state({task_id})",
+        )
+        if state in self._TERMINAL_STATES:
+            return False
+
         obj_ref = await self._call(
             self._tsm.get_object_ref.remote(task_id),
             task_description=f"get_object_ref({task_id})",
@@ -237,12 +245,18 @@ class WorkerDispatcher(IndexingDispatcher):
         if obj_ref is None:
             return False
 
-        ray.cancel(obj_ref["ref"], recursive=True)
-        await self._call(
-            self._tsm.set_state.remote(task_id, "CANCELLED"),
-            task_description=f"set_state({task_id})",
+        state = await self._call(
+            self._tsm.get_state.remote(task_id),
+            task_description=f"get_state({task_id})",
         )
-        return True
+        if state in self._TERMINAL_STATES:
+            return False
+
+        ray.cancel(obj_ref["ref"], recursive=True)
+        return await self._call(
+            self._tsm.set_cancelled_if_active.remote(task_id),
+            task_description=f"set_cancelled_if_active({task_id})",
+        )
 
 
 def from_ray_namespace(

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
+from core.models.catalog import TERMINAL_TASK_STATES
 from core.utils.logging import get_logger
 
 logger = get_logger()
@@ -30,7 +31,6 @@ class WorkerDispatcher(IndexingDispatcher):
             "next_section_id",
         }
     )
-    _TERMINAL_STATES = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
 
     def __init__(
         self,
@@ -231,13 +231,6 @@ class WorkerDispatcher(IndexingDispatcher):
     async def cancel_task(self, task_id: str) -> bool:
         import ray
 
-        state = await self._call(
-            self._tsm.get_state.remote(task_id),
-            task_description=f"get_state({task_id})",
-        )
-        if state in self._TERMINAL_STATES:
-            return False
-
         obj_ref = await self._call(
             self._tsm.get_object_ref.remote(task_id),
             task_description=f"get_object_ref({task_id})",
@@ -245,11 +238,14 @@ class WorkerDispatcher(IndexingDispatcher):
         if obj_ref is None:
             return False
 
+        # Re-checked atomically in set_cancelled_if_active below; this early
+        # check just avoids an unnecessary ray.cancel() call on a task that
+        # has already reached a terminal state.
         state = await self._call(
             self._tsm.get_state.remote(task_id),
             task_description=f"get_state({task_id})",
         )
-        if state in self._TERMINAL_STATES:
+        if state in TERMINAL_TASK_STATES:
             return False
 
         ray.cancel(obj_ref["ref"], recursive=True)

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -66,6 +66,15 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
+    async def set_cancelled_if_active(self, task_id: str) -> bool:
+        async with self.lock:
+            info = self.tasks.get(task_id)
+            if info is None or info.state in {"COMPLETED", "FAILED", "CANCELLED"}:
+                return False
+            info.state = "CANCELLED"
+            return True
+
+    @ray.method(concurrency_group="set")
     async def set_details(
         self,
         task_id: str,

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import ray
+from core.models.catalog import TERMINAL_TASK_STATES
 
 try:
     from core.config import load_config as _load_config
@@ -69,7 +70,7 @@ class TaskStateManager:
     async def set_cancelled_if_active(self, task_id: str) -> bool:
         async with self.lock:
             info = self.tasks.get(task_id)
-            if info is None or info.state in {"COMPLETED", "FAILED", "CANCELLED"}:
+            if info is None or info.state in TERMINAL_TASK_STATES:
                 return False
             info.state = "CANCELLED"
             return True

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import ray
-from core.models.catalog import TERMINAL_TASK_STATES
+from core.models.catalog import TERMINAL_TASK_STATES, DocumentStatus
 
 try:
     from core.config import load_config as _load_config
@@ -47,6 +47,8 @@ class TaskStateManager:
     async def set_state(self, task_id: str, state: str) -> None:
         async with self.lock:
             info = await self._ensure_task(task_id)
+            if info.state == DocumentStatus.CANCELLED and state != DocumentStatus.CANCELLED:
+                return
             info.state = state
 
     @ray.method(concurrency_group="set")

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -196,7 +196,6 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
     ref = object()
     tsm = _task_state_manager()
     tsm.get_object_ref.remote = AsyncMock(return_value={"ref": ref})
-    tsm.get_state.remote = AsyncMock(return_value="SERIALIZING")
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -210,8 +209,8 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
         result = await dispatcher.cancel_task("task-1")
 
     assert result is True
-    cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_cancelled_if_active.remote.assert_called_once_with("task-1")
+    cancel.assert_called_once_with(ref, recursive=True)
 
 
 @pytest.mark.asyncio
@@ -221,7 +220,7 @@ async def test_cancel_task_does_not_cancel_terminal_task() -> None:
     ref = object()
     tsm = _task_state_manager()
     tsm.get_object_ref.remote = AsyncMock(return_value={"ref": ref})
-    tsm.get_state.remote = AsyncMock(return_value="COMPLETED")
+    tsm.set_cancelled_if_active.remote = AsyncMock(return_value=False)
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -235,8 +234,8 @@ async def test_cancel_task_does_not_cancel_terminal_task() -> None:
         result = await dispatcher.cancel_task("task-1")
 
     assert result is False
+    tsm.set_cancelled_if_active.remote.assert_called_once_with("task-1")
     cancel.assert_not_called()
-    tsm.set_cancelled_if_active.remote.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -61,6 +61,7 @@ def _workspace_repo() -> MagicMock:
 def _task_state_manager() -> MagicMock:
     tsm = MagicMock()
     tsm.set_state = _remote_mock()
+    tsm.set_cancelled_if_active = _remote_mock(True)
     tsm.set_details = _remote_mock()
     tsm.set_object_ref = _remote_mock()
     tsm.get_state = _remote_mock("SERIALIZING")
@@ -210,11 +211,11 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
 
     assert result is True
     cancel.assert_called_once_with(ref, recursive=True)
-    tsm.set_state.remote.assert_called_once_with("task-1", "CANCELLED")
+    tsm.set_cancelled_if_active.remote.assert_called_once_with("task-1")
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_marks_cancelled_even_if_worker_finished_first() -> None:
+async def test_cancel_task_does_not_cancel_terminal_task() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     ref = object()
@@ -230,11 +231,12 @@ async def test_cancel_task_marks_cancelled_even_if_worker_finished_first() -> No
         collection="default",
     )
 
-    with patch("ray.cancel"):
+    with patch("ray.cancel") as cancel:
         result = await dispatcher.cancel_task("task-1")
 
-    assert result is True
-    tsm.set_state.remote.assert_called_once_with("task-1", "CANCELLED")
+    assert result is False
+    cancel.assert_not_called()
+    tsm.set_cancelled_if_active.remote.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from services.workers.task_state import TaskStateManager
+
+
+def _task_state_manager() -> Any:
+    return TaskStateManager.__ray_metadata__.modified_class()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_state_is_not_overwritten_by_worker_transitions() -> None:
+    manager = _task_state_manager()
+
+    await manager.set_state("task-1", "QUEUED")
+    assert await manager.set_cancelled_if_active("task-1") is True
+
+    await manager.set_state("task-1", "SERIALIZING")
+    await manager.set_state("task-1", "COMPLETED")
+
+    assert await manager.get_state("task-1") == "CANCELLED"

--- a/ui/src/components/shared/data-table.test.tsx
+++ b/ui/src/components/shared/data-table.test.tsx
@@ -119,4 +119,18 @@ describe("DataTable selection", () => {
     fireEvent.click(screen.getAllByRole("checkbox")[0]);
     expect(screen.queryByText(/selected/)).toBeNull();
   });
+
+  it("disables select-all when the visible rows cannot be selected", () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(2)}
+        enableSelection
+        canSelectRow={() => false}
+        getRowId={(r) => String(r.id)}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: /select visible rows/i }).hasAttribute("disabled")).toBe(true);
+  });
 });

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -74,16 +74,20 @@ export function DataTable<TData, TValue>({
     const selectColumn: ColumnDef<TData, TValue> = {
       id: "__select",
       enableSorting: false,
-      header: ({ table }) => (
-        <Checkbox
-          checked={
-            table.getIsAllPageRowsSelected() ||
-            (table.getIsSomePageRowsSelected() && "indeterminate")
-          }
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select visible rows"
-        />
-      ),
+      header: ({ table }) => {
+        const hasSelectablePageRows = table.getRowModel().rows.some((row) => row.getCanSelect());
+        return (
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && "indeterminate")
+            }
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+            disabled={!hasSelectablePageRows}
+            aria-label="Select visible rows"
+          />
+        );
+      },
       cell: ({ row }) => (
         <Checkbox
           checked={row.getIsSelected()}

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -31,6 +31,8 @@ interface BaseDataTableProps<TData, TValue> {
   initialSorting?: SortingState;
   /** Render a leading checkbox column. */
   enableSelection?: boolean;
+  /** Optional row-level selection guard for pages with state-dependent bulk actions. */
+  canSelectRow?: (row: TData) => boolean;
   /** Stable row id (e.g. file_id) so selection survives a data refetch. */
   getRowId?: (row: TData) => string;
 }
@@ -54,6 +56,7 @@ export function DataTable<TData, TValue>({
   pageSize = 10,
   initialSorting = [],
   enableSelection = false,
+  canSelectRow,
   getRowId,
   rowSelection: controlledRowSelection,
   onRowSelectionChange,
@@ -85,6 +88,7 @@ export function DataTable<TData, TValue>({
         <Checkbox
           checked={row.getIsSelected()}
           onCheckedChange={(value) => row.toggleSelected(!!value)}
+          disabled={!row.getCanSelect()}
           aria-label="Select row"
         />
       ),
@@ -103,7 +107,9 @@ export function DataTable<TData, TValue>({
     onColumnFiltersChange: setColumnFilters,
     onPaginationChange: setPagination,
     onRowSelectionChange: setRowSelection,
-    enableRowSelection: enableSelection,
+    enableRowSelection: enableSelection
+      ? (row) => (canSelectRow ? canSelectRow(row.original) : true)
+      : false,
     getRowId,
     // Keep the user on their current page when the rows change underneath them
     // (e.g. deleting a row refetches the list). TanStack resets pageIndex to 0

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -3,8 +3,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listTasks } from "@/lib/api/jobs";
+import { cancelTask, listTasks, type TaskState } from "@/lib/api/jobs";
 import JobListPage from "./list";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/permissions", () => ({
   usePermissions: () => ({
@@ -13,12 +20,16 @@ vi.mock("@/lib/permissions", () => ({
 }));
 
 vi.mock("@/lib/api/jobs", () => ({
+  cancelTask: vi.fn(),
+  isActiveState: (state: string) => ["QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"].includes(state),
+  isTerminalState: (state: string) => ["COMPLETED", "FAILED", "CANCELLED"].includes(state),
   listTasks: vi.fn(),
 }));
 
+const cancelTaskMock = vi.mocked(cancelTask);
 const listTasksMock = vi.mocked(listTasks);
 
-const task = (task_id: string, state: "COMPLETED" | "FAILED", filename: string) => ({
+const task = (task_id: string, state: TaskState, filename: string) => ({
   task_id,
   state,
   details: {
@@ -48,6 +59,7 @@ function renderJobs() {
 
 describe("JobListPage filters", () => {
   beforeEach(() => {
+    cancelTaskMock.mockResolvedValue({ message: "Cancellation signal sent" });
     listTasksMock.mockImplementation(async (status?: string) => ({
       tasks:
         status === "FAILED"
@@ -72,5 +84,32 @@ describe("JobListPage filters", () => {
 
     await waitFor(() => expect(search.value).toBe(""));
     expect(await screen.findByText("failed.pdf")).not.toBeNull();
+  });
+
+  it("bulk-cancels only selected active jobs", async () => {
+    listTasksMock.mockResolvedValue({
+      tasks: [
+        task("queued-task", "QUEUED", "queued.pdf"),
+        task("completed-task", "COMPLETED", "completed.pdf"),
+      ],
+    });
+
+    renderJobs();
+
+    expect(await screen.findByText("queued.pdf")).not.toBeNull();
+    expect(screen.getByText("completed.pdf")).not.toBeNull();
+
+    const rowCheckboxes = screen.getAllByRole("checkbox", { name: /select row/i });
+    expect(rowCheckboxes[0].hasAttribute("disabled")).toBe(false);
+    expect(rowCheckboxes[1].hasAttribute("disabled")).toBe(true);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /select visible rows/i }));
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel selected/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => expect(cancelTaskMock).toHaveBeenCalledWith("queued-task"));
+    expect(cancelTaskMock).not.toHaveBeenCalledWith("completed-task");
   });
 });

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -21,13 +21,15 @@ vi.mock("@/lib/permissions", () => ({
   }),
 }));
 
-vi.mock("@/lib/api/jobs", () => ({
-  cancelTask: vi.fn(),
-  getQueueInfo: vi.fn(),
-  isActiveState: (state: string) => ["QUEUED", "SERIALIZING", "CHUNKING", "INSERTING"].includes(state),
-  isTerminalState: (state: string) => ["COMPLETED", "FAILED", "CANCELLED"].includes(state),
-  listTasks: vi.fn(),
-}));
+vi.mock("@/lib/api/jobs", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/jobs")>("@/lib/api/jobs");
+  return {
+    ...actual,
+    cancelTask: vi.fn(),
+    getQueueInfo: vi.fn(),
+    listTasks: vi.fn(),
+  };
+});
 
 const cancelTaskMock = vi.mocked(cancelTask);
 const getQueueInfoMock = vi.mocked(getQueueInfo);

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cancelTask, getQueueInfo, listTasks, type TaskState } from "@/lib/api/jobs";
 import JobListPage from "./list";
@@ -34,6 +35,7 @@ vi.mock("@/lib/api/jobs", async () => {
 const cancelTaskMock = vi.mocked(cancelTask);
 const getQueueInfoMock = vi.mocked(getQueueInfo);
 const listTasksMock = vi.mocked(listTasks);
+const toastErrorMock = vi.mocked(toast.error);
 
 const task = (task_id: string, state: TaskState, filename: string) => ({
   task_id,
@@ -129,6 +131,43 @@ describe("JobListPage filters", () => {
 
     await waitFor(() => expect(cancelTaskMock).toHaveBeenCalledWith("queued-task"));
     expect(cancelTaskMock).not.toHaveBeenCalledWith("completed-task");
+  });
+
+  it("rechecks selected jobs before bulk cancelling", async () => {
+    let tasks = [task("queued-task", "QUEUED", "queued.pdf")];
+    listTasksMock.mockImplementation(async () => ({ tasks }));
+
+    renderJobs();
+
+    expect(await screen.findByText("queued.pdf")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /select row/i }));
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    tasks = [task("queued-task", "COMPLETED", "queued.pdf")];
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel selected/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith("1 task(s) were no longer active"));
+    expect(cancelTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("clears selected jobs when the search changes", async () => {
+    listTasksMock.mockResolvedValue({
+      tasks: [task("queued-task", "QUEUED", "queued.pdf"), task("other-task", "QUEUED", "other.pdf")],
+    });
+
+    renderJobs();
+
+    expect(await screen.findByText("queued.pdf")).not.toBeNull();
+
+    await userEvent.click(screen.getAllByRole("checkbox", { name: /select row/i })[0]);
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    await userEvent.type(screen.getByPlaceholderText("Search jobs..."), "other");
+
+    await waitFor(() => expect(screen.queryByText("1 selected")).toBeNull());
   });
 
   it("shows queue and worker pressure from the backend", async () => {

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import type { ColumnDef } from "@tanstack/react-table";
-import { RefreshCw, Search } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ColumnDef, RowSelectionState } from "@tanstack/react-table";
+import { Ban, RefreshCw, Search } from "lucide-react";
+import { toast } from "sonner";
 import { usePermissions } from "@/lib/permissions";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { DataTable } from "@/components/shared/data-table";
 import { StatusBadge } from "@/components/shared/status-badge";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { listTasks, type TaskListItem } from "@/lib/api/jobs";
+import { cancelTask, isActiveState, listTasks, type TaskListItem } from "@/lib/api/jobs";
 
 // OpenRag exposes per-file indexing tasks (TaskStateManager), not batch "jobs".
 const STATUS_TABS = ["ALL", "ACTIVE", "COMPLETED", "FAILED", "CANCELLED"] as const;
@@ -49,9 +51,11 @@ const columns: ColumnDef<TaskListItem, unknown>[] = [
 
 export default function JobListPage() {
   const { isAdmin } = usePermissions();
+  const queryClient = useQueryClient();
   const [statusTab, setStatusTab] = useState<string>("ALL");
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [manualRefreshing, setManualRefreshing] = useState(false);
 
   useEffect(() => {
@@ -78,11 +82,31 @@ export default function JobListPage() {
       );
     });
   }, [tasks, debouncedSearch]);
+  const selectedActiveTasks = useMemo(
+    () => filteredTasks.filter((task) => rowSelection[task.task_id] && isActiveState(task.state)),
+    [filteredTasks, rowSelection],
+  );
+
+  const bulkCancelMutation = useMutation({
+    mutationFn: async (taskIds: string[]) => {
+      const results = await Promise.allSettled(taskIds.map((taskId) => cancelTask(taskId)));
+      const ok = results.filter((result) => result.status === "fulfilled").length;
+      return { ok, failed: results.length - ok };
+    },
+    onSuccess: ({ ok, failed }) => {
+      if (ok) toast.success(`${ok} task(s) cancelled`);
+      if (failed) toast.error(`${failed} task(s) failed to cancel`);
+      setRowSelection({});
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+    onError: (error: Error) => toast.error(`Bulk cancel failed: ${error.message}`),
+  });
 
   const handleStatusTabChange = (value: string) => {
     setStatusTab(value);
     setSearch("");
     setDebouncedSearch("");
+    setRowSelection({});
   };
 
   return (
@@ -104,6 +128,25 @@ export default function JobListPage() {
             <p className="text-sm text-muted-foreground">
               {filteredTasks.length} job{filteredTasks.length === 1 ? "" : "s"}
             </p>
+            {selectedActiveTasks.length > 0 && (
+              <>
+                <ConfirmDialog
+                  title="Cancel selected tasks?"
+                  description={`Send a cancellation signal for ${selectedActiveTasks.length} active task(s)? Already-completed work is not rolled back.`}
+                  onConfirm={() =>
+                    bulkCancelMutation.mutate(selectedActiveTasks.map((task) => task.task_id))
+                  }
+                >
+                  <Button variant="outline" size="sm" disabled={bulkCancelMutation.isPending}>
+                    <Ban className="h-4 w-4" />
+                    Cancel selected
+                  </Button>
+                </ConfirmDialog>
+                <p className="text-sm text-muted-foreground">
+                  {selectedActiveTasks.length} selected
+                </p>
+              </>
+            )}
             <Button
               variant="outline"
               size="icon-sm"
@@ -138,7 +181,16 @@ export default function JobListPage() {
               </div>
             ) : (
               // Remounting resets pagination for a new tab/search context; sort state resets with it.
-              <DataTable key={`${statusTab}:${debouncedSearch}`} columns={columns} data={filteredTasks} />
+              <DataTable
+                key={`${statusTab}:${debouncedSearch}`}
+                columns={columns}
+                data={filteredTasks}
+                enableSelection
+                canSelectRow={(task) => isActiveState(task.state)}
+                getRowId={(task) => task.task_id}
+                rowSelection={rowSelection}
+                onRowSelectionChange={setRowSelection}
+              />
             )}
           </TabsContent>
         ))}

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -99,6 +99,7 @@ export default function JobListPage() {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [manualRefreshing, setManualRefreshing] = useState(false);
+  const taskStatusFilter = statusTab === "ALL" ? undefined : statusTab === "ACTIVE" ? "active" : statusTab;
 
   useEffect(() => {
     const timeout = window.setTimeout(() => setDebouncedSearch(search), JOB_SEARCH_DEBOUNCE_MS);
@@ -107,7 +108,7 @@ export default function JobListPage() {
 
   const tasksQuery = useQuery({
     queryKey: ["tasks", statusTab],
-    queryFn: () => listTasks(statusTab === "ALL" ? undefined : statusTab === "ACTIVE" ? "active" : statusTab),
+    queryFn: () => listTasks(taskStatusFilter),
     refetchInterval: JOBS_REFETCH_INTERVAL_MS, // poll — OpenRag has no task SSE
   });
   const queueInfoQuery = useQuery({
@@ -137,13 +138,19 @@ export default function JobListPage() {
 
   const bulkCancelMutation = useMutation({
     mutationFn: async (taskIds: string[]) => {
-      const results = await Promise.allSettled(taskIds.map((taskId) => cancelTask(taskId)));
+      const latestTasks = await listTasks(taskStatusFilter);
+      const selectedIds = new Set(taskIds);
+      const activeTaskIds = latestTasks.tasks
+        .filter((task) => selectedIds.has(task.task_id) && isActiveState(task.state))
+        .map((task) => task.task_id);
+      const results = await Promise.allSettled(activeTaskIds.map((taskId) => cancelTask(taskId)));
       const ok = results.filter((result) => result.status === "fulfilled").length;
-      return { ok, failed: results.length - ok };
+      return { ok, failed: results.length - ok, skipped: taskIds.length - activeTaskIds.length };
     },
-    onSuccess: ({ ok, failed }) => {
+    onSuccess: ({ ok, failed, skipped }) => {
       if (ok) toast.success(`${ok} task(s) cancelled`);
       if (failed) toast.error(`${failed} task(s) failed to cancel`);
+      if (skipped) toast.error(`${skipped} task(s) were no longer active`);
       setRowSelection({});
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
@@ -168,7 +175,10 @@ export default function JobListPage() {
             <Input
               placeholder="Search jobs..."
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setRowSelection({});
+              }}
               className="pl-9"
             />
           </div>


### PR DESCRIPTION
## Context

Admins can cancel one active task from the detail page, but cancelling several active jobs still required API calls or scripts.

## Change

Add safe bulk cancellation to the existing Jobs table:

- only active jobs are selectable for bulk cancellation
- completed, failed, and cancelled jobs are disabled for selection
- selected active jobs can be cancelled through the existing task cancellation endpoint
- partial success/failure is reported through the existing toast pattern

Partially addresses #545.

## Limitation

Retry is not implemented here. The current API does not expose a safe retry operation or enough durable submission data to recreate the original indexing request without risking duplicate or incorrect submissions. That should be a separate backend/API design before adding a retry button.

## Validation

- npm test -- data-table.test.tsx jobs/list.test.tsx
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added row-level selection to shared data tables, with “select visible rows” respecting per-row eligibility.
  - Added bulk “cancel selected tasks” workflow for eligible (active) jobs with confirmation, success/failure counts, and pending-state controls.
- **Bug Fixes**
  - Completed/failed/cancelled tasks can’t be selected or cancelled in bulk; selection auto-resets on tab/search changes.
  - Cancellation now returns a conflict when a task is already in a terminal state.
- **Tests**
  - Added/expanded UI tests for disabled select-all/eligibility behavior and updated backend/unit tests for terminal-state cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->