### PR TITLE
fix(indexing): use the configured image-captioning prompt instead of the bare VLM default

### DIFF
--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -35,7 +35,11 @@ class IndexerWorkerActor:
         from core.utils.logging import get_logger
         from services.storage.milvus_store import MilvusVectorStore
         from services.storage.postgres_store import PostgresStore
-        from services.workers.parsers.parser_dispatcher import build_caption_vlm, build_parser_dispatcher
+        from services.workers.parsers.parser_dispatcher import (
+            build_caption_vlm,
+            build_parser_dispatcher,
+            load_caption_prompt,
+        )
         from services.workers.pipeline_builder import build_indexing_pipeline
 
         cfg = load_config()
@@ -43,6 +47,7 @@ class IndexerWorkerActor:
         parser = build_parser_dispatcher(cfg)
         parser_factory = _build_parser_factory(parser)
         vlm = build_caption_vlm(cfg)
+        caption_prompt = load_caption_prompt(cfg) if vlm is not None else None
         chunker = _build_chunker(cfg)
         embedder_factory = _build_embedder_factory(cfg)
         vlm_factory = _build_vlm_factory(cfg)
@@ -68,6 +73,7 @@ class IndexerWorkerActor:
             embedder=embedder,
             vector_store=self._vector_store,
             vlm=vlm,
+            caption_prompt=caption_prompt,
             timeouts=_build_pipeline_timeouts(cfg),
             chunker_factory=_build_chunker_from_config,
             parser_factory=parser_factory,

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -47,7 +47,14 @@ class IndexerWorkerActor:
         parser = build_parser_dispatcher(cfg)
         parser_factory = _build_parser_factory(parser)
         vlm = build_caption_vlm(cfg)
-        caption_prompt = load_caption_prompt(cfg) if vlm is not None else None
+        # Loaded unconditionally: a preset can caption through a *named* VLM
+        # endpoint (resolved per-row via vlm_factory, see
+        # IndexingPipeline._select_vlm) even when no global default is
+        # configured, so gating this on `vlm is not None` would silently skip
+        # the prompt for that deployment shape. load_caption_prompt already
+        # degrades to None on any load failure, so there's no safety
+        # trade-off in always calling it.
+        caption_prompt = load_caption_prompt(cfg)
         chunker = _build_chunker(cfg)
         embedder_factory = _build_embedder_factory(cfg)
         vlm_factory = _build_vlm_factory(cfg)

--- a/openrag/services/workers/parsers/file_serializer.py
+++ b/openrag/services/workers/parsers/file_serializer.py
@@ -25,11 +25,16 @@ class ParserFileSerializer(FileSerializer):
 
     def __init__(self) -> None:
         from core.config import load_config
-        from services.workers.parsers.parser_dispatcher import build_caption_vlm, build_parser_dispatcher
+        from services.workers.parsers.parser_dispatcher import (
+            build_caption_vlm,
+            build_parser_dispatcher,
+            load_caption_prompt,
+        )
 
         config = load_config()
         self._dispatcher = build_parser_dispatcher(config)
         self._vlm = build_caption_vlm(config)
+        self._caption_prompt = load_caption_prompt(config) if self._vlm is not None else None
         # Global gate for captioning images embedded in other documents.
         # Standalone image files are always captioned (see ``serialize``).
         self._image_captioning = bool(config.loader.image_captioning)
@@ -57,7 +62,7 @@ class ParserFileSerializer(FileSerializer):
             and (document.content_type is DocumentType.IMAGE or self._image_captioning)
         )
         if should_caption:
-            processed = await _caption_document(processed, self._vlm, None)
+            processed = await _caption_document(processed, self._vlm, self._caption_prompt)
 
         return "\n\n".join(block.text for block in processed.text_blocks if block.text)
 

--- a/openrag/services/workers/parsers/parser_dispatcher.py
+++ b/openrag/services/workers/parsers/parser_dispatcher.py
@@ -307,4 +307,29 @@ def build_caption_vlm(config: Any) -> Any | None:
     )
 
 
-__all__ = ["ParserDispatcher", "build_parser_dispatcher", "build_caption_vlm"]
+def load_caption_prompt(config: Any) -> str | None:
+    """Load the configured image-captioning template (``prompts.image_describer``).
+
+    Returns the template text, or ``None`` if it can't be resolved — in which
+    case captioning falls back to the VLM client's built-in default rather than
+    failing indexing. Mirrors how the contextualizer/topic-tagger prompts are
+    loaded (``load_template_by_key``).
+
+    FORWARD-COMPAT: the config key is ``image_describer`` but the corresponding
+    ``PromptType`` in the planned prompt-management work is ``image_captioning``
+    — the two will be unified there. This disk-template load is that design's
+    tier-3 (ultimate) fallback; a future ``PromptService`` will front it with
+    per-partition and global-default tiers.
+    """
+    from core.prompts import load_template_by_key
+
+    try:
+        return load_template_by_key(config.paths.prompts_dir, config.prompts, "image_describer")
+    except (ValueError, FileNotFoundError, AttributeError) as exc:
+        # Missing template / partial config must never break indexing — captioning
+        # degrades to the VLM client's built-in default prompt.
+        logger.warning(f"Could not load image-captioning prompt (image_describer); using VLM default: {exc}")
+        return None
+
+
+__all__ = ["ParserDispatcher", "build_parser_dispatcher", "build_caption_vlm", "load_caption_prompt"]

--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -53,6 +53,7 @@ class IndexingPipeline:
     embedder: Embedder
     vector_store: VectorStore
     vlm: VLM | None = None
+    caption_prompt: str | None = None
     contextualizer: ChunkContextualizer | None = None
     topic_tagger: TopicTagger | None = None
     timeouts: PipelineTimeouts = PipelineTimeouts()
@@ -113,6 +114,19 @@ class IndexingPipeline:
                 embedder=str(row.get("embedder_name") or "default"),
             ).debug("model endpoints resolved for indexing (None = stage disabled)")
             if vlm is not None:
+                # Inject the configured captioning template (image_describer)
+                # unless the row already carries an explicit override, so the VLM
+                # gets the real prompt instead of its bare built-in fallback.
+                #
+                # FORWARD-COMPAT: this ``row["caption_prompt"]`` seam is the
+                # intended hook for the planned DB-backed prompt management — a
+                # future ``PromptService.resolve(partition, "image_captioning")``
+                # would populate it per-partition here (partition override →
+                # global default → disk seed), superseding the process-wide
+                # ``self.caption_prompt`` default. ``setdefault`` already lets a
+                # per-row value win, so that migration is a one-line change.
+                if self.caption_prompt is not None:
+                    row.setdefault("caption_prompt", self.caption_prompt)
                 await _timed(
                     "caption",
                     caption_stage(
@@ -366,6 +380,7 @@ def build_indexing_pipeline(
     embedder: Embedder,
     vector_store: VectorStore,
     vlm: VLM | None = None,
+    caption_prompt: str | None = None,
     contextualizer: ChunkContextualizer | None = None,
     topic_tagger: TopicTagger | None = None,
     timeouts: PipelineTimeouts | None = None,
@@ -385,6 +400,7 @@ def build_indexing_pipeline(
         embedder=embedder,
         vector_store=vector_store,
         vlm=vlm,
+        caption_prompt=caption_prompt,
         contextualizer=contextualizer,
         topic_tagger=topic_tagger,
         timeouts=timeouts or PipelineTimeouts(),

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1052,6 +1052,76 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
     assert captured["vlm_factory"] is vlm_factory
 
 
+def test_indexer_pool_loads_caption_prompt_without_global_vlm_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A preset can caption through a *named* VLM endpoint (resolved per-row via
+    # vlm_factory) even when no global default VLM is configured. The caption
+    # prompt must still be loaded in that case, or that preset silently falls
+    # back to the VLM client's bare default (#692 regression for named VLMs).
+    import core.config
+    import core.embeddings
+    import services.storage.milvus_store as milvus_store
+    import services.storage.postgres_store as postgres_store
+    import services.workers.indexer_pool as module
+    import services.workers.parsers.parser_dispatcher as parser_dispatcher
+    import services.workers.pipeline_builder as pipeline_builder
+
+    captured = {}
+
+    class RDBConfig:
+        def model_copy(self, *, update):
+            return SimpleNamespace(**update)
+
+    cfg = SimpleNamespace(
+        embedder=SimpleNamespace(
+            base_url="http://embedder/v1",
+            model_name="embed-model",
+            api_key="embed-key",
+            max_model_len=2048,
+            timeout=30,
+            batch_size=32,
+            embed_concurrency=2,
+        ),
+        loader=SimpleNamespace(parse_timeout=3600, save_uploaded_files=True),
+        vectordb=SimpleNamespace(collection_name="vdb_test"),
+        rdb=RDBConfig(),
+    )
+
+    class Store:
+        document_repo = object()
+        topic_tag_repo = object()
+
+    class Worker:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_build_pipeline(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(core.config, "load_config", lambda: cfg)
+    monkeypatch.setattr(module, "_build_chunker", lambda _cfg: object())
+    monkeypatch.setattr(module, "_build_embedder_factory", lambda _cfg: object())
+    monkeypatch.setattr(module, "_build_vlm_factory", lambda _cfg: object())
+    monkeypatch.setattr(module, "_build_contextualizer_factory", lambda _cfg: object())
+    monkeypatch.setattr(module, "_build_topic_tagger_factory", lambda _cfg: object())
+    monkeypatch.setattr(core.embeddings.embedder_registry, "create", lambda *args, **kwargs: object())
+    monkeypatch.setattr(milvus_store, "MilvusVectorStore", lambda _cfg: object())
+    monkeypatch.setattr(postgres_store, "PostgresStore", lambda *args, **kwargs: Store())
+    monkeypatch.setattr(parser_dispatcher, "build_parser_dispatcher", lambda _cfg: object())
+    # No global default VLM endpoint configured.
+    monkeypatch.setattr(parser_dispatcher, "build_caption_vlm", lambda _cfg: None)
+    monkeypatch.setattr(parser_dispatcher, "load_caption_prompt", lambda _cfg: "TEMPLATE TEXT")
+    monkeypatch.setattr(pipeline_builder, "build_indexing_pipeline", fake_build_pipeline)
+    monkeypatch.setattr(module.ray, "get_actor", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module, "IndexerWorker", Worker)
+
+    actor_class = module.IndexerWorkerActor.__ray_metadata__.modified_class
+    actor_class()
+
+    assert captured["vlm"] is None
+    assert captured["caption_prompt"] == "TEMPLATE TEXT"
+
+
 # ---------------------------------------------------------------------------
 # Tests — IndexerWorkerActor.process_file upload cleanup (SAVE_UPLOADED_FILES)
 #

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -1,8 +1,22 @@
+from contextlib import asynccontextmanager
+
 import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
 from core.models.chunk import Chunk
 from core.models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock
 from services.workers.pipeline_builder import build_indexing_pipeline
+from services.workers.stages import caption as caption_module
+
+
+@pytest.fixture(autouse=True)
+def _noop_vlm_semaphore(monkeypatch):
+    """Stub the cluster-wide VLM semaphore so caption tests don't boot Ray."""
+
+    @asynccontextmanager
+    async def _noop():
+        yield
+
+    monkeypatch.setattr(caption_module, "get_vlm_semaphore", _noop)
 
 
 class FakeParser:
@@ -57,9 +71,11 @@ class FakeVectorStore:
 class FakeVLM:
     def __init__(self) -> None:
         self.calls: list[bytes] = []
+        self.prompts: list[str | None] = []
 
     async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
         self.calls.append(image_bytes)
+        self.prompts.append(prompt)
         return "caption"
 
 
@@ -173,6 +189,45 @@ async def test_pipeline_indexation_config_disables_caption_and_contextualization
     assert vlm.calls == []
     assert contextualizer.calls == []
     assert row["stage"] == "stored"
+
+
+def _caption_pipeline(vlm: FakeVLM, caption_prompt: str | None):
+    document = Document(filename="note.txt", text="hello", partition="tenant-a")
+    processed = ProcessedDocument(
+        document_id=document.id,
+        text_blocks=[TextBlock(text="hello")],
+        images=[ImageBlock(image_bytes=b"png")],
+    )
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([Chunk(id="c1", text="hello", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=FakeVectorStore(),
+        vlm=vlm,
+        caption_prompt=caption_prompt,
+    )
+    return pipeline, document
+
+
+@pytest.mark.asyncio
+async def test_pipeline_injects_configured_caption_prompt():
+    # The captioning template configured on the pipeline (image_describer) must
+    # reach the VLM instead of its bare built-in fallback.
+    vlm = FakeVLM()
+    pipeline, document = _caption_pipeline(vlm, caption_prompt="DESCRIBE THE IMAGE TEMPLATE")
+    await pipeline.run({"document": document, "partition": "tenant-a", "filename": "note.txt"})
+    assert vlm.prompts == ["DESCRIBE THE IMAGE TEMPLATE"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_row_caption_prompt_overrides_configured_default():
+    # An explicit per-row caption_prompt wins over the pipeline default.
+    vlm = FakeVLM()
+    pipeline, document = _caption_pipeline(vlm, caption_prompt="DEFAULT TEMPLATE")
+    await pipeline.run(
+        {"document": document, "partition": "tenant-a", "filename": "note.txt", "caption_prompt": "ROW OVERRIDE"}
+    )
+    assert vlm.prompts == ["ROW OVERRIDE"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #692.

## Problem
The VLM image-captioning prompt template was never wired into the pipeline, so captioning silently used the client fallback `"Describe this image in detail."` instead of the shipped `image_captioning_tmpl.txt`. `caption_stage` reads `row["caption_prompt"]`, but nothing ever set it; `PromptsConfig.image_describer` and `IndexationPipelineConfig.vlm_caption_prompt_name` had no consumers (wiring dropped in the hexagonal refactor).

Impact: the rich prompt (transcribe text, format tables as markdown, emit `[Image Placeholder]` for non-informative images) was not used — and the chunker depends on it (`BaseChunker._prepare_md_elements` skips blocks containing `[image placeholder]`, which the bare prompt never produces).

## Fix
Mirror how the contextualizer prompt is loaded (`load_template_by_key(cfg.paths.prompts_dir, cfg.prompts, "chunk_contextualizer")`):
- New `load_caption_prompt(config)` loads `prompts.image_describer`, degrading to `None` (VLM built-in default) on a missing template / partial config so indexing never fails.
- Injected on both caption paths: the indexing pipeline (new `IndexingPipeline.caption_prompt`, set on `row["caption_prompt"]` and honoring a per-row override) and the extract path (`ParserFileSerializer`).

The `row["caption_prompt"]` seam is intentionally the hook for the planned DB-backed prompt management (a future `PromptService.resolve(partition, "image_captioning")` populates it per-partition; this disk load is that design's tier-3 fallback) — noted in code comments.

## Tests
- New: template reaches the VLM; an explicit per-row `caption_prompt` overrides the configured default.
- All `tests/unit/services/workers/` pass (176); `ruff check` / `ruff format --check` / `check_layer_imports.py` green.

## Verification caveat
Verified at the wiring level (the VLM now receives the template) via unit tests. True end-to-end captioning (a real caption containing `[Image Placeholder]`, chunker skipping it) needs a VLM+GPU and should be smoke-tested on a deployment before merge.

Follow-up (separate): honor the per-preset `vlm_caption_prompt_name` override — deferred, and likely superseded by the `partition_prompts` mechanism in the prompt-management plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image captioning now supports a configurable prompt template, which is loaded during worker/pipeline setup and forwarded to the captioning stage.
  * A pipeline default caption prompt can be applied automatically, while per-row/per-image caption prompt values override it when provided.
* **Bug Fixes**
  * Caption prompt loading no longer relies on a global captioning VLM being configured; if the template can’t be loaded, captioning safely falls back to the VLM’s default.
* **Tests**
  * Added unit tests to verify prompt forwarding, per-row override precedence, and prompt loading without a global caption VLM default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->