### PR TITLE
fix(di): stop leaking batch_size into LLM/VLM/reranker request bodies

### DIFF
--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -154,8 +154,14 @@ class ServiceContainer:
             endpoint's ``extra`` omits them (an explicit ``extra`` value wins).
 
             Also carries ``batch_size`` — only the embedder consumes it, so it is
-            injected here rather than for every kind (see factories.py / #712)."""
-            defaults: dict[str, Any] = {"batch_size": cfg.batch_size}
+            injected here rather than for every kind (see factories.py / #712).
+            Backfilled only when ``extra`` omits it, so an explicit ``extra``
+            value still wins (extra_kwargs_fn is merged last, so an
+            unconditional value would override the extra the base kwargs already
+            applied)."""
+            defaults: dict[str, Any] = {}
+            if "batch_size" not in cfg.extra:
+                defaults["batch_size"] = cfg.batch_size
             if "max_model_len" not in cfg.extra:
                 defaults["max_model_len"] = embed_defaults.max_model_len
             if "embed_concurrency" not in cfg.extra:

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -151,8 +151,11 @@ class ServiceContainer:
 
         def _embedder_extra_kwargs(cfg: Any) -> dict[str, Any]:
             """Backfill max_model_len/embed_concurrency from static settings when the
-            endpoint's ``extra`` omits them (an explicit ``extra`` value wins)."""
-            defaults: dict[str, Any] = {}
+            endpoint's ``extra`` omits them (an explicit ``extra`` value wins).
+
+            Also carries ``batch_size`` — only the embedder consumes it, so it is
+            injected here rather than for every kind (see factories.py / #712)."""
+            defaults: dict[str, Any] = {"batch_size": cfg.batch_size}
             if "max_model_len" not in cfg.extra:
                 defaults["max_model_len"] = embed_defaults.max_model_len
             if "embed_concurrency" not in cfg.extra:

--- a/openrag/di/factories.py
+++ b/openrag/di/factories.py
@@ -88,10 +88,15 @@ def make_component_factory(
             # constructor argument, so it is read out before splatting `extra`.
             impl_kwargs = {k: v for k, v in model_cfg.extra.items() if k != "implementation"}
             impl = model_cfg.extra.get("implementation", default_impl)
+            # NOTE: batch_size is deliberately NOT passed here. Only the embedder
+            # constructor consumes it; the LLM/VLM clients absorb unknown kwargs
+            # into ``self._defaults`` and splat them into the request body, so an
+            # unconditional batch_size leaked a bogus field onto every chat and
+            # caption call (#712). The embedder factory injects it via
+            # ``extra_kwargs_fn`` instead.
             kwargs: dict[str, Any] = {
                 "endpoint": model_cfg.endpoint,
                 "model_name": model_cfg.model_name,
-                "batch_size": model_cfg.batch_size,
                 "timeout": model_cfg.timeout,
                 **impl_kwargs,
             }

--- a/tests/unit/di/test_container.py
+++ b/tests/unit/di/test_container.py
@@ -585,6 +585,20 @@ class TestPhase14NamedComponentFactories:
         assert embedder.kwargs["max_model_len"] == 4096
         assert embedder.kwargs["embed_concurrency"] == 9
 
+    def test_embedder_extra_batch_size_wins_over_top_level(self):
+        """An explicit extra['batch_size'] must override the top-level value.
+
+        The top-level field is backfilled only when extra omits it, so moving
+        batch_size into extra_kwargs_fn (#712) does not invert the precedence the
+        base kwargs applied — extra still wins.
+        """
+        settings = _settings_with_named_models()
+        settings.models.embedder["embed-a"].batch_size = 16
+        settings.models.embedder["embed-a"].extra["batch_size"] = 128
+        c = ServiceContainer(settings)
+
+        assert c.embedder_factory("embed-a").kwargs["batch_size"] == 128
+
     def test_named_factories_cache_by_endpoint_name(self):
         """Repeated factory calls for the same endpoint return one client."""
         c = ServiceContainer(_settings_with_named_models())

--- a/tests/unit/di/test_container.py
+++ b/tests/unit/di/test_container.py
@@ -568,6 +568,12 @@ class TestPhase14NamedComponentFactories:
         assert vlm.kwargs["endpoint"] == "http://vlm:8000/v1"
         assert vlm.kwargs["max_tokens"] == 256
 
+        # batch_size is embedder-only. The LLM/VLM/reranker clients absorb
+        # unknown kwargs into the request body, so it must not reach them (#712).
+        assert "batch_size" not in llm.kwargs
+        assert "batch_size" not in vlm.kwargs
+        assert "batch_size" not in reranker.kwargs
+
     def test_embedder_extra_overrides_backfilled_embedder_defaults(self):
         """Per-endpoint embedder extras win over the settings defaults."""
         settings = _settings_with_named_models()

--- a/tests/unit/di/test_factories.py
+++ b/tests/unit/di/test_factories.py
@@ -117,9 +117,39 @@ class TestMakeComponentFactory:
 
         assert kwargs["endpoint"] == "http://host:8000/v1"
         assert kwargs["model_name"] == "m"
-        assert kwargs["batch_size"] == 8
         assert kwargs["timeout"] == 30.0
         assert kwargs["api_key"] == "secret"
+
+    def test_batch_size_is_not_forwarded_generically(self):
+        """batch_size must NOT reach LLM/VLM/reranker constructors (#712).
+
+        Only the embedder consumes it; the VLLM chat/vision clients absorb
+        unknown kwargs into ``self._defaults`` and splat them into the request
+        body, so an unconditional batch_size leaked a bogus field onto every
+        chat and caption call. The embedder factory injects it explicitly via
+        ``extra_kwargs_fn`` instead — see ``test_extra_kwargs_fn_merges_last``
+        for the inject-and-win path.
+        """
+        factory, _ = make_component_factory(
+            _registry(),
+            {"default": _FakeEndpoint(batch_size=64)},
+            default_impl="vllm",
+            client_caches=[],
+        )
+
+        assert "batch_size" not in factory("default").kwargs
+
+    def test_extra_kwargs_fn_can_reinject_batch_size_for_the_embedder(self):
+        """The embedder factory supplies batch_size through extra_kwargs_fn."""
+        factory, _ = make_component_factory(
+            _registry(),
+            {"default": _FakeEndpoint(batch_size=64)},
+            default_impl="vllm",
+            client_caches=[],
+            extra_kwargs_fn=lambda cfg: {"batch_size": cfg.batch_size},
+        )
+
+        assert factory("default").kwargs["batch_size"] == 64
 
     def test_extra_kwargs_fn_merges_last(self):
         """``extra_kwargs_fn`` output overrides config-derived kwargs."""


### PR DESCRIPTION
Closes #712.

## Problem

`make_component_factory` (`di/factories.py`) passed `batch_size` to **every** model kind:
```python
kwargs = {"endpoint": ..., "model_name": ..., "batch_size": model_cfg.batch_size, "timeout": ..., **impl_kwargs}
```
But only `VLLMEmbedder` consumes it. `VLLMClient` (chat) and `VLLMVision` (caption) absorb unknown kwargs into `self._defaults` (`vllm_client.py:76`) and splat them into the request body (`:128`, `:148`), so every chat completion and every caption sent a bogus `"batch_size": 32` field.

vLLM tolerates unknown body keys; a strict OpenAI-compatible gateway or LiteLLM proxy rejects with 400 — so an endpoint that works in dev fails behind a proxy, for a reason nothing in the config surface explains.

## Fix

Drop `batch_size` from the generic factory kwargs; inject it only in the embedder factory's existing `extra_kwargs_fn` (`container.py`). The embedder still receives it; the other three kinds no longer do. (Reranker/ollama use `**_kwargs` so they discarded it already, but it no longer reaches their constructors either.)

## Tests assert the effect, not the call

Reverting the production fix while keeping the tests shows the leak explicitly and fails two levels:

```
AssertionError: assert 'batch_size' not in
  {'batch_size': 32, 'endpoint': 'http://llm:8000/v1', 'model_name': 'chat-model', ...}
FAILED test_factories.py::...::test_batch_size_is_not_forwarded_generically
FAILED test_container.py::...::test_container_wires_named_factories_from_models_config
```

- unit: `batch_size` absent from a generically-built client, present when supplied via `extra_kwargs_fn`
- end-to-end container: LLM/VLM/reranker clients built from real settings have no `batch_size`; the embedder still does (16)

Full suite: **1812 passed**; ruff check / format / layer-import-guard green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured `batch_size` is applied only to embedding components.
  * Prevented `batch_size` from being forwarded to language, vision, and reranking clients.
  * Updated embedder batching behavior so an embedder-specific `extra["batch_size"]` takes precedence over top-level endpoint settings.
* **Tests**
  * Expanded unit tests to verify no `batch_size` leakage into non-embedder components.
  * Added tests confirming embedder `extra_kwargs_fn` correctly injects `batch_size` when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->