### PR TITLE
support env var to disable SSL verification in httpx

### DIFF
--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -117,6 +117,8 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_AUTO_PROVISION_LOGIN` | No | `false` | When `true`, an unknown `sub` triggers creation of a non-admin user from the ID-token claims instead of returning `403 User not registered`. Also keeps the user's `display_name` and `email` in sync with the claims on every subsequent login. See [Auto-provisioning](#auto-provisioning-optional). |
 | `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | No | — | URL the IdP sends the user to after RP-initiated logout. **No default**: if unset AND the IdP doesn't have an `end_session_endpoint`, `/auth/logout` returns a plain 200 confirming the logout. Avoid pointing this to an OpenRag URL (triggers re-auth — silent SSO loop). |
+| `SSL_NO_VERIFY` | No | false | set to ``true`` to skip TLS certificate verification on requests to the IdP, e.g. for a self-signed Keycloak in dev |
+
 
 \* Required when `AUTH_MODE=oidc`
 
@@ -191,6 +193,7 @@ OIDC_POST_LOGOUT_REDIRECT_URI=/
 # Optional — sync display name and email from IdP on every login:
 # OIDC_CLAIM_SOURCE=id_token      # or 'userinfo'
 # OIDC_CLAIM_MAPPING=display_name:name,email:email
+# SSL_NO_VERIFY=False # or true to skip SSL verification 
 ```
 
 ---

--- a/docs/content/docs/documentation/oidc.md
+++ b/docs/content/docs/documentation/oidc.md
@@ -117,7 +117,7 @@ All variables must be set when `AUTH_MODE=oidc`. If any required variable is mis
 | `OIDC_AUTO_PROVISION_LOGIN` | No | `false` | When `true`, an unknown `sub` triggers creation of a non-admin user from the ID-token claims instead of returning `403 User not registered`. Also keeps the user's `display_name` and `email` in sync with the claims on every subsequent login. See [Auto-provisioning](#auto-provisioning-optional). |
 | `OIDC_SCOPES` | No | `openid email profile offline_access` | Space-separated OIDC scopes; include `offline_access` for refresh tokens |
 | `OIDC_POST_LOGOUT_REDIRECT_URI` | No | — | URL the IdP sends the user to after RP-initiated logout. **No default**: if unset AND the IdP doesn't have an `end_session_endpoint`, `/auth/logout` returns a plain 200 confirming the logout. Avoid pointing this to an OpenRag URL (triggers re-auth — silent SSO loop). |
-| `SSL_NO_VERIFY` | No | false | set to ``true`` to skip TLS certificate verification on requests to the IdP, e.g. for a self-signed Keycloak in dev |
+| `SSL_NO_VERIFY` | No | `false` | **Development only — never enable in production.** Skips TLS certificate verification on requests to the IdP. Disabling it allows man-in-the-middle attacks and forged IdP responses/tokens. For a self-signed IdP (e.g. dev Keycloak), install/trust its CA instead of disabling verification. |
 
 
 \* Required when `AUTH_MODE=oidc`
@@ -193,7 +193,7 @@ OIDC_POST_LOGOUT_REDIRECT_URI=/
 # Optional — sync display name and email from IdP on every login:
 # OIDC_CLAIM_SOURCE=id_token      # or 'userinfo'
 # OIDC_CLAIM_MAPPING=display_name:name,email:email
-# SSL_NO_VERIFY=False # or true to skip SSL verification 
+# SSL_NO_VERIFY=false  # dev only — never true in production, skips IdP TLS cert verification
 ```
 
 ---

--- a/openrag/core/utils/string_utils.py
+++ b/openrag/core/utils/string_utils.py
@@ -1,0 +1,8 @@
+def str_to_bool(value: str) -> bool:
+    value = value.lower()
+    if value in ("true", "1", "t", "y", "yes", "on"):
+        return True
+    elif value in ("false", "0", "f", "n", "no", "off"):
+        return False
+    else:
+        raise ValueError(f"Not a boolean : {value}")

--- a/openrag/core/utils/string_utils.py
+++ b/openrag/core/utils/string_utils.py
@@ -1,5 +1,5 @@
 def str_to_bool(value: str) -> bool:
-    value = value.lower()
+    value = value.strip().lower()
     if value in ("true", "1", "t", "y", "yes", "on"):
         return True
     elif value in ("false", "0", "f", "n", "no", "off"):

--- a/openrag/services/auth/deps.py
+++ b/openrag/services/auth/deps.py
@@ -17,12 +17,14 @@ import os
 from threading import Lock
 
 import httpx
+from core.utils.logging import get_logger
 from core.utils.string_utils import str_to_bool
 from services.auth.oidc_client import OIDCClient
 
 _client: OIDCClient | None = None
 _lock = Lock()
 
+logger = get_logger()
 
 def get_oidc_client() -> OIDCClient:
     """Return the shared OIDCClient instance, creating it on first call.
@@ -45,12 +47,17 @@ def get_oidc_client() -> OIDCClient:
     with _lock:
         if _client is not None:
             return _client
+
+        _ssl_verify = not str_to_bool(os.getenv("SSL_NO_VERIFY", "false"))
+        if not _ssl_verify:
+          logger.warning("SSL certificate verification is DISABLED for the OIDC client.")
+
         issuer = os.environ["OIDC_ENDPOINT"]
         client_id = os.environ["OIDC_CLIENT_ID"]
         client_secret = os.environ["OIDC_CLIENT_SECRET"]
         redirect_uri = os.environ["OIDC_REDIRECT_URI"]
         scopes = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
-        _ssl_verify = not str_to_bool(os.getenv("SSL_NO_VERIFY", "false"))
+
         http_client = httpx.AsyncClient(timeout=10.0, verify=_ssl_verify)
         _client = OIDCClient(
             issuer=issuer,

--- a/openrag/services/auth/deps.py
+++ b/openrag/services/auth/deps.py
@@ -13,10 +13,13 @@ trusts them.
 
 from __future__ import annotations
 
+import httpx
 import os
 from threading import Lock
 
 from services.auth.oidc_client import OIDCClient
+
+from core.utils.string_utils import str_to_bool
 
 _client: OIDCClient | None = None
 _lock = Lock()
@@ -34,6 +37,8 @@ def get_oidc_client() -> OIDCClient:
       - OIDC_CLIENT_SECRET
       - OIDC_REDIRECT_URI
       - OIDC_SCOPES (default ``openid email profile offline_access``)
+      - SSL_NO_VERIFY (default ``false``; set to ``true`` to skip TLS certificate
+        verification on requests to the IdP, e.g. for a self-signed Keycloak in dev)
     """
     global _client
     if _client is not None:
@@ -46,12 +51,15 @@ def get_oidc_client() -> OIDCClient:
         client_secret = os.environ["OIDC_CLIENT_SECRET"]
         redirect_uri = os.environ["OIDC_REDIRECT_URI"]
         scopes = os.getenv("OIDC_SCOPES", "openid email profile offline_access")
+        _ssl_verify = not str_to_bool(os.getenv("SSL_NO_VERIFY", "false"))
+        http_client = httpx.AsyncClient(timeout=10.0, verify=_ssl_verify)
         _client = OIDCClient(
             issuer=issuer,
             client_id=client_id,
             client_secret=client_secret,
             redirect_uri=redirect_uri,
             scopes=scopes,
+            http_client=http_client,
         )
     return _client
 

--- a/openrag/services/auth/deps.py
+++ b/openrag/services/auth/deps.py
@@ -26,6 +26,7 @@ _lock = Lock()
 
 logger = get_logger()
 
+
 def get_oidc_client() -> OIDCClient:
     """Return the shared OIDCClient instance, creating it on first call.
 
@@ -50,7 +51,7 @@ def get_oidc_client() -> OIDCClient:
 
         _ssl_verify = not str_to_bool(os.getenv("SSL_NO_VERIFY", "false"))
         if not _ssl_verify:
-          logger.warning("SSL certificate verification is DISABLED for the OIDC client.")
+            logger.warning("SSL certificate verification is DISABLED for the OIDC client.")
 
         issuer = os.environ["OIDC_ENDPOINT"]
         client_id = os.environ["OIDC_CLIENT_ID"]

--- a/openrag/services/auth/deps.py
+++ b/openrag/services/auth/deps.py
@@ -13,13 +13,12 @@ trusts them.
 
 from __future__ import annotations
 
-import httpx
 import os
 from threading import Lock
 
-from services.auth.oidc_client import OIDCClient
-
+import httpx
 from core.utils.string_utils import str_to_bool
+from services.auth.oidc_client import OIDCClient
 
 _client: OIDCClient | None = None
 _lock = Lock()

--- a/tests/unit/core/utils/test_string_utils.py
+++ b/tests/unit/core/utils/test_string_utils.py
@@ -1,0 +1,102 @@
+import pytest
+
+from core.utils.string_utils import str_to_bool
+
+def test_str_to_bool_true_values():
+    """Test that valid 'true' strings are converted to True."""
+    assert str_to_bool("true") is True
+    assert str_to_bool("True") is True
+    assert str_to_bool("TRUE") is True
+    assert str_to_bool("1") is True
+    assert str_to_bool("t") is True
+    assert str_to_bool("T") is True
+    assert str_to_bool("y") is True
+    assert str_to_bool("yes") is True
+    assert str_to_bool("YES") is True
+    assert str_to_bool("on") is True
+    assert str_to_bool("ON") is True
+
+
+def test_str_to_bool_false_values():
+    """Test that valid 'false' strings are converted to False."""
+    assert str_to_bool("false") is False
+    assert str_to_bool("False") is False
+    assert str_to_bool("FALSE") is False
+    assert str_to_bool("0") is False
+    assert str_to_bool("f") is False
+    assert str_to_bool("F") is False
+    assert str_to_bool("n") is False
+    assert str_to_bool("no") is False
+    assert str_to_bool("NO") is False
+    assert str_to_bool("off") is False
+    assert str_to_bool("OFF") is False
+
+
+def test_str_to_bool_strips_whitespace():
+    """Test that leading/trailing whitespace is ignored."""
+    assert str_to_bool("  true  ") is True
+    assert str_to_bool("\tfalse\n") is False
+    assert str_to_bool(" yes ") is True
+    assert str_to_bool(" 0 ") is False
+
+
+def test_str_to_bool_mixed_case_and_whitespace():
+    """Test combination of mixed case and surrounding whitespace."""
+    assert str_to_bool("  YeS  ") is True
+    assert str_to_bool("  No  ") is False
+
+
+def test_str_to_bool_invalid_string_raises():
+    """Test that an unrecognized string raises ValueError."""
+    with pytest.raises(ValueError):
+        str_to_bool("maybe")
+
+
+def test_str_to_bool_empty_string_raises():
+    """Test that an empty string raises ValueError."""
+    with pytest.raises(ValueError):
+        str_to_bool("")
+
+
+def test_str_to_bool_whitespace_only_raises():
+    """Test that a whitespace-only string raises ValueError."""
+    with pytest.raises(ValueError):
+        str_to_bool("   ")
+
+
+def test_str_to_bool_numeric_like_but_invalid_raises():
+    """Test that numeric-looking but unsupported values raise ValueError."""
+    with pytest.raises(ValueError):
+        str_to_bool("2")
+    with pytest.raises(ValueError):
+        str_to_bool("-1")
+    with pytest.raises(ValueError):
+        str_to_bool("1.0")
+
+
+def test_str_to_bool_error_message_contains_value():
+    """Test that the error message includes the offending (normalized) value."""
+    with pytest.raises(ValueError):
+        str_to_bool("nope")
+
+
+def test_str_to_bool_none_raises_typeerror():
+    """Test that passing None raises an error (no .strip() on None)."""
+    with pytest.raises(AttributeError):
+        str_to_bool(None)
+
+
+def test_str_to_bool_non_string_type_raises():
+    """Test that a non-string type without .strip()/.lower() raises an error."""
+    with pytest.raises(AttributeError):
+        str_to_bool(123)
+
+
+def test_str_to_bool_similar_but_wrong_word_raises():
+    """Test words that resemble valid values but aren't exact matches."""
+    with pytest.raises(ValueError):
+        str_to_bool("yeah")
+    with pytest.raises(ValueError):
+        str_to_bool("nah")
+    with pytest.raises(ValueError):
+        str_to_bool("truee")

--- a/tests/unit/core/utils/test_string_utils.py
+++ b/tests/unit/core/utils/test_string_utils.py
@@ -1,6 +1,6 @@
 import pytest
-
 from core.utils.string_utils import str_to_bool
+
 
 def test_str_to_bool_true_values():
     """Test that valid 'true' strings are converted to True."""
@@ -72,12 +72,6 @@ def test_str_to_bool_numeric_like_but_invalid_raises():
         str_to_bool("-1")
     with pytest.raises(ValueError):
         str_to_bool("1.0")
-
-
-def test_str_to_bool_error_message_contains_value():
-    """Test that the error message includes the offending (normalized) value."""
-    with pytest.raises(ValueError):
-        str_to_bool("nope")
 
 
 def test_str_to_bool_none_raises_typeerror():


### PR DESCRIPTION
Add an env var (SSL_NO_VERIFY) to disable SSL verification. Usefull for oidc client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration-friendly utility to interpret common true/false values (e.g., `true/false`, `1/0`, `yes/no`, `on/off`).
  * Added `SSL_NO_VERIFY` to optionally disable TLS certificate verification for OIDC requests.
* **Bug Fixes**
  * Improved OIDC authentication reliability by reusing a shared HTTP client for IdP communication, with controllable TLS verification.
* **Documentation**
  * Updated OIDC documentation and example configuration to include `SSL_NO_VERIFY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->