### PR TITLE
fix(quota): arbitrate the reserved file-slot release instead of leaking it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,16 @@ Consequences to respect when touching this code:
   so do the MCP tools that create rows (`MCPService.index_url`, `MCPService.copy_file`),
   which have no dependency chain and therefore reserve inline;
   `put_file` (replace re-index) does not, since it reuses an existing row.
+- **After dispatch, ownership is arbitrated, not assumed.** A task that
+  `ray.cancel` retires before `process_file`'s body runs never executes that
+  `finally`, so `WorkerDispatcher.cancel_task` releases instead. Both call
+  `TaskStateManager.claim_quota_release`, a one-shot compare-and-set in the
+  (single-threaded) state actor: the first caller wins and the other stands
+  down. Any new release path must go through the same claim — releasing
+  directly reintroduces the double-release, and skipping the release when the
+  claim is *lost* is correct, but skipping it when the claim cannot be *made*
+  is not. When the arbiter is unreachable, release: an undercount is
+  recoverable, a leak is permanent.
 - Any new early return between admission and dispatch is automatically covered by the
   teardown — but any new code path that *creates a file row without reserving*, or
   *reserves without either committing or releasing*, leaks the counter. A leak is

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -584,6 +584,7 @@ class ServiceContainer:
                     workspace_repo=self.workspace_repo,
                     collection=settings.vectordb.collection_name,
                     job_repo=self.job_repo,
+                    user_repo=self.user_repo,
                 ),
                 config=settings,
                 partition_service=self.partition_service,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -63,6 +63,7 @@ class WorkerDispatcher(IndexingDispatcher):
         collection: str,
         timeout: float = DEFAULT_TIMEOUT,
         job_repo: Any = None,
+        user_repo: Any = None,
     ) -> None:
         self._pool = pool
         self._tsm = task_state_manager
@@ -76,6 +77,10 @@ class WorkerDispatcher(IndexingDispatcher):
         # is absent, job state degrades to the in-memory actor — the pre-#660
         # behaviour.
         self._job_repo = job_repo
+        # Optional for the same reason as ``job_repo``. Without it a cancel that
+        # beats the worker to the task cannot return the reserved slot, which is
+        # the pre-#664 behaviour rather than a new failure.
+        self._user_repo = user_repo
         self._last_job_purge_at: float | None = None
 
     async def _call(self, future: Any, task_description: str) -> Any:
@@ -95,6 +100,7 @@ class WorkerDispatcher(IndexingDispatcher):
         partition: str,
         metadata: dict[str, Any],
         user_id: int | None,
+        quota_reserved: bool = False,
     ) -> bool:
         remote = _remote_actor_method(self._tsm, "set_queued_details")
         if remote is not None:
@@ -105,6 +111,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     partition=partition,
                     metadata=metadata,
                     user_id=user_id,
+                    quota_reserved=quota_reserved,
                 ),
                 task_description=f"set_queued_details({task_id})",
             )
@@ -121,6 +128,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 partition=partition,
                 metadata=metadata,
                 user_id=user_id,
+                quota_reserved=quota_reserved,
             ),
             task_description=f"set_details({task_id})",
         )
@@ -168,6 +176,9 @@ class WorkerDispatcher(IndexingDispatcher):
             partition=partition,
             metadata=user_metadata,
             user_id=user.get("id") if user else None,
+            # Tells the actor a slot is outstanding for this task, so
+            # ``claim_quota_release`` can arbitrate who gives it back.
+            quota_reserved=quota_reserved,
         )
         if not accepted:
             raise RuntimeError(
@@ -683,16 +694,52 @@ class WorkerDispatcher(IndexingDispatcher):
             # raises: the actor has already claimed the cancellation, and
             # leaving the worker running would contradict both records.
             ray.cancel(obj_ref["ref"], recursive=True)
-        # The reserved quota slot (#664) is deliberately not released here.
-        # A task cancelled mid-flight gives its slot back in
-        # ``IndexerWorker.process_file``'s ``finally``; releasing here too
-        # would double-release. But a task that ``ray.cancel`` retires
-        # *before* that body runs never executes the ``finally``, so its slot
-        # leaks -- and the CANCELLED row written just above is terminal, hence
-        # indistinguishable from a clean cancel. Recovering it needs the #676
-        # reconciliation to *recount* ``file_count`` (completed files + active
-        # job rows), not merely sweep orphaned active rows.
+        # Return the reserved quota slot (#664) if -- and only if -- this
+        # cancel is the reason nobody else will. A task cancelled mid-flight
+        # releases in ``IndexerWorker.process_file``'s ``finally``; a task that
+        # ``ray.cancel`` retires before that body runs never executes it, and
+        # used to leak the slot outright. ``claim_quota_release`` is a one-shot
+        # token in the state actor, so exactly one of the two wins and the
+        # outcome no longer depends on how far the worker got.
+        #
+        # After the release, not inside the ``finally`` above: the claim is
+        # only meaningful once ``ray.cancel`` has actually retired the task,
+        # and a failure here must not stop the worker from being killed.
+        await self._release_cancelled_slot(task_id)
         return True
+
+    async def _release_cancelled_slot(self, task_id: str) -> None:
+        """Give a cancelled task's reserved file slot back, if we own it.
+
+        Best-effort throughout: a cancellation the user already asked for and
+        already saw must not fail because quota bookkeeping did. A lost release
+        leaves ``file_count`` one too high, which the #676 reconciliation
+        recount is there to repair.
+        """
+        if self._user_repo is None:
+            return
+        try:
+            details = await self._call(
+                self._tsm.get_details.remote(task_id),
+                task_description=f"get_details({task_id})",
+            )
+            user_id = (details or {}).get("user_id")
+            if user_id is None:
+                return
+            claimed = await self._call(
+                self._tsm.claim_quota_release.remote(task_id),
+                task_description=f"claim_quota_release({task_id})",
+            )
+            if not claimed:
+                return
+            await self._user_repo.release_file_slot(user_id)
+        except Exception as exc:  # noqa: BLE001 - the cancellation itself already succeeded
+            logger.warning(
+                "Could not release the reserved file slot for a cancelled task; "
+                "the user file_count may be one too high until reconciliation.",
+                task_id=task_id,
+                error=str(exc),
+            )
 
 
 def from_ray_namespace(
@@ -704,6 +751,7 @@ def from_ray_namespace(
     workspace_repo: Any,
     collection: str,
     job_repo: Any = None,
+    user_repo: Any = None,
 ) -> WorkerDispatcher:
     import ray
     from services.workers.indexer_pool import build_indexer_pool
@@ -717,6 +765,7 @@ def from_ray_namespace(
         collection=collection,
         timeout=timeout,
         job_repo=job_repo,
+        user_repo=user_repo,
     )
 
 

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -223,7 +223,7 @@ class IndexerWorker:
             )
             raise
         finally:
-            if release_slot:
+            if release_slot and await claim_quota_release(self._tsm, task_id):
                 await release_quota_slot(self._user_repo, user_id)
         # The raw upload is purged (when configured) by the enclosing actor, not
         # here: cleanup must also cover failures that happen *before* this method
@@ -479,6 +479,28 @@ def _display_filename(path: str, metadata: dict[str, Any]) -> str:
     if filename:
         return str(filename)
     return Path(path).name
+
+
+async def claim_quota_release(tsm: Any, task_id: str) -> bool:
+    """Ask the state actor whether *we* are the ones who owe the slot back.
+
+    ``WorkerDispatcher.cancel_task`` can reach the same conclusion for the same
+    task, so the actor arbitrates with a one-shot token (#664). Only the winner
+    releases.
+
+    An unreachable actor answers ``True``: a slot was reserved and this is the
+    last code that knows it, so releasing risks an undercount while staying
+    silent risks a permanent leak. This branch prefers the recoverable failure,
+    which is also exactly the pre-arbitration behaviour.
+    """
+    try:
+        return bool(await tsm.claim_quota_release.remote(task_id))
+    except Exception:  # noqa: BLE001 - cleanup must never mask the indexing error
+        logger.warning(
+            "Could not arbitrate the reserved file slot release; releasing it anyway.",
+            task_id=task_id,
+        )
+        return True
 
 
 async def release_quota_slot(user_repo: Any, user_id: int | None) -> None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -9,6 +9,7 @@ from typing import Any
 import ray
 from services.workers.indexer_actor import (
     IndexerWorker,
+    claim_quota_release,
     delete_uploaded_file,
     mark_dispatch_orphan_failed,
     release_quota_slot,
@@ -69,8 +70,8 @@ class IndexerWorkerActor:
         task_state_manager = ray.get_actor("TaskStateManager", namespace="openrag")
         # Kept on the actor as well as handed to the worker: setup can fail
         # before the worker is ever entered, and that path has to settle the
-        # task itself (see ``process_file``).
-        self._task_state_manager = task_state_manager
+        # task itself and arbitrate the quota release (see ``process_file``).
+        self._tsm = task_state_manager
         pipeline = build_indexing_pipeline(
             parser=parser,
             chunker=chunker,
@@ -244,7 +245,11 @@ class IndexerWorkerActor:
                 # release too, and ``release_quota_slot`` swallows it, leaking the
                 # slot. Nothing local can fix that (the DB *is* the counter);
                 # recovering it needs the reconciliation sweep tracked in #676.
-                if quota_reserved:
+                #
+                # Routed through the same one-shot claim as every other release
+                # path: a cancellation *during* setup lands here and in
+                # ``cancel_task``, and without arbitration both would release.
+                if quota_reserved and await claim_quota_release(self._tsm, task_id):
                     await release_quota_slot(self._catalog_store.user_repo, (user or {}).get("id"))
                 # The task is QUEUED in both stores and ``IndexerWorker`` --
                 # the only writer of SERIALIZING/COMPLETED/FAILED -- is never
@@ -262,7 +267,7 @@ class IndexerWorkerActor:
                 # unreachable Postgres still leaves an evictable, terminal
                 # ``TaskInfo`` rather than a pinned one.
                 await mark_dispatch_orphan_failed(
-                    self._task_state_manager,
+                    self._tsm,
                     self._catalog_store.job_repo,
                     task_id,
                 )

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -62,6 +62,12 @@ class TaskInfo:
     error: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
     object_ref: ray.ObjectRef | None = None
+    # #664. ``quota_reserved`` records that admission charged one
+    # ``users.file_count`` slot for this task; ``quota_release_claimed`` is the
+    # one-shot token that decides *who* gives it back. Kept on the record rather
+    # than in ``details`` because ``details`` is surfaced in API responses.
+    quota_reserved: bool = False
+    quota_release_claimed: bool = False
 
 
 @ray.remote(concurrency_groups={"set": 1000, "get": 1000, "queue_info": 1000})
@@ -253,6 +259,7 @@ class TaskStateManager:
         partition: str,
         metadata: dict[str, Any],
         user_id: int | None,
+        quota_reserved: bool = False,
     ) -> None:
         async with self.lock:
             info = self._live_task(task_id)
@@ -268,6 +275,7 @@ class TaskStateManager:
                 metadata=metadata,
                 user_id=user_id,
             )
+            info.quota_reserved = quota_reserved
 
     @ray.method(concurrency_group="set")
     async def set_queued_details(
@@ -278,6 +286,7 @@ class TaskStateManager:
         partition: str,
         metadata: dict[str, Any],
         user_id: int | None,
+        quota_reserved: bool = False,
     ) -> bool:
         async with self.lock:
             info = await self._ensure_task(task_id)
@@ -291,10 +300,39 @@ class TaskStateManager:
                 metadata=metadata,
                 user_id=user_id,
             )
+            info.quota_reserved = quota_reserved
             if self._file_delete_fenced(partition=partition, file_id=file_id):
                 info.state = "CANCELLED"
                 return False
             info.state = "QUEUED"
+            return True
+
+    @ray.method(concurrency_group="set")
+    async def claim_quota_release(self, task_id: str) -> bool:
+        """Hand the task's reserved file slot to exactly one releaser (#664).
+
+        Two parties can end up believing they owe the uploader a slot back:
+        ``IndexerWorker.process_file``'s ``finally``, and
+        ``WorkerDispatcher.cancel_task`` when ``ray.cancel`` retires the task
+        before that body ever runs. Letting both release double-counts; letting
+        neither leaks. This actor is single-threaded, so a compare-and-set here
+        settles it: the first caller wins, every later one is told to stand
+        down.
+
+        Returns ``True`` for a task the actor no longer knows. A slot was
+        reserved for *some* task and nothing else will give it back, and this
+        branch prefers an undercount (recoverable, and self-heals on the next
+        reconciliation) over a leak (permanent, and silently narrows the user's
+        quota). In practice it is unreachable: eviction is FIFO by settle time,
+        so a task that just settled is the last candidate to be dropped.
+        """
+        async with self.lock:
+            info = self.tasks.get(task_id)
+            if info is None:
+                return True
+            if not info.quota_reserved or info.quota_release_claimed:
+                return False
+            info.quota_release_claimed = True
             return True
 
     @ray.method(concurrency_group="set")

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -91,6 +91,9 @@ def _task_state_manager() -> MagicMock:
     tsm.set_queued_details = _remote_mock(True)
     tsm.begin_file_delete = _remote_mock()
     tsm.end_file_delete = _remote_mock()
+    # #700: the cancel path asks who owns the reserved slot, then claims it.
+    tsm.get_details = _remote_mock({"user_id": 42})
+    tsm.claim_quota_release = _remote_mock(True)
     return tsm
 
 
@@ -157,6 +160,7 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         partition="tenant-a",
         metadata={"filename": "report.txt"},
         user_id=42,
+        quota_reserved=False,
     )
     tsm.set_state.remote.assert_not_called()
     tsm.set_details.remote.assert_not_called()
@@ -247,6 +251,7 @@ async def test_dispatch_indexing_uses_split_queue_registration_for_legacy_task_s
         partition="tenant-a",
         metadata={"filename": "report.txt"},
         user_id=42,
+        quota_reserved=False,
     )
     tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
 
@@ -1733,3 +1738,89 @@ async def test_an_empty_source_copies_nothing_and_reports_no_row():
 
     assert created is False
     dispatcher._document_repo.add_file_to_partition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancel_releases_a_slot_the_worker_will_never_release() -> None:
+    """The cancel-before-start leak (#664).
+
+    After dispatch the worker owns the reserved slot and hands it back in
+    ``process_file``'s ``finally``. If ``ray.cancel`` retires the task before
+    that body ever runs, the ``finally`` never executes and the slot used to
+    leak outright — permanently narrowing the uploader's quota, and
+    indistinguishable from a clean cancel because the CANCELLED row is terminal
+    either way. The state actor now arbitrates, so the cancel releases it.
+    """
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_object_ref.remote = AsyncMock(return_value={"ref": object()})
+    user_repo = MagicMock()
+    user_repo.release_file_slot = AsyncMock()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        user_repo=user_repo,
+    )
+
+    with patch("ray.cancel"):
+        assert await dispatcher.cancel_task("task-1") is True
+
+    tsm.claim_quota_release.remote.assert_called_once_with("task-1")
+    user_repo.release_file_slot.assert_awaited_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_cancel_does_not_release_a_slot_the_worker_already_owns() -> None:
+    """A task cancelled *mid-flight* still runs its ``finally``.
+
+    Both paths then believe they owe the slot back; the claim is what stops the
+    second one, and a double release would drive ``file_count`` below reality
+    and hand out free quota.
+    """
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.claim_quota_release.remote = AsyncMock(return_value=False)
+    user_repo = MagicMock()
+    user_repo.release_file_slot = AsyncMock()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        user_repo=user_repo,
+    )
+
+    with patch("ray.cancel"):
+        assert await dispatcher.cancel_task("task-1") is True
+
+    user_repo.release_file_slot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failing_slot_release_does_not_fail_the_cancellation() -> None:
+    """The user asked to cancel and the cancel landed; bookkeeping is secondary."""
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    user_repo = MagicMock()
+    user_repo.release_file_slot = AsyncMock(side_effect=RuntimeError("postgres is down"))
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        user_repo=user_repo,
+    )
+
+    with patch("ray.cancel"):
+        assert await dispatcher.cancel_task("task-1") is True

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1094,7 +1094,7 @@ def _bare_worker_actor(*, save_uploaded_files: bool, worker: _RecordingWorker):
     actor._ensure_registry_fresh = _noop
     actor._worker = worker
     actor._catalog_store = SimpleNamespace(workspace_repo=SimpleNamespace(), job_repo=None)
-    actor._task_state_manager = _FakeStateManager()
+    actor._tsm = _FakeStateManager()
     actor._save_uploaded_files = save_uploaded_files
     actor._logger = SimpleNamespace(debug=lambda *a, **k: None, warning=lambda *a, **k: None)
     return actor
@@ -1235,7 +1235,7 @@ def _pool_with_broken_setup(user_repo, *, error: BaseException, tsm=None, job_re
     cls = IndexerWorkerActor.__ray_metadata__.modified_class
     pool = cls.__new__(cls)
     pool._catalog_store = _FakeCatalogStore(user_repo, job_repo)
-    pool._task_state_manager = tsm if tsm is not None else _FakeStateManager()
+    pool._tsm = tsm if tsm is not None else _FakeStateManager()
 
     async def _boom() -> None:
         raise error

--- a/tests/unit/services/workers/test_indexer_worker_quota_release.py
+++ b/tests/unit/services/workers/test_indexer_worker_quota_release.py
@@ -58,19 +58,23 @@ class _Pipeline:
         return {**row, "stored_count": 3, "stage": "stored", "indexed_at": None}
 
 
-def _tsm() -> MagicMock:
+def _tsm(*, claim: bool = True) -> MagicMock:
     tsm = MagicMock()
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
     tsm.set_failed_if_not_cancelled = MagicMock()
     tsm.set_failed_if_not_cancelled.remote = AsyncMock(return_value=True)
+    # The slot is released by whoever wins this claim; ``cancel_task`` can be
+    # the other contender (#664).
+    tsm.claim_quota_release = MagicMock()
+    tsm.claim_quota_release.remote = AsyncMock(return_value=claim)
     return tsm
 
 
-def _worker(pipeline, doc_repo, user_repo) -> IndexerWorker:
+def _worker(pipeline, doc_repo, user_repo, *, tsm=None) -> IndexerWorker:
     return IndexerWorker(
         pipeline=pipeline,
-        task_state_manager=_tsm(),
+        task_state_manager=tsm or _tsm(),
         document_repo=doc_repo,
         topic_tag_repo=None,
         user_repo=user_repo,
@@ -103,6 +107,47 @@ async def test_success_consumes_the_slot(tmp_path):
     assert result["stored_count"] == 3
     assert len(doc_repo.add_calls) == 1
     assert user_repo.released == []
+
+
+@pytest.mark.asyncio
+async def test_a_lost_claim_leaves_the_release_to_the_canceller(tmp_path):
+    """Only one party may hand the slot back.
+
+    A task cancelled mid-flight runs this ``finally`` *and* reaches
+    ``WorkerDispatcher.cancel_task``. Both would otherwise release, driving
+    ``file_count`` below reality and handing the user free quota.
+    """
+    user_repo = FakeUserRepo()
+    worker = _worker(
+        _Pipeline(error=RuntimeError("boom")),
+        FakeDocumentRepo(),
+        user_repo,
+        tsm=_tsm(claim=False),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _run(worker, tmp_path)
+
+    assert user_repo.released == []
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_state_actor_still_releases(tmp_path):
+    """Arbitration is an optimisation; not leaking is the requirement.
+
+    If the claim itself cannot be made, release anyway: an undercount is
+    recoverable and self-heals on reconciliation, whereas a leak permanently
+    narrows the uploader's quota.
+    """
+    user_repo = FakeUserRepo()
+    tsm = _tsm()
+    tsm.claim_quota_release.remote = AsyncMock(side_effect=RuntimeError("actor is gone"))
+    worker = _worker(_Pipeline(error=RuntimeError("boom")), FakeDocumentRepo(), user_repo, tsm=tsm)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _run(worker, tmp_path)
+
+    assert user_repo.released == [42]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -193,9 +193,16 @@ def _manager():
     return _ACTOR()
 
 
-async def _dispatch(mgr, task_id: str, user_id: int = 1) -> None:
+async def _dispatch(mgr, task_id: str, user_id: int = 1, *, quota_reserved: bool = False) -> None:
     await mgr.set_state(task_id, "QUEUED")
-    await mgr.set_details(task_id, file_id=f"f-{task_id}", partition="p", metadata={}, user_id=user_id)
+    await mgr.set_details(
+        task_id,
+        file_id=f"f-{task_id}",
+        partition="p",
+        metadata={},
+        user_id=user_id,
+        quota_reserved=quota_reserved,
+    )
 
 
 async def test_terminal_tasks_are_evicted_beyond_the_cap(monkeypatch):
@@ -288,6 +295,42 @@ async def test_a_claimed_cancellation_is_evictable(monkeypatch):
     assert mgr.tasks == {}
     assert mgr.terminal_at == {}
     assert mgr.user_index == {}
+
+
+async def test_the_quota_release_is_claimable_exactly_once():
+    """One reserved slot, one releaser (#664).
+
+    ``process_file``'s ``finally`` and ``cancel_task`` can both conclude they
+    owe the slot back. The actor is single-threaded, so this compare-and-set is
+    what makes the outcome independent of how far the worker got.
+    """
+    mgr = _manager()
+    await _dispatch(mgr, "t0", quota_reserved=True)
+
+    assert await mgr.claim_quota_release("t0") is True
+    assert await mgr.claim_quota_release("t0") is False
+    assert await mgr.claim_quota_release("t0") is False
+
+
+async def test_a_task_that_reserved_nothing_has_no_slot_to_claim():
+    """`put_file` (replace re-index) reuses an existing row and never reserves."""
+    mgr = _manager()
+    await _dispatch(mgr, "t0")
+
+    assert await mgr.claim_quota_release("t0") is False
+
+
+async def test_an_unknown_task_claims_rather_than_leaks():
+    """Prefer the recoverable failure.
+
+    A slot was reserved for *some* task and the caller is the last code that
+    knows it. Releasing risks an undercount, which reconciliation repairs;
+    staying silent risks a leak, which is permanent and silently narrows the
+    user's quota.
+    """
+    mgr = _manager()
+
+    assert await mgr.claim_quota_release("never-seen") is True
 
 
 async def test_set_error_truncates_long_tracebacks():


### PR DESCRIPTION
Closes the cancel-before-start quota-slot leak that #677 documents as a known gap.

> **Stacked on #677** (base = `fix/660-durable-job-state`). It builds directly on the reserve/release machinery introduced there, so it cannot land first. Review #677 before this. Once #677 merges, this retargets to `develop` cleanly.

## The leak

After dispatch the worker owns the uploader's reserved file slot and hands it back in `IndexerWorker.process_file`'s `finally`. When `ray.cancel` retires a task *before* that body runs, the `finally` never executes and nothing else gives the slot back. The `CANCELLED` row written by `cancel_task` is terminal, so the loss is indistinguishable from a clean cancel — the uploader's quota is permanently one narrower, silently.

`cancel_task` could not simply release. A task cancelled *mid-flight* does run its `finally`, so releasing in both places would drive `file_count` below reality and hand the user free quota. The two cases were distinguishable only by how far the worker happened to get — which is exactly the kind of thing the caller cannot observe.

## The fix

`TaskStateManager` is a single-threaded Ray actor that already arbitrates precisely this shape of race (`set_cancelled_if_active`, `set_failed_if_not_cancelled`). A one-shot `claim_quota_release` compare-and-set is the idiomatic primitive here:

- `process_file`'s `finally` asks before releasing.
- `cancel_task` asks after claiming the cancellation.
- The `indexer_pool` setup-failure release asks too — a cancellation *during* setup reaches both it and `cancel_task`.

Exactly one caller is told to release; the outcome no longer depends on worker progress. The dispatcher records `quota_reserved` on the task at admission so the actor knows whether a slot is outstanding at all (`put_file` reuses an existing row and reserves nothing).

**This also closes the dispatch-partial-success double-release** that #677 accepts as a deliberate trade-off: the worker and the request teardown can no longer both consume the same reservation.

## Failure behaviour

Biased the same way the rest of the reserve/release design is — **an unreachable arbiter releases anyway.** An undercount is recoverable and self-heals under the #676 recount; a leak is permanent and silent. `_release_cancelled_slot` is best-effort throughout, because a cancellation the user already asked for and already saw must not fail on quota bookkeeping.

The one case that stays open is genuinely un-arbitrable and belongs to #676: outright process death between reserve and dispatch, and an unreachable Postgres inside the release itself.

## Why now rather than in #676

#685 shipped a cancel-all UI that fires one `cancelTask` per selected task (`Promise.allSettled(activeTaskIds.map(...))`). The leak was previously one slot per manual cancel; it is now N slots from a single click, which moves it out of "acceptable known gap" territory.

## Verification

- `ruff check` / `ruff format --check` clean; `scripts/check_layer_imports.py` → `layer import guard: OK`.
- **Unit: 1839 passed, 0 failed** (1831 on the #677 base, +8 here).
- **Integration against real Postgres: 119 passed, 1 failed** — unchanged from the base; the failure is the pre-existing `test_create_is_idempotent_per_name`, fixed separately in #691.
- New tests cover both directions of the race and the degraded paths: the claim is grantable exactly once; a task that reserved nothing has nothing to claim; an unknown task claims rather than leaks; the cancel releases when the worker never started; the cancel declines when the worker already owns it; a failing release does not fail the cancellation; and an unreachable state actor still releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reserved file-slot handling for indexing tasks canceled before execution by using single-ownership arbitration for quota release.
  * Prevented duplicate quota releases while ensuring the correct path returns reserved slots when a worker loses or fails during release.
  * Added best-effort safeguards so release failures during cancellation don’t block task completion.
* **Tests**
  * Expanded unit coverage for quota-release claiming, cancellation scenarios, and quota state arbitration edge cases.
* **Documentation**
  * Clarified quota reservation/release ownership behavior after dispatch and handling of unreachable arbitration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->