### PR TITLE
fix(security): block caller-set 'source' on REST metadata writes

### DIFF
--- a/openrag/core/utils/conts.py
+++ b/openrag/core/utils/conts.py
@@ -18,3 +18,32 @@ def is_internal_metadata_key(key: object) -> bool:
 
 def strip_internal_metadata(row: dict) -> dict:
     return {key: value for key, value in row.items() if not is_internal_metadata_key(key)}
+
+
+# Catalog/store-managed fields a caller must never be able to spoof through the
+# free-form metadata dict on a write path. ``source`` is the load-bearing one:
+# it is the filesystem path served by ``GET /static/{extract_id}``, so letting a
+# caller set it turns a metadata write into a cross-tenant file read (#713).
+#
+# ``partition`` is intentionally NOT here — the MCP update tool uses it as an
+# authorized move control and re-checks editor access on the destination.
+#
+# Lives in core/ (not in one orchestrator) so every transport shares one guard:
+# the upload path, the MCP tools, and the REST PATCH path previously each
+# re-implemented this and the REST one simply omitted it.
+PROTECTED_METADATA_KEYS: frozenset[str] = frozenset(
+    {"file_id", "source", "created_by", "file_size", "file_count", "_id", "vector", "text"}
+)
+
+
+def strip_protected_metadata(metadata: dict | None) -> tuple[dict, list[str]]:
+    """Drop server-managed keys from caller-supplied metadata.
+
+    Returns the cleaned dict and the sorted list of dropped keys so the caller
+    can log the rejection with its own context. Never mutates the input.
+    """
+    md = dict(metadata or {})
+    removed = sorted(k for k in md if k in PROTECTED_METADATA_KEYS)
+    for key in removed:
+        del md[key]
+    return md, removed

--- a/openrag/core/utils/conts.py
+++ b/openrag/core/utils/conts.py
@@ -25,6 +25,10 @@ def strip_internal_metadata(row: dict) -> dict:
 # it is the filesystem path served by ``GET /static/{extract_id}``, so letting a
 # caller set it turns a metadata write into a cross-tenant file read (#713).
 #
+# ``content_sha256`` is the server-computed dedup hash: a caller-set value would
+# corrupt dedup (spoofed ``DOCUMENT_CONTENT_EXISTS``), so it is protected here and
+# re-set from the server side on the copy path after this strip runs.
+#
 # ``partition`` is intentionally NOT here — the MCP update tool uses it as an
 # authorized move control and re-checks editor access on the destination.
 #
@@ -32,7 +36,7 @@ def strip_internal_metadata(row: dict) -> dict:
 # the upload path, the MCP tools, and the REST PATCH path previously each
 # re-implemented this and the REST one simply omitted it.
 PROTECTED_METADATA_KEYS: frozenset[str] = frozenset(
-    {"file_id", "source", "created_by", "file_size", "file_count", "_id", "vector", "text"}
+    {"file_id", "source", "created_by", "file_size", "file_count", "_id", "vector", "text", "content_sha256"}
 )
 
 

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -278,8 +278,6 @@ class IndexingService:
             logger.bind(file_id=file_id, partition=partition).warning(
                 f"Dropped protected metadata keys from file metadata update: {dropped}"
             )
-        # content_sha256 is server-computed at ingest; never let a caller set it.
-        metadata.pop("content_sha256", None)
         metadata["file_id"] = file_id
         await self._dispatcher.update_file_metadata(file_id, metadata, partition, user)
 

--- a/openrag/services/orchestrators/indexing_service.py
+++ b/openrag/services/orchestrators/indexing_service.py
@@ -18,6 +18,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from core.utils.conts import strip_protected_metadata
 from core.utils.exceptions import AuthError, PartitionNotFoundError, ValidationError
 from core.utils.filename import extract_temporal_fields
 from core.utils.logging import get_logger
@@ -240,7 +241,18 @@ class IndexingService:
         partition: str,
         user: dict | None,
     ) -> None:
-        metadata = dict(metadata or {})
+        # Drop server-managed keys before they reach the store (#713). Without
+        # this a partition editor could repoint ``source`` at another tenant's
+        # upload under the shared data dir and read it back through
+        # ``GET /static/{extract_id}`` — that route authorizes on the chunk's
+        # partition, which is unchanged by the write. The upload path
+        # (``dispatcher.dispatch_indexing``) and the MCP tools already filtered
+        # these; only this REST path did not.
+        metadata, dropped = strip_protected_metadata(metadata)
+        if dropped:
+            logger.bind(file_id=file_id, partition=partition).warning(
+                f"Dropped protected metadata keys from file metadata update: {dropped}"
+            )
         metadata["file_id"] = file_id
         await self._dispatcher.update_file_metadata(file_id, metadata, partition, user)
 
@@ -254,7 +266,13 @@ class IndexingService:
         metadata: dict,
         user: dict | None,
     ) -> None:
-        metadata = dict(metadata or {})
+        # Same guard as update_metadata (#713): the copy carries caller-supplied
+        # metadata onto the new rows, so a spoofed ``source`` would land there too.
+        metadata, dropped = strip_protected_metadata(metadata)
+        if dropped:
+            logger.bind(file_id=target_file_id, partition=target_partition).warning(
+                f"Dropped protected metadata keys from file copy: {dropped}"
+            )
         metadata["file_id"] = target_file_id
         metadata["partition"] = target_partition
         await self._dispatcher.copy_file(source_file_id, metadata, source_partition, user)

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -66,7 +66,7 @@ def _strip_protected_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]
     """
     md, removed = strip_protected_metadata(metadata)
     if removed:
-        logger.warning("Dropped protected metadata keys from MCP write", keys=removed)
+        logger.bind(keys=removed).warning("Dropped protected metadata keys from MCP write")
     return md
 
 

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
-from core.utils.conts import is_internal_metadata_key
+from core.utils.conts import is_internal_metadata_key, strip_protected_metadata
 from core.utils.exceptions import ValidationError
 from core.utils.log_tail import collect_task_logs
 from core.utils.logging import get_logger
@@ -57,23 +57,16 @@ _MAX_REDIRECTS = 10
 _MAX_CHUNKS_PER_CALL = 200
 _MAX_FUZZY_CANDIDATES = 5000
 
-# Catalog/store-managed fields a caller must not be able to spoof via the
-# free-form metadata dict on write tools. ``partition`` is intentionally NOT
-# here — update_file_metadata uses it as an authorized move control (and
-# re-checks editor access on the destination).
-_PROTECTED_METADATA_KEYS: frozenset[str] = frozenset(
-    {"file_id", "source", "created_by", "file_size", "file_count", "_id", "vector", "text"}
-)
-
 
 def _strip_protected_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
-    """Drop server-managed keys from caller-supplied metadata (defense in depth)."""
-    md = dict(metadata or {})
-    removed = [k for k in md if k in _PROTECTED_METADATA_KEYS]
-    for k in removed:
-        del md[k]
+    """Drop server-managed keys from caller-supplied metadata (defense in depth).
+
+    Thin wrapper over the shared guard in ``core.utils.conts`` — the key set now
+    lives there so the REST and upload paths enforce the same one (#713).
+    """
+    md, removed = strip_protected_metadata(metadata)
     if removed:
-        logger.warning("Dropped protected metadata keys from MCP write", keys=sorted(removed))
+        logger.warning("Dropped protected metadata keys from MCP write", keys=removed)
     return md
 
 

--- a/tests/unit/services/orchestrators/test_indexing_service.py
+++ b/tests/unit/services/orchestrators/test_indexing_service.py
@@ -584,3 +584,57 @@ async def test_cancel_task_passthrough():
     svc = _service(disp=disp)
     assert await svc.cancel_task("t1") is False
     assert disp.cancelled == ["t1"]
+
+
+# --- #713: server-managed metadata keys must never come from the caller ----
+
+
+@pytest.mark.asyncio
+async def test_update_metadata_drops_protected_keys():
+    """A partition editor must not be able to repoint ``source``.
+
+    ``source`` is the filesystem path served by ``GET /static/{extract_id}``,
+    which authorizes on the chunk's partition — unchanged by this write. Left
+    unfiltered, an editor could aim it at another tenant's upload in the shared
+    data dir and read it back.
+    """
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.update_metadata(
+        "f1",
+        {
+            "author": "bob",
+            "source": "/app/data/other_tenant_secret.pdf",
+            "created_by": 999,
+            "file_size": 1,
+            "vector": [0.1],
+            "text": "spoofed",
+            "_id": "x",
+            "file_count": 42,
+        },
+        "p1",
+        {"id": 1},
+    )
+    _, md, _, _ = disp.updated[0]
+    assert md == {"author": "bob", "file_id": "f1"}
+    for key in ("source", "created_by", "file_size", "vector", "text", "_id", "file_count"):
+        assert key not in md
+
+
+@pytest.mark.asyncio
+async def test_copy_file_drops_protected_keys():
+    disp = FakeDispatcher()
+    svc = _service(disp=disp)
+    await svc.copy_file(
+        source_file_id="src",
+        source_partition="p1",
+        target_file_id="dst",
+        target_partition="p2",
+        metadata={"author": "bob", "source": "/app/data/other_tenant_secret.pdf"},
+        user={"id": 1},
+    )
+    _, md, _, _ = disp.copied[0]
+    assert "source" not in md
+    assert md["author"] == "bob"
+    assert md["file_id"] == "dst"
+    assert md["partition"] == "p2"


### PR DESCRIPTION
Closes #713.

## Problem

`PATCH /partition/{partition}/file/{file_id}` let a partition **editor** overwrite `source` — the filesystem path served by `GET /static/{extract_id}`. That route authorizes on the **chunk's** partition, which this write leaves untouched, so an editor could point `source` at another tenant's upload in the shared flat data dir and read it back. `created_by` was equally writable, which corrupts quota accounting.

The other two write paths already blocked these keys:

| Path | Guard | Blocked `source`? |
|---|---|---|
| Upload — `dispatcher.dispatch_indexing:142` | inline `{"file_id", "source"}` | yes |
| MCP tools — `mcp_service._strip_protected_metadata` | `_PROTECTED_METADATA_KEYS` | yes |
| **REST PATCH — `IndexingService.update_metadata`** | none | **no** |

`strip_internal_metadata` doesn't help — it only drops keys prefixed `_openrag` (`core/utils/conts.py:13-20`), so `source` passes straight through to `entity.update(public_metadata)`.

## Fix

Rather than add a third copy of the filter, the key set and helper move into `core/utils/conts.py` as `PROTECTED_METADATA_KEYS` / `strip_protected_metadata`, and the transports share it. `copy_file` gets the same guard — it carries caller-supplied metadata onto the new rows.

`partition` is deliberately **not** in the set: the MCP update tool uses it as an authorized move control and re-checks editor access on the destination.

## Tests

Two regression tests assert the *effect* — that the keys are absent from what reaches the dispatcher — rather than that a filter was called:

- `test_update_metadata_drops_protected_keys` — all 7 protected keys stripped, user keys preserved
- `test_copy_file_drops_protected_keys`

Full suite green (1802), `ruff check` / `ruff format --check` / `check_layer_imports.py` all pass.

## Known follow-up

`dispatch_indexing` still hardcodes its own `{"file_id", "source"}` filter instead of using the shared set — a third copy of the same idea. Folding it in touches the upload path, so it's left out of a security patch deliberately. Worth a follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented caller-supplied metadata from overwriting server-managed fields during REST update and file copy operations.
  * Server-managed keys such as `source` are now automatically stripped from incoming metadata to avoid unintended persistence.
* **Tests**
  * Added unit tests covering metadata hardening for both update and copy paths, verifying protected keys are removed while required fields (like target identifiers) are still set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->