### PR TITLE
Prevent duplicate document content within a partition

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -154,13 +154,16 @@ prompts:
 
 # --- Document loader ---
 loader:
-  # Env: IMAGE_CAPTIONING, IMAGE_CAPTIONING_URL, SAVE_MARKDOWN, SAVE_UPLOADED_FILES
+  # Env: IMAGE_CAPTIONING, IMAGE_CAPTIONING_URL, SAVE_MARKDOWN, SAVE_UPLOADED_FILES,
+  #      CONTENT_DEDUPLICATION_ENABLED
   image_captioning: true
   image_captioning_url: true
   save_markdown: false
   # Keep the raw upload on disk after indexation (needed for source viewing in
   # Chainlit). Set false for clients that manage their own files (e.g. Twake).
   save_uploaded_files: true
+  # Reject identical content inside the same partition before indexing.
+  content_deduplication_enabled: true
 
   mimetypes:
     text/plain: .txt

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -21,7 +21,8 @@ Openrag loads all files into a pivot markdown file format before proceeding to c
 | `IMAGE_CAPTIONING` | `bool` | `true` | If `true`, an LLM is used to describe images and convert them into text using a [specific prompt](https://github.com/linagora/openrag/blob/main/openrag/prompts/templates/image_captioning_tmpl.txt). The image in files are replaced by their descriptions |
 | `IMAGE_CAPTIONING_URL` | `bool` | `true` | If `true`, HTTP/HTTPS image URLs in markdown files are fetched and described by the VLM. |
 | `SAVE_MARKDOWN` | `bool` | `false` | If `true`, the pivot-format markdown produced during parsing is saved. Useful for debugging and verifying the correctness of the generated markdown. |
-|`SAVE_UPLOADED_FILES`|`bool`|`false`| When `true`, uploaded files are stored on disk. You must enable this option if you want Chainlit to show sources while chatting.|
+|`SAVE_UPLOADED_FILES`|`bool`|`true`| When `true`, uploaded files are stored on disk. You must enable this option if you want Chainlit to show sources while chatting.|
+| `CONTENT_DEDUPLICATION_ENABLED` | `bool` | `true` | Rejects a file when identical content already exists in the same partition. Set it to `false` when a test intentionally indexes duplicates. |
 | `PDFLOADER` | `str` | `PyMuPDFLoader` | PDF parsing engine. `PyMuPDFLoader` (default) is a lightweight, fast, CPU-friendly backend for searchable PDFs. Switch to `MarkerLoader` for OCR / scanned documents, complex layouts and embedded images (heavier; GPU-friendly). Other options: `DoclingLoader`, `DotsOCRLoader`.|
 | `PARSE_TIMEOUT` | `int` | `3600` | Outer wall-clock bound (in seconds) for a single file's parse stage, whichever loader runs it. Marker and Docling self-limit via their own timeouts, but `PyMuPDFLoader` has none — this bound stops a wedged parse from stalling indexing: the file fails and is reported instead. |
 

--- a/openrag/api/dependencies/files.py
+++ b/openrag/api/dependencies/files.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,13 @@ from di.providers import get_config
 from fastapi import Depends, Form, UploadFile
 
 FORBIDDEN_CHARS_IN_FILE_ID = set("/")
+
+
+@dataclass(frozen=True, slots=True)
+class SavedUpload:
+    path: Path
+    sha256: str
+    size_bytes: int
 
 
 def _max_upload_size_bytes() -> int:
@@ -59,6 +68,40 @@ async def save_file_to_disk(
     with_random_prefix: bool = False,
 ) -> Path:
     """Save an uploaded file to disk in chunks and return the saved path."""
+    saved = await _save_file_to_disk(
+        file=file,
+        dest_dir=dest_dir,
+        chunk_size=chunk_size,
+        with_random_prefix=with_random_prefix,
+        calculate_sha256=False,
+    )
+    return saved.path
+
+
+async def save_file_to_disk_with_sha256(
+    file: UploadFile,
+    dest_dir: Path,
+    chunk_size: int = consts.FILE_READ_CHUNK_SIZE,
+    with_random_prefix: bool = False,
+) -> SavedUpload:
+    """Save an upload and calculate its SHA-256 digest in the same pass."""
+    return await _save_file_to_disk(
+        file=file,
+        dest_dir=dest_dir,
+        chunk_size=chunk_size,
+        with_random_prefix=with_random_prefix,
+        calculate_sha256=True,
+    )
+
+
+async def _save_file_to_disk(
+    *,
+    file: UploadFile,
+    dest_dir: Path,
+    chunk_size: int,
+    with_random_prefix: bool,
+    calculate_sha256: bool,
+) -> SavedUpload:
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_dir = dest_dir.resolve()
 
@@ -76,6 +119,7 @@ async def save_file_to_disk(
 
     max_bytes = _max_upload_size_bytes()
     total = 0
+    hasher = hashlib.sha256() if calculate_sha256 else None
     try:
         async with aiofiles.open(file_path, "wb") as buffer:
             while True:
@@ -88,10 +132,16 @@ async def save_file_to_disk(
                         f"File exceeds the maximum allowed size of {max_bytes // (1024 * 1024)} MB.",
                         status_code=413,
                     )
+                if hasher is not None:
+                    hasher.update(chunk)
                 await buffer.write(chunk)
-    except ValidationError:
+    except BaseException:
         # Remove the partially written file before propagating.
         file_path.unlink(missing_ok=True)
         raise
 
-    return file_path
+    return SavedUpload(
+        path=file_path,
+        sha256=hasher.hexdigest() if hasher is not None else "",
+        size_bytes=total,
+    )

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -298,17 +298,26 @@ async def put_file(
     # duplicates behind (recoverable; #658/#660 reconciliation covers that).
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
-    if getattr(getattr(config, "loader", None), "content_deduplication_enabled", True):
-        saved_upload = await save_file_to_disk_with_sha256(
-            file,
-            Path(config.paths.data_dir),
-            with_random_prefix=True,
+    try:
+        if getattr(getattr(config, "loader", None), "content_deduplication_enabled", True):
+            saved_upload = await save_file_to_disk_with_sha256(
+                file,
+                Path(config.paths.data_dir),
+                with_random_prefix=True,
+            )
+            file_path = saved_upload.path
+            content_sha256 = saved_upload.sha256
+        else:
+            file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
+            content_sha256 = None
+    except OpenRAGError:
+        raise
+    except Exception as e:
+        logger.exception("Failed to save file to disk.", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save uploaded file.",
         )
-        file_path = saved_upload.path
-        content_sha256 = saved_upload.sha256
-    else:
-        file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
-        content_sha256 = None
 
     try:
         task_id = await service.add_file(

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -25,13 +25,14 @@ from api.dependencies.auth import (
 )
 from api.dependencies.files import (
     save_file_to_disk,
+    save_file_to_disk_with_sha256,
     validate_file_format,
     validate_file_id,
     validate_metadata,
 )
 from api.routers.admin.task_logs import collect_task_logs
 from core.models.catalog import TERMINAL_TASK_STATES
-from core.utils.exceptions import OpenRAGError
+from core.utils.exceptions import ConflictError, OpenRAGError
 from core.utils.filename import sanitize_filename
 from core.utils.log_tail import app_log_file
 from core.utils.logging import get_logger
@@ -136,24 +137,6 @@ async def add_file(
             detail=f"File '{file_id}' already exists in partition {partition}",
         )
 
-    original_filename = file.filename
-    file.filename = sanitize_filename(file.filename)
-    try:
-        file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
-    except OpenRAGError:
-        # Domain errors (e.g. 413 too-large, 400 bad filename) carry their own
-        # HTTP status; let the OpenRAGError handler map them instead of masking
-        # the upload rejection as a 500.
-        raise
-    except Exception as e:
-        # Log the full error server-side; return a generic message so we don't
-        # leak filesystem paths or internals to the client.
-        logger.exception("Failed to save file to disk.", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to save uploaded file.",
-        )
-
     parsed_workspace_ids = None
     if workspace_ids:
         try:
@@ -173,16 +156,49 @@ async def add_file(
                     detail=f"Workspace '{ws_id}' not found in partition '{partition}'",
                 )
 
-    task_id = await service.add_file(
-        file_path=str(file_path),
-        file_id=file_id,
-        partition=partition,
-        metadata=metadata,
-        sanitized_filename=file.filename,
-        original_filename=original_filename,
-        user=user,
-        workspace_ids=parsed_workspace_ids,
-    )
+    original_filename = file.filename
+    file.filename = sanitize_filename(file.filename)
+    try:
+        if getattr(getattr(config, "loader", None), "content_deduplication_enabled", True):
+            saved_upload = await save_file_to_disk_with_sha256(
+                file,
+                Path(config.paths.data_dir),
+                with_random_prefix=True,
+            )
+            file_path = saved_upload.path
+            content_sha256 = saved_upload.sha256
+        else:
+            file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
+            content_sha256 = None
+    except OpenRAGError:
+        # Domain errors (e.g. 413 too-large, 400 bad filename) carry their own
+        # HTTP status; let the OpenRAGError handler map them instead of masking
+        # the upload rejection as a 500.
+        raise
+    except Exception as e:
+        # Log the full error server-side; return a generic message so we don't
+        # leak filesystem paths or internals to the client.
+        logger.exception("Failed to save file to disk.", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save uploaded file.",
+        )
+
+    try:
+        task_id = await service.add_file(
+            file_path=str(file_path),
+            file_id=file_id,
+            partition=partition,
+            metadata=metadata,
+            sanitized_filename=file.filename,
+            original_filename=original_filename,
+            user=user,
+            workspace_ids=parsed_workspace_ids,
+            content_sha256=content_sha256,
+        )
+    except BaseException:
+        file_path.unlink(missing_ok=True)
+        raise
 
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
@@ -282,18 +298,33 @@ async def put_file(
     # duplicates behind (recoverable; #658/#660 reconciliation covers that).
     original_filename = file.filename
     file.filename = sanitize_filename(file.filename)
-    file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
+    if getattr(getattr(config, "loader", None), "content_deduplication_enabled", True):
+        saved_upload = await save_file_to_disk_with_sha256(
+            file,
+            Path(config.paths.data_dir),
+            with_random_prefix=True,
+        )
+        file_path = saved_upload.path
+        content_sha256 = saved_upload.sha256
+    else:
+        file_path = await save_file_to_disk(file, Path(config.paths.data_dir), with_random_prefix=True)
+        content_sha256 = None
 
-    task_id = await service.add_file(
-        file_path=str(file_path),
-        file_id=file_id,
-        partition=partition,
-        metadata=metadata,
-        sanitized_filename=file.filename,
-        original_filename=original_filename,
-        user=user,
-        replace=True,
-    )
+    try:
+        task_id = await service.add_file(
+            file_path=str(file_path),
+            file_id=file_id,
+            partition=partition,
+            metadata=metadata,
+            sanitized_filename=file.filename,
+            original_filename=original_filename,
+            user=user,
+            replace=True,
+            content_sha256=content_sha256,
+        )
+    except BaseException:
+        file_path.unlink(missing_ok=True)
+        raise
 
     return JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,

--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -32,7 +32,7 @@ from api.dependencies.files import (
 )
 from api.routers.admin.task_logs import collect_task_logs
 from core.models.catalog import TERMINAL_TASK_STATES
-from core.utils.exceptions import ConflictError, OpenRAGError
+from core.utils.exceptions import OpenRAGError
 from core.utils.filename import sanitize_filename
 from core.utils.log_tail import app_log_file
 from core.utils.logging import get_logger

--- a/openrag/core/config/indexation.py
+++ b/openrag/core/config/indexation.py
@@ -166,6 +166,10 @@ class LoaderConfig(ConfigMixin):
     # keeps its own copy: the file is then removed from disk once indexing settles,
     # so only the derived chunks are retained.
     save_uploaded_files: bool = True
+    # Reject identical content inside one partition before expensive parsing,
+    # embedding, and storage. The upload hash is calculated while streaming the
+    # file to disk, so this does not add a second read for HTTP uploads.
+    content_deduplication_enabled: bool = True
     mimetypes: MimetypesConfig = Field(default_factory=MimetypesConfig)
     local_whisper: LocalWhisperConfig = Field(default_factory=LocalWhisperConfig)
     file_loaders: FileLoadersConfig = Field(default_factory=FileLoadersConfig)

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -97,6 +97,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("IMAGE_CAPTIONING_URL", "loader.image_captioning_url", bool),
     ("SAVE_MARKDOWN", "loader.save_markdown", bool),
     ("SAVE_UPLOADED_FILES", "loader.save_uploaded_files", bool),
+    ("CONTENT_DEDUPLICATION_ENABLED", "loader.content_deduplication_enabled", bool),
     ("PDFLOADER", "loader.file_loaders.pdf", str),
     ("AUDIOLOADER", "loader.file_loaders.wav", str),
     ("MARKER_MAX_TASKS_PER_CHILD", "loader.marker_max_tasks_per_child", int),

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -54,6 +54,7 @@ class DocumentRecord(BaseModel):
     created_by: int | None = None
     relationship_id: str | None = None
     parent_id: str | None = None
+    content_sha256: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/openrag/core/ports/document_repo.py
+++ b/openrag/core/ports/document_repo.py
@@ -42,6 +42,41 @@ class DocumentRepository(ABC):
     async def file_exists_in_partition(self, file_id: str, partition: str) -> bool: ...
 
     @abstractmethod
+    async def get_content_sha256(self, file_id: str, partition: str) -> str | None: ...
+
+    @abstractmethod
+    async def claim_content_sha256(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+        replace: bool = False,
+    ) -> str | None:
+        """Reserve content for indexing, returning a conflicting file id."""
+        ...
+
+    @abstractmethod
+    async def renew_content_sha256_claim(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+    ) -> bool:
+        """Extend an active content claim owned by this file."""
+        ...
+
+    @abstractmethod
+    async def release_content_sha256_claim(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+    ) -> None: ...
+
+    @abstractmethod
     async def get_file_ids_by_relationship(self, partition: str, relationship_id: str) -> list[str]: ...
 
     @abstractmethod

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -13,6 +13,8 @@ returned via ``HTTPException``.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -49,6 +51,14 @@ def _human_readable_size(size_bytes: int) -> str:
             return f"{size:.2f} {unit}"
         size /= 1024
     return f"{size:.2f} PB"
+
+
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 class IndexingService:
@@ -98,6 +108,7 @@ class IndexingService:
         file_id: str,
         sanitized_filename: str,
         original_filename: str | None,
+        content_sha256: str | None,
     ) -> dict:
         """Assemble the indexing metadata exactly as the legacy router did."""
         metadata = dict(metadata or {})
@@ -111,6 +122,7 @@ class IndexingService:
         file_stat = Path(file_path).stat()
         metadata["file_size"] = _human_readable_size(file_stat.st_size)
         metadata["file_id"] = file_id
+        metadata["content_sha256"] = content_sha256
         metadata.update(extract_temporal_fields(metadata, temporal_fields=TEMPORAL_FIELDS))
         return metadata
 
@@ -118,6 +130,12 @@ class IndexingService:
         if self._config is None:
             return {}
         return getattr(self._config, "partitions", {}) or {}
+
+    def _deduplication_enabled(self) -> bool:
+        return bool(
+            self._config is not None
+            and getattr(getattr(self._config, "loader", None), "content_deduplication_enabled", False)
+        )
 
     @asynccontextmanager
     async def _partition_admission(self, partition: str) -> AsyncIterator[bool]:
@@ -199,18 +217,25 @@ class IndexingService:
         user: dict | None,
         workspace_ids: list[str] | None = None,
         replace: bool = False,
+        content_sha256: str | None = None,
     ) -> str:
         """Assemble metadata and queue an (re)indexing job; return its task id.
 
         Workspace association happens inside the worker's ``add_file``
         after a successful index — the router only pre-validates the ids.
         """
+        if self._deduplication_enabled() and content_sha256 is None:
+            content_sha256 = await asyncio.to_thread(_sha256_file, file_path)
+        if not self._deduplication_enabled():
+            content_sha256 = None
+
         full_metadata = self._build_metadata(
             metadata=metadata,
             file_path=file_path,
             file_id=file_id,
             sanitized_filename=sanitized_filename,
             original_filename=original_filename,
+            content_sha256=content_sha256,
         )
         async with self._partition_admission(partition) as partition_existed_at_admission:
             await self._ensure_partition_exists(partition, user)
@@ -241,6 +266,7 @@ class IndexingService:
         user: dict | None,
     ) -> None:
         metadata = dict(metadata or {})
+        metadata.pop("content_sha256", None)
         metadata["file_id"] = file_id
         await self._dispatcher.update_file_metadata(file_id, metadata, partition, user)
 
@@ -255,8 +281,12 @@ class IndexingService:
         user: dict | None,
     ) -> None:
         metadata = dict(metadata or {})
+        content_sha256 = None
+        if self._deduplication_enabled():
+            content_sha256 = await self._document_repo.get_content_sha256(source_file_id, source_partition)
         metadata["file_id"] = target_file_id
         metadata["partition"] = target_partition
+        metadata["content_sha256"] = content_sha256
         await self._dispatcher.copy_file(source_file_id, metadata, source_partition, user)
 
     # ------------------------------------------------------------------

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -609,11 +609,15 @@ class MCPService:
         suffix = Path(filename).suffix or ""
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp_path = Path(tmp.name)
+        download_complete = False
         try:
             await self._safe_download(url, tmp_path)
+            download_complete = True
         except Exception as exc:
-            tmp_path.unlink(missing_ok=True)
             raise RuntimeError(f"Failed to download '{url}': {exc}") from exc
+        finally:
+            if not download_complete:
+                tmp_path.unlink(missing_ok=True)
 
         metadata = _strip_protected_metadata(extra_metadata)
         metadata["source_url"] = url
@@ -621,15 +625,19 @@ class MCPService:
         if guessed_mime and "mimetype" not in metadata:
             metadata["mimetype"] = guessed_mime
 
-        task_id = await self._indexing.add_file(
-            file_path=str(tmp_path),
-            file_id=file_id,
-            partition=partition,
-            metadata=metadata,
-            sanitized_filename=filename,
-            original_filename=filename,
-            user={"id": user_id, "is_admin": is_admin} if user_id is not None else None,
-        )
+        try:
+            task_id = await self._indexing.add_file(
+                file_path=str(tmp_path),
+                file_id=file_id,
+                partition=partition,
+                metadata=metadata,
+                sanitized_filename=filename,
+                original_filename=filename,
+                user={"id": user_id, "is_admin": is_admin} if user_id is not None else None,
+            )
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
         return {
             "partition": partition,
             "file_id": file_id,

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -71,8 +71,9 @@ class PgDocumentRepository(DocumentRepository):
         await self.pool.execute(
             """
             INSERT INTO files (file_id, partition_name, file_metadata,
-                               indexation_config, created_by, relationship_id, parent_id)
-            VALUES ($1, $2, $3::json, $4::jsonb, $5, $6, $7)
+                               indexation_config, created_by, relationship_id, parent_id,
+                               content_sha256)
+            VALUES ($1, $2, $3::json, $4::jsonb, $5, $6, $7, $8)
             """,
             file_id,
             doc.partition,
@@ -81,6 +82,7 @@ class PgDocumentRepository(DocumentRepository):
             doc.created_by,
             doc.relationship_id,
             doc.parent_id,
+            doc.content_sha256,
         )
         return doc.model_copy(update={"file_id": file_id, "metadata": metadata})
 
@@ -258,6 +260,114 @@ class PgDocumentRepository(DocumentRepository):
             partition,
         )
 
+    async def get_content_sha256(self, file_id: str, partition: str) -> str | None:
+        return await self.pool.fetchval(
+            "SELECT content_sha256 FROM files WHERE file_id = $1 AND partition_name = $2",
+            file_id,
+            partition,
+        )
+
+    async def claim_content_sha256(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+        replace: bool = False,
+    ) -> str | None:
+        """Atomically reserve content while it is being indexed."""
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+                    partition,
+                    content_sha256,
+                )
+                existing_file_id = await conn.fetchval(
+                    """
+                    SELECT file_id FROM files
+                    WHERE partition_name = $1 AND content_sha256 = $2
+                    LIMIT 1
+                    """,
+                    partition,
+                    content_sha256,
+                )
+                if existing_file_id is not None and not (replace and existing_file_id == file_id):
+                    return existing_file_id
+
+                await conn.execute(
+                    """
+                    DELETE FROM file_content_claims
+                    WHERE partition_name = $1 AND content_sha256 = $2 AND expires_at <= NOW()
+                    """,
+                    partition,
+                    content_sha256,
+                )
+                claimed = await conn.fetchval(
+                    """
+                    INSERT INTO file_content_claims (partition_name, content_sha256, file_id)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (partition_name, content_sha256) DO NOTHING
+                    RETURNING file_id
+                    """,
+                    partition,
+                    content_sha256,
+                    file_id,
+                )
+                if claimed is not None:
+                    return None
+                return await conn.fetchval(
+                    """
+                    SELECT file_id FROM file_content_claims
+                    WHERE partition_name = $1 AND content_sha256 = $2
+                    """,
+                    partition,
+                    content_sha256,
+                )
+
+    async def renew_content_sha256_claim(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+    ) -> bool:
+        result = await self.pool.execute(
+            """
+            UPDATE file_content_claims
+            SET expires_at = NOW() + interval '24 hours'
+            WHERE partition_name = $1 AND content_sha256 = $2 AND file_id = $3
+            """,
+            partition,
+            content_sha256,
+            file_id,
+        )
+        return result.endswith(" 1")
+
+    async def release_content_sha256_claim(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+    ) -> None:
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+                    partition,
+                    content_sha256,
+                )
+                await conn.execute(
+                    """
+                    DELETE FROM file_content_claims
+                    WHERE partition_name = $1 AND content_sha256 = $2 AND file_id = $3
+                    """,
+                    partition,
+                    content_sha256,
+                    file_id,
+                )
+
     # ── Legacy method names used by the Phase 7C shim ────────────────
     # These are NOT on the ABC. Phase 8 orchestrators must not depend on
     # them — they exist solely so the shim can keep every legacy caller
@@ -275,6 +385,7 @@ class PgDocumentRepository(DocumentRepository):
         indexation_config: dict | None = None,
         indexed_at: datetime | None = None,
         require_existing_partition: bool = False,
+        content_sha256: str | None = None,
     ) -> bool:
         """TODO(phase-9): remove. Mirror of legacy ``add_file_to_partition``.
 
@@ -335,6 +446,7 @@ class PgDocumentRepository(DocumentRepository):
                     "created_by",
                     "relationship_id",
                     "parent_id",
+                    "content_sha256",
                 ]
                 values: list[Any] = [
                     file_id,
@@ -344,6 +456,7 @@ class PgDocumentRepository(DocumentRepository):
                     user_id,
                     relationship_id,
                     parent_id,
+                    content_sha256,
                 ]
                 # Omit indexed_at to let the server default fire (legacy path).
                 if indexed_at is not None:
@@ -425,6 +538,7 @@ class PgDocumentRepository(DocumentRepository):
         parent_id: object = _UNSET,
         indexation_config: object = _UNSET,
         indexed_at: datetime | None = None,
+        content_sha256: object = _UNSET,
     ) -> bool:
         """TODO(phase-9): remove. PUT-style in-place update.
 
@@ -452,6 +566,9 @@ class PgDocumentRepository(DocumentRepository):
         if indexed_at is not None:
             params.append(indexed_at)
             sets.append(f"indexed_at = ${len(params)}")
+        if content_sha256 is not self._UNSET:
+            params.append(content_sha256)
+            sets.append(f"content_sha256 = ${len(params)}")
         if not sets:
             # Match legacy: report whether the row exists at all.
             return await self.file_exists_in_partition(file_id, partition)
@@ -595,6 +712,7 @@ class PgDocumentRepository(DocumentRepository):
             "relationship_id": row["relationship_id"],
             "parent_id": row["parent_id"],
             **metadata,
+            "content_sha256": row.get("content_sha256"),
             # Authoritative system insert time, materialized on the row. Placed
             # after the spread so the column wins over any ``indexed_at`` the
             # copy/restore path copies into file_metadata from chunk metadata
@@ -624,6 +742,7 @@ class PgDocumentRepository(DocumentRepository):
             created_by=row["created_by"],
             relationship_id=row["relationship_id"],
             parent_id=row["parent_id"],
+            content_sha256=row.get("content_sha256"),
             indexation_config=row["indexation_config"],
         )
 

--- a/openrag/services/persistence/migrations/alembic/versions/c3d4e5f6a7b8_add_document_content_hashes.py
+++ b/openrag/services/persistence/migrations/alembic/versions/c3d4e5f6a7b8_add_document_content_hashes.py
@@ -1,0 +1,61 @@
+"""add document content hashes
+
+Revision ID: c3d4e5f6a7b8
+Revises: b7c1d2e3f4a5
+Create Date: 2026-07-20 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from schema_helpers import column_exists, index_exists, table_exists
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: str | Sequence[str] | None = "b7c1d2e3f4a5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not column_exists("files", "content_sha256"):
+        op.add_column("files", sa.Column("content_sha256", sa.String(length=64), nullable=True))
+
+    if not index_exists("files", "uix_files_partition_content_sha256"):
+        op.create_index(
+            "uix_files_partition_content_sha256",
+            "files",
+            ["partition_name", "content_sha256"],
+            unique=True,
+            postgresql_where=sa.text("content_sha256 IS NOT NULL"),
+        )
+
+    if not table_exists("file_content_claims"):
+        op.create_table(
+            "file_content_claims",
+            sa.Column("partition_name", sa.String(), nullable=False),
+            sa.Column("content_sha256", sa.String(length=64), nullable=False),
+            sa.Column("file_id", sa.String(), nullable=False),
+            sa.Column(
+                "expires_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now() + interval '24 hours'"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["partition_name"],
+                ["partitions.partition"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("partition_name", "content_sha256"),
+        )
+
+
+def downgrade() -> None:
+    if table_exists("file_content_claims"):
+        op.drop_table("file_content_claims")
+    if index_exists("files", "uix_files_partition_content_sha256"):
+        op.drop_index("uix_files_partition_content_sha256", table_name="files")
+    if column_exists("files", "content_sha256"):
+        op.drop_column("files", "content_sha256")

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -137,6 +137,7 @@ files = Table(
     ),
     Column("relationship_id", String, nullable=True, index=True),
     Column("parent_id", String, nullable=True, index=True),
+    Column("content_sha256", String(64), nullable=True),
     Column(
         "indexed_at",
         DateTime(timezone=True),
@@ -147,6 +148,33 @@ files = Table(
     Index("ix_partition_file", "partition_name", "file_id"),
     Index("ix_relationship_partition", "relationship_id", "partition_name"),
     Index("ix_parent_partition", "parent_id", "partition_name"),
+    Index(
+        "uix_files_partition_content_sha256",
+        "partition_name",
+        "content_sha256",
+        unique=True,
+        postgresql_where=text("content_sha256 IS NOT NULL"),
+    ),
+)
+
+
+file_content_claims = Table(
+    "file_content_claims",
+    metadata,
+    Column(
+        "partition_name",
+        String,
+        ForeignKey("partitions.partition", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("content_sha256", String(64), primary_key=True),
+    Column("file_id", String, nullable=False),
+    Column(
+        "expires_at",
+        DateTime(timezone=True),
+        server_default=text("now() + interval '24 hours'"),
+        nullable=False,
+    ),
 )
 
 

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -8,6 +8,7 @@ from typing import Any
 from core.indexing.dispatcher import IndexingDispatcher
 from core.models.catalog import TASK_CREATED_AT_METADATA_KEY, TASK_FINISHED_AT_METADATA_KEY
 from core.utils.conts import is_internal_metadata_key, strip_internal_metadata
+from core.utils.exceptions import ConflictError
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout
@@ -142,6 +143,24 @@ class WorkerDispatcher(IndexingDispatcher):
         allow_legacy_require_existing_partition_retry: bool = False,
     ) -> str:
         task_id = uuid.uuid4().hex
+        file_id = str(metadata.get("file_id") or "")
+        content_sha256 = metadata.get("content_sha256")
+        claimed_content = False
+
+        if content_sha256:
+            conflicting_file_id = await self._document_repo.claim_content_sha256(
+                file_id=file_id,
+                partition=partition,
+                content_sha256=content_sha256,
+                replace=replace,
+            )
+            if conflicting_file_id is not None:
+                raise ConflictError(
+                    f"This document already exists in partition '{partition}'.",
+                    code="DOCUMENT_CONTENT_EXISTS",
+                    existing_file_id=conflicting_file_id,
+                )
+            claimed_content = True
 
         user_metadata = {
             key: value
@@ -150,18 +169,30 @@ class WorkerDispatcher(IndexingDispatcher):
         }
         user_metadata[TASK_CREATED_AT_METADATA_KEY] = _utc_now_iso()
         task_details = {
-            "file_id": metadata.get("file_id"),
+            "file_id": file_id,
             "partition": partition,
             "metadata": user_metadata,
             "user_id": user.get("id") if user else None,
         }
-        accepted = await self._set_queued_details(
-            task_id,
-            **task_details,
-        )
+        try:
+            accepted = await self._set_queued_details(task_id, **task_details)
+        except BaseException:
+            if claimed_content:
+                await self._document_repo.release_content_sha256_claim(
+                    file_id=file_id,
+                    partition=partition,
+                    content_sha256=content_sha256,
+                )
+            raise
         if not accepted:
+            if claimed_content:
+                await self._document_repo.release_content_sha256_claim(
+                    file_id=file_id,
+                    partition=partition,
+                    content_sha256=content_sha256,
+                )
             raise RuntimeError(
-                f"Task {task_id} was rejected because file {metadata.get('file_id')!r} "
+                f"Task {task_id} was rejected because file {file_id!r} "
                 f"in partition {partition!r} is being deleted"
             )
 
@@ -193,15 +224,23 @@ class WorkerDispatcher(IndexingDispatcher):
             if registered is False:
                 raise RuntimeError(f"Task {task_id} was cancelled before worker ref registration")
             self._track_completion(task_id, task)
-        except Exception:
+        except BaseException:
             mark_submit_failed = True
-            if task is not None:
-                mark_submit_failed = await self._cancel_submitted_task(task_id, task)
+            try:
+                if task is not None:
+                    mark_submit_failed = await self._cancel_submitted_task(task_id, task)
+                    if mark_submit_failed:
+                        await self._cleanup_submitted_vectors(task_id, metadata=metadata, partition=partition)
+                await self._record_finished_at(task_id, task_details)
                 if mark_submit_failed:
-                    await self._cleanup_submitted_vectors(task_id, metadata=metadata, partition=partition)
-            await self._record_finished_at(task_id, task_details)
-            if mark_submit_failed:
-                await self._mark_submit_failed(task_id, traceback.format_exc())
+                    await self._mark_submit_failed(task_id, traceback.format_exc())
+            finally:
+                if claimed_content and (task is None or mark_submit_failed):
+                    await self._document_repo.release_content_sha256_claim(
+                        file_id=file_id,
+                        partition=partition,
+                        content_sha256=content_sha256,
+                    )
             raise
         return task_id
 
@@ -411,36 +450,61 @@ class WorkerDispatcher(IndexingDispatcher):
         partition: str,
         user: dict | None,
     ) -> None:
-        rows = await self._vector_store.query_chunks_by_filter(
-            self._collection,
-            {"partition": partition, "file_id": file_id},
-            output_fields=["*", "vector"],
-        )
-        if not rows:
-            return
-
-        public_metadata = strip_internal_metadata(metadata)
-        entities = []
-        for row in rows:
-            entity = strip_internal_metadata(row)
-            entity.pop("_id", None)
-            entity.update(public_metadata)
-            entities.append(entity)
-
-        await self._insert_entities(entities)
-
         target_file_id = metadata.get("file_id", file_id)
         target_partition = metadata.get("partition", partition)
-        file_metadata = self._file_metadata_from_chunk(rows[0])
-        file_metadata.update(public_metadata)
-        await self._document_repo.add_file_to_partition(
-            file_id=target_file_id,
-            partition=target_partition,
-            file_metadata=file_metadata,
-            user_id=user.get("id") if user else None,
-            relationship_id=file_metadata.get("relationship_id"),
-            parent_id=file_metadata.get("parent_id"),
-        )
+        content_sha256 = metadata.get("content_sha256")
+        claimed_content = False
+        if content_sha256:
+            conflicting_file_id = await self._document_repo.claim_content_sha256(
+                file_id=target_file_id,
+                partition=target_partition,
+                content_sha256=content_sha256,
+            )
+            if conflicting_file_id is not None:
+                raise ConflictError(
+                    f"This document already exists in partition '{target_partition}'.",
+                    code="DOCUMENT_CONTENT_EXISTS",
+                    existing_file_id=conflicting_file_id,
+                )
+            claimed_content = True
+
+        try:
+            rows = await self._vector_store.query_chunks_by_filter(
+                self._collection,
+                {"partition": partition, "file_id": file_id},
+                output_fields=["*", "vector"],
+            )
+            if not rows:
+                return
+
+            public_metadata = strip_internal_metadata(metadata)
+            entities = []
+            for row in rows:
+                entity = strip_internal_metadata(row)
+                entity.pop("_id", None)
+                entity.update(public_metadata)
+                entities.append(entity)
+
+            await self._insert_entities(entities)
+
+            file_metadata = self._file_metadata_from_chunk(rows[0])
+            file_metadata.update(public_metadata)
+            await self._document_repo.add_file_to_partition(
+                file_id=target_file_id,
+                partition=target_partition,
+                file_metadata=file_metadata,
+                user_id=user.get("id") if user else None,
+                relationship_id=file_metadata.get("relationship_id"),
+                parent_id=file_metadata.get("parent_id"),
+                content_sha256=content_sha256,
+            )
+        finally:
+            if claimed_content:
+                await self._document_repo.release_content_sha256_claim(
+                    file_id=target_file_id,
+                    partition=target_partition,
+                    content_sha256=content_sha256,
+                )
 
     async def _upsert_entities(self, entities: list[dict[str, Any]]) -> None:
         upsert_entities = getattr(self._vector_store, "upsert_entities", None)
@@ -476,6 +540,10 @@ class WorkerDispatcher(IndexingDispatcher):
     async def cancel_task(self, task_id: str) -> bool:
         import ray
 
+        details = await self._call(
+            self._tsm.get_details.remote(task_id),
+            task_description=f"get_details({task_id})",
+        )
         obj_ref = await self._call(
             self._tsm.get_object_ref.remote(task_id),
             task_description=f"get_object_ref({task_id})",
@@ -496,6 +564,16 @@ class WorkerDispatcher(IndexingDispatcher):
             return False
 
         ray.cancel(obj_ref["ref"], recursive=True)
+        metadata = (details or {}).get("metadata") or {}
+        content_sha256 = metadata.get("content_sha256")
+        file_id = (details or {}).get("file_id")
+        partition = (details or {}).get("partition")
+        if content_sha256 and file_id and partition:
+            await self._document_repo.release_content_sha256_claim(
+                file_id=file_id,
+                partition=partition,
+                content_sha256=content_sha256,
+            )
         return True
 
 

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -192,8 +192,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     content_sha256=content_sha256,
                 )
             raise RuntimeError(
-                f"Task {task_id} was rejected because file {file_id!r} "
-                f"in partition {partition!r} is being deleted"
+                f"Task {task_id} was rejected because file {file_id!r} in partition {partition!r} is being deleted"
             )
 
         task: Any | None = None
@@ -540,10 +539,6 @@ class WorkerDispatcher(IndexingDispatcher):
     async def cancel_task(self, task_id: str) -> bool:
         import ray
 
-        details = await self._call(
-            self._tsm.get_details.remote(task_id),
-            task_description=f"get_details({task_id})",
-        )
         obj_ref = await self._call(
             self._tsm.get_object_ref.remote(task_id),
             task_description=f"get_object_ref({task_id})",
@@ -564,16 +559,6 @@ class WorkerDispatcher(IndexingDispatcher):
             return False
 
         ray.cancel(obj_ref["ref"], recursive=True)
-        metadata = (details or {}).get("metadata") or {}
-        content_sha256 = metadata.get("content_sha256")
-        file_id = (details or {}).get("file_id")
-        partition = (details or {}).get("partition")
-        if content_sha256 and file_id and partition:
-            await self._document_repo.release_content_sha256_claim(
-                file_id=file_id,
-                partition=partition,
-                content_sha256=content_sha256,
-            )
         return True
 
 

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -167,6 +167,7 @@ async def _write_catalog_record(
             relationship_id=metadata.get("relationship_id"),
             parent_id=metadata.get("parent_id"),
             indexed_at=indexed_at,
+            content_sha256=metadata.get("content_sha256"),
             **config_kwargs,
         )
 
@@ -179,6 +180,7 @@ async def _write_catalog_record(
         parent_id=metadata.get("parent_id"),
         indexed_at=indexed_at,
         require_existing_partition=require_existing_partition,
+        content_sha256=metadata.get("content_sha256"),
         **config_kwargs,
     )
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -15,6 +15,7 @@ from openrag.core.config.root import Settings
 # this window (and on a miss), bounding both staleness and DB load regardless
 # of indexing throughput.
 _MODEL_REGISTRY_TTL_SECONDS = 60.0
+_CONTENT_CLAIM_RENEW_INTERVAL_SECONDS = 60 * 60
 _INDEXER_POOL_DISPATCHER_ACTOR_NAME = "IndexerPoolDispatcher"
 
 
@@ -254,6 +255,18 @@ class IndexerWorkerActor:
                     pass
             return result
         finally:
+            content_sha256 = metadata.get("content_sha256")
+            file_id = metadata.get("file_id")
+            if content_sha256 and file_id:
+                try:
+                    await self._ensure_catalog()
+                    await self._catalog_store.document_repo.release_content_sha256_claim(
+                        file_id=file_id,
+                        partition=partition,
+                        content_sha256=content_sha256,
+                    )
+                except Exception as exc:  # noqa: BLE001 - stale claims expire automatically
+                    self._logger.warning(f"Failed to release content deduplication claim for {file_id}: {exc}")
             # Purge the raw upload (when configured) after indexing settles —
             # success or failure. Enforced here rather than in the worker so it
             # also covers pre-processing failures (catalog/registry init, or the
@@ -304,6 +317,8 @@ class IndexerPool:
         ]
         self._inflight = [0] * len(self._workers)
         self._release_tasks: set[asyncio.Task[Any]] = set()
+        self._claim_store: Any = None
+        self._claim_store_lock = asyncio.Lock()
 
     async def size(self) -> int:
         return len(self._workers)
@@ -324,18 +339,78 @@ class IndexerPool:
             # a dead actor); roll back so load balancing stays accurate.
             self._inflight[idx] -= 1
             raise
-        task = asyncio.get_running_loop().create_task(self._release(idx, ref))
+        metadata = kwargs.get("metadata") or {}
+        content_sha256 = metadata.get("content_sha256")
+        file_id = metadata.get("file_id")
+        claim = None
+        if content_sha256 and file_id:
+            claim = {
+                "file_id": str(file_id),
+                "partition": str(kwargs.get("partition") or ""),
+                "content_sha256": str(content_sha256),
+            }
+        task = asyncio.get_running_loop().create_task(self._release(idx, ref, claim=claim))
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
         return [ref]
 
-    async def _release(self, idx: int, ref: Any) -> None:
+    async def _release(self, idx: int, ref: Any, *, claim: dict[str, str] | None = None) -> None:
+        renewal_task = None
+        if claim is not None:
+            renewal_task = asyncio.create_task(self._keep_content_claim_alive(**claim))
         try:
             # return_exceptions=True so a failed/cancelled task still decrements.
             await asyncio.gather(ref, return_exceptions=True)
         finally:
+            if renewal_task is not None:
+                renewal_task.cancel()
+                await asyncio.gather(renewal_task, return_exceptions=True)
             self._inflight[idx] -= 1
+
+    async def _claim_document_repo(self) -> Any:
+        if self._claim_store is None:
+            async with self._claim_store_lock:
+                if self._claim_store is None:
+                    from core.config import load_config
+                    from services.storage.postgres_store import PostgresStore
+
+                    cfg = load_config()
+                    rdb_cfg = cfg.rdb.model_copy(
+                        update={"database": f"partitions_for_collection_{cfg.vectordb.collection_name}"}
+                    )
+                    store = PostgresStore(rdb_cfg, run_migrations=False)
+                    await store.initialize()
+                    self._claim_store = store
+        return self._claim_store.document_repo
+
+    async def _keep_content_claim_alive(
+        self,
+        *,
+        file_id: str,
+        partition: str,
+        content_sha256: str,
+    ) -> None:
+        while True:
+            await asyncio.sleep(_CONTENT_CLAIM_RENEW_INTERVAL_SECONDS)
+            try:
+                repo = await self._claim_document_repo()
+                renewed = await repo.renew_content_sha256_claim(
+                    file_id=file_id,
+                    partition=partition,
+                    content_sha256=content_sha256,
+                )
+                if not renewed:
+                    return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - lease renewal retries until the task settles
+                from core.utils.logging import get_logger
+
+                get_logger().bind(file_id=file_id, partition=partition).warning(
+                    "Failed to renew content deduplication claim; retrying.",
+                    error=str(exc),
+                )
 
 
 def build_indexer_pool(namespace: str = "openrag") -> Any:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -366,6 +366,17 @@ class IndexerPool:
             if renewal_task is not None:
                 renewal_task.cancel()
                 await asyncio.gather(renewal_task, return_exceptions=True)
+            if claim is not None:
+                try:
+                    repo = await self._claim_document_repo()
+                    await repo.release_content_sha256_claim(**claim)
+                except Exception as exc:  # noqa: BLE001 - stale claims expire automatically
+                    from core.utils.logging import get_logger
+
+                    get_logger().bind(file_id=claim["file_id"], partition=claim["partition"]).warning(
+                        "Failed to release settled content deduplication claim.",
+                        error=str(exc),
+                    )
             self._inflight[idx] -= 1
 
     async def _claim_document_repo(self) -> Any:

--- a/tests/integration/api/test_indexer.py
+++ b/tests/integration/api/test_indexer.py
@@ -78,7 +78,7 @@ class TestFileIndexing:
         assert response.status_code in [200, 201, 202]
 
     def test_upload_duplicate_file_replaces(self, api_client, created_partition, sample_text_file):
-        """Test uploading duplicate file ID - API may allow replacement or reject."""
+        """Uploading the same content under the same file ID remains a valid replacement."""
         file_id = "duplicate-file"
 
         with open(sample_text_file, "rb") as f:
@@ -89,19 +89,46 @@ class TestFileIndexing:
             )
 
         assert first_response.status_code in [200, 201, 202]
-
-        # Wait briefly for first upload to register
-        time.sleep(2)
+        wait_for_task(api_client, get_task_id(first_response.json()))
 
         with open(sample_text_file, "rb") as f:
-            response = api_client.post(
+            response = api_client.put(
                 f"/indexer/partition/{created_partition}/file/{file_id}",
                 files={"file": ("test.txt", f, "text/plain")},
                 data={"metadata": "{}"},
             )
 
-        # API may allow replacement (201) or reject duplicate (400/409)
-        assert response.status_code in [200, 201, 202, 400, 409]
+        assert response.status_code in [200, 201, 202]
+
+    def test_duplicate_content_with_different_file_id_returns_conflict(
+        self,
+        api_client,
+        created_partition,
+        sample_text_file,
+    ):
+        """Identical content must not be indexed twice in one partition."""
+        first_file_id = "content-dedup-source"
+        duplicate_file_id = "content-dedup-copy"
+
+        with open(sample_text_file, "rb") as file_handle:
+            first_response = api_client.post(
+                f"/indexer/partition/{created_partition}/file/{first_file_id}",
+                files={"file": ("source.txt", file_handle, "text/plain")},
+                data={"metadata": "{}"},
+            )
+
+        assert first_response.status_code in [200, 201, 202]
+        wait_for_task(api_client, get_task_id(first_response.json()))
+
+        with open(sample_text_file, "rb") as file_handle:
+            duplicate_response = api_client.post(
+                f"/indexer/partition/{created_partition}/file/{duplicate_file_id}",
+                files={"file": ("copy.txt", file_handle, "text/plain")},
+                data={"metadata": "{}"},
+            )
+
+        assert duplicate_response.status_code == 409
+        assert duplicate_response.json()["extra"]["existing_file_id"] == first_file_id
 
 
 class TestIndexedDocuments:

--- a/tests/integration/api/test_search.py
+++ b/tests/integration/api/test_search.py
@@ -489,12 +489,12 @@ class TestSearchFiltering:
 It contains information about machine learning and artificial intelligence.
 The document is used to verify that search filtering works correctly.
 Key topics include: neural networks, deep learning, and natural language processing.
-This content is intentionally repeated across multiple files to test filtering.
+Each fixture adds a unique document marker while keeping this shared searchable text.
 """
 
     @pytest.fixture
     def filter_test_files(self, tmp_path):
-        """Create 6 files with the same content but different metadata."""
+        """Create 6 distinct files with shared searchable content and different metadata."""
         files_config = [
             {
                 "file_id": "filter-file-1",
@@ -538,7 +538,7 @@ This content is intentionally repeated across multiple files to test filtering.
         for config in files_config:
             file_id = config.pop("file_id")
             file_path = tmp_path / f"{file_id}.txt"
-            file_path.write_text(self.COMMON_CONTENT)
+            file_path.write_text(f"{self.COMMON_CONTENT}\nFixture document: {file_id}\n")
             config["path"] = file_path
             file_paths[file_id] = config
 

--- a/tests/integration/api/test_workspaces.py
+++ b/tests/integration/api/test_workspaces.py
@@ -76,8 +76,9 @@ class TestWorkspaceCRUD:
 
 class TestWorkspaceFiles:
     @staticmethod
-    def _upload_file(api_client, partition: str, file_id: str, content: str = "Test content"):
-        file_obj = io.BytesIO(content.encode())
+    def _upload_file(api_client, partition: str, file_id: str, content: str | None = None):
+        file_content = content if content is not None else f"Test content for {file_id}"
+        file_obj = io.BytesIO(file_content.encode())
         response = api_client.post(
             f"/indexer/partition/{partition}/file/{file_id}",
             files={"file": (f"{file_id}.txt", file_obj, "text/plain")},
@@ -189,8 +190,9 @@ class TestPartitionDeletionCascade:
 class TestFileWorkspaceMembership:
     """Test that file workspace memberships survive file replace operations."""
 
-    def _upload_file(self, api_client, partition: str, file_id: str, content: str = "Test content"):
-        file_obj = io.BytesIO(content.encode())
+    def _upload_file(self, api_client, partition: str, file_id: str, content: str | None = None):
+        file_content = content if content is not None else f"Test content for {file_id}"
+        file_obj = io.BytesIO(file_content.encode())
         return api_client.post(
             f"/indexer/partition/{partition}/file/{file_id}",
             files={"file": (f"{file_id}.txt", file_obj, "text/plain")},

--- a/tests/unit/api/dependencies/test_files.py
+++ b/tests/unit/api/dependencies/test_files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from api.dependencies import files as files_dep
-from api.dependencies.files import save_file_to_disk
+from api.dependencies.files import save_file_to_disk, save_file_to_disk_with_sha256
 from core.utils.exceptions import ValidationError
 from core.utils.filename import extract_temporal_fields, sanitize_filename
 from fastapi import UploadFile
@@ -29,6 +29,17 @@ async def test_save_file_to_disk_writes_content(tmp_path: Path):
         saved_content = f.read()
 
     assert saved_content == content
+
+
+@pytest.mark.asyncio
+async def test_save_file_to_disk_calculates_sha256_while_streaming(tmp_path: Path):
+    upload = UploadFile(file=io.BytesIO(b"hello world"), filename="test.bin")
+
+    saved = await save_file_to_disk_with_sha256(upload, tmp_path, chunk_size=4)
+
+    assert saved.path.read_bytes() == b"hello world"
+    assert saved.sha256 == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    assert saved.size_bytes == 11
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/dependencies/test_files.py
+++ b/tests/unit/api/dependencies/test_files.py
@@ -1,5 +1,7 @@
+import asyncio
 import io
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from api.dependencies import files as files_dep
@@ -55,6 +57,17 @@ async def test_save_file_to_disk_rejects_oversize_upload(tmp_path: Path, monkeyp
     assert exc.value.status_code == 413
     # The partially written file must have been cleaned up.
     assert not (dest_dir / "big.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_save_file_to_disk_removes_partial_file_when_upload_is_cancelled(tmp_path: Path):
+    upload = UploadFile(file=io.BytesIO(), filename="cancelled.bin")
+    upload.read = AsyncMock(side_effect=[b"partial", asyncio.CancelledError()])
+
+    with pytest.raises(asyncio.CancelledError):
+        await save_file_to_disk(file=upload, dest_dir=tmp_path, chunk_size=4)
+
+    assert not (tmp_path / "cancelled.bin").exists()
 
 
 def test_max_upload_size_reads_env_at_call_time(monkeypatch):

--- a/tests/unit/api/routers/admin/test_indexing_upload_errors.py
+++ b/tests/unit/api/routers/admin/test_indexing_upload_errors.py
@@ -42,6 +42,7 @@ class _DispatchFailureService(_FakeIndexingService):
 
 class _ExistingFileService(_FakeIndexingService):
     def __init__(self) -> None:
+        super().__init__()
         self.dispatched = False
 
     async def file_exists(self, file_id: str, partition: str) -> bool:
@@ -67,6 +68,7 @@ def _build_app(tmp_path, monkeypatch, content: bytes, *, service=None, deduplica
     cfg = SimpleNamespace(
         paths=SimpleNamespace(data_dir=str(tmp_path / "data")),
         loader=SimpleNamespace(content_deduplication_enabled=deduplication_enabled),
+        server=SimpleNamespace(preferred_url_scheme="http"),
     )
 
     app.dependency_overrides[validate_file_id] = lambda: "f1"

--- a/tests/unit/api/routers/admin/test_indexing_upload_errors.py
+++ b/tests/unit/api/routers/admin/test_indexing_upload_errors.py
@@ -15,6 +15,7 @@ from api.dependencies.auth import check_user_file_quota, require_partition_edito
 from api.dependencies.files import validate_file_format, validate_file_id, validate_metadata
 from api.error_handlers import register_error_handlers
 from api.routers.admin.indexing import router as indexer_router
+from core.utils.exceptions import ConflictError
 from di.providers import get_config, get_indexing_service
 from fastapi import FastAPI, UploadFile
 
@@ -22,6 +23,13 @@ from fastapi import FastAPI, UploadFile
 class _FakeIndexingService:
     async def file_exists(self, file_id: str, partition: str) -> bool:
         return False
+
+    async def add_file(self, **_kwargs):
+        raise ConflictError(
+            "This document already exists in partition 'p1'.",
+            code="DOCUMENT_CONTENT_EXISTS",
+            existing_file_id="existing-file",
+        )
 
 
 def _empty_metadata() -> dict:
@@ -56,3 +64,16 @@ async def test_add_file_oversize_returns_413_not_500(tmp_path, monkeypatch):
         resp = await client.post("/indexer/partition/p1/file/f1", data={"_": "1"})
 
     assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_add_file_duplicate_content_returns_409_and_removes_upload(tmp_path, monkeypatch):
+    app = _build_app(tmp_path, monkeypatch, content=b"same")
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 409
+    assert resp.json()["extra"]["existing_file_id"] == "existing-file"
+    assert list((tmp_path / "data").iterdir()) == []

--- a/tests/unit/api/routers/admin/test_indexing_upload_errors.py
+++ b/tests/unit/api/routers/admin/test_indexing_upload_errors.py
@@ -40,11 +40,23 @@ class _DispatchFailureService(_FakeIndexingService):
         raise RuntimeError("dispatcher unavailable")
 
 
+class _ExistingFileService(_FakeIndexingService):
+    def __init__(self) -> None:
+        self.dispatched = False
+
+    async def file_exists(self, file_id: str, partition: str) -> bool:
+        return True
+
+    async def add_file(self, **_kwargs):
+        self.dispatched = True
+        return "unexpected-task"
+
+
 def _empty_metadata() -> dict:
     return {}
 
 
-def _build_app(tmp_path, monkeypatch, content: bytes, *, service=None) -> FastAPI:
+def _build_app(tmp_path, monkeypatch, content: bytes, *, service=None, deduplication_enabled=True) -> FastAPI:
     # Cap at ~8 bytes so a small upload trips the limit.
     monkeypatch.setattr("api.dependencies.files._max_upload_size_bytes", lambda: 8)
 
@@ -52,7 +64,10 @@ def _build_app(tmp_path, monkeypatch, content: bytes, *, service=None) -> FastAP
     register_error_handlers(app)
     app.include_router(indexer_router, prefix="/indexer")
 
-    cfg = SimpleNamespace(paths=SimpleNamespace(data_dir=str(tmp_path / "data")))
+    cfg = SimpleNamespace(
+        paths=SimpleNamespace(data_dir=str(tmp_path / "data")),
+        loader=SimpleNamespace(content_deduplication_enabled=deduplication_enabled),
+    )
 
     app.dependency_overrides[validate_file_id] = lambda: "f1"
     app.dependency_overrides[validate_file_format] = lambda: UploadFile(file=io.BytesIO(content), filename="big.bin")
@@ -70,6 +85,22 @@ async def test_add_file_oversize_returns_413_not_500(tmp_path, monkeypatch):
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         resp = await client.post("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_put_file_oversize_returns_413_not_500(tmp_path, monkeypatch):
+    app = _build_app(
+        tmp_path,
+        monkeypatch,
+        content=b"x" * 100,
+        service=_ExistingFileService(),
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.put("/indexer/partition/p1/file/f1", data={"_": "1"})
 
     assert resp.status_code == 413
 
@@ -117,3 +148,40 @@ async def test_add_file_dispatch_failure_removes_upload(tmp_path, monkeypatch):
 
     assert resp.status_code == 500
     assert list((tmp_path / "data").iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("deduplication_enabled", "save_function"),
+    [
+        (True, "save_file_to_disk_with_sha256"),
+        (False, "save_file_to_disk"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_put_file_save_failure_returns_safe_error(
+    tmp_path,
+    monkeypatch,
+    deduplication_enabled,
+    save_function,
+):
+    async def fail_save(*_args, **_kwargs):
+        raise OSError("private path: /srv/openrag/data")
+
+    monkeypatch.setattr(f"api.routers.admin.indexing.{save_function}", fail_save)
+    service = _ExistingFileService()
+    app = _build_app(
+        tmp_path,
+        monkeypatch,
+        content=b"replacement",
+        service=service,
+        deduplication_enabled=deduplication_enabled,
+    )
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.put("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "Failed to save uploaded file."}
+    assert "private path" not in resp.text
+    assert service.dispatched is False

--- a/tests/unit/api/routers/admin/test_indexing_upload_errors.py
+++ b/tests/unit/api/routers/admin/test_indexing_upload_errors.py
@@ -31,12 +31,20 @@ class _FakeIndexingService:
             existing_file_id="existing-file",
         )
 
+    async def get_workspace(self, _workspace_id: str):
+        return None
+
+
+class _DispatchFailureService(_FakeIndexingService):
+    async def add_file(self, **_kwargs):
+        raise RuntimeError("dispatcher unavailable")
+
 
 def _empty_metadata() -> dict:
     return {}
 
 
-def _build_app(tmp_path, monkeypatch, content: bytes) -> FastAPI:
+def _build_app(tmp_path, monkeypatch, content: bytes, *, service=None) -> FastAPI:
     # Cap at ~8 bytes so a small upload trips the limit.
     monkeypatch.setattr("api.dependencies.files._max_upload_size_bytes", lambda: 8)
 
@@ -52,7 +60,7 @@ def _build_app(tmp_path, monkeypatch, content: bytes) -> FastAPI:
     app.dependency_overrides[require_partition_editor] = lambda: {"id": 1, "is_admin": True}
     app.dependency_overrides[check_user_file_quota] = lambda: None
     app.dependency_overrides[get_config] = lambda: cfg
-    app.dependency_overrides[get_indexing_service] = lambda: _FakeIndexingService()
+    app.dependency_overrides[get_indexing_service] = lambda: service or _FakeIndexingService()
     return app
 
 
@@ -76,4 +84,36 @@ async def test_add_file_duplicate_content_returns_409_and_removes_upload(tmp_pat
 
     assert resp.status_code == 409
     assert resp.json()["extra"]["existing_file_id"] == "existing-file"
+    assert list((tmp_path / "data").iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_add_file_invalid_workspace_is_rejected_before_upload_is_saved(tmp_path, monkeypatch):
+    app = _build_app(tmp_path, monkeypatch, content=b"same")
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/indexer/partition/p1/file/f1",
+            data={"workspace_ids": '["missing"]'},
+        )
+
+    assert resp.status_code == 404
+    assert not (tmp_path / "data").exists()
+
+
+@pytest.mark.asyncio
+async def test_add_file_dispatch_failure_removes_upload(tmp_path, monkeypatch):
+    app = _build_app(
+        tmp_path,
+        monkeypatch,
+        content=b"same",
+        service=_DispatchFailureService(),
+    )
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 500
     assert list((tmp_path / "data").iterdir()) == []

--- a/tests/unit/core/config/test_indexation.py
+++ b/tests/unit/core/config/test_indexation.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from core.config import load_config
 from core.config.indexation import (
     _DEFAULT_DIRECT_UPLOAD_SUFFIXES,
+    LoaderConfig,
     TranscriberConfig,
 )
 
@@ -29,3 +31,15 @@ def test_transcriber_config_drops_empty_components():
 def test_transcriber_config_set_input_passes_through():
     cfg = TranscriberConfig(direct_upload_suffixes={".wav", ".m4a"})
     assert cfg.direct_upload_suffixes == {".wav", ".m4a"}
+
+
+def test_content_deduplication_is_enabled_by_default():
+    assert LoaderConfig().content_deduplication_enabled is True
+
+
+def test_content_deduplication_can_be_disabled_by_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CONTENT_DEDUPLICATION_ENABLED", "false")
+
+    settings = load_config(conf_dir=tmp_path)
+
+    assert settings.loader.content_deduplication_enabled is False

--- a/tests/unit/core/config/test_indexation.py
+++ b/tests/unit/core/config/test_indexation.py
@@ -40,6 +40,6 @@ def test_content_deduplication_is_enabled_by_default():
 def test_content_deduplication_can_be_disabled_by_env(monkeypatch, tmp_path):
     monkeypatch.setenv("CONTENT_DEDUPLICATION_ENABLED", "false")
 
-    settings = load_config(conf_dir=tmp_path)
+    settings = load_config(config_path=tmp_path)
 
     assert settings.loader.content_deduplication_enabled is False

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 from core.config.indexation_pipeline import IndexationPipelineConfig
@@ -13,14 +14,18 @@ from services.orchestrators.indexing_service import IndexingService
 
 
 class FakeDocumentRepo:
-    def __init__(self, *, exists: bool = False, raise_on_check: bool = False):
+    def __init__(self, *, exists: bool = False, raise_on_check: bool = False, content_sha256: str | None = None):
         self._exists = exists
         self._raise = raise_on_check
+        self._content_sha256 = content_sha256
 
     async def file_exists_in_partition(self, file_id: str, partition: str) -> bool:
         if self._raise:
             raise RuntimeError("boom")
         return self._exists
+
+    async def get_content_sha256(self, file_id: str, partition: str) -> str | None:
+        return self._content_sha256
 
 
 class FakeWorkspaceRepo:
@@ -243,6 +248,53 @@ async def test_add_file_builds_metadata_and_dispatches(tmp_path):
     assert md["original_filename"] == "Doc Original.txt"
     assert md["file_id"] == "f1"
     assert md["file_size"] == "11.00 B"
+    assert md["content_sha256"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_file_uses_precomputed_content_hash_when_deduplication_is_enabled(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("hello world")
+    disp = FakeDispatcher()
+    config = SimpleNamespace(loader=SimpleNamespace(content_deduplication_enabled=True), partitions={})
+    svc = _service(disp=disp, config=config)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="p1",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+        content_sha256="abc123",
+    )
+
+    assert disp.dispatched[0]["metadata"]["content_sha256"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_add_file_hashes_non_http_input_when_digest_is_not_precomputed(tmp_path):
+    f = tmp_path / "doc.txt"
+    f.write_text("hello world")
+    disp = FakeDispatcher()
+    config = SimpleNamespace(loader=SimpleNamespace(content_deduplication_enabled=True), partitions={})
+    svc = _service(disp=disp, config=config)
+
+    await svc.add_file(
+        file_path=str(f),
+        file_id="f1",
+        partition="p1",
+        metadata={},
+        sanitized_filename="doc.txt",
+        original_filename="doc.txt",
+        user={"id": 7},
+    )
+
+    assert (
+        disp.dispatched[0]["metadata"]["content_sha256"]
+        == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    )
 
 
 @pytest.mark.asyncio
@@ -552,6 +604,21 @@ async def test_update_metadata_injects_file_id():
 
 
 @pytest.mark.asyncio
+async def test_update_metadata_cannot_override_content_hash():
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+
+    await svc.update_metadata(
+        "f1",
+        {"content_sha256": "client-controlled", "author": "bob"},
+        "p1",
+        {"id": 1},
+    )
+
+    assert disp.updated[0][1] == {"author": "bob", "file_id": "f1"}
+
+
+@pytest.mark.asyncio
 async def test_copy_file_sets_target_fields():
     disp = FakeDispatcher()
     svc = _service(disp=disp)
@@ -566,8 +633,26 @@ async def test_copy_file_sets_target_fields():
     file_id, md, partition, user = disp.copied[0]
     assert file_id == "src"
     assert partition == "p-src"
-    assert md == {"k": "v", "file_id": "dst", "partition": "p-dst"}
+    assert md == {"k": "v", "file_id": "dst", "partition": "p-dst", "content_sha256": None}
     assert user == {"id": 2}
+
+
+@pytest.mark.asyncio
+async def test_copy_file_preserves_content_hash_when_deduplication_is_enabled():
+    disp = FakeDispatcher()
+    config = SimpleNamespace(loader=SimpleNamespace(content_deduplication_enabled=True), partitions={})
+    svc = _service(doc=FakeDocumentRepo(content_sha256="abc123"), disp=disp, config=config)
+
+    await svc.copy_file(
+        source_file_id="src",
+        source_partition="p-src",
+        target_file_id="dst",
+        target_partition="p-dst",
+        metadata={},
+        user={"id": 2},
+    )
+
+    assert disp.copied[0][1]["content_sha256"] == "abc123"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -87,9 +87,10 @@ class RaceLostPartitions(FakePartitions):
 
 
 class FakeIndexing:
-    def __init__(self, *, state="COMPLETED", error="boom"):
+    def __init__(self, *, state="COMPLETED", error="boom", add_error: Exception | None = None):
         self._state = state
         self._error = error
+        self._add_error = add_error
         self.deleted: list[tuple[str, str]] = []
         self.updated: list[tuple] = []
         self.copied: list[dict] = []
@@ -112,6 +113,8 @@ class FakeIndexing:
 
     async def add_file(self, **kwargs):
         self.added.append(kwargs)
+        if self._add_error is not None:
+            raise self._add_error
         return "task-123"
 
 
@@ -697,6 +700,40 @@ async def test_index_url_auto_creates_partition_and_indexes(monkeypatch):
     assert added["metadata"]["author"] == "me"
     assert "created_by" not in added["metadata"]  # protected key dropped
     assert out["task_id"] == "task-123"
+
+
+@pytest.mark.asyncio
+async def test_index_url_removes_download_when_content_is_duplicate(monkeypatch):
+    from core.utils.exceptions import ConflictError
+
+    parts = FakePartitions(exists=False, partition_exists=True, members=[{"user_id": 7, "role": "editor"}])
+    indexing = FakeIndexing(
+        add_error=ConflictError(
+            "This document already exists in partition 'p1'.",
+            code="DOCUMENT_CONTENT_EXISTS",
+        )
+    )
+    svc = _service(partitions=parts, indexing=indexing)
+    downloaded_path = None
+
+    async def fake_download(url, dest):
+        nonlocal downloaded_path
+        downloaded_path = dest
+        dest.write_bytes(b"duplicate")
+
+    monkeypatch.setattr(svc, "_safe_download", fake_download)
+
+    with pytest.raises(ConflictError):
+        await svc.index_url(
+            url="https://example.com/report.pdf",
+            partition="p1",
+            file_id="f2",
+            allowed_partitions=["p1"],
+            user_id=7,
+        )
+
+    assert downloaded_path is not None
+    assert not downloaded_path.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -7,6 +7,7 @@ fuzzy ranking, task assembly and URL-indexation guards in isolation.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 
@@ -87,7 +88,7 @@ class RaceLostPartitions(FakePartitions):
 
 
 class FakeIndexing:
-    def __init__(self, *, state="COMPLETED", error="boom", add_error: Exception | None = None):
+    def __init__(self, *, state="COMPLETED", error="boom", add_error: BaseException | None = None):
         self._state = state
         self._error = error
         self._add_error = add_error
@@ -724,6 +725,33 @@ async def test_index_url_removes_download_when_content_is_duplicate(monkeypatch)
     monkeypatch.setattr(svc, "_safe_download", fake_download)
 
     with pytest.raises(ConflictError):
+        await svc.index_url(
+            url="https://example.com/report.pdf",
+            partition="p1",
+            file_id="f2",
+            allowed_partitions=["p1"],
+            user_id=7,
+        )
+
+    assert downloaded_path is not None
+    assert not downloaded_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_index_url_removes_download_when_dispatch_is_cancelled(monkeypatch):
+    parts = FakePartitions(exists=False, partition_exists=True, members=[{"user_id": 7, "role": "editor"}])
+    indexing = FakeIndexing(add_error=asyncio.CancelledError())
+    svc = _service(partitions=parts, indexing=indexing)
+    downloaded_path = None
+
+    async def fake_download(url, dest):
+        nonlocal downloaded_path
+        downloaded_path = dest
+        dest.write_bytes(b"partial")
+
+    monkeypatch.setattr(svc, "_safe_download", fake_download)
+
+    with pytest.raises(asyncio.CancelledError):
         await svc.index_url(
             url="https://example.com/report.pdf",
             partition="p1",

--- a/tests/unit/services/persistence/test_add_file_to_partition_user_id.py
+++ b/tests/unit/services/persistence/test_add_file_to_partition_user_id.py
@@ -102,6 +102,29 @@ async def test_add_file_to_partition_persists_indexation_config_column():
 
 
 @pytest.mark.asyncio
+async def test_add_file_to_partition_persists_content_hash_column():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _FakePool()
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert (
+        await repo.add_file_to_partition(
+            file_id="f1",
+            partition="new-part",
+            user_id=42,
+            content_sha256="abc123",
+        )
+        is True
+    )
+    insert_query, insert_params = next(
+        (query, params) for query, params in pool.conn.executed if "INSERT INTO files" in query
+    )
+    assert "content_sha256" in insert_query
+    assert "abc123" in insert_params
+
+
+@pytest.mark.asyncio
 async def test_require_existing_partition_does_not_auto_create_missing_partition():
     from services.persistence.document_repo import PgDocumentRepository
 
@@ -154,6 +177,20 @@ async def test_update_file_in_partition_persists_indexation_config_column():
     query, params = pool.executed[0]
     assert "indexation_config" in query
     assert snapshot in params
+
+
+@pytest.mark.asyncio
+async def test_update_file_in_partition_updates_content_hash_column():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _DirectExecutePool()
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert await repo.update_file_in_partition("f1", "tenant-a", content_sha256="abc123") is True
+
+    query, params = pool.executed[0]
+    assert "content_sha256" in query
+    assert "abc123" in params
 
 
 def test_row_to_document_exposes_indexation_config_snapshot():

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -133,6 +133,28 @@ async def test_release_content_hash_claim_is_scoped_to_its_owner() -> None:
     assert params == ("tenant-a", "abc123", "new-file")
 
 
+@pytest.mark.asyncio
+async def test_renew_content_hash_claim_extends_only_its_owner() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool([])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert (
+        await repo.renew_content_sha256_claim(
+            file_id="new-file",
+            partition="tenant-a",
+            content_sha256="abc123",
+        )
+        is True
+    )
+
+    query, params = pool.executed[0]
+    assert "SET expires_at" in query
+    assert "file_id = $3" in query
+    assert params == ("tenant-a", "abc123", "new-file")
+
+
 def test_persistence_schema_enforces_partition_scoped_content_uniqueness() -> None:
     from services.persistence.schema import file_content_claims, files
 

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ClaimConnection:
+    def __init__(self, fetch_values):
+        self.fetch_values = deque(fetch_values)
+        self.executed: list[tuple[str, tuple]] = []
+
+    def transaction(self):
+        return _AsyncContext(self)
+
+    async def fetchval(self, query: str, *params):
+        self.executed.append((query, params))
+        return self.fetch_values.popleft()
+
+    async def execute(self, query: str, *params):
+        self.executed.append((query, params))
+        return "DELETE 0"
+
+
+class _ClaimPool:
+    def __init__(self, fetch_values):
+        self.conn = _ClaimConnection(fetch_values)
+        self.executed: list[tuple[str, tuple]] = []
+
+    def acquire(self):
+        return _AsyncContext(self.conn)
+
+    async def execute(self, query: str, *params):
+        self.executed.append((query, params))
+        return "DELETE 1"
+
+
+@pytest.mark.asyncio
+async def test_claim_content_hash_reserves_new_content() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool([None, "new-file"])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    conflict = await repo.claim_content_sha256(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+    assert conflict is None
+    assert any("INSERT INTO file_content_claims" in query for query, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_claim_content_hash_returns_completed_duplicate() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool(["existing-file"])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    conflict = await repo.claim_content_sha256(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+    assert conflict == "existing-file"
+    assert not any("INSERT INTO file_content_claims" in query for query, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_claim_content_hash_returns_active_duplicate() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool([None, None, "active-file"])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    conflict = await repo.claim_content_sha256(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+    assert conflict == "active-file"
+
+
+@pytest.mark.asyncio
+async def test_replacement_can_claim_its_own_existing_content() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool(["same-file", "same-file"])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    conflict = await repo.claim_content_sha256(
+        file_id="same-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+        replace=True,
+    )
+
+    assert conflict is None
+
+
+@pytest.mark.asyncio
+async def test_release_content_hash_claim_is_scoped_to_its_owner() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool([])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    await repo.release_content_sha256_claim(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+    query, params = next(
+        (query, params) for query, params in pool.conn.executed if "DELETE FROM file_content_claims" in query
+    )
+    assert "file_id = $3" in query
+    assert params == ("tenant-a", "abc123", "new-file")
+
+
+def test_persistence_schema_enforces_partition_scoped_content_uniqueness() -> None:
+    from services.persistence.schema import file_content_claims, files
+
+    assert "content_sha256" in files.c
+    index = next(index for index in files.indexes if index.name == "uix_files_partition_content_sha256")
+    assert index.unique is True
+    assert [column.name for column in index.columns] == ["partition_name", "content_sha256"]
+    assert set(file_content_claims.primary_key.columns.keys()) == {"partition_name", "content_sha256"}

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -877,15 +877,10 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_releases_content_claim() -> None:
+async def test_cancel_task_leaves_content_claim_for_task_settlement() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     tsm = _task_state_manager()
-    tsm.get_details.remote.return_value = {
-        "file_id": "file-1",
-        "partition": "tenant-a",
-        "metadata": {"content_sha256": "abc123"},
-    }
     repo = _document_repo()
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
@@ -900,11 +895,8 @@ async def test_cancel_task_releases_content_claim() -> None:
     with patch("ray.cancel"):
         assert await dispatcher.cancel_task("task-1") is True
 
-    repo.release_content_sha256_claim.assert_awaited_once_with(
-        file_id="file-1",
-        partition="tenant-a",
-        content_sha256="abc123",
-    )
+    repo.release_content_sha256_claim.assert_not_awaited()
+    tsm.get_details.remote.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -63,6 +63,8 @@ def _vector_store() -> MagicMock:
 
 def _document_repo() -> MagicMock:
     repo = MagicMock()
+    repo.claim_content_sha256 = AsyncMock(return_value=None)
+    repo.release_content_sha256_claim = AsyncMock()
     repo.remove_file_from_partition = AsyncMock()
     repo.update_file_metadata_in_db = AsyncMock(return_value=True)
     repo.add_file_to_partition = AsyncMock(return_value=True)
@@ -84,6 +86,7 @@ def _task_state_manager() -> MagicMock:
     tsm.set_object_ref = _remote_mock()
     tsm.get_state = _remote_mock("SERIALIZING")
     tsm.get_error = _remote_mock("traceback")
+    tsm.get_details = _remote_mock(None)
     tsm.get_object_ref = _remote_mock({"ref": object()})
     tsm.get_matching_active_task_refs_v2 = _remote_mock({})
     tsm.get_matching_active_task_refs = _remote_mock({})
@@ -234,6 +237,73 @@ async def test_dispatch_indexing_registers_completion_with_detached_tracker() ->
         )
     tracker.track.remote.assert_called_once_with("task-1", {"ref": ref})
     tsm.set_details.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_rejects_content_already_claimed() -> None:
+    from core.utils.exceptions import ConflictError
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    repo.claim_content_sha256.return_value = "existing-file"
+    pool = _pool_with_ref(object())
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=_task_state_manager(),
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with pytest.raises(ConflictError) as exc:
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "new-file", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert exc.value.code == "DOCUMENT_CONTENT_EXISTS"
+    assert exc.value.extra["existing_file_id"] == "existing-file"
+    pool.submit.remote.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_releases_claim_when_queueing_fails() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    tsm = _task_state_manager()
+    tsm.set_queued_details.remote.side_effect = RuntimeError("queue unavailable")
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with pytest.raises(RuntimeError, match="queue unavailable"):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "new-file", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
 
 
 @pytest.mark.asyncio
@@ -773,6 +843,7 @@ async def test_worker_dispatcher_mutates_files_without_legacy_indexer() -> None:
         user_id=None,
         relationship_id=None,
         parent_id=None,
+        content_sha256=None,
     )
     vector_store.upsert_entities.assert_awaited_once()
     vector_store.insert_entities.assert_awaited_once()
@@ -803,6 +874,37 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
     assert result is True
     tsm.set_cancelled_if_active.remote.assert_called_once_with("task-1")
     cancel.assert_called_once_with(ref, recursive=True)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_releases_content_claim() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_details.remote.return_value = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"content_sha256": "abc123"},
+    }
+    repo = _document_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("ray.cancel"):
+        assert await dispatcher.cancel_task("task-1") is True
+
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -976,6 +976,39 @@ async def test_pool_rolls_back_inflight_when_submission_raises() -> None:
     assert pool._inflight == [0]
 
 
+@pytest.mark.asyncio
+async def test_pool_renews_content_claim_while_task_is_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.indexer_pool as module
+
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    renewed = asyncio.Event()
+
+    async def renew(**_kwargs):
+        renewed.set()
+        return True
+
+    repo = SimpleNamespace(renew_content_sha256_claim=AsyncMock(side_effect=renew))
+    pool._claim_store = SimpleNamespace(document_repo=repo)
+    pool._claim_store_lock = asyncio.Lock()
+    monkeypatch.setattr(module, "_CONTENT_CLAIM_RENEW_INTERVAL_SECONDS", 0.001)
+
+    await pool.submit(
+        task_id="task-1",
+        partition="tenant-a",
+        metadata={"file_id": "file-1", "content_sha256": "abc123"},
+    )
+    await asyncio.wait_for(renewed.wait(), timeout=1)
+    await _settle_pool_release_tasks(pool, worker.futures[0])
+
+    repo.renew_content_sha256_claim.assert_awaited()
+    assert repo.renew_content_sha256_claim.await_args.kwargs == {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "content_sha256": "abc123",
+    }
+
+
 def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPatch) -> None:
     import core.config
     import core.embeddings

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -888,6 +888,8 @@ def _bare_pool(workers: list) -> object:
     pool._workers = list(workers)
     pool._inflight = [0] * len(workers)
     pool._release_tasks = set()
+    pool._claim_store = None
+    pool._claim_store_lock = asyncio.Lock()
     return pool
 
 
@@ -988,7 +990,10 @@ async def test_pool_renews_content_claim_while_task_is_active(monkeypatch: pytes
         renewed.set()
         return True
 
-    repo = SimpleNamespace(renew_content_sha256_claim=AsyncMock(side_effect=renew))
+    repo = SimpleNamespace(
+        renew_content_sha256_claim=AsyncMock(side_effect=renew),
+        release_content_sha256_claim=AsyncMock(),
+    )
     pool._claim_store = SimpleNamespace(document_repo=repo)
     pool._claim_store_lock = asyncio.Lock()
     monkeypatch.setattr(module, "_CONTENT_CLAIM_RENEW_INTERVAL_SECONDS", 0.001)
@@ -1007,6 +1012,38 @@ async def test_pool_renews_content_claim_while_task_is_active(monkeypatch: pytes
         "partition": "tenant-a",
         "content_sha256": "abc123",
     }
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pool_keeps_content_claim_until_cancelled_task_settles() -> None:
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    repo = SimpleNamespace(
+        renew_content_sha256_claim=AsyncMock(return_value=True),
+        release_content_sha256_claim=AsyncMock(),
+    )
+    pool._claim_store = SimpleNamespace(document_repo=repo)
+
+    await pool.submit(
+        task_id="task-1",
+        partition="tenant-a",
+        metadata={"file_id": "file-1", "content_sha256": "abc123"},
+    )
+
+    worker.futures[0].cancel()
+    assert repo.release_content_sha256_claim.await_count == 0
+    await _settle_pool_release_tasks(pool)
+
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
 
 
 def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from core.config.model_endpoints import ModelEndpointConfig
@@ -1158,7 +1159,10 @@ def _bare_worker_actor(*, save_uploaded_files: bool, worker: _RecordingWorker):
     actor._ensure_catalog = _noop
     actor._ensure_registry_fresh = _noop
     actor._worker = worker
-    actor._catalog_store = SimpleNamespace(workspace_repo=SimpleNamespace())
+    actor._catalog_store = SimpleNamespace(
+        workspace_repo=SimpleNamespace(),
+        document_repo=SimpleNamespace(release_content_sha256_claim=AsyncMock()),
+    )
     actor._save_uploaded_files = save_uploaded_files
     actor._logger = SimpleNamespace(debug=lambda *a, **k: None, warning=lambda *a, **k: None)
     return actor
@@ -1175,6 +1179,26 @@ async def test_actor_keeps_upload_by_default(tmp_path) -> None:
     # Default: the raw upload stays on disk so the source-download route can
     # serve it back for Chainlit source viewing.
     assert path.exists()
+
+
+@pytest.mark.asyncio
+async def test_actor_releases_content_claim_after_indexing(tmp_path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"x")
+    actor = _bare_worker_actor(save_uploaded_files=True, worker=_RecordingWorker())
+
+    await actor.process_file(
+        task_id="t",
+        path=str(path),
+        metadata={"file_id": "f", "content_sha256": "abc123"},
+        partition="p",
+    )
+
+    actor._catalog_store.document_repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="f",
+        partition="p",
+        content_sha256="abc123",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -364,6 +364,7 @@ async def test_process_file_creates_catalog_record_after_successful_pipeline(tmp
         "relationship_id": "rel",
         "parent_id": "parent",
         "require_existing_partition": False,
+        "content_sha256": None,
     }
     assert repo.update_calls == []
 
@@ -478,6 +479,7 @@ async def test_process_file_updates_catalog_record_on_replace(tmp_path: Path) ->
         "file_metadata": {"file_id": "f1"},
         "relationship_id": None,
         "parent_id": None,
+        "content_sha256": None,
     }
     assert repo.add_calls == []
 


### PR DESCRIPTION
## Summary

This PR prevents the same document content from being indexed more than once in a partition, even when the uploads use different filenames or file IDs.

Deduplication is intentionally scoped to a partition. The same document can still be indexed in another partition because partitions may represent separate users, workspaces, or retrieval contexts.

## Why this is needed

OpenRAG currently identifies documents by their file ID. Two uploads containing identical bytes can therefore enter the indexing pipeline under different IDs, consuming parser, embedding, storage, and queue capacity twice. A simple database uniqueness check is not sufficient because concurrent uploads can both start indexing before either document is stored.

This change addresses both completed duplicates and uploads that are still in progress.

## Behavior

OpenRAG calculates a SHA-256 digest while the upload is already being written to disk. This avoids a second full read and keeps memory usage constant for large documents.

Before queue submission, the content is reserved atomically for its partition. If another completed or in-progress document already has the same digest, the request is rejected with a conflict response that identifies the existing file. PostgreSQL transaction locking and a short-lived claim prevent concurrent requests from both entering expensive indexing work.

Claims are released after completion, failure, cancellation, or a submission error. Expired claims are also recoverable after an interrupted worker. Replacement remains valid when the content belongs to the same file ID, and copy and URL-indexing paths follow the same rule.

The digest is backend-owned. Metadata updates cannot inject or replace it.

## Configuration

Deduplication is enabled by default. It can be disabled with CONTENT_DEDUPLICATION_ENABLED=false, primarily for controlled benchmarks that need to exclude hashing overhead or intentionally index repeated content.

## Database migration

The migration adds a nullable content digest to the document catalog, a partition-scoped uniqueness constraint for populated digests, and a small table for active indexing claims.

Existing rows remain nullable. This makes the migration safe and fast for existing deployments, but documents indexed before this change will not be compared until a separate controlled backfill is performed. New uploads, replacements, copies, and URL-indexed documents are protected immediately.

## Compatibility

Document IDs, routes, partition behavior, and retrieval behavior remain unchanged. No frontend change is required. Duplicate uploads now return a conflict instead of starting another indexing task.

## Validation

- Full unit suite: 1,751 passed
- Final focused regression suite after concurrency hardening: 79 passed
- Ruff lint and format checks passed
- Python compilation passed
- Alembic reports a single migration head
- Migration was applied successfully to PostgreSQL 15
- Real PostgreSQL claim/release behavior was verified, including rejection of a concurrent duplicate and acceptance after claim release
- Database constraints were verified to reject the same digest in one partition while allowing it in another
- Diff integrity check passed

## Follow-up

A separate backfill should calculate hashes for existing catalog rows from their stored source files. Keeping that work separate avoids turning the release migration into a long-running filesystem scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SHA-256–based content deduplication for uploaded and copied documents.
  * Identical content within the same partition is deduplicated by default, returning HTTP 409 that references the existing file (including when using different file IDs).
  * Re-uploading identical content under the same file ID is treated as a valid replacement.

* **Bug Fixes**
  * Improved cleanup of temporary uploaded/downloaded files when indexing fails, is cancelled, or conflicts.
  * More predictable upload error handling (e.g., correct 409/413 behavior) and safer error responses.

* **Documentation**
  * Updated environment variable docs with `CONTENT_DEDUPLICATION_ENABLED` (default `true`).
  * `SAVE_UPLOADED_FILES` now defaults to `true`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->