### PR TITLE
fix(inference): make embedder transport failures retryable

### DIFF
--- a/openrag/core/utils/exceptions.py
+++ b/openrag/core/utils/exceptions.py
@@ -295,10 +295,38 @@ class EmbeddingError(OpenRAGError):
 
 
 class EmbeddingAPIError(EmbeddingError):
-    """API error with the embedding provider."""
+    """API error with the embedding provider.
+
+    ``status_code`` is overridable so transport failures can carry a *retryable*
+    code. ``_retry._is_retryable`` only retries ``OpenRAGError`` when the status
+    is in {429, 502, 503, 504}; hardcoding 500 here made ``@with_retry`` on the
+    embedder dead code (#704). Callers should prefer the two subclasses below.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 500, **kwargs):
+        super().__init__(message, code="EMBEDDING_API_ERROR", status_code=status_code, **kwargs)
+
+
+class EmbeddingTimeoutError(EmbeddingAPIError):
+    """Embedding request timed out. Maps to HTTP 504 — retryable.
+
+    Mirrors :class:`InferenceTimeoutError`, which the LLM/VLM/reranker clients
+    already use; the embedder was the only client whose transport failures
+    landed on a non-retryable 500.
+    """
 
     def __init__(self, message: str, **kwargs):
-        super().__init__(message, code="EMBEDDING_API_ERROR", status_code=500, **kwargs)
+        super().__init__(message, status_code=504, **kwargs)
+
+
+class EmbeddingConnectionError(EmbeddingAPIError):
+    """Cannot reach the embedding provider. Maps to HTTP 503 — retryable.
+
+    Mirrors :class:`InferenceConnectionError`.
+    """
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message, status_code=503, **kwargs)
 
 
 class EmbeddingResponseError(EmbeddingError):

--- a/openrag/services/inference/ollama_client.py
+++ b/openrag/services/inference/ollama_client.py
@@ -166,16 +166,18 @@ class OllamaEmbedder(Embedder):
             resp = await self._client.post(f"{self._endpoint}/embeddings", json=body)
             resp.raise_for_status()
         # Retryable statuses so @with_retry above actually fires (#704).
-        except httpx.ConnectError as exc:
-            raise EmbeddingConnectionError(
-                f"Cannot reach Ollama embedder at {self._endpoint}",
+        # TimeoutException before TransportError (it is a subclass); the broader
+        # net catches a mid-request connection reset (httpx ReadError) too.
+        except httpx.TimeoutException as exc:
+            raise EmbeddingTimeoutError(
+                f"Ollama embedder request timed out at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),
             ) from exc
-        except httpx.TimeoutException as exc:
-            raise EmbeddingTimeoutError(
-                f"Ollama embedder request timed out at {self._endpoint}",
+        except httpx.TransportError as exc:
+            raise EmbeddingConnectionError(
+                f"Cannot reach Ollama embedder at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),

--- a/openrag/services/inference/ollama_client.py
+++ b/openrag/services/inference/ollama_client.py
@@ -17,7 +17,9 @@ from core.embeddings import Embedder, embedder_registry
 from core.llm import LLM, llm_registry
 from core.utils.exceptions import (
     EmbeddingAPIError,
+    EmbeddingConnectionError,
     EmbeddingResponseError,
+    EmbeddingTimeoutError,
     InferenceConnectionError,
     InferenceError,
     InferenceTimeoutError,
@@ -163,15 +165,16 @@ class OllamaEmbedder(Embedder):
         try:
             resp = await self._client.post(f"{self._endpoint}/embeddings", json=body)
             resp.raise_for_status()
+        # Retryable statuses so @with_retry above actually fires (#704).
         except httpx.ConnectError as exc:
-            raise EmbeddingAPIError(
+            raise EmbeddingConnectionError(
                 f"Cannot reach Ollama embedder at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),
             ) from exc
         except httpx.TimeoutException as exc:
-            raise EmbeddingAPIError(
+            raise EmbeddingTimeoutError(
                 f"Ollama embedder request timed out at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
@@ -180,6 +183,7 @@ class OllamaEmbedder(Embedder):
         except httpx.HTTPStatusError as exc:
             raise EmbeddingAPIError(
                 f"Ollama embedder API error ({exc.response.status_code})",
+                status_code=exc.response.status_code,
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=_error_snippet(exc.response.text),

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -21,7 +21,9 @@ from core.embeddings import Embedder, embedder_registry
 from core.llm import LLM, llm_registry
 from core.utils.exceptions import (
     EmbeddingAPIError,
+    EmbeddingConnectionError,
     EmbeddingResponseError,
+    EmbeddingTimeoutError,
     InferenceConnectionError,
     InferenceError,
     InferenceTimeoutError,
@@ -293,23 +295,30 @@ class VLLMEmbedder(Embedder):
         try:
             resp = await self._client.post(f"{self._endpoint}/embeddings", json=body)
             resp.raise_for_status()
+        # Transport failures must carry a retryable status so @with_retry above
+        # actually fires (#704) — the translation happens inside the retried
+        # body, so the decorator never sees the underlying httpx exception and
+        # judges retryability purely on the status code we choose here.
         except httpx.ConnectError as exc:
-            raise EmbeddingAPIError(
+            raise EmbeddingConnectionError(
                 f"Cannot reach embedder at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),
             ) from exc
         except httpx.TimeoutException as exc:
-            raise EmbeddingAPIError(
+            raise EmbeddingTimeoutError(
                 f"Embedder request timed out at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),
             ) from exc
         except httpx.HTTPStatusError as exc:
+            # Preserve the upstream status, as the LLM path already does, so 429
+            # and 5xx are retried while 4xx (bad request, auth) fail fast.
             raise EmbeddingAPIError(
                 f"Embedder API error ({exc.response.status_code})",
+                status_code=exc.response.status_code,
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=exc.response.text,

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -299,16 +299,23 @@ class VLLMEmbedder(Embedder):
         # actually fires (#704) — the translation happens inside the retried
         # body, so the decorator never sees the underlying httpx exception and
         # judges retryability purely on the status code we choose here.
-        except httpx.ConnectError as exc:
-            raise EmbeddingConnectionError(
-                f"Cannot reach embedder at {self._endpoint}",
+        #
+        # TimeoutException is caught first: it is a subclass of TransportError,
+        # so the broader clause below would otherwise swallow it as a 503. The
+        # TransportError net (not just ConnectError) covers a connection reset
+        # mid-request, which httpx raises as ReadError, plus WriteError/protocol
+        # errors — all transient and safe to retry since the embed POST is
+        # idempotent. HTTPStatusError is not a TransportError, so it is unaffected.
+        except httpx.TimeoutException as exc:
+            raise EmbeddingTimeoutError(
+                f"Embedder request timed out at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),
             ) from exc
-        except httpx.TimeoutException as exc:
-            raise EmbeddingTimeoutError(
-                f"Embedder request timed out at {self._endpoint}",
+        except httpx.TransportError as exc:
+            raise EmbeddingConnectionError(
+                f"Cannot reach embedder at {self._endpoint}",
                 model_name=self._model,
                 base_url=self._endpoint,
                 error=str(exc),

--- a/tests/unit/services/inference/test_ollama_client.py
+++ b/tests/unit/services/inference/test_ollama_client.py
@@ -285,6 +285,30 @@ class TestOllamaEmbedder:
             await embedder.embed(["text"])
 
     @pytest.mark.asyncio
+    async def test_embed_retries_on_connection_reset(self):
+        """A mid-request reset is httpx.ReadError (NetworkError), not
+        ConnectError. It must be retried, not escape raw. Regression for #718."""
+        import tenacity
+
+        retrying = OllamaEmbedder.embed.retry
+        original_wait = retrying.wait
+        retrying.wait = tenacity.wait_none()
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise httpx.ReadError("connection reset by peer")
+            return httpx.Response(200, json={"data": [{"index": 0, "embedding": [0.7]}]})
+
+        try:
+            embedder = self._make_embedder(handler)
+            assert await embedder.embed(["text"]) == [[0.7]]
+            assert calls["n"] == 2, "a ReadError mid-request must be retried"
+        finally:
+            retrying.wait = original_wait
+
+    @pytest.mark.asyncio
     async def test_embed_timeout(self):
         async def fail(*a, **kw):
             raise httpx.TimeoutException("timeout")

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+import tenacity
 from core.utils.exceptions import (
     EmbeddingAPIError,
     EmbeddingResponseError,
@@ -602,3 +603,85 @@ class TestRegistryIntegration:
         from core.vlm import vlm_registry
 
         assert "vllm" in vlm_registry
+
+
+# ---------------------------------------------------------------------------
+# #704 — embedder transport failures must actually be retried
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedderRetryFires:
+    """Assert the retry *re-invokes*, not merely that an exception type changed.
+
+    Before #704, ``EmbeddingAPIError`` hardcoded ``status_code=500``. Since
+    ``_is_retryable`` only accepts {429, 502, 503, 504} and the httpx exception
+    is translated *inside* the retried body, ``@with_retry(max_attempts=3)`` on
+    ``_embed_batch`` could never fire — one transient 503 failed the whole file.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_backoff(self):
+        """Drop the exponential backoff so these tests don't really sleep.
+
+        The retry decorator is applied at import time, so patching the module
+        function has no effect — reach into the tenacity Retrying object the
+        decorator attached and restore it afterwards.
+        """
+        retrying = VLLMEmbedder._embed_batch.retry
+        original = retrying.wait
+        retrying.wait = tenacity.wait_none()
+        yield
+        retrying.wait = original
+
+    def _embedder(self, handler):
+        embedder = VLLMEmbedder(
+            endpoint="http://embed.test/v1",
+            model_name="embed-model",
+            batch_size=8,
+        )
+        embedder._client = httpx.AsyncClient(transport=_make_transport(handler))
+        return embedder
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds_on_transient_503(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return httpx.Response(503, text="upstream busy")
+            return _embed_response([[0.1, 0.2]])
+
+        embedder = self._embedder(handler)
+        out = await embedder._embed_batch(["hello"])
+
+        assert out == [[0.1, 0.2]]
+        assert calls["n"] == 3, "expected two retries before success"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_429_rate_limit(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return httpx.Response(429, text="slow down")
+            return _embed_response([[1.0]])
+
+        embedder = self._embedder(handler)
+        assert await embedder._embed_batch(["x"]) == [[1.0]]
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_client_error(self):
+        """A 400 is not transient — it must fail fast, not burn three attempts."""
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            return httpx.Response(400, text="bad request")
+
+        embedder = self._embedder(handler)
+        with pytest.raises(EmbeddingAPIError):
+            await embedder._embed_batch(["x"])
+        assert calls["n"] == 1, "4xx must not be retried"

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -673,6 +673,38 @@ class TestEmbedderRetryFires:
         assert calls["n"] == 2
 
     @pytest.mark.asyncio
+    async def test_retries_on_connection_reset_mid_request(self):
+        """A connection reset after the request starts is httpx.ReadError, not
+        ConnectError (a NetworkError under TransportError). The first fix only
+        caught ConnectError/TimeoutException, so a reset escaped raw and was not
+        retried. Regression for the #718 review."""
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise httpx.ReadError("connection reset by peer")
+            return _embed_response([[0.5]])
+
+        embedder = self._embedder(handler)
+        assert await embedder._embed_batch(["x"]) == [[0.5]]
+        assert calls["n"] == 2, "a ReadError mid-request must be retried"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_connect_error(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise httpx.ConnectError("cannot connect")
+            return _embed_response([[0.6]])
+
+        embedder = self._embedder(handler)
+        assert await embedder._embed_batch(["x"]) == [[0.6]]
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
     async def test_does_not_retry_client_error(self):
         """A 400 is not transient — it must fail fast, not burn three attempts."""
         calls = {"n": 0}


### PR DESCRIPTION
Closes #704.

## Problem

`@with_retry(max_attempts=3)` on the embedder was **dead code** — it could never fire.

`_is_retryable` (`services/inference/_retry.py:14-24`) retries an `OpenRAGError` only when its status is in `{429, 502, 503, 504}`. `EmbeddingAPIError` hardcoded `status_code=500` (`core/utils/exceptions.py:301`), which isn't in that set.

The `httpx` branches of the predicate can't rescue it either: `_embed_batch` is the decorated function and it translates every transport failure into `EmbeddingAPIError` **inside its own body**, so the decorator only ever sees the already-translated 500.

**Impact:** a single transient 429/503 aborted `embed()`, which cancels its sibling batches and fails the whole file. During bulk ingestion that turns routine embedder backpressure into mass failure — while `@with_retry(max_attempts=3)` in the source reads as though it's handled.

## Why this is an oversight, not a policy

Every other inference client maps to a retryable code:

| Exception | status_code | Retried |
|---|---|---|
| `InferenceError` | 503 | yes |
| `InferenceTimeoutError` | 504 | yes |
| `InferenceConnectionError` | 503 | yes |
| **`EmbeddingAPIError`** (before) | **500** | **no** |

The LLM path also preserves the upstream status (`vllm_client.py:139`); the embedder discarded it.

## Fix

Mirror the `Inference*` family:

- `EmbeddingConnectionError` → 503
- `EmbeddingTimeoutError` → 504
- `EmbeddingAPIError` gains a `status_code` override; the HTTP branch now preserves the upstream status

## Scope note — ollama is included

`ollama_client.embed` had the **identical** bug: same `@with_retry(max_attempts=3)`, all three raisers on a hardcoded 500. It's reachable via `{"implementation": "ollama"}` (`core/config/model_endpoints.py:19`), so it's fixed in the same change rather than left as a known-broken sibling. Happy to split it out if reviewers prefer.

## Behavioural change beyond "retries now work"

Preserving the upstream status means a **4xx now fails fast** instead of burning three attempts. That's correct, but it is a change in behaviour worth noting.

## Tests

They assert the retry **re-invokes** (call counts), not merely that an exception type changed:

- `test_retries_then_succeeds_on_transient_503` — 2 retries then success, `calls == 3`
- `test_retries_on_429_rate_limit` — `calls == 2`
- `test_does_not_retry_client_error` — `calls == 1` on a 400

**Verification:** reverting only the production fix while keeping these tests fails the 503 and 429 cases, while the 4xx case still passes — so they detect this specific bug rather than agreeing with the new code.

An autouse fixture swaps the tenacity wait for `wait_none()` (the decorator is applied at import time, so patching the module function has no effect) — 6.5s → 0.23s.

Full suite green (1802); ruff check / format / layer-import-guard all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding error handling by distinguishing timeout vs connection failures with dedicated retryable exception types.
  * Embedding failures now surface the upstream HTTP status code so retry logic can correctly treat transient/service/rate-limit errors as retryable and client errors as non-retryable.

* **Tests**
  * Added unit tests to verify vLLM and Ollama embedder retries on transient timeouts and connection/reset scenarios, and confirm no retries occur for non-retryable client errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->