### PR TITLE
Document indexing stage progress design

### DIFF
--- a/docs/refactoring/issue-542-indexing-stage-progress.md
+++ b/docs/refactoring/issue-542-indexing-stage-progress.md
@@ -27,6 +27,10 @@ the Jobs APIs after refresh, completion, failure, or worker restart.
 Add real stage events to the task state model before changing the UI:
 
 - task id
+- event id, unique within the task and stable across a retry of the write
+- attempt number, starting at 1 and increasing when a stage is retried
+- sequence number, assigned by the state manager and increasing monotonically
+  for every stage event on the task
 - stage name
 - status: pending, running, completed, failed, skipped
 - started_at and finished_at
@@ -35,8 +39,38 @@ Add real stage events to the task state model before changing the UI:
 - last_error for the failed stage
 - optional counters such as pages parsed, chunks created, images captioned, and vectors inserted
 
-The task detail API can then expose a stable `stages` array. The Jobs list can show
-the current running stage, and the Job detail page can show the full timeline.
+Stage events should be append-only and ordered by sequence number, not by client
+timestamps. A worker restart or retry must create a new attempt instead of
+rewriting the previous failed attempt. Duplicate writes for the same event id
+with the same payload should be treated as already applied; a duplicate event id
+with conflicting payload should be rejected or logged as a state-write bug, not
+shown as another timeline row.
+
+Valid status movement is intentionally narrow:
+
+- pending to running, skipped, failed
+- running to completed, failed, skipped
+- failed to a new attempt for the same stage
+
+This keeps the timeline readable when a stage is retried: the first attempt can
+end as failed, and the later attempt can complete without producing impossible
+states such as a single event moving from failed back to running.
+
+The existing task-status URL returned by upload and replacement endpoints stays
+unchanged. `GET /indexer/task/{task_id}` continues to return the current broad
+task fields (`task_id`, `task_state`, `details`, and `error_url` when relevant)
+and is augmented with a `stages` field containing the ordered stage history. Old
+clients that only poll the broad task state can keep working, while newer clients
+can render the timeline from the same task-status response.
+
+Stage history must also be bounded. Keep stage events at least as long as the
+task remains visible in task history, but cap retention with a configurable TTL
+and a per-task event limit. The proposed defaults are 30 days and 200 events per
+task. When the event limit is exceeded, keep the latest events and enough summary
+data to explain the final stage state. Cleanup should run from the same
+task-history cleanup path, so old stage data does not grow forever after
+completed or failed jobs. Older tasks that predate stage tracking should return
+an empty `stages` array rather than a guessed timeline.
 
 ## Follow-Up Work
 
@@ -44,7 +78,7 @@ the current running stage, and the Job detail page can show the full timeline.
 2. Emit start/finish/fail events from the indexing pipeline stages.
 3. Preserve stage history after completion and failure.
 4. Keep broad task states unchanged for compatibility.
-5. Add API fields for stage history.
+5. Add the `stages` field to the existing task-status response.
 6. Add UI timeline only after the API returns real persisted stage data.
 
 ## Non-Goal

--- a/docs/refactoring/issue-542-indexing-stage-progress.md
+++ b/docs/refactoring/issue-542-indexing-stage-progress.md
@@ -50,7 +50,10 @@ a conflicting duplicate is rejected or logged as a state-write bug.
 Running a stage again is different from retrying an event write. A real stage
 retry creates a new attempt id and increments the attempt number, preserving the
 previous attempt as history. A worker restart follows the same rule unless it is
-only resending a transition that was already accepted.
+only resending a transition that was already accepted. Before a restarted worker
+begins a new attempt, recovery must close any previous `pending` or `running`
+attempt with a terminal `failed` event and a worker-interruption reason. A retry
+must never leave the previous attempt looking active beside the new one.
 
 Valid transition sequences within one attempt are intentionally narrow:
 

--- a/docs/refactoring/issue-542-indexing-stage-progress.md
+++ b/docs/refactoring/issue-542-indexing-stage-progress.md
@@ -1,0 +1,53 @@
+# Issue 542: Indexing Stage Progress
+
+## Context
+
+Admins need to know where a slow or failed indexing job is spending time: parsing,
+captioning, chunking, contextualizing, embedding, or storing vectors.
+
+The UI should not guess this from the broad task state. A job that is still marked
+`SERIALIZING` may already be parsing, captioning, embedding, or waiting on a
+shared worker pool. Showing fake progress would make production debugging worse.
+
+## Current Gap
+
+Today the task state manager keeps only:
+
+- broad task state
+- task details
+- traceback on failure
+- worker/queue totals
+
+The indexing pipeline already measures per-stage timings, but those timings are
+written to logs only. They are not persisted per task and are not available from
+the Jobs APIs after refresh, completion, failure, or worker restart.
+
+## Proposed Shape
+
+Add real stage events to the task state model before changing the UI:
+
+- task id
+- stage name
+- status: pending, running, completed, failed, skipped
+- started_at and finished_at
+- duration_ms when finished
+- processed and total when a stage can report it
+- last_error for the failed stage
+- optional counters such as pages parsed, chunks created, images captioned, and vectors inserted
+
+The task detail API can then expose a stable `stages` array. The Jobs list can show
+the current running stage, and the Job detail page can show the full timeline.
+
+## Follow-Up Work
+
+1. Extend `TaskStateManager` with stage-event storage and read APIs.
+2. Emit start/finish/fail events from the indexing pipeline stages.
+3. Preserve stage history after completion and failure.
+4. Keep broad task states unchanged for compatibility.
+5. Add API fields for stage history.
+6. Add UI timeline only after the API returns real persisted stage data.
+
+## Non-Goal
+
+Do not infer stage progress from logs, task state names, or client-side timers.
+Those signals are not reliable enough for production debugging.

--- a/docs/refactoring/issue-542-indexing-stage-progress.md
+++ b/docs/refactoring/issue-542-indexing-stage-progress.md
@@ -27,41 +27,54 @@ the Jobs APIs after refresh, completion, failure, or worker restart.
 Add real stage events to the task state model before changing the UI:
 
 - task id
-- event id, unique within the task and stable across a retry of the write
-- attempt number, starting at 1 and increasing when a stage is retried
+- event id, unique within the task and stable across a retry of the same transition write
+- attempt id, shared by every transition from one execution of a stage
+- attempt number, starting at 1 and increasing when the stage is run again
 - sequence number, assigned by the state manager and increasing monotonically
   for every stage event on the task
 - stage name
-- status: pending, running, completed, failed, skipped
+- status: pending, running, completed, failed, skipped, cancelled
 - started_at and finished_at
 - duration_ms when finished
 - processed and total when a stage can report it
-- last_error for the failed stage
+- last_error or cancellation reason for an unsuccessful stage
 - optional counters such as pages parsed, chunks created, images captioned, and vectors inserted
 
-Stage events should be append-only and ordered by sequence number, not by client
-timestamps. A worker restart or retry must create a new attempt instead of
-rewriting the previous failed attempt. Duplicate writes for the same event id
-with the same payload should be treated as already applied; a duplicate event id
-with conflicting payload should be rejected or logged as a state-write bug, not
-shown as another timeline row.
+Stage events should be immutable and ordered by sequence number, not by client
+timestamps. Each status transition is a separate event: for example, `running`
+and `completed` have different event ids but share one attempt id. The state
+manager assigns the sequence number when it first accepts an event. Retrying the
+same write reuses its event id; an identical duplicate is already applied, while
+a conflicting duplicate is rejected or logged as a state-write bug.
 
-Valid status movement is intentionally narrow:
+Running a stage again is different from retrying an event write. A real stage
+retry creates a new attempt id and increments the attempt number, preserving the
+previous attempt as history. A worker restart follows the same rule unless it is
+only resending a transition that was already accepted.
 
-- pending to running, skipped, failed
-- running to completed, failed, skipped
-- failed to a new attempt for the same stage
+Valid transition sequences within one attempt are intentionally narrow:
+
+- pending to running, skipped, failed, cancelled
+- running to completed, failed, skipped, cancelled
+- a terminal status never changes; another execution uses a new attempt
 
 This keeps the timeline readable when a stage is retried: the first attempt can
 end as failed, and the later attempt can complete without producing impossible
 states such as a single event moving from failed back to running.
 
+Cancelling a task must also close any active stage attempt. The cancellation
+path appends a terminal `cancelled` event with its finish time and reason before
+the broad task is reported as cancelled. If no stage has started, no synthetic
+stage event is needed. This prevents a cancelled task from returning a timeline
+whose last stage remains `running` indefinitely.
+
 The existing task-status URL returned by upload and replacement endpoints stays
 unchanged. `GET /indexer/task/{task_id}` continues to return the current broad
 task fields (`task_id`, `task_state`, `details`, and `error_url` when relevant)
-and is augmented with a `stages` field containing the ordered stage history. Old
-clients that only poll the broad task state can keep working, while newer clients
-can render the timeline from the same task-status response.
+and is augmented with a `stages` field containing the ordered transition events,
+grouped by attempt id. Old clients that only poll the broad task state can keep
+working, while newer clients can render the timeline from the same task-status
+response.
 
 Stage history must also be bounded. Keep stage events at least as long as the
 task remains visible in task history, but cap retention with a configurable TTL
@@ -76,7 +89,7 @@ an empty `stages` array rather than a guessed timeline.
 
 1. Extend `TaskStateManager` with stage-event storage and read APIs.
 2. Emit start/finish/fail events from the indexing pipeline stages.
-3. Preserve stage history after completion and failure.
+3. Preserve stage history after completion, failure, and cancellation.
 4. Keep broad task states unchanged for compatibility.
 5. Add the `stages` field to the existing task-status response.
 6. Add UI timeline only after the API returns real persisted stage data.


### PR DESCRIPTION
## Context

Issue #542 needs real stage-level indexing progress. The current backend only persists broad task states and tracebacks; per-stage timings are logged but not stored per task.

## Change

Add a focused design note explaining the backend-first shape needed before the Admin UI can show stage progress honestly.

References #542.

## Why this is docs-only

I did not add UI progress here because the API does not yet expose persisted stage transitions. Showing inferred progress from task state names, timers, or logs would be misleading in production.

## Validation

Docs-only change; no runtime tests were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new reference guide for persisting real per-stage indexing progress in task state.
  * Defined an ordered per-stage event schema with attempt semantics, stable identifiers, stage status/timing/counters, and per-stage error/cancellation reasons.
  * Clarified compatibility expectations for existing task-status fields, including returning progress via an ordered `stages` field.
  * Specified stage-history retention controls (TTL and event limits) and documented non-goals around deriving progress from logs or timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->