### PR TITLE
fix(docling): make the docling pool and workers restartable (max_restarts)

### DIFF
--- a/openrag/services/workers/parsers/docling_workers.py
+++ b/openrag/services/workers/parsers/docling_workers.py
@@ -80,7 +80,9 @@ class DoclingWorker:
             return await asyncio.to_thread(self.converter.convert, str(file_path))
 
 
-@ray.remote
+# max_restarts mirrors MarkerPool: the detached pool supervisor must survive its
+# own crashes rather than staying permanently dead (#722). Ray's default is 0.
+@ray.remote(max_restarts=5)
 class DoclingPool:
     def __init__(self):
         self.logger = get_logger()
@@ -88,8 +90,12 @@ class DoclingPool:
         self.pool_size = self.config.loader.docling_pool_size
         self.max_tasks_per_worker = self.config.loader.docling_max_tasks_per_worker
 
+        # max_restarts mirrors MarkerWorker: a worker that OOMs/CUDA-faults is
+        # restarted in place (same actor id), so the handle already queued keeps
+        # working instead of every retry drawing the same dead handle (#722).
         self.actors = [
-            DoclingWorker.options(num_gpus=_docling_num_gpus(self.config)).remote() for _ in range(self.pool_size)
+            DoclingWorker.options(num_gpus=_docling_num_gpus(self.config), max_restarts=5).remote()
+            for _ in range(self.pool_size)
         ]
         self._queue: asyncio.Queue[ray.actor.ActorHandle] = asyncio.Queue()
 

--- a/tests/unit/services/workers/parsers/test_docling_workers.py
+++ b/tests/unit/services/workers/parsers/test_docling_workers.py
@@ -30,3 +30,21 @@ def test_docling_num_gpus_zero_when_not_requested(monkeypatch):
     monkeypatch.setattr(docling_workers.ray, "cluster_resources", lambda: {"GPU": 1.0})
 
     assert docling_workers._docling_num_gpus(_config(docling_num_gpus=0)) == 0
+
+
+# --- #722: the detached pool supervisor must survive its own crashes ----------
+
+
+def test_docling_pool_sets_max_restarts():
+    """DoclingPool had a bare @ray.remote — Ray's default max_restarts is 0, so
+    one crash left the detached actor permanently dead and every docling parse
+    afterwards failed. It must be restartable like MarkerPool/WhisperActor."""
+    assert docling_workers.DoclingPool.__ray_metadata__.max_restarts == 5
+
+
+def test_docling_pool_restart_policy_matches_marker():
+    """Parity guard: if MarkerPool's policy changes, this flags that DoclingPool
+    should be reconsidered too, rather than silently drifting apart."""
+    from services.workers.parsers.marker_workers import MarkerPool
+
+    assert docling_workers.DoclingPool.__ray_metadata__.max_restarts == MarkerPool.__ray_metadata__.max_restarts


### PR DESCRIPTION
Closes #722.

## Problem

`DoclingPool` and `DoclingWorker` used a bare `@ray.remote`, so Ray's default `max_restarts=0` applied — a single OOM or CUDA fault killed the actor permanently.

`DoclingPool` is detached, and its worker handles are queued once in `__init__` and re-queued unconditionally after each use (`docling_workers.py:106-114`) with no liveness check. With the default `docling_pool_size=1` there is exactly one worker, so every subsequent docling parse drew the same dead handle and failed until the container was restarted. Because failures surface per-file, it reads as "some PDFs fail" rather than "the pool is dead".

## Sibling parity

Both other GPU parsers already survive crashes — docling was the sole gap:

| | restart policy |
|---|---|
| `MarkerPool` | `@ray.remote(max_restarts=5)` (`marker_workers.py:259`) |
| `MarkerWorker` | `.options(..., max_restarts=5)` (`marker_workers.py:270`) |
| `WhisperActor` | `max_restarts=5` via `whisper_actor_options` (`whisper_workers.py:45`) |
| **`DoclingPool` / `DoclingWorker`** | **none** |

## Fix

Mirror marker exactly: `max_restarts=5` on the `DoclingPool` decorator and on the `DoclingWorker.options(...)` call. A restarted Ray actor keeps its actor id, so the handle already sitting in the queue self-heals instead of staying dead — which is precisely the "every retry draws the same dead handle" failure.

## Tests

- `test_docling_pool_sets_max_restarts` — asserts the pool metadata; reverting the decorator fails it
- `test_docling_pool_restart_policy_matches_marker` — pins docling to parity with `MarkerPool` so the two can't silently drift apart again

The worker-side `.options(max_restarts=5)` is applied at actor-creation time, so it is not statically inspectable without a Ray runtime — it mirrors `MarkerWorker:270` and is verified by reading.

Full suite: **1812 passed**; ruff check / format / layer-import-guard green.

## Out of scope (follow-up)

Marker also has an active `ensure_worker_pool_healthy` / `is_pool_broken` recreate loop that docling lacks entirely. That's a larger enhancement; `max_restarts` is the minimal fix for the permanent-death bug this issue is about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing resilience by automatically restarting failed processing workers up to five times.
  * Reduced the risk of interrupted document processing after worker or supervisor crashes.

* **Tests**
  * Added coverage to verify worker restart behavior and configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->