### PR TITLE
test(repos): assert create_partition rejects duplicates, as it does

### DIFF
--- a/tests/integration/repos/test_partition_repo.py
+++ b/tests/integration/repos/test_partition_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from core.utils.exceptions import ValidationError
 from services.storage.postgres_store import PostgresStore
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
@@ -23,12 +24,28 @@ class TestCreateList:
         names = {row["partition"] for row in await repo.list_partitions()}
         assert {"p1", "p2"} <= names
 
-    async def test_create_is_idempotent_per_name(self, postgres_store: PostgresStore):
+    async def test_create_rejects_a_duplicate_name(self, postgres_store: PostgresStore):
+        """A second create is a 409, not a silent success.
+
+        The repo deliberately does not treat an existing partition as a
+        successful create: the service layer needs the distinction so it does
+        not overwrite preset/config fields for a partition it did not create.
+        Callers that want ensure-exists opt in explicitly — seed_default_partition
+        guards with partition_exists first, and IndexingService catches
+        PARTITION_EXISTS to treat the create race as success.
+
+        This test used to assert the opposite ("the legacy method swallows the
+        conflict") and had been failing on develop ever since that behaviour was
+        deliberately changed.
+        """
         repo = postgres_store.partition_repo
         await repo.create_partition("dup")
-        # The legacy method swallows the conflict and returns the existing row
-        # rather than raising. Orchestrators rely on this for "ensure exists".
-        await repo.create_partition("dup")
+
+        with pytest.raises(ValidationError) as excinfo:
+            await repo.create_partition("dup")
+        assert excinfo.value.code == "PARTITION_EXISTS"
+
+        # The rejected create must not have left a second row behind.
         assert await repo.partition_exists("dup") is True
         assert len([r for r in await repo.list_partitions() if r["partition"] == "dup"]) == 1
 


### PR DESCRIPTION
`test_create_is_idempotent_per_name` has been failing on `develop`. It asserts that a second `create_partition` swallows the conflict and returns the existing row:

```python
# The legacy method swallows the conflict and returns the existing row
# rather than raising. Orchestrators rely on this for "ensure exists".
await repo.create_partition("dup")
```

`PgPartitionRepository.create_partition` deliberately does the opposite — it raises `PARTITION_EXISTS`, and says why:

> Existing partitions are not treated as successful creates. The service layer needs that distinction so it does not update preset/config fields for a partition it did not create.

So the test was asserting behaviour that had been intentionally removed. **No production bug** — I checked both ensure-exists callers and they opt in explicitly: `seed_default_partition` guards with `partition_exists` first, and `IndexingService` catches `PARTITION_EXISTS` to treat the create race as success. Only the test was stale.

Rewritten to pin the real contract: a duplicate create raises `PARTITION_EXISTS` and leaves no second row. The docstring now records the intent and names the two opt-in callers, so the next reader doesn't "restore" the old behaviour.

## Verification

- `tests/integration/repos` against a real Postgres: **82 passed, 1 failed** (was 81/2).
- `ruff check` / `ruff format --check` clean.
- The one remaining failure — `test_delete_cascades_files_and_decrements_uploader_count`, dead on a `create_legacy_user` signature drift — is fixed in #677, which owns that test because it redefines the `file_count` counter the test asserts. Kept out of here to avoid conflicting on the same hunk.

Found while reviewing #677; unrelated to it, so it is split out rather than widening that diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate partition names are now rejected with a clear validation error.
  * Failed duplicate creation attempts no longer create additional partition records.

* **Tests**
  * Updated coverage to verify the error code and ensure data remains unchanged after a rejected request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->