### PR TITLE
feat(ui): add partition upload action

### DIFF
--- a/ui/src/lib/permissions.test.tsx
+++ b/ui/src/lib/permissions.test.tsx
@@ -5,17 +5,23 @@ import { renderHook } from "@testing-library/react";
 // /config query — mock both (vi.hoisted so the factories may reference the shared
 // state) instead of standing up AuthProvider + a QueryClient.
 const auth = vi.hoisted(() => ({ isAdmin: false }));
-const cfg = vi.hoisted(() => ({ superAdminMode: false }));
+const cfg = vi.hoisted(() => ({ superAdminMode: false, loading: false, error: false }));
 vi.mock("./auth", () => ({ useAuth: () => ({ isAdmin: auth.isAdmin }) }));
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: { super_admin_mode: cfg.superAdminMode } }),
+  useQuery: () => ({
+    data: cfg.loading || cfg.error ? undefined : { super_admin_mode: cfg.superAdminMode },
+    isSuccess: !cfg.loading && !cfg.error,
+    isError: cfg.error,
+  }),
 }));
 
 import { usePermissions } from "./permissions";
 
-function perms(isAdmin: boolean, superAdminMode = false) {
+function perms(isAdmin: boolean, superAdminMode = false, state: Partial<typeof cfg> = {}) {
   auth.isAdmin = isAdmin;
   cfg.superAdminMode = superAdminMode;
+  cfg.loading = state.loading ?? false;
+  cfg.error = state.error ?? false;
   return renderHook(() => usePermissions()).result.current;
 }
 
@@ -23,6 +29,7 @@ describe("usePermissions — platform scopes", () => {
   it("grants every platform capability to admins", () => {
     const p = perms(true);
     expect(p.isAdmin).toBe(true);
+    expect(p.superAdminModeResolved).toBe(true);
     expect(p.canViewPlatform).toBe(true);
     expect(p.canViewSystem).toBe(true);
     expect(p.canManageUsers).toBe(true);
@@ -33,6 +40,7 @@ describe("usePermissions — platform scopes", () => {
 
   it("denies platform capabilities to non-admins", () => {
     const p = perms(false);
+    expect(p.superAdminModeResolved).toBe(true);
     expect(p.canViewSystem).toBe(false);
     expect(p.canManageUsers).toBe(false);
     expect(p.canManageModels).toBe(false);
@@ -70,6 +78,12 @@ describe("usePermissions — partition-scoped roles (non-admin)", () => {
 });
 
 describe("usePermissions — admin bypass is gated on SUPER_ADMIN_MODE", () => {
+  it("keeps the admin bypass unresolved while /config is loading", () => {
+    const p = perms(true, false, { loading: true });
+    expect(p.superAdmin).toBe(false);
+    expect(p.superAdminModeResolved).toBe(false);
+  });
+
   it("a plain admin (mode off) does NOT bypass partition-role checks", () => {
     const p = perms(true, false);
     expect(p.superAdmin).toBe(false);

--- a/ui/src/lib/permissions.ts
+++ b/ui/src/lib/permissions.ts
@@ -25,6 +25,9 @@ export interface Permissions {
   // will reject. TODO(org): becomes "platform super-admin OR org-admin of the
   // resource's org" once orgs exist.
   superAdmin: boolean;
+  // True once the SUPER_ADMIN_MODE lookup can no longer change the client-side
+  // partition permission decision for the current user.
+  superAdminModeResolved: boolean;
   // Platform-scoped (today: global admin). Models/Presets/Users/Partitions become
   // org-admin too under SaaS; System/Platform stay platform-operator only.
   canViewPlatform: boolean;
@@ -51,17 +54,21 @@ export function usePermissions(): Permissions {
   // SUPER_ADMIN_MODE governs the backend's admin→all-partitions bypass. /config is
   // admin-only and only admins need the flag (a non-admin never hits the bypass
   // branch), so the probe is admin-gated; it never changes at runtime.
-  const { data: config } = useQuery({
+  const configQuery = useQuery({
     queryKey: ["system-config"],
     queryFn: getConfig,
     enabled: isAdmin,
     staleTime: Infinity,
   });
+  const config = configQuery.data;
   const superAdmin = isAdmin && config?.super_admin_mode === true;
+  const superAdminModeResolved =
+    !isAdmin || configQuery.isSuccess || configQuery.isError || config !== undefined;
 
   return {
     isAdmin,
     superAdmin,
+    superAdminModeResolved,
     canViewPlatform: isAdmin,
     canViewSystem: isAdmin,
     canManageUsers: isAdmin,

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -72,7 +72,7 @@ function LocationProbe() {
   return <output data-testid="location">{location.pathname}</output>;
 }
 
-function renderDocuments() {
+function renderDocuments(initialEntries = ["/documents"]) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -82,7 +82,7 @@ function renderDocuments() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <DocumentListPage />
         <LocationProbe />
       </MemoryRouter>
@@ -110,6 +110,15 @@ describe("DocumentListPage", () => {
     const fileLink = await screen.findByRole("link", { name: "a.pdf" });
     expect(fileLink.getAttribute("title")).toBe("a.pdf");
     expect(fileLink.className).toContain("truncate");
+  });
+
+  it("opens the upload dialog for a partition upload link", async () => {
+    renderDocuments(["/documents?partition=docs&upload=1"]);
+
+    expect(await screen.findByRole("dialog")).not.toBeNull();
+    expect(screen.getByText(/Index one or more files into/i)).not.toBeNull();
+    expect(screen.getByText("docs")).not.toBeNull();
+    expect(screen.getByTestId("location").textContent).toBe("/documents");
   });
 
   it("selects all documents from the table header and deletes the selected files", async () => {

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -16,10 +16,13 @@ vi.mock("sonner", () => ({
   },
 }));
 
+const permissions = vi.hoisted(() => ({
+  canWrite: vi.fn(() => true),
+  superAdminModeResolved: true,
+}));
+
 vi.mock("@/lib/permissions", () => ({
-  usePermissions: () => ({
-    canWrite: () => true,
-  }),
+  usePermissions: () => permissions,
 }));
 
 vi.mock("@/lib/api/partitions", () => ({
@@ -80,19 +83,25 @@ function renderDocuments(initialEntries = ["/documents"]) {
     },
   });
 
-  return render(
+  const ui = () => (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
         <DocumentListPage />
         <LocationProbe />
       </MemoryRouter>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const view = render(ui());
+  return Object.assign(view, {
+    rerenderDocuments: () => view.rerender(ui()),
+  });
 }
 
 describe("DocumentListPage", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    permissions.canWrite.mockImplementation(() => true);
+    permissions.superAdminModeResolved = true;
     deleteFileMock.mockClear();
     uploadFileMock.mockReset();
     toastSuccessMock.mockClear();
@@ -125,6 +134,53 @@ describe("DocumentListPage", () => {
 
   it("does not open upload when the requested partition falls back", async () => {
     renderDocuments(["/documents?partition=missing&upload=1"]);
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs"));
+  });
+
+  it("keeps the upload route while super-admin write access is still resolving", async () => {
+    permissions.canWrite.mockImplementation(() => false);
+    permissions.superAdminModeResolved = false;
+
+    renderDocuments(["/documents?partition=docs&upload=1"]);
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs&upload=1");
+  });
+
+  it("opens the upload dialog when delayed write access resolves", async () => {
+    permissions.canWrite.mockImplementation(() => false);
+    permissions.superAdminModeResolved = false;
+    const view = renderDocuments(["/documents?partition=docs&upload=1"]);
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs&upload=1");
+
+    permissions.canWrite.mockImplementation(() => true);
+    permissions.superAdminModeResolved = true;
+    view.rerenderDocuments();
+
+    expect(await screen.findByRole("dialog")).not.toBeNull();
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs"));
+  });
+
+  it("clears the upload route after write access is rejected", async () => {
+    permissions.canWrite.mockImplementation(() => false);
+    permissions.superAdminModeResolved = true;
+
+    renderDocuments(["/documents?partition=docs&upload=1"]);
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs"));
+  });
+
+  it("clears upload-only routes without opening a fallback partition", async () => {
+    renderDocuments(["/documents?upload=1"]);
 
     expect(await screen.findByText("a.pdf")).not.toBeNull();
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/ui/src/pages/admin/documents/list.test.tsx
+++ b/ui/src/pages/admin/documents/list.test.tsx
@@ -69,7 +69,7 @@ const toastSuccessMock = vi.mocked(toast.success);
 
 function LocationProbe() {
   const location = useLocation();
-  return <output data-testid="location">{location.pathname}</output>;
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
 }
 
 function renderDocuments(initialEntries = ["/documents"]) {
@@ -92,6 +92,7 @@ function renderDocuments(initialEntries = ["/documents"]) {
 
 describe("DocumentListPage", () => {
   beforeEach(() => {
+    sessionStorage.clear();
     deleteFileMock.mockClear();
     uploadFileMock.mockReset();
     toastSuccessMock.mockClear();
@@ -115,10 +116,19 @@ describe("DocumentListPage", () => {
   it("opens the upload dialog for a partition upload link", async () => {
     renderDocuments(["/documents?partition=docs&upload=1"]);
 
-    expect(await screen.findByRole("dialog")).not.toBeNull();
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).not.toBeNull();
     expect(screen.getByText(/Index one or more files into/i)).not.toBeNull();
-    expect(screen.getByText("docs")).not.toBeNull();
-    expect(screen.getByTestId("location").textContent).toBe("/documents");
+    expect(dialog.textContent).toContain("docs");
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs"));
+  });
+
+  it("does not open upload when the requested partition falls back", async () => {
+    renderDocuments(["/documents?partition=missing&upload=1"]);
+
+    expect(await screen.findByText("a.pdf")).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(screen.getByTestId("location").textContent).toBe("/documents?partition=docs"));
   });
 
   it("selects all documents from the table header and deletes the selected files", async () => {

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -41,7 +41,7 @@ const fileLabel = (f: PartitionFile) => (f.filename as string) || f.file_id;
 export default function DocumentListPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { canWrite } = usePermissions();
+  const { canWrite, superAdminModeResolved } = usePermissions();
 
   // OpenRag has no flat/cross-partition file list — files live inside a
   // partition, so the view is partition-scoped (pick one, see its files). The
@@ -85,13 +85,21 @@ export default function DocumentListPage() {
     sessionStorage.setItem("documents.partition", selected);
     const urlPartition = searchParams.get("partition");
     const requestedUpload = searchParams.get("upload") === "1";
+    const uploadPermissionResolved = writable || superAdminModeResolved;
     const shouldOpenUpload = requestedUpload && urlPartition === selected && selectedPartitionExists && writable;
     if (shouldOpenUpload) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Open the existing upload dialog from the route action.
       setUploadOpen(true);
     }
+    const shouldClearUpload =
+      requestedUpload &&
+      partitionsSettled &&
+      (shouldOpenUpload ||
+        !urlPartition ||
+        urlPartition !== selected ||
+        (selectedPartitionExists && uploadPermissionResolved));
     const shouldUpdateRoute =
-      partitionsSettled && (requestedUpload || (urlPartition && urlPartition !== selected));
+      partitionsSettled && (shouldClearUpload || (urlPartition && urlPartition !== selected));
     if (shouldUpdateRoute) {
       setSearchParams(
         (prev) => {
@@ -103,7 +111,15 @@ export default function DocumentListPage() {
         { replace: true },
       );
     }
-  }, [selected, searchParams, selectedPartitionExists, partitionsSettled, setSearchParams, writable]);
+  }, [
+    selected,
+    searchParams,
+    selectedPartitionExists,
+    partitionsSettled,
+    setSearchParams,
+    superAdminModeResolved,
+    writable,
+  ]);
 
   const selectPartition = (p: string) => {
     setFileSelection({ partition: p, rows: {} });

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -77,6 +77,8 @@ export default function DocumentListPage() {
     partitions,
     partitionsQuery.isSuccess || partitionsQuery.isError,
   );
+  const role = partitions.find((p) => p.partition === selected)?.role;
+  const writable = canWrite(role);
 
   // Keep the remembered partition in sync, and heal a stale ?partition= URL so a
   // refresh / shared link doesn't re-trigger the not-found error.
@@ -84,16 +86,22 @@ export default function DocumentListPage() {
     if (!selected) return;
     sessionStorage.setItem("documents.partition", selected);
     const urlPartition = searchParams.get("partition");
-    if (urlPartition && urlPartition !== selected) {
+    const shouldOpenUpload = searchParams.get("upload") === "1" && writable;
+    if (shouldOpenUpload) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Open the existing upload dialog from the route action.
+      setUploadOpen(true);
+    }
+    if ((urlPartition && urlPartition !== selected) || shouldOpenUpload) {
       setSearchParams(
         (prev) => {
           prev.set("partition", selected);
+          prev.delete("upload");
           return prev;
         },
         { replace: true },
       );
     }
-  }, [selected, searchParams, setSearchParams]);
+  }, [selected, searchParams, setSearchParams, writable]);
 
   const selectPartition = (p: string) => {
     setFileSelection({ partition: p, rows: {} });
@@ -103,9 +111,6 @@ export default function DocumentListPage() {
       return prev;
     });
   };
-
-  const role = partitions.find((p) => p.partition === selected)?.role;
-  const writable = canWrite(role);
 
   const filesQuery = useQuery({
     queryKey: ["partition-files", selected],

--- a/ui/src/pages/admin/documents/list.tsx
+++ b/ui/src/pages/admin/documents/list.tsx
@@ -72,11 +72,9 @@ export default function DocumentListPage() {
   // must stop treating the (unverifiable) candidate as sticky, or the view stays
   // stuck on a phantom partition with the error swallowed. On error `partitions`
   // is [], so this resolves to "" → the empty-state branch surfaces the error.
-  const selected = resolveDocumentsPartition(
-    candidate,
-    partitions,
-    partitionsQuery.isSuccess || partitionsQuery.isError,
-  );
+  const partitionsSettled = partitionsQuery.isSuccess || partitionsQuery.isError;
+  const selected = resolveDocumentsPartition(candidate, partitions, partitionsSettled);
+  const selectedPartitionExists = partitions.some((p) => p.partition === selected);
   const role = partitions.find((p) => p.partition === selected)?.role;
   const writable = canWrite(role);
 
@@ -86,22 +84,26 @@ export default function DocumentListPage() {
     if (!selected) return;
     sessionStorage.setItem("documents.partition", selected);
     const urlPartition = searchParams.get("partition");
-    const shouldOpenUpload = searchParams.get("upload") === "1" && writable;
+    const requestedUpload = searchParams.get("upload") === "1";
+    const shouldOpenUpload = requestedUpload && urlPartition === selected && selectedPartitionExists && writable;
     if (shouldOpenUpload) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Open the existing upload dialog from the route action.
       setUploadOpen(true);
     }
-    if ((urlPartition && urlPartition !== selected) || shouldOpenUpload) {
+    const shouldUpdateRoute =
+      partitionsSettled && (requestedUpload || (urlPartition && urlPartition !== selected));
+    if (shouldUpdateRoute) {
       setSearchParams(
         (prev) => {
-          prev.set("partition", selected);
-          prev.delete("upload");
-          return prev;
+          const next = new URLSearchParams(prev);
+          next.set("partition", selected);
+          next.delete("upload");
+          return next;
         },
         { replace: true },
       );
     }
-  }, [selected, searchParams, setSearchParams, writable]);
+  }, [selected, searchParams, selectedPartitionExists, partitionsSettled, setSearchParams, writable]);
 
   const selectPartition = (p: string) => {
     setFileSelection({ partition: p, rows: {} });
@@ -117,7 +119,7 @@ export default function DocumentListPage() {
     queryFn: () => listPartitionFiles(selected),
     // Only fetch once we've confirmed `selected` is a real, still-existing
     // partition — avoids a 404 flash for a stale/deleted selection during load.
-    enabled: !!selected && partitions.some((p) => p.partition === selected),
+    enabled: !!selected && selectedPartitionExists,
     // A file only appears here once its indexing job finishes (the catalog row
     // is written post-indexing), so poll to pick up freshly-indexed files
     // without the user having to switch partitions. Mirrors the Jobs page;

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -107,8 +107,11 @@ describe("PartitionListPage bulk actions", () => {
     permissions.canManagePartitions = true;
     renderPartitions();
 
-    expect(await screen.findByRole("link", { name: /edit owned-a/i })).not.toBeNull();
-    expect(screen.getByRole("button", { name: /delete owned-a/i })).not.toBeNull();
+    const edit = await screen.findByRole("link", { name: /edit owned-a/i });
+    const deleteAction = screen.getByRole("button", { name: /delete owned-a/i });
+
+    expect(edit.getAttribute("data-size")).toBe("icon-xs");
+    expect(deleteAction.getAttribute("data-size")).toBe("icon-xs");
   });
 
   it("keeps long partition names constrained while exposing the full name", async () => {

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -132,6 +132,17 @@ describe("PartitionListPage bulk actions", () => {
     expect(partitionLink.className).toContain("truncate");
   });
 
+  it("shows the upload action for editor-only partitions", async () => {
+    listPartitionsMock.mockResolvedValue({
+      partitions: [makePartition("editable-docs", "editor")],
+    });
+
+    renderPartitions();
+
+    expect(await screen.findByRole("link", { name: /upload documents to editable-docs/i })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /delete editable-docs/i })).toBeNull();
+  });
+
   it("selects all deletable partitions and deletes only those partitions", async () => {
     renderPartitions();
 

--- a/ui/src/pages/admin/partitions/list.test.tsx
+++ b/ui/src/pages/admin/partitions/list.test.tsx
@@ -9,6 +9,7 @@ import PartitionListPage from "./list";
 const permissions = vi.hoisted(() => ({
   canManagePartitions: false,
   canConfigurePartition: vi.fn((role?: string) => role === "owner"),
+  canWrite: vi.fn((role?: string) => role === "owner" || role === "editor"),
 }));
 
 vi.mock("@/lib/permissions", () => ({
@@ -77,6 +78,7 @@ describe("PartitionListPage bulk actions", () => {
   beforeEach(() => {
     permissions.canManagePartitions = false;
     permissions.canConfigurePartition.mockImplementation((role?: string) => role === "owner");
+    permissions.canWrite.mockImplementation((role?: string) => role === "owner" || role === "editor");
     deletePartitionMock.mockClear();
     deletePartitionMock.mockResolvedValue();
     listPartitionsMock.mockResolvedValue({
@@ -107,9 +109,12 @@ describe("PartitionListPage bulk actions", () => {
     permissions.canManagePartitions = true;
     renderPartitions();
 
+    const upload = await screen.findByRole("link", { name: /upload documents to owned-a/i });
     const edit = await screen.findByRole("link", { name: /edit owned-a/i });
     const deleteAction = screen.getByRole("button", { name: /delete owned-a/i });
 
+    expect(upload.getAttribute("href")).toBe("/documents?partition=owned-a&upload=1");
+    expect(upload.getAttribute("data-size")).toBe("icon-xs");
     expect(edit.getAttribute("data-size")).toBe("icon-xs");
     expect(deleteAction.getAttribute("data-size")).toBe("icon-xs");
   });

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -80,13 +80,13 @@ function RowActions({
   return (
     <div className="flex items-center gap-1">
       {showEdit && (
-        <Button variant="ghost" size="sm" asChild>
+        <Button variant="ghost" size="icon-xs" asChild>
           <Link
             to={partitionDetailPath(partition.name)}
             aria-label={`Edit ${partition.name}`}
             title={`Edit ${partition.name}`}
           >
-            <Pencil className="h-3 w-3" />
+            <Pencil className="h-3.5 w-3.5" />
           </Link>
         </Button>
       )}
@@ -98,12 +98,12 @@ function RowActions({
         >
           <Button
             variant="ghost"
-            size="sm"
+            size="icon-xs"
             disabled={deleteMutation.isPending}
             aria-label={`Delete ${partition.name}`}
             title={`Delete ${partition.name}`}
           >
-            <Trash2 className="h-3 w-3 text-destructive" />
+            <Trash2 className="h-3.5 w-3.5 text-destructive" />
           </Button>
         </ConfirmDialog>
       )}

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw, ChevronLeft, ChevronRight } from "lucide-react";
+import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw, ChevronLeft, ChevronRight, FilePlus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -57,10 +57,12 @@ const PARTITIONS_REFETCH_INTERVAL_MS = 5000;
 
 function RowActions({
   partition,
+  showUpload,
   showEdit,
   showDelete,
 }: {
   partition: PartitionResponse;
+  showUpload: boolean;
   showEdit: boolean;
   showDelete: boolean;
 }) {
@@ -79,6 +81,17 @@ function RowActions({
 
   return (
     <div className="flex items-center gap-1">
+      {showUpload && (
+        <Button variant="ghost" size="icon-xs" asChild>
+          <Link
+            to={`/documents?partition=${encodeURIComponent(partition.name)}&upload=1`}
+            aria-label={`Upload documents to ${partition.name}`}
+            title={`Upload documents to ${partition.name}`}
+          >
+            <FilePlus className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      )}
       {showEdit && (
         <Button variant="ghost" size="icon-xs" asChild>
           <Link
@@ -128,7 +141,7 @@ function SortButton({ label, active, direction, onClick }: { label: string; acti
 
 export default function PartitionListPage() {
   const queryClient = useQueryClient();
-  const { canManagePartitions, canConfigurePartition } = usePermissions();
+  const { canManagePartitions, canConfigurePartition, canWrite } = usePermissions();
   const [dialogOpen, setDialogOpen] = useState(false);
 
   // Open the create dialog directly when arriving from the Overview quick action
@@ -583,6 +596,7 @@ export default function PartitionListPage() {
                       <TableCell>
                         <RowActions
                           partition={p}
+                          showUpload={canWrite(p.role)}
                           showEdit={canManagePartitions}
                           showDelete={canConfigurePartition(p.role)}
                         />

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -275,12 +275,11 @@ export default function PartitionListPage() {
     return items;
   }, [partitionsQuery.data, search, sortDir, sortColumn]);
 
-  // Show a delete affordance for anyone the backend (`require_partition_owner`)
-  // would allow: admins (satisfied via SUPER_ADMIN_MODE) and partition owners.
-  // `canConfigurePartition(role)` is `superAdmin || role === "owner"`, so a
-  // non-admin owner can delete their own partition — not just admins.
+  // Show the actions column whenever the row has at least one available row
+  // action: upload for writable partitions, or edit/delete for admins/owners.
   const showActions =
-    canManagePartitions || filteredAndSorted.some((p) => canConfigurePartition(p.role));
+    canManagePartitions ||
+    filteredAndSorted.some((p) => canWrite(p.role) || canConfigurePartition(p.role));
 
   const pageCount = Math.ceil(filteredAndSorted.length / PARTITIONS_PAGE_SIZE);
   useEffect(() => {

--- a/ui/src/pages/admin/users/list.test.tsx
+++ b/ui/src/pages/admin/users/list.test.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listUsers } from "@/lib/api/users";
+import UserListPage from "./list";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/system", () => ({
+  getConfig: vi.fn().mockResolvedValue({ rdb: { default_file_quota: 200 } }),
+}));
+
+vi.mock("@/lib/api/users", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/users")>("@/lib/api/users");
+  return {
+    ...actual,
+    listUsers: vi.fn(),
+    deleteUser: vi.fn(),
+    createUser: vi.fn(),
+  };
+});
+
+const listUsersMock = vi.mocked(listUsers);
+
+function renderUsers() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <UserListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("UserListPage", () => {
+  beforeEach(() => {
+    listUsersMock.mockResolvedValue({
+      users: [
+        {
+          id: 2,
+          display_name: "Ada Lovelace",
+          external_user_id: "ada",
+          email: "ada@example.test",
+          is_admin: false,
+          file_quota: null,
+          file_count: 0,
+          created_at: null,
+        },
+      ],
+    });
+  });
+
+  it("uses compact labelled row icon actions", async () => {
+    renderUsers();
+
+    const view = await screen.findByRole("link", { name: /view ada lovelace/i });
+    const deleteAction = screen.getByRole("button", { name: /delete ada lovelace/i });
+
+    expect(view.getAttribute("data-size")).toBe("icon-xs");
+    expect(deleteAction.getAttribute("data-size")).toBe("icon-xs");
+  });
+});

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -119,30 +119,36 @@ export default function UserListPage() {
     {
       id: "actions",
       header: "Actions",
-      cell: ({ row }) => (
-        <div className="flex gap-1">
-          <Button size="sm" variant="ghost" asChild>
-            <Link to={`/users/${row.original.id}`}>
-              <Eye className="h-3 w-3" />
-            </Link>
-          </Button>
-          <ConfirmDialog
-            title="Delete user?"
-            description={`Permanently delete "${row.original.display_name || `User #${row.original.id}`}"? This removes them from all partitions and invalidates their token.`}
-            onConfirm={() => deleteMut.mutate(row.original.id)}
-          >
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-destructive"
-              disabled={row.original.id === 1}
-              title={row.original.id === 1 ? "The default admin cannot be deleted" : undefined}
-            >
-              <Trash2 className="h-3 w-3" />
+      cell: ({ row }) => {
+        const label = row.original.display_name || `User #${row.original.id}`;
+        const deleteLabel = row.original.id === 1 ? "The default admin cannot be deleted" : `Delete ${label}`;
+
+        return (
+          <div className="flex items-center gap-1">
+            <Button size="icon-xs" variant="ghost" asChild>
+              <Link to={`/users/${row.original.id}`} aria-label={`View ${label}`} title={`View ${label}`}>
+                <Eye className="h-3.5 w-3.5" />
+              </Link>
             </Button>
-          </ConfirmDialog>
-        </div>
-      ),
+            <ConfirmDialog
+              title="Delete user?"
+              description={`Permanently delete "${label}"? This removes them from all partitions and invalidates their token.`}
+              onConfirm={() => deleteMut.mutate(row.original.id)}
+            >
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                className="text-destructive"
+                disabled={row.original.id === 1}
+                aria-label={deleteLabel}
+                title={deleteLabel}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </ConfirmDialog>
+          </div>
+        );
+      },
     },
   ];
 


### PR DESCRIPTION
## Summary

Fixes #689.

This keeps row action buttons consistent across the Admin UI tables. Documents already used the compact icon-only treatment; Partitions and Users now use the same compact size so the action columns line up visually.

It also adds a compact upload action on each writable partition row. The action sends the user to Documents with that partition selected and opens the existing upload dialog, so users can add documents directly from the partition they are looking at.

The Users table also gets accessible names and titles for the icon-only view/delete actions while keeping the existing behavior unchanged.

## Validation

- `npm test -- --run`
- `npm test -- --run src/pages/admin/partitions/list.test.tsx src/pages/admin/documents/list.test.tsx src/pages/admin/users/list.test.tsx`
- `npm run lint`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permission-gated per-row upload action to partitions.
  * Enhanced document upload dialog handling via URL parameters, including scoped upload routing and automatic query cleanup when alignment fails.
* **Accessibility**
  * Improved “view” and “delete” controls with consistent aria-labels/titles and updated confirmation text.
* **Style**
  * Standardized admin list action icons to a compact icon size.
* **Bug Fixes**
  * Ensured upload/delete visibility matches effective write permissions, including editor-only and super-admin resolution behavior.
* **Tests**
  * Expanded documents/partitions/users and permissions test coverage for icon sizing, dialog behavior, and permission resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->