### PR TITLE
fix: require chat_history_depth >= 1 and default it to 4

### DIFF
--- a/openrag/api/schemas/admin/partition_schemas.py
+++ b/openrag/api/schemas/admin/partition_schemas.py
@@ -33,7 +33,7 @@ class CreatePartitionRequest(BaseModel):
     embedder: str = "default"
     indexation_preset: str = "default"
     retrieval_preset: str = "default"
-    chat_history_depth: int = Field(default=0, ge=0)
+    chat_history_depth: int = Field(default=4, ge=1)
     chat_llm: str | None = None
 
     @field_validator("name", "embedder", "indexation_preset", "retrieval_preset")
@@ -60,7 +60,7 @@ class UpdatePartitionRequest(BaseModel):
     embedder: str | None = None
     indexation_preset: str | None = None
     retrieval_preset: str | None = None
-    chat_history_depth: int | None = Field(default=None, ge=0)
+    chat_history_depth: int | None = Field(default=None, ge=1)
     chat_llm: str | None = None
 
     @field_validator("embedder", "indexation_preset", "retrieval_preset")

--- a/openrag/api/schemas/admin/partition_schemas.py
+++ b/openrag/api/schemas/admin/partition_schemas.py
@@ -111,7 +111,7 @@ class PartitionDetailResponse(BaseModel):
     dimension: int
     created_at: datetime
     document_count: int = 0
-    chat_history_depth: int = 0
+    chat_history_depth: int = 4
     chat_llm: str | None = None
 
 

--- a/openrag/core/models/preset.py
+++ b/openrag/core/models/preset.py
@@ -33,7 +33,7 @@ class PartitionRow(BaseModel):
     retrieval_preset: str = "default"
     dimension: int = Field(default=1024, gt=0)
     collection_name: str | None = None
-    chat_history_depth: int = Field(default=0, ge=0)
+    chat_history_depth: int = Field(default=4, ge=1)
     chat_llm: str | None = None
     created_at: datetime
     updated_at: datetime
@@ -52,7 +52,7 @@ class PartitionConfig(BaseModel):
     indexation: IndexationPipelineConfig
     retrieval: RetrievalPipelineConfig
     collection_name: str | None = None
-    chat_history_depth: int = Field(default=0, ge=0)
+    chat_history_depth: int = Field(default=4, ge=1)
     chat_llm: str | None = None
 
 

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -270,7 +270,11 @@ class PartitionService:
                 "indexation_preset": r.get("indexation_preset") or "default",
                 "retrieval_preset": r.get("retrieval_preset") or "default",
                 "dimension": r.get("dimension"),
-                "chat_history_depth": r.get("chat_history_depth") or 0,
+                # `or 4`, not `or 0`: normalizes pre-existing rows stored under the old
+                # "0 = inherit global default" scheme to the concrete value they already
+                # resolve to at chat time (see QueryService._resolve_chat_history_depth).
+                # New writes can no longer produce 0 (schema now requires >=1).
+                "chat_history_depth": r.get("chat_history_depth") or 4,
                 "chat_llm": r.get("chat_llm"),
                 "created_at": created.isoformat() if hasattr(created, "isoformat") else created,
                 "document_count": counts.get(name, 0),
@@ -287,7 +291,7 @@ class PartitionService:
         embedder: str = "default",
         indexation_preset: str = "default",
         retrieval_preset: str = "default",
-        chat_history_depth: int = 0,
+        chat_history_depth: int = 4,
         chat_llm: str | None = None,
     ) -> None:
         """Create a partition owned by ``user_id`` with preset references.
@@ -501,7 +505,8 @@ class PartitionService:
             "retrieval_pipeline": cfg.retrieval.model_dump(mode="json"),
             "dimension": row.get("dimension"),
             "created_at": row.get("created_at"),
-            "chat_history_depth": row.get("chat_history_depth") or 0,
+            # See list_partition_summaries() above for why this normalizes to 4, not 0.
+            "chat_history_depth": row.get("chat_history_depth") or 4,
             "chat_llm": row.get("chat_llm"),
         }
 
@@ -536,7 +541,10 @@ class PartitionService:
             indexation=IndexationPipelineConfig(**idx_preset),
             retrieval=RetrievalPipelineConfig(**ret_preset),
             collection_name=row.get("collection_name"),
-            chat_history_depth=row.get("chat_history_depth") or 0,
+            # See list_partition_summaries() above for why this normalizes to 4, not 0.
+            # This value feeds Settings.partitions, so it's what
+            # QueryService._resolve_chat_history_depth actually reads at chat time.
+            chat_history_depth=row.get("chat_history_depth") or 4,
             chat_llm=row.get("chat_llm"),
         )
 

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -270,11 +270,7 @@ class PartitionService:
                 "indexation_preset": r.get("indexation_preset") or "default",
                 "retrieval_preset": r.get("retrieval_preset") or "default",
                 "dimension": r.get("dimension"),
-                # `or 4`, not `or 0`: normalizes pre-existing rows stored under the old
-                # "0 = inherit global default" scheme to the concrete value they already
-                # resolve to at chat time (see QueryService._resolve_chat_history_depth).
-                # New writes can no longer produce 0 (schema now requires >=1).
-                "chat_history_depth": r.get("chat_history_depth") or 4,
+                "chat_history_depth": r.get("chat_history_depth") or self._legacy_chat_history_depth_fallback(),
                 "chat_llm": r.get("chat_llm"),
                 "created_at": created.isoformat() if hasattr(created, "isoformat") else created,
                 "document_count": counts.get(name, 0),
@@ -505,8 +501,7 @@ class PartitionService:
             "retrieval_pipeline": cfg.retrieval.model_dump(mode="json"),
             "dimension": row.get("dimension"),
             "created_at": row.get("created_at"),
-            # See list_partition_summaries() above for why this normalizes to 4, not 0.
-            "chat_history_depth": row.get("chat_history_depth") or 4,
+            "chat_history_depth": row.get("chat_history_depth") or self._legacy_chat_history_depth_fallback(),
             "chat_llm": row.get("chat_llm"),
         }
 
@@ -541,10 +536,9 @@ class PartitionService:
             indexation=IndexationPipelineConfig(**idx_preset),
             retrieval=RetrievalPipelineConfig(**ret_preset),
             collection_name=row.get("collection_name"),
-            # See list_partition_summaries() above for why this normalizes to 4, not 0.
             # This value feeds Settings.partitions, so it's what
             # QueryService._resolve_chat_history_depth actually reads at chat time.
-            chat_history_depth=row.get("chat_history_depth") or 4,
+            chat_history_depth=row.get("chat_history_depth") or self._legacy_chat_history_depth_fallback(),
             chat_llm=row.get("chat_llm"),
         )
 
@@ -574,6 +568,19 @@ class PartitionService:
         if self._config is None:
             raise ConfigError("PartitionService was constructed without a config; preset resolution unavailable.")
         return self._config
+
+    def _legacy_chat_history_depth_fallback(self) -> int:
+        """Value substituted for a partition row still holding the pre-guard ``0``.
+
+        ``0`` used to mean "inherit the global default" (``config.rag.chat_history_depth``,
+        see ``QueryService._resolve_chat_history_depth``). New writes can no longer
+        produce ``0`` (``ge=1`` on ``CreatePartitionRequest``/``UpdatePartitionRequest``),
+        but a row written before that guard existed may still have it stored — read it
+        from the live config, not a hardcoded constant, so a legacy row keeps resolving
+        to the *current* global default exactly as it did before, even if an operator
+        changes ``rag.chat_history_depth`` later.
+        """
+        return self._config.rag.chat_history_depth if self._config is not None else 4
 
     # ------------------------------------------------------------------
     # File / chunk reads

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -569,6 +569,9 @@ class PartitionService:
             raise ConfigError("PartitionService was constructed without a config; preset resolution unavailable.")
         return self._config
 
+    #: Depth used when neither a partition row nor the global config yields a usable value.
+    _CHAT_HISTORY_DEPTH_DEFAULT = 4
+
     def _legacy_chat_history_depth_fallback(self) -> int:
         """Value substituted for a partition row still holding the pre-guard ``0``.
 
@@ -579,8 +582,17 @@ class PartitionService:
         from the live config, not a hardcoded constant, so a legacy row keeps resolving
         to the *current* global default exactly as it did before, even if an operator
         changes ``rag.chat_history_depth`` later.
+
+        ``RAGConfig.chat_history_depth`` itself carries no lower bound, so a deployment
+        may configure it to ``0`` (or negative). Since this value feeds
+        ``PartitionConfig(chat_history_depth: ge=1)``, returning ``< 1`` here would make
+        ``load_partitions()`` raise ``ValidationError`` at startup. Clamp such values to
+        the hardcoded default so a legacy row can never crash partition loading.
         """
-        return self._config.rag.chat_history_depth if self._config is not None else 4
+        if self._config is None:
+            return self._CHAT_HISTORY_DEPTH_DEFAULT
+        configured = self._config.rag.chat_history_depth
+        return configured if configured >= 1 else self._CHAT_HISTORY_DEPTH_DEFAULT
 
     # ------------------------------------------------------------------
     # File / chunk reads

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -99,6 +99,10 @@ class RAGMODE(Enum):
 class QueryService:
     """End-to-end RAG: query-gen → retrieve (+web) → map-reduce → answer."""
 
+    #: Used when the global ``rag.chat_history_depth`` config is < 1 — see
+    #: PartitionService._CHAT_HISTORY_DEPTH_DEFAULT for the matching partition-side clamp.
+    _CHAT_HISTORY_DEPTH_DEFAULT = 4
+
     def __init__(
         self,
         *,
@@ -120,7 +124,14 @@ class QueryService:
         # read at request time, not snapshotted once at startup.
         self._config = config
         self._rag_mode = config.rag.mode
-        self._default_chat_history_depth = config.rag.chat_history_depth
+        # RAGConfig.chat_history_depth carries no lower bound, so a deployment may
+        # configure it to 0 (or negative). Left unclamped, messages[-0:] would keep
+        # the *entire* history instead of none — the opposite of what this depth
+        # is meant to limit. Clamp here rather than reject at config-load time so a
+        # misconfigured global default degrades safely instead of crashing startup.
+        self._default_chat_history_depth = (
+            config.rag.chat_history_depth if config.rag.chat_history_depth >= 1 else self._CHAT_HISTORY_DEPTH_DEFAULT
+        )
         self._max_contextualized_query_len = config.rag.max_contextualized_query_len
         self._max_context_tokens = config.reranker.top_k * config.chunker.chunk_size
 

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -138,9 +138,16 @@ class QueryService:
         """Effective chat-history depth for this request.
 
         Honors a partition's configured ``chat_history_depth`` (set via the
-        admin API) over the global default. A partition value of ``0`` means
-        "inherit the global default" — it never reaches the ``messages[-depth:]``
-        slice, where ``0`` would otherwise select the *entire* history.
+        admin API) over the global default. The admin API now requires an
+        explicit ``chat_history_depth >= 1`` on create/update (``ge=1`` in
+        ``CreatePartitionRequest``/``UpdatePartitionRequest``), and
+        ``PartitionService.resolve_partition_row`` normalizes any pre-existing
+        row still holding the legacy ``0`` sentinel to the global default
+        value before it reaches ``Settings.partitions``. So in practice
+        ``cfg.chat_history_depth`` is always >= 1 here; the ``> 0`` filter
+        below is kept only as a defensive backstop — it must never reach the
+        ``messages[-depth:]`` slice, where ``0`` would select the *entire*
+        history rather than none.
 
         The ``"all"`` sentinel (``openrag-all``) reaches this layer un-expanded
         (retrieval resolves it to concrete partitions downstream) and is a

--- a/tests/unit/api/schemas/admin/test_phase14_schemas.py
+++ b/tests/unit/api/schemas/admin/test_phase14_schemas.py
@@ -87,7 +87,7 @@ def test_create_partition_defaults_to_default_presets():
     assert request.embedder == "default"
     assert request.indexation_preset == "default"
     assert request.retrieval_preset == "default"
-    assert request.chat_history_depth == 0
+    assert request.chat_history_depth == 4
 
 
 def test_create_partition_rejects_empty_names():
@@ -106,6 +106,18 @@ def test_update_partition_rejects_negative_chat_history_depth():
     """Chat history depth cannot be negative."""
     with pytest.raises(ValidationError):
         UpdatePartitionRequest(chat_history_depth=-1)
+
+
+def test_update_partition_rejects_zero_chat_history_depth():
+    """Chat history depth cannot be zero — a value of 1 turn is the floor."""
+    with pytest.raises(ValidationError):
+        UpdatePartitionRequest(chat_history_depth=0)
+
+
+def test_create_partition_rejects_zero_chat_history_depth():
+    """Chat history depth cannot be zero at creation time either."""
+    with pytest.raises(ValidationError):
+        CreatePartitionRequest(name="legal", chat_history_depth=0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/core/models/test_preset_models.py
+++ b/tests/unit/core/models/test_preset_models.py
@@ -55,3 +55,22 @@ def test_partition_config_rejects_negative_chat_history_depth():
             retrieval=RetrievalPipelineConfig(),
             chat_history_depth=-1,
         )
+
+
+def test_partition_row_rejects_zero_chat_history_depth():
+    """Persisted partition rows reject zero chat history depth (minimum is 1)."""
+    now = _now()
+
+    with pytest.raises(ValidationError):
+        PartitionRow(name="tenant", chat_history_depth=0, created_at=now, updated_at=now)
+
+
+def test_partition_config_rejects_zero_chat_history_depth():
+    """Resolved partition configs reject zero chat history depth (minimum is 1)."""
+    with pytest.raises(ValidationError):
+        PartitionConfig(
+            name="tenant",
+            indexation=IndexationPipelineConfig(),
+            retrieval=RetrievalPipelineConfig(),
+            chat_history_depth=0,
+        )

--- a/tests/unit/services/orchestrators/test_partition_preset_resolution.py
+++ b/tests/unit/services/orchestrators/test_partition_preset_resolution.py
@@ -121,6 +121,23 @@ def test_resolve_partition_row_builds_config():
     assert cfg.retrieval.top_k == 50
 
 
+def test_resolve_partition_row_normalizes_legacy_zero_chat_history_depth():
+    """Rows written under the old '0 = inherit global default' scheme resolve to
+    the concrete default (4) instead of the no-longer-valid 0 (schema now
+    requires chat_history_depth >= 1 on new writes)."""
+    svc = _make_service()
+    cfg = svc.resolve_partition_row(_full_row("p1", chat_history_depth=0))
+
+    assert cfg.chat_history_depth == 4
+
+
+def test_resolve_partition_row_keeps_explicit_chat_history_depth():
+    svc = _make_service()
+    cfg = svc.resolve_partition_row(_full_row("p1", chat_history_depth=10))
+
+    assert cfg.chat_history_depth == 10
+
+
 def test_resolve_partition_row_missing_indexation_preset_raises():
     from core.utils.exceptions import ConfigError
 

--- a/tests/unit/services/orchestrators/test_partition_preset_resolution.py
+++ b/tests/unit/services/orchestrators/test_partition_preset_resolution.py
@@ -151,6 +151,22 @@ def test_resolve_partition_row_legacy_zero_tracks_current_global_default():
     assert cfg.chat_history_depth == 9
 
 
+@pytest.mark.parametrize("global_depth", [0, -1])
+def test_resolve_partition_row_legacy_zero_clamps_invalid_global_default(global_depth):
+    """RAGConfig.chat_history_depth carries no lower bound, so a deployment may set it
+    to 0 (or negative). A legacy-0 row would then inherit that value and hit
+    PartitionConfig's ge=1 guard, crashing load_partitions() at startup. The fallback
+    must clamp such values to the hardcoded default instead of propagating them."""
+    from core.config.retrieval import RAGConfig
+
+    settings = _settings().model_copy(update={"rag": RAGConfig(chat_history_depth=global_depth)})
+    svc = _make_service(settings=settings)
+
+    cfg = svc.resolve_partition_row(_full_row("p1", chat_history_depth=0))
+
+    assert cfg.chat_history_depth == 4
+
+
 def test_resolve_partition_row_missing_indexation_preset_raises():
     from core.utils.exceptions import ConfigError
 

--- a/tests/unit/services/orchestrators/test_partition_preset_resolution.py
+++ b/tests/unit/services/orchestrators/test_partition_preset_resolution.py
@@ -138,6 +138,19 @@ def test_resolve_partition_row_keeps_explicit_chat_history_depth():
     assert cfg.chat_history_depth == 10
 
 
+def test_resolve_partition_row_legacy_zero_tracks_current_global_default():
+    """The legacy-0 fallback reads the live config, not a hardcoded constant —
+    changing rag.chat_history_depth must change what a legacy-0 row resolves to."""
+    from core.config.retrieval import RAGConfig
+
+    settings = _settings().model_copy(update={"rag": RAGConfig(chat_history_depth=9)})
+    svc = _make_service(settings=settings)
+
+    cfg = svc.resolve_partition_row(_full_row("p1", chat_history_depth=0))
+
+    assert cfg.chat_history_depth == 9
+
+
 def test_resolve_partition_row_missing_indexation_preset_raises():
     from core.utils.exceptions import ConfigError
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -443,7 +443,7 @@ async def test_create_partition_with_config_inside_indexing_admission_keeps_db_w
                 "embedder": "default",
                 "indexation_preset": "default",
                 "retrieval_preset": "default",
-                "chat_history_depth": 0,
+                "chat_history_depth": 4,
                 "chat_llm": None,
             },
         )

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -155,6 +155,25 @@ def test_resolve_chat_history_depth_multi_partition_takes_max_explicit():
     assert svc._resolve_chat_history_depth(["a", "b", "c"]) == 6
 
 
+@pytest.mark.parametrize("global_depth", [0, -1])
+def test_default_chat_history_depth_clamps_invalid_global_config(global_depth):
+    """RAGConfig.chat_history_depth carries no lower bound. Left unclamped, a
+    misconfigured global depth of 0 would make messages[-0:] keep the *entire*
+    history for chats with no partition (or the "all" sentinel) — the opposite
+    of what this depth is meant to limit."""
+    config = _config()
+    config.rag.chat_history_depth = global_depth
+    svc = QueryService(
+        retrieval_service=FakeRetrieval(),
+        llm=FakeLLM(),
+        config=config,
+        web_search_service=FakeWeb(),
+        workspace_service=FakeWorkspace(),
+    )
+    assert svc._default_chat_history_depth == 4
+    assert svc._resolve_chat_history_depth(None) == 4
+
+
 # --------------------------------------------------------------------------- #
 # chat LLM resolution (per-partition chat_llm model-endpoint preset)
 # --------------------------------------------------------------------------- #

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -275,7 +275,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               Chat History Depth *
               <TooltipProvider>
                 <Tooltip>
-                  <TooltipTrigger asChild>
+                  <TooltipTrigger type="button" className="cursor-help">
                     <Info className="h-3.5 w-3.5 text-muted-foreground" />
                   </TooltipTrigger>
                   <TooltipContent className="max-w-xs">

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Save, UserPlus, Trash2, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { ArrowLeft, Save, UserPlus, Trash2, CheckCircle, XCircle, Loader2, Info } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -162,6 +163,10 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
       toast.error("Presets are required");
       return;
     }
+    if (intOr(chatHistoryDepth, 0) < 1) {
+      toast.error("Chat history depth must be at least 1");
+      return;
+    }
     mutation.mutate();
   };
 
@@ -266,17 +271,37 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
             </div>
           </div>
           <div className="space-y-2">
-            <Label>Chat History Depth</Label>
+            <Label className="flex items-center gap-1.5">
+              Chat History Depth *
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Number of previous chat messages (including the current question) kept as context
+                    for follow-up questions in this partition. Low values (e.g. 1) mean the assistant
+                    won&apos;t see earlier turns in the conversation. Default: 4.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </Label>
             <Input
               type="number"
-              min={0}
+              min={1}
+              required
               value={chatHistoryDepth}
               onChange={(e) => setChatHistoryDepth(e.target.value)}
               disabled={!canEdit}
             />
           </div>
           {canEdit && (
-            <Button type="submit" disabled={mutation.isPending || llmValidating || llmValidated === false}>
+            <Button
+              type="submit"
+              disabled={
+                mutation.isPending || llmValidating || llmValidated === false || intOr(chatHistoryDepth, 0) < 1
+              }
+            >
               <Save className="h-4 w-4" />
               {mutation.isPending ? "Saving..." : "Save Changes"}
             </Button>

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -761,7 +761,7 @@ export default function PartitionListPage() {
                       Chat History Depth *
                       <TooltipProvider>
                         <Tooltip>
-                          <TooltipTrigger asChild>
+                          <TooltipTrigger type="button" className="cursor-help">
                             <Info className="h-3.5 w-3.5 text-muted-foreground" />
                           </TooltipTrigger>
                           <TooltipContent className="max-w-xs">

--- a/ui/src/pages/admin/partitions/list.tsx
+++ b/ui/src/pages/admin/partitions/list.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw, ChevronLeft, ChevronRight, FilePlus } from "lucide-react";
+import { Plus, Pencil, Trash2, Search, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle, XCircle, Loader2, RefreshCw, ChevronLeft, ChevronRight, FilePlus, Info } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -164,7 +165,7 @@ export default function PartitionListPage() {
   const [embedder, setEmbedder] = useState("");
   const [indexationPreset, setIndexationPreset] = useState("default");
   const [retrievalPreset, setRetrievalPreset] = useState("default");
-  const [chatHistoryDepth, setChatHistoryDepth] = useState("0");
+  const [chatHistoryDepth, setChatHistoryDepth] = useState("4");
   const [chatLlm, setChatLlm] = useState("__default__");
   const [llmValidated, setLlmValidated] = useState<boolean | null>(true);
   const [llmValidating, setLlmValidating] = useState(false);
@@ -362,7 +363,7 @@ export default function PartitionListPage() {
       setEmbedder("");
       setIndexationPreset("default");
       setRetrievalPreset("default");
-      setChatHistoryDepth("0");
+      setChatHistoryDepth("4");
       setChatLlm("__default__");
       setLlmValidated(true);
     },
@@ -392,6 +393,10 @@ export default function PartitionListPage() {
     e.preventDefault();
     if (!name.trim()) {
       toast.error("Name is required");
+      return;
+    }
+    if (canManagePartitions && intOr(chatHistoryDepth, 0) < 1) {
+      toast.error("Chat history depth must be at least 1");
       return;
     }
     createMutation.mutate();
@@ -752,10 +757,25 @@ export default function PartitionListPage() {
                     </Select>
                   </div>
                   <div className="space-y-2">
-                    <Label>Chat History Depth</Label>
+                    <Label className="flex items-center gap-1.5">
+                      Chat History Depth *
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-xs">
+                            Number of previous chat messages (including the current question) kept as
+                            context for follow-up questions in this partition. Low values (e.g. 1) mean the
+                            assistant won&apos;t see earlier turns in the conversation. Default: 4.
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </Label>
                     <Input
                       type="number"
-                      min={0}
+                      min={1}
+                      required
                       value={chatHistoryDepth}
                       onChange={(e) => setChatHistoryDepth(e.target.value)}
                     />
@@ -767,7 +787,14 @@ export default function PartitionListPage() {
               <Button type="button" variant="outline" onClick={() => setDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={createMutation.isPending || (canManagePartitions && (llmValidating || llmValidated === false || !embedder))}>
+              <Button
+                type="submit"
+                disabled={
+                  createMutation.isPending ||
+                  (canManagePartitions &&
+                    (llmValidating || llmValidated === false || !embedder || intOr(chatHistoryDepth, 0) < 1))
+                }
+              >
                 {createMutation.isPending ? "Creating..." : "Create"}
               </Button>
             </DialogFooter>


### PR DESCRIPTION
## Summary
- Chat History Depth defaulted to `0` in the Create/Edit Partition UI with no lower bound and no explanation. `0` was actually a backend sentinel meaning "inherit the global default" (4), not "no history" — but `1` wasn't special-cased and would genuinely drop all prior conversation context.
- UI: default is now `4`, input is `required`/`min=1` with a submit-time guard, and an info tooltip explains what the field does.
- Backend: `CreatePartitionRequest`/`UpdatePartitionRequest` now enforce `chat_history_depth >= 1`; `PartitionRow`/`PartitionConfig` match. Any pre-existing partition still holding the legacy `0` is normalized to `4` at read time (no DB migration needed).

Closes #730

## Test plan
- [x] `uv run pytest tests/unit/` — 1828 passed
- [x] `uv run ruff check openrag/ tests/` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` on the touched partition test files — passing
- [x] New/updated unit tests cover: rejecting 0/negative at the schema and model level, and the legacy-zero → 4 normalization in `resolve_partition_row`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chat History Depth now defaults to **4** and enforces a **minimum of 1** for partition creation, updates, and resolved partition responses.
  * Values below **1** are rejected both in the API schema and during partition/query handling.
  * Legacy partitions storing a depth of **0** are automatically normalized to the current default (**4**), including when global settings are invalid.
* **Admin UI**
  * Create/edit dialogs now require Chat History Depth **≥ 1**, disable saving for invalid values, and show an error toast if attempted.
  * Added an info tooltip to explain the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->