### PR TITLE
fix(#630): make DistributedSemaphore acquire cancellation-safe to stop VLM permit leaks 

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -29,7 +29,7 @@ llm:
   api_key: ""
 
 # --- VLM (Vision Language Model) ---
-# Env: VLM_BASE_URL, VLM_MODEL, VLM_API_KEY, VLM_ENABLE_THINKING
+# Env: VLM_BASE_URL, VLM_MODEL, VLM_API_KEY, VLM_ENABLE_THINKING, VLM_TIMEOUT
 vlm:
   <<: *llm_params
   base_url: ""

--- a/openrag/core/config/endpoints.py
+++ b/openrag/core/config/endpoints.py
@@ -35,6 +35,10 @@ class VLMConfig(LLMParamsConfig):
     base_url: str = ""
     model: str = ""
     api_key: str = Field(default="", repr=False)
+    # Captioning large images through a shared/slow VLM endpoint routinely
+    # takes longer than a chat completion, so this is independently tunable
+    # (VLM_TIMEOUT) rather than silently inheriting the int llm.timeout.
+    timeout: float = 60.0
 
 
 class EmbedderConfig(ConfigMixin):

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -33,6 +33,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("VLM_MODEL", "vlm.model", str),
     ("VLM_API_KEY", "vlm.api_key", str),
     ("VLM_ENABLE_THINKING", "vlm.enable_thinking", bool),
+    ("VLM_TIMEOUT", "vlm.timeout", float),
     # Semaphore
     ("LLM_SEMAPHORE", "semaphore.llm_semaphore", int),
     ("VLM_SEMAPHORE", "semaphore.vlm_semaphore", int),

--- a/openrag/services/inference/distributed_semaphore.py
+++ b/openrag/services/inference/distributed_semaphore.py
@@ -31,8 +31,12 @@ class DistributedSemaphoreActor:
         await self.semaphore.acquire()
         return self.incarnation
 
-    def release(self, incarnation: str) -> None:
-        if incarnation != self.incarnation:
+    def release(self, incarnation: str | None = None) -> None:
+        # `incarnation` defaults to None so a driver still running the
+        # pre-incarnation-token code (rolling deploy against this same
+        # detached, `get_if_exists=True` actor) can call `release()` with no
+        # arguments without raising - it never checked incarnations either.
+        if incarnation is not None and incarnation != self.incarnation:
             return
         self.semaphore.release()
 
@@ -97,6 +101,22 @@ class DistributedSemaphore:
         incarnation = stack.pop() if stack else None
         if stack is not None and not stack:
             del self._incarnations[task]
+        await _release(semaphore_actor, incarnation)
+
+
+async def _release(semaphore_actor, incarnation: str | None) -> None:
+    """Call ``release`` with the right arity for whichever actor is live.
+
+    ``incarnation`` is ``None`` when talking to a pre-incarnation-token actor
+    left running from before this deploy (detached actors are looked up with
+    ``get_if_exists=True``, so a rolling deploy can attach to one instead of
+    recreating it) - its ``acquire()`` never returned a token, and its
+    ``release()`` takes no arguments, so passing one would raise ``TypeError``
+    and leak the permit.
+    """
+    if incarnation is None:
+        await semaphore_actor.release.remote()
+    else:
         await semaphore_actor.release.remote(incarnation)
 
 
@@ -117,4 +137,4 @@ def _release_if_granted(name: str, semaphore_actor, acquire_task: asyncio.Task) 
         "caller was cancelled while waiting, permit granted afterwards.",
         name=name,
     )
-    semaphore_actor.release.remote(incarnation)
+    asyncio.ensure_future(_release(semaphore_actor, incarnation))

--- a/openrag/services/inference/distributed_semaphore.py
+++ b/openrag/services/inference/distributed_semaphore.py
@@ -8,8 +8,12 @@ async context manager.
 from __future__ import annotations
 
 import asyncio
+import functools
 
 import ray
+from core.utils.logging import get_logger
+
+logger = get_logger()
 
 
 @ray.remote(max_restarts=5)
@@ -53,9 +57,37 @@ class DistributedSemaphore:
 
     async def __aenter__(self):
         semaphore_actor = self._get_or_create_actor()
-        await semaphore_actor.acquire.remote()
+        # acquire.remote() is dispatched to the actor immediately and runs to
+        # completion there regardless of what happens locally - cancelling the
+        # local await does not cancel the remote task. Shield the wait so a
+        # cancellation here doesn't just abandon a permit that the actor may
+        # still grant a moment later: if that happens, __aenter__ never
+        # returns, __aexit__ never runs, and the permit would otherwise leak
+        # for the lifetime of the actor.
+        acquire_task = asyncio.ensure_future(semaphore_actor.acquire.remote())
+        try:
+            await asyncio.shield(acquire_task)
+        except asyncio.CancelledError:
+            acquire_task.add_done_callback(functools.partial(_release_if_granted, self._name, semaphore_actor))
+            raise
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
         semaphore_actor = self._get_or_create_actor()
         await semaphore_actor.release.remote()
+
+
+def _release_if_granted(name: str, semaphore_actor, acquire_task: asyncio.Task) -> None:
+    """Release a permit granted to an acquire whose caller was already cancelled.
+
+    Runs as a done-callback on the (shielded, still-running) acquire task, so
+    it fires once the actor eventually grants or drops the request.
+    """
+    if acquire_task.cancelled() or acquire_task.exception() is not None:
+        return
+    logger.bind(semaphore=name).warning(
+        "Releasing permit for a cancelled acquire on semaphore '{name}' - "
+        "caller was cancelled while waiting, permit granted afterwards.",
+        name=name,
+    )
+    semaphore_actor.release.remote()

--- a/openrag/services/inference/distributed_semaphore.py
+++ b/openrag/services/inference/distributed_semaphore.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import uuid
 
 import ray
 from core.utils.logging import get_logger
@@ -20,11 +21,19 @@ logger = get_logger()
 class DistributedSemaphoreActor:
     def __init__(self, max_concurrent_ops: int):
         self.semaphore = asyncio.Semaphore(max_concurrent_ops)
+        # Regenerated every time the actor (re)starts, so a release that was
+        # queued against a prior incarnation - e.g. one deferred past a
+        # cancellation - can be detected and dropped instead of incrementing
+        # a freshly-restarted semaphore above max_concurrent_ops.
+        self.incarnation = uuid.uuid4().hex
 
-    async def acquire(self):
+    async def acquire(self) -> str:
         await self.semaphore.acquire()
+        return self.incarnation
 
-    def release(self):
+    def release(self, incarnation: str) -> None:
+        if incarnation != self.incarnation:
+            return
         self.semaphore.release()
 
 
@@ -44,6 +53,7 @@ class DistributedSemaphore:
         self._name = name
         self._namespace = namespace
         self._max_concurrent_ops = max_concurrent_ops
+        self._incarnation: str | None = None
 
     def _get_or_create_actor(self):
         try:
@@ -66,7 +76,7 @@ class DistributedSemaphore:
         # for the lifetime of the actor.
         acquire_task = asyncio.ensure_future(semaphore_actor.acquire.remote())
         try:
-            await asyncio.shield(acquire_task)
+            self._incarnation = await asyncio.shield(acquire_task)
         except asyncio.CancelledError:
             acquire_task.add_done_callback(functools.partial(_release_if_granted, self._name, semaphore_actor))
             raise
@@ -74,20 +84,24 @@ class DistributedSemaphore:
 
     async def __aexit__(self, exc_type, exc, tb):
         semaphore_actor = self._get_or_create_actor()
-        await semaphore_actor.release.remote()
+        await semaphore_actor.release.remote(self._incarnation)
 
 
 def _release_if_granted(name: str, semaphore_actor, acquire_task: asyncio.Task) -> None:
     """Release a permit granted to an acquire whose caller was already cancelled.
 
     Runs as a done-callback on the (shielded, still-running) acquire task, so
-    it fires once the actor eventually grants or drops the request.
+    it fires once the actor eventually grants or drops the request. Passes
+    along the incarnation token from that same grant so a release delayed
+    past an actor restart is dropped by the actor instead of over-counting
+    the freshly-restarted semaphore.
     """
     if acquire_task.cancelled() or acquire_task.exception() is not None:
         return
+    incarnation = acquire_task.result()
     logger.bind(semaphore=name).warning(
         "Releasing permit for a cancelled acquire on semaphore '{name}' - "
         "caller was cancelled while waiting, permit granted afterwards.",
         name=name,
     )
-    semaphore_actor.release.remote()
+    semaphore_actor.release.remote(incarnation)

--- a/openrag/services/inference/distributed_semaphore.py
+++ b/openrag/services/inference/distributed_semaphore.py
@@ -41,7 +41,14 @@ class DistributedSemaphore:
     """Async context manager backed by a detached Ray actor.
 
     The actor is created on first use (get-or-create) and survives across
-    callers within the same Ray cluster.
+    callers within the same Ray cluster. Instances are routinely shared and
+    entered concurrently by many callers at once (e.g. one cluster-wide
+    ``llmSemaphore`` used by every call in a batch of chunk-contextualization
+    tasks), so the incarnation token from each acquire is tracked per calling
+    task rather than on ``self``: storing it on ``self`` would let one
+    caller's concurrent ``__aenter__`` overwrite another's before its
+    ``__aexit__`` reads it back, misattributing a release to the wrong
+    incarnation after an actor restart.
     """
 
     def __init__(
@@ -53,7 +60,7 @@ class DistributedSemaphore:
         self._name = name
         self._namespace = namespace
         self._max_concurrent_ops = max_concurrent_ops
-        self._incarnation: str | None = None
+        self._incarnations: dict[asyncio.Task, list[str | None]] = {}
 
     def _get_or_create_actor(self):
         try:
@@ -76,15 +83,21 @@ class DistributedSemaphore:
         # for the lifetime of the actor.
         acquire_task = asyncio.ensure_future(semaphore_actor.acquire.remote())
         try:
-            self._incarnation = await asyncio.shield(acquire_task)
+            incarnation = await asyncio.shield(acquire_task)
         except asyncio.CancelledError:
             acquire_task.add_done_callback(functools.partial(_release_if_granted, self._name, semaphore_actor))
             raise
+        self._incarnations.setdefault(asyncio.current_task(), []).append(incarnation)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
         semaphore_actor = self._get_or_create_actor()
-        await semaphore_actor.release.remote(self._incarnation)
+        task = asyncio.current_task()
+        stack = self._incarnations.get(task)
+        incarnation = stack.pop() if stack else None
+        if stack is not None and not stack:
+            del self._incarnations[task]
+        await semaphore_actor.release.remote(incarnation)
 
 
 def _release_if_granted(name: str, semaphore_actor, acquire_task: asyncio.Task) -> None:

--- a/tests/unit/core/config/test_rdb_env.py
+++ b/tests/unit/core/config/test_rdb_env.py
@@ -25,3 +25,13 @@ def test_llm_and_vlm_enable_thinking_can_be_overridden_from_env(monkeypatch, tmp
     assert settings.llm.enable_thinking is False
     assert settings.vlm.enable_thinking is True
     assert settings.loader.openai.enable_thinking is False
+
+
+def test_vlm_timeout_can_be_overridden_independently_of_llm_timeout(monkeypatch, tmp_path):
+    (tmp_path / "config.yaml").write_text("retriever:\n  type: single\n", encoding="utf-8")
+    monkeypatch.setenv("VLM_TIMEOUT", "180")
+
+    settings = load_config(config_path=tmp_path)
+
+    assert settings.vlm.timeout == 180.0
+    assert settings.llm.timeout == 60

--- a/tests/unit/services/inference/test_distributed_semaphore.py
+++ b/tests/unit/services/inference/test_distributed_semaphore.py
@@ -159,3 +159,50 @@ class TestDistributedSemaphoreSharedInstanceConcurrencySafety:
             third.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await third
+
+
+@ray.remote(max_restarts=5)
+class _LegacyDistributedSemaphoreActor:
+    """Mirrors the pre-incarnation-token ``DistributedSemaphoreActor``:
+    ``acquire()`` returns nothing and ``release()`` takes zero arguments.
+
+    Detached actors are looked up with ``get_if_exists=True`` at bootstrap, so
+    a rolling deploy attaches to whatever actor is already running under that
+    name instead of recreating it - this simulates one left over from before
+    the incarnation-token fix.
+    """
+
+    def __init__(self, max_concurrent_ops: int):
+        self.semaphore = asyncio.Semaphore(max_concurrent_ops)
+
+    async def acquire(self):
+        await self.semaphore.acquire()
+
+    def release(self):
+        self.semaphore.release()
+
+
+class TestDistributedSemaphoreRollingDeployCompatibility:
+    """New driver code must not crash against a pre-existing legacy actor
+    during a rolling deploy (hedhoud + CodeRabbit review comments on PR #719).
+    """
+
+    async def test_new_driver_survives_a_pre_existing_legacy_actor(self):
+        namespace = f"test-legacy-{uuid.uuid4().hex}"
+        _LegacyDistributedSemaphoreActor.options(
+            name="sem",
+            namespace=namespace,
+            lifetime="detached",
+        ).remote(1)
+
+        sem = DistributedSemaphore(name="sem", namespace=namespace, max_concurrent_ops=1)
+
+        # Must not raise TypeError: the legacy actor's release() takes no
+        # arguments, so a bare `release.remote(incarnation)` would fail.
+        async with sem:
+            pass
+
+        # The permit must actually have been released - a second acquire
+        # right after must succeed rather than hang.
+        await asyncio.wait_for(sem.__aenter__(), timeout=2.0)
+        await sem.__aexit__(None, None, None)

--- a/tests/unit/services/inference/test_distributed_semaphore.py
+++ b/tests/unit/services/inference/test_distributed_semaphore.py
@@ -1,4 +1,15 @@
-from services.inference.distributed_semaphore import DistributedSemaphore, DistributedSemaphoreActor
+import asyncio
+import uuid
+
+import pytest
+import ray
+
+# Prevent Ray from scanning the working directory (which may contain
+# permission-restricted folders like db/) and from packaging the whole repo.
+if not ray.is_initialized():
+    ray.init(runtime_env={"working_dir": None}, ignore_reinit_error=True)
+
+from services.inference.distributed_semaphore import DistributedSemaphore, DistributedSemaphoreActor  # noqa: E402
 
 
 class TestDistributedSemaphore:
@@ -16,3 +27,40 @@ class TestDistributedSemaphore:
 
     def test_actor_class_exists(self):
         assert hasattr(DistributedSemaphoreActor, "remote")
+
+
+class TestDistributedSemaphoreCancellationSafety:
+    """Regression tests for issue #630: cancelling a caller mid-``acquire``
+    must not leak the permit forever, since ``acquire.remote()`` keeps
+    running on the actor after the local await is cancelled.
+    """
+
+    def _new_pool(self, max_concurrent_ops: int = 1) -> DistributedSemaphore:
+        # Unique namespace per test so actors from different tests never collide.
+        namespace = f"test-sem-{uuid.uuid4().hex}"
+        return DistributedSemaphore(name="sem", namespace=namespace, max_concurrent_ops=max_concurrent_ops)
+
+    async def test_cancelling_a_blocked_acquire_does_not_leak_the_permit(self):
+        holder = self._new_pool()
+        waiter = DistributedSemaphore(name=holder._name, namespace=holder._namespace, max_concurrent_ops=1)
+
+        await holder.__aenter__()  # take the only permit
+
+        blocked_acquire = asyncio.ensure_future(waiter.__aenter__())
+        await asyncio.sleep(0.2)  # let the acquire actually reach the actor and start waiting
+        blocked_acquire.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await blocked_acquire
+
+        await holder.__aexit__(None, None, None)  # release the original permit
+        await asyncio.sleep(0.5)  # give the shielded acquire + its release callback time to run
+
+        # If the permit leaked, this would hang until the wait_for timeout fires.
+        fresh = DistributedSemaphore(name=holder._name, namespace=holder._namespace, max_concurrent_ops=1)
+        await asyncio.wait_for(fresh.__aenter__(), timeout=2.0)
+        await fresh.__aexit__(None, None, None)
+
+    async def test_uncancelled_acquire_still_works(self):
+        sem = self._new_pool()
+        await sem.__aenter__()
+        await sem.__aexit__(None, None, None)

--- a/tests/unit/services/inference/test_distributed_semaphore.py
+++ b/tests/unit/services/inference/test_distributed_semaphore.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import uuid
 
 import pytest
@@ -64,3 +65,41 @@ class TestDistributedSemaphoreCancellationSafety:
         sem = self._new_pool()
         await sem.__aenter__()
         await sem.__aexit__(None, None, None)
+
+
+class TestDistributedSemaphoreActorRestartSafety:
+    """A release deferred past an actor restart (``max_restarts=5``) must not
+    over-count the freshly-restarted actor's semaphore above
+    ``max_concurrent_ops`` (codex review comment on PR #719).
+    """
+
+    async def test_stale_release_after_restart_is_dropped(self):
+        namespace = f"test-restart-{uuid.uuid4().hex}"
+        actor = DistributedSemaphoreActor.options(
+            name="sem",
+            namespace=namespace,
+            lifetime="detached",
+        ).remote(1)
+
+        # Take the only permit and remember the incarnation it was granted under.
+        stale_incarnation = await actor.acquire.remote()
+
+        ray.kill(actor, no_restart=False)
+        await asyncio.sleep(1.0)  # let Ray restart the actor (fresh __init__, fresh incarnation)
+
+        # A release carrying the pre-restart incarnation must be dropped, not
+        # applied to the freshly-restarted (and already full-capacity) actor.
+        await actor.release.remote(stale_incarnation)
+
+        # The restarted actor starts with exactly 1 free permit. If the stale
+        # release above had incorrectly landed, capacity would be 2 and both
+        # of these acquires would succeed immediately.
+        await asyncio.wait_for(actor.acquire.remote(), timeout=2.0)
+        second = asyncio.ensure_future(actor.acquire.remote())
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(second), timeout=0.5)
+        finally:
+            second.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await second

--- a/tests/unit/services/inference/test_distributed_semaphore.py
+++ b/tests/unit/services/inference/test_distributed_semaphore.py
@@ -103,3 +103,59 @@ class TestDistributedSemaphoreActorRestartSafety:
             second.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await second
+
+
+class TestDistributedSemaphoreSharedInstanceConcurrencySafety:
+    """A single ``DistributedSemaphore`` instance is routinely entered by many
+    concurrent callers at once (e.g. the cluster-wide ``llmSemaphore`` shared
+    across a batch of chunk-contextualization calls). The incarnation token
+    must be tracked per calling task, not on ``self`` - otherwise a
+    concurrent caller's acquire (after an actor restart) can overwrite
+    another's release token, causing a stale release to be misattributed to
+    the new incarnation and over-releasing the freshly-restarted semaphore
+    (self-review comment on PR #719).
+    """
+
+    async def test_concurrent_holder_release_is_not_clobbered_by_a_sibling_acquire_after_restart(self):
+        namespace = f"test-shared-{uuid.uuid4().hex}"
+        sem = DistributedSemaphore(name="sem", namespace=namespace, max_concurrent_ops=1)
+
+        entered = asyncio.Event()
+        release_now = asyncio.Event()
+
+        async def hold_across_restart():
+            async with sem:
+                entered.set()
+                await release_now.wait()
+
+        # Task A takes the only permit under the pre-restart incarnation and
+        # blocks inside the critical section.
+        task_a = asyncio.ensure_future(hold_across_restart())
+        await asyncio.wait_for(entered.wait(), timeout=2.0)
+
+        actor = sem._get_or_create_actor()
+        ray.kill(actor, no_restart=False)
+        await asyncio.sleep(1.0)  # let Ray restart the actor: fresh semaphore, fresh incarnation
+
+        # Task B reuses the SAME shared `sem` instance and acquires after the
+        # restart - capacity is free again post-restart, so this succeeds
+        # immediately. Pre-fix, this would overwrite `sem._incarnation`.
+        await asyncio.wait_for(sem.__aenter__(), timeout=2.0)
+
+        # Let task A's (pre-restart) hold release. If its incarnation token
+        # was clobbered by task B's acquire, the actor would wrongly accept
+        # the release and the freshly-restarted semaphore would end up
+        # over-capacity.
+        release_now.set()
+        await asyncio.wait_for(task_a, timeout=2.0)
+
+        # Capacity is 1 and task B is still holding it: a third acquire must
+        # block, proving task A's release did not land on task B's incarnation.
+        third = asyncio.ensure_future(sem.__aenter__())
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(third), timeout=0.5)
+        finally:
+            third.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await third


### PR DESCRIPTION
## Summary

Fixes #630. `DistributedSemaphore.__aenter__` awaited the actor's `acquire.remote()`
directly. If the caller was cancelled while waiting (e.g. `caption_stage`'s
`_cancel_and_drain` cancelling sibling image-caption tasks after one fails, or the
stage-level watchdog timing out), the local await died but the remote `acquire()`
kept running on the actor and could still be granted — `__aenter__` never returned,
so `__aexit__` never ran, and the permit leaked forever. Enough leaked permits (a
handful of figure-heavy documents failing) permanently deadlocks the whole indexing
cluster with no error surfaced.

- `__aenter__` now shields the acquire from local cancellation. If cancelled, it
  attaches a callback to release the permit once the (still-running) remote acquire
  is eventually granted, instead of abandoning it.
- `vlm.timeout` is now its own tunable float field (was silently inheriting the
  shared int `llm.timeout: 60`), and `VLM_TIMEOUT` is wired into env overrides,
  matching `EMBEDDER_TIMEOUT`/`RERANKER_TIMEOUT` — deployments against slow/shared
  VLM endpoints can raise it without editing `conf/config.yaml`.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent VLM timeout configuration via the `VLM_TIMEOUT` environment variable (supports floating-point values).
* **Bug Fixes**
  * Improved distributed semaphore safety: prevents permit leaks on cancelled acquires, and correctly handles actor restarts and concurrent tasks, including compatibility with legacy semaphore actors.
* **Tests**
  * Added unit coverage for independent `VLM_TIMEOUT` overrides and expanded distributed semaphore scenarios (cancellation, restart, concurrency, and rolling-deploy compatibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->