### PR TITLE
fix(retrieval): extract chat content so multiQuery and hyde stop crashing

### DIFF
--- a/openrag/core/llm/llm.py
+++ b/openrag/core/llm/llm.py
@@ -4,6 +4,27 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
+from typing import Any
+
+
+def chat_content(response: Any) -> str:
+    """Extract the assistant message text from an OpenAI-shaped chat response.
+
+    ``LLM.chat`` returns the raw provider payload (a ``dict``), not a string —
+    callers that want the text must reach into ``choices[0].message.content``.
+    Doing that inline is easy to forget: ``multiQuery``/``hyde`` both treated the
+    dict as a ``str`` and raised ``AttributeError`` on every query (#703).
+
+    Returns ``""`` for a malformed or empty payload rather than raising, so a
+    non-compliant provider degrades to "no expansion" instead of failing the
+    whole search — callers already handle an empty result by falling back to the
+    original query.
+    """
+    try:
+        content = response["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        return ""
+    return content if isinstance(content, str) else ""
 
 
 class LLM(ABC):

--- a/openrag/core/retrieval/retriever.py
+++ b/openrag/core/retrieval/retriever.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from itertools import chain as ichain
 from typing import Any
 
-from core.llm.llm import LLM
+from core.llm.llm import LLM, chat_content
 from core.models.chunk import Chunk
 from core.prompts.query_rewriter import (
     build_hyde_prompt,
@@ -135,7 +135,7 @@ class MultiQueryRetriever(BaseRetriever):
         response = await self.llm.chat([{"role": "user", "content": prompt}])
         # Cap to k_queries — a non-compliant LLM response can otherwise fan
         # out far more searches than configured.
-        queries = split_multi_query_response(response)[: self.k_queries]
+        queries = split_multi_query_response(chat_content(response))[: self.k_queries]
         return queries or [query]
 
     async def retrieve(
@@ -181,7 +181,8 @@ class HyDeRetriever(BaseRetriever):
 
     async def get_hyde(self, query: str) -> str:
         prompt = build_hyde_prompt(self.hyde_template, query)
-        return await self.llm.chat([{"role": "user", "content": prompt}])
+        response = await self.llm.chat([{"role": "user", "content": prompt}])
+        return chat_content(response)
 
     async def retrieve(
         self,

--- a/tests/unit/core/retrieval/test_retriever.py
+++ b/tests/unit/core/retrieval/test_retriever.py
@@ -7,6 +7,7 @@ the new core/ retriever has clean dependencies.
 from __future__ import annotations
 
 import pytest
+from core.llm.llm import chat_content
 from core.models.chunk import Chunk
 from core.retrieval.retriever import (
     HyDeRetriever,
@@ -48,16 +49,29 @@ class FakeSearcher(RetrievalSearcher):
 
 
 class FakeLLM:
+    """Test double for the ``LLM`` port.
+
+    Returns the OpenAI-shaped ``dict`` the real port declares (``LLM.chat ->
+    dict``), NOT a bare ``str``. A previous ``-> str`` fake was more permissive
+    than production and hid #703: ``multiQuery``/``hyde`` called ``.split()`` /
+    ``.strip()`` straight on the response and raised ``AttributeError`` on every
+    real query while these tests stayed green.
+    """
+
     def __init__(self, response: str) -> None:
         self.response = response
         self.chat_calls: list[list[dict]] = []
 
-    async def generate(self, prompt: str, **kwargs) -> str:
-        return self.response
+    @staticmethod
+    def _envelope(content: str) -> dict:
+        return {"choices": [{"message": {"role": "assistant", "content": content}}]}
 
-    async def chat(self, messages: list[dict], **kwargs) -> str:
+    async def generate(self, prompt: str, **kwargs) -> dict:
+        return self._envelope(self.response)
+
+    async def chat(self, messages: list[dict], **kwargs) -> dict:
         self.chat_calls.append(messages)
-        return self.response
+        return self._envelope(self.response)
 
 
 def _chunk(idv: str, text: str = "x", document_id: str = "", partition: str = "p1") -> Chunk:
@@ -272,3 +286,70 @@ async def test_expansion_dedupes_ancestor_fetches_per_file():
     ]
     await r.expand_search_results(initial)
     assert s.ancestor_call_count == 1
+
+
+# --- #703 regression: LLM.chat returns a dict, not a str -------------------
+
+
+def test_chat_content_extracts_assistant_message():
+    assert chat_content({"choices": [{"message": {"content": "hello"}}]}) == "hello"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"choices": []},
+        {"choices": [{}]},
+        {"choices": [{"message": {}}]},
+        {"choices": [{"message": {"content": None}}]},
+        None,
+        "already a string",
+    ],
+)
+def test_chat_content_degrades_to_empty_on_malformed_payload(payload):
+    """A non-compliant provider must not crash retrieval — callers fall back
+    to the original query when expansion yields nothing."""
+    assert chat_content(payload) == ""
+
+
+@pytest.mark.asyncio
+async def test_multi_query_handles_dict_response_from_llm_port():
+    """Regression for #703: the real ``LLM.chat`` returns a dict. Calling
+    ``.split()`` on it raised AttributeError on every multiQuery search."""
+    s = FakeSearcher()
+    llm = FakeLLM("alpha[SEP]beta")
+    r = MultiQueryRetriever(
+        searcher=s,
+        llm=llm,
+        multi_query_template="generate {k_queries} variants of: {query}",
+        k_queries=2,
+    )
+    await r.retrieve(partition=["p1"], query="seed")
+    assert s.multi_calls[0]["queries"] == ["alpha", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_hyde_handles_dict_response_from_llm_port():
+    """Regression for #703: ``.strip()`` on the dict raised AttributeError on
+    every hyde search."""
+    s = FakeSearcher()
+    llm = FakeLLM("  hypothetical answer  ")
+    r = HyDeRetriever(searcher=s, llm=llm, hyde_template="Answer: {question}")
+    await r.retrieve(partition=["p1"], query="seed")
+    assert s.multi_calls[0]["queries"] == ["hypothetical answer"]
+
+
+@pytest.mark.asyncio
+async def test_hyde_falls_back_to_seed_when_llm_returns_malformed_payload():
+    s = FakeSearcher()
+    llm = FakeLLM("")
+
+    async def _malformed(messages, **kwargs):
+        llm.chat_calls.append(messages)
+        return {"unexpected": "shape"}
+
+    llm.chat = _malformed
+    r = HyDeRetriever(searcher=s, llm=llm, hyde_template="Answer: {question}")
+    await r.retrieve(partition=["p1"], query="seed")
+    assert s.multi_calls[0]["queries"] == ["seed"]


### PR DESCRIPTION
Closes #703.

## Problem

`LLM.chat` returns the raw provider payload (a `dict`, `openrag/core/llm/llm.py:18`), but both expansion retrievers treated it as a `str`:

- `retriever.py:137` — `split_multi_query_response(response)` → `.split()` on a dict
- `retriever.py:193` — `get_hyde()` returned the dict straight into `.strip()`

Every `multiQuery` / `hyde` query raised `AttributeError`. `type` is a per-partition preset field (`retrieval_pipeline.py:20`) exposed as a live Strategy dropdown in the admin UI, so two of the three selectable strategies could not work — any partition configured that way failed every chat and search request.

## Fix

Add `chat_content()` alongside the `LLM` port and use it at both call sites. The same extraction already existed inline elsewhere (`vllm_client.py:413`, `query_service.py:235`); this gives it one name.

It returns `""` on a malformed/empty payload rather than raising, so a non-compliant provider degrades to "no expansion" (callers already fall back to the seed query) instead of failing the whole search.

## Why this shipped green

The test double was **more permissive than the port it stood in for** — `test_retriever.py:58` declared `async def chat(...) -> str` while the real port returns `dict`, making the crash unreachable in tests. Same class of gap as #692.

`FakeLLM` now returns the OpenAI-shaped dict the real port declares.

## Verification

Reverting **only** the production call sites while keeping the corrected fake fails 10 tests — 7 of which passed before this PR:

```
FAILED test_hyde_retriever_uses_hyde_only_by_default
FAILED test_hyde_retriever_combine_appends_original_query
FAILED test_multi_query_retriever_splits_llm_response
FAILED test_multi_query_retriever_caps_response_to_k_queries
... 10 failed, 18 passed
```

With the fix in place: **1810 passed**, `ruff check` / `ruff format --check` / `check_layer_imports.py` all green.

New coverage: `chat_content` extraction, 7 malformed-payload shapes, and end-to-end dict handling for both strategies.

## Note

Base is `develop` and the repo default branch is `main`, so `Closes #703` will not auto-close on merge — needs closing manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of chat responses during retrieval.
  * Multi-query and HyDE retrieval now correctly process structured LLM responses.
  * Added safe fallbacks when responses are malformed or missing content, including retaining the original query when needed.

* **Tests**
  * Added coverage for valid, malformed, and unexpected chat response formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->