### PR TITLE
fix(security): ship web-search TLS verification enabled

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -343,7 +343,7 @@ websearch:
   fetch_max_results: 3
   fetch_timeout: 1.0
   fetch_max_tokens: 500
-  fetch_verify_ssl: false
+  fetch_verify_ssl: true
 
 # --- MCP server ---
 # Env: OPENRAG_MCP_SERVER_NAME, OPENRAG_MCP_HOST, OPENRAG_MCP_PORT,

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -481,7 +481,7 @@ Web search allows the LLM to augment RAG document context with live web results.
 | `WEBSEARCH_FETCH_MAX_RESULTS` | `int` | `3` | Number of top URLs to fetch content from (the remaining results use their search snippet). |
 | `WEBSEARCH_FETCH_TIMEOUT` | `float` | `1.0` | Per-URL timeout in seconds for content fetching. URLs that don't respond within this time fall back to their snippet. |
 | `WEBSEARCH_FETCH_MAX_TOKENS` | `int` | `500` | Maximum approximate tokens of content to extract per page. Content is truncated at word boundaries. |
-| `WEBSEARCH_FETCH_VERIFY_SSL` | `bool` | `false` | Whether to verify SSL certificates when fetching page content. |
+| `WEBSEARCH_FETCH_VERIFY_SSL` | `bool` | `true` | Whether to verify SSL certificates when fetching page content. Set to `false` only for internal CAs — fetched pages are injected into the LLM context as cited sources. |
 
 :::tip[How to Enable Web Search?]
 When chatting, you can enable web search through the OpenAI-compatible API by setting `"websearch": true` in the `metadata` field of the request body. See the [API documentation](/openrag/documentation/api/#extra-arguments) for examples.

--- a/tests/unit/services/websearch/test_content_fetcher.py
+++ b/tests/unit/services/websearch/test_content_fetcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket
+from pathlib import Path
 
 import httpx
 import pytest
@@ -305,6 +306,24 @@ def test_fetch_verify_ssl_default_is_true():
 
     cfg = StaanWebSearchConfig()
     assert cfg.fetch_verify_ssl is True
+
+
+def test_fetch_verify_ssl_is_true_in_the_shipped_yaml():
+    """The *effective* value must be True, not just the Pydantic default.
+
+    Regression for #714. The test above constructs the model directly, so it
+    passes on the declared default and never sees ``conf/config.yaml``. Since
+    the loader merges YAML over that default, `conf/config.yaml` shipping
+    ``fetch_verify_ssl: false`` silently disabled TLS verification at runtime
+    while this file stayed green — the #404 fix never took effect.
+
+    Assert the shipped YAML directly so a config-level override cannot
+    re-disable it without turning a test red.
+    """
+    import yaml
+
+    conf = yaml.safe_load((Path(__file__).parents[4] / "conf" / "config.yaml").read_text())
+    assert conf["websearch"]["fetch_verify_ssl"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #714.

## Problem

TLS verification was **off at runtime** for web-search page fetches, whose text is injected into the LLM context as a cited source.

```
load_config().websearch.fetch_verify_ssl = False    # before this PR
```

`conf/config.yaml:346` shipped `fetch_verify_ssl: false`, and the loader merges YAML over the Pydantic default — so `core/config/retrieval.py:130` declaring `True` never took effect.

## Why the existing fix didn't hold

Not a regression. The timeline runs the other way:

| When | What |
|---|---|
| 2026-03-22 | `9779fea1` "YAML-first config" moves defaults into `conf/config.yaml`, writing `false` — correct at the time, since the Python default was then `False` |
| 2026-05-21 | PR #404 fixes #382 by flipping the **Python** default to `True`, and adds a regression test |

PR #404 never touched the YAML. The fix was incomplete the day it merged, two months after the refactor it might otherwise be blamed on.

## Why the regression test didn't catch it

```python
def test_fetch_verify_ssl_default_is_true():
    cfg = StaanWebSearchConfig()      # constructed directly — bypasses the YAML loader
    assert cfg.fetch_verify_ssl is True
```

It asserts the **declared default**, never the **effective loaded value**, so it has been green since May while verification was disabled in production.

## Fix

- `conf/config.yaml` → `fetch_verify_ssl: true`
- `docs/.../env_vars.md` corrected (it documented the default as `false`, matching the bug rather than the intent)
- New test `test_fetch_verify_ssl_is_true_in_the_shipped_yaml` reads the shipped YAML directly

**Verification of the test itself:** reverting `config.yaml` to `false` fails the new test **while the original test still passes** — which is exactly the blindness being fixed.

## Reviewer notes

Two judgement calls worth a second opinion:

1. The new test asserts the **shipped YAML** rather than going through `load_config()`. `load_config()` would be the truer end-to-end check, but it's env-sensitive — a stray `WEBSEARCH_FETCH_VERIFY_SSL` in CI could flip it either way. The YAML assertion is deterministic but narrower: it catches this class of bug and would *not* catch a future loader-precedence bug.
2. `Path(__file__).parents[4]` is path-fragile if the test file moves. A repo-root fixture would be sturdier; kept direct to hold the change small.

43 websearch tests pass; full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Web Search now verifies TLS certificates when fetching web content by default, improving connection security.

* **Documentation**
  * Updated the Web Search configuration documentation to reflect the new certificate verification default.

* **Tests**
  * Added coverage to ensure the shipped configuration enables TLS certificate verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->