### PR TITLE
fix(indexing): recover from pymupdf font-digest errors instead of failing the file

### DIFF
--- a/openrag/core/indexing/parsers/pdf/pymupdf.py
+++ b/openrag/core/indexing/parsers/pdf/pymupdf.py
@@ -29,6 +29,7 @@ from typing import Literal
 
 import pymupdf
 import pymupdf4llm
+from core.utils.logging import get_logger
 
 from ....models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock
 from ..document_parser import DocumentParser
@@ -36,17 +37,23 @@ from ..registry import parser_registry
 
 ParseMode = Literal["markdown", "text"]
 
+logger = get_logger()
+
 # Single dedicated worker for pymupdf — see "Threading note" in module docstring.
 _PYMUPDF_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pymupdf")
 
 
-def _extract_text(raw: bytes) -> tuple[list[str], list[ImageBlock]]:
+def _extract_text(raw: bytes, filename: str) -> tuple[list[str], list[ImageBlock]]:
     """Return one stripped plain-text string per page; no images."""
     with pymupdf.open(stream=raw, filetype="pdf") as doc:
         return [page.get_text().strip() for page in doc], []
 
 
-def _extract_markdown(raw: bytes) -> tuple[list[str], list[ImageBlock]]:
+def _to_markdown(doc: pymupdf.Document) -> list[dict]:
+    return pymupdf4llm.to_markdown(doc, page_chunks=True, embed_images=False, write_images=False)
+
+
+def _extract_markdown(raw: bytes, filename: str) -> tuple[list[str], list[ImageBlock]]:
     """Return structured Markdown per page (no images).
 
     pymupdf is the lightweight, no-VLM backend. ``pymupdf4llm`` preserves
@@ -58,12 +65,22 @@ def _extract_markdown(raw: bytes) -> tuple[list[str], list[ImageBlock]]:
     are produced here.
     """
     with pymupdf.open(stream=raw, filetype="pdf") as doc:
-        chunks = pymupdf4llm.to_markdown(
-            doc,
-            page_chunks=True,
-            embed_images=False,
-            write_images=False,
-        )
+        try:
+            chunks = _to_markdown(doc)
+        except RuntimeError as exc:
+            # MuPDF hard-errors on some legal-but-unusual object graphs — e.g.
+            # Type3 fonts with no embedded font file trip "code=4: no font file
+            # for digest" on a single page and take the whole document down
+            # with them (openrag#640). `garbage=4, clean=True` rewrites the PDF,
+            # dropping unreferenced/orphaned objects (including the bad font
+            # refs) without touching visible content, and recovers the full
+            # document — retry once against that cleaned copy before giving up.
+            logger.bind(filename=filename, error=str(exc)).warning(
+                "pymupdf4llm.to_markdown failed; retrying against a garbage-collected/cleaned copy"
+            )
+            cleaned = doc.tobytes(garbage=4, clean=True)
+            with pymupdf.open(stream=cleaned, filetype="pdf") as clean_doc:
+                chunks = _to_markdown(clean_doc)
     pages = [(chunk.get("text") or "").strip() for chunk in chunks]
     return pages, []
 
@@ -95,7 +112,7 @@ class PyMuPDFParser(DocumentParser):
             )
 
         pages, images = await asyncio.get_running_loop().run_in_executor(
-            _PYMUPDF_EXECUTOR, self._extract, document.raw_bytes
+            _PYMUPDF_EXECUTOR, self._extract, document.raw_bytes, document.filename
         )
         # Keep one TextBlock per source page (including empties) so callers
         # can preserve a 1-to-1 mapping with the original PDF's pagination.

--- a/tests/unit/core/indexing/parsers/pdf/test_pymupdf.py
+++ b/tests/unit/core/indexing/parsers/pdf/test_pymupdf.py
@@ -1,0 +1,68 @@
+"""Unit tests for the pymupdf ``DocumentParser`` (issue #640 fallback path)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pymupdf
+import pytest
+from core.indexing.parsers.pdf.pymupdf import PyMuPDFParser, _extract_markdown
+from core.models.document import Document, DocumentType
+
+_TO_MARKDOWN = "core.indexing.parsers.pdf.pymupdf.pymupdf4llm.to_markdown"
+
+
+def _minimal_pdf_bytes() -> bytes:
+    doc = pymupdf.open()
+    try:
+        page = doc.new_page()
+        page.insert_text((72, 72), "hello world")
+        return doc.tobytes()
+    finally:
+        doc.close()
+
+
+class TestExtractMarkdownFallback:
+    def test_retries_once_against_cleaned_copy_on_runtime_error(self):
+        raw = _minimal_pdf_bytes()
+        good_chunks = [{"text": "hello world"}]
+
+        with patch(_TO_MARKDOWN, side_effect=[RuntimeError("code=4: no font file for digest"), good_chunks]) as mock:
+            pages, images = _extract_markdown(raw, "broken.pdf")
+
+        assert pages == ["hello world"]
+        assert images == []
+        assert mock.call_count == 2
+
+    def test_only_retries_once_and_propagates_if_still_failing(self):
+        raw = _minimal_pdf_bytes()
+
+        with patch(_TO_MARKDOWN, side_effect=RuntimeError("still broken")) as mock:
+            with pytest.raises(RuntimeError, match="still broken"):
+                _extract_markdown(raw, "broken.pdf")
+
+        assert mock.call_count == 2
+
+    def test_no_retry_when_first_attempt_succeeds(self):
+        raw = _minimal_pdf_bytes()
+        good_chunks = [{"text": "hello world"}]
+
+        with patch(_TO_MARKDOWN, return_value=good_chunks) as mock:
+            pages, _ = _extract_markdown(raw, "clean.pdf")
+
+        assert pages == ["hello world"]
+        assert mock.call_count == 1
+
+
+class TestPyMuPDFParserRecovery:
+    @pytest.mark.asyncio
+    async def test_parse_recovers_from_transient_runtime_error(self):
+        raw = _minimal_pdf_bytes()
+        document = Document(filename="broken.pdf", content_type=DocumentType.PDF, raw_bytes=raw)
+        good_chunks = [{"text": "hello world"}]
+
+        with patch(_TO_MARKDOWN, side_effect=[RuntimeError("code=4: no font file for digest"), good_chunks]):
+            result = await PyMuPDFParser().parse(document)
+
+        assert [block.text for block in result.text_blocks] == ["hello world"]
+        assert result.page_count == 1

--- a/tests/unit/services/workers/parsers/test_parser_dispatcher.py
+++ b/tests/unit/services/workers/parsers/test_parser_dispatcher.py
@@ -167,7 +167,7 @@ def test_pymupdf_backend_builds_in_markdown_mode_without_images() -> None:
     raw = doc.tobytes()
     doc.close()
 
-    pages, images = _extract_markdown(raw)
+    pages, images = _extract_markdown(raw, "doc.pdf")
     assert images == []  # pymupdf must not extract/inline images
     assert not any("data:image" in p for p in pages)
 


### PR DESCRIPTION
## Summary
- A PDF page with orphaned Type3 font references (no embedded font file) makes `pymupdf4llm.to_markdown` hard-error with `RuntimeError: code=4: no font file for digest`, which previously propagated straight out of `PyMuPDFParser.parse()` and failed the entire document — no retry, no degraded extraction, no operator-visible signal.
- `_extract_markdown` now catches that `RuntimeError`, logs a warning (with filename), and retries once against an in-memory garbage-collected/cleaned copy of the doc (`doc.tobytes(garbage=4, clean=True)`), which drops the orphaned object refs without touching visible content. If the cleaned retry still fails, the exception propagates as before.

Fixes #640

## Test plan
- [x] `uv run pytest tests/unit/core/indexing/parsers/pdf/test_pymupdf.py` — new tests: retry-and-recover, retry-once-then-propagate, no-retry-on-success, end-to-end `PyMuPDFParser.parse()` recovery
- [x] `uv run pytest tests/unit/core/indexing/parsers/` — no regressions (36 passed)
- [x] `uv run ruff check` / `ruff format --check`
- [x] Verified against the exact repro file from the issue (arXiv `2412.01370v2.pdf`, 21 pages): direct `to_markdown` call reproduces `RuntimeError: code=4: no font file for digest`; with the fix, `PyMuPDFParser.parse()` recovers all 21 pages (101,048 markdown chars, no empty pages), matching the ~101K chars reported in the issue's manual workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF Markdown extraction reliability when documents contain problematic or missing font data.
  - Added automatic recovery by cleaning and retrying affected PDF files.
  - Preserved clear error reporting when extraction cannot be completed after recovery attempts.
  - Improved parser feedback during PDF processing, including more useful file-specific warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->