### PR TITLE
fix(indexing): sanitize embedded HTML images

### DIFF
--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -34,7 +34,7 @@ DATA_URI_IMAGE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)
-DATA_URI_REFERENCE_IMAGE_PATTERN = re.compile(r"!\[([^]]+)\](?:\[([^]]*)\]|(?!\())")
+DATA_URI_REFERENCE_IMAGE_PATTERN = re.compile(r"!\[([^]]*)\](?:\[([^]]*)\]|(?!\())")
 DATA_URI_REFERENCE_DEFINITION_PATTERN = re.compile(
     r"^[ \t]{0,3}\[([^]\r\n]+)\]:[ \t]*"
     r"(<?data:image/[^\r\n]*(?:(?<!=)\r?\n[ \t]*[A-Za-z0-9+/]+={0,2})*)$",
@@ -161,7 +161,7 @@ def _residual_data_uri_end(text: str, start: int, prefix_end: int) -> int:
         return _contextual_data_uri_end(text, prefix_end, closing_delimiter)
 
     end = prefix_end
-    while end < len(text) and text[end] != " " and text[end] not in _URI_DELIMITERS:
+    while end < len(text) and not text[end].isspace() and text[end] not in _URI_DELIMITERS:
         end += 1
     return end
 

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,7 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[([^]]*)\]\((<?data:image/(?:[^)'\"]|'[^']*'|\"[^\"]*\")*)\)",
+    r"""!\[([^]]*)\]\((<?data:image/(?:[^()"']+|"[^"\r\n]*"|'[^'\r\n]*'|\([^\)\r\n]*\))*)\)""",
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,8 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"""!\[([^]]*)\]\((<?data:image/(?:[^()"']+|"[^"\r\n]*"|'[^'\r\n]*'|\([^\)\r\n]*\))*)\)""",
+    r"""!\[((?:\\[^\r\n]|(?!\]\()[^\\\r\n])*)\]\("""
+    r"""(<?data:image/(?:[^()"']+|"[^"\r\n]*"|'[^'\r\n]*'|\([^\)\r\n]*\))*)\)""",
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,7 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[([^]]*)\]\((<?data:image/[^)]*)\)",
+    r"!\[([^]]*)\]\((<?data:image/(?:[^)'\"]|'[^']*'|\"[^\"]*\")*)\)",
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,7 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[(.*?)\]\((<?data:image/[^)]*)\)",
+    r"!\[([^]]*)\]\((<?data:image/[^)]*)\)",
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -34,17 +34,11 @@ DATA_URI_IMAGE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)
-_DATA_URI_PATTERN = (
-    r"data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
-    r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*"
-)
-_MARKDOWN_TITLE_PATTERN = r"(?:[ \t\r\n\f\v]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
 _VALID_DATA_URI_TARGET_PATTERN = re.compile(
-    rf"^({_DATA_URI_PATTERN}){_MARKDOWN_TITLE_PATTERN}[ \t\r\n\f\v]*$",
-    re.IGNORECASE,
-)
-_VALID_ANGLED_DATA_URI_TARGET_PATTERN = re.compile(
-    rf"^<({_DATA_URI_PATTERN})>{_MARKDOWN_TITLE_PATTERN}[ \t\r\n\f\v]*$",
+    r"^(data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
+    r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*)"
+    r"(?:[ \t\r\n\f\v]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
+    r"[ \t\r\n\f\v]*$",
     re.IGNORECASE,
 )
 
@@ -114,10 +108,13 @@ def mime_from_data_uri(data_uri: str) -> str:
 
 def _data_uri_from_markdown_target(target: str) -> str | None:
     """Return a validated data URI without an optional Markdown title."""
-    for pattern in (_VALID_DATA_URI_TARGET_PATTERN, _VALID_ANGLED_DATA_URI_TARGET_PATTERN):
-        if match := pattern.fullmatch(target):
-            return match.group(1)
-    return None
+    if target.startswith("<"):
+        closing_bracket = target.find(">")
+        if closing_bracket == -1:
+            return None
+        target = target[1:closing_bracket] + target[closing_bracket + 1 :]
+    match = _VALID_DATA_URI_TARGET_PATTERN.fullmatch(target)
+    return match.group(1) if match else None
 
 
 def _estimated_base64_size(encoded: str) -> int:

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,15 +30,21 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[(.*?)\]\((data:image/[^)]*)\)",
+    r"!\[(.*?)\]\((<?data:image/[^)]*)\)",
     re.IGNORECASE,
 )
-DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(data:image/[^)]*\)", re.IGNORECASE)
+DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)
+_DATA_URI_PATTERN = (
+    r"data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
+    r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*"
+)
+_MARKDOWN_TITLE_PATTERN = r"(?:[ \t\r\n\f\v]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
 _VALID_DATA_URI_TARGET_PATTERN = re.compile(
-    r"^(data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
-    r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*)"
-    r"(?:[ \t\r\n\f\v]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
-    r"[ \t\r\n\f\v]*$",
+    rf"^({_DATA_URI_PATTERN}){_MARKDOWN_TITLE_PATTERN}[ \t\r\n\f\v]*$",
+    re.IGNORECASE,
+)
+_VALID_ANGLED_DATA_URI_TARGET_PATTERN = re.compile(
+    rf"^<({_DATA_URI_PATTERN})>{_MARKDOWN_TITLE_PATTERN}[ \t\r\n\f\v]*$",
     re.IGNORECASE,
 )
 
@@ -108,8 +114,10 @@ def mime_from_data_uri(data_uri: str) -> str:
 
 def _data_uri_from_markdown_target(target: str) -> str | None:
     """Return a validated data URI without an optional Markdown title."""
-    match = _VALID_DATA_URI_TARGET_PATTERN.fullmatch(target)
-    return match.group(1) if match else None
+    for pattern in (_VALID_DATA_URI_TARGET_PATTERN, _VALID_ANGLED_DATA_URI_TARGET_PATTERN):
+        if match := pattern.fullmatch(target):
+            return match.group(1)
+    return None
 
 
 def _estimated_base64_size(encoded: str) -> int:

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -36,9 +36,11 @@ DATA_URI_IMAGE_PATTERN = re.compile(
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)
 DATA_URI_REFERENCE_IMAGE_PATTERN = re.compile(r"!\[([^]]+)\](?:\[([^]]*)\]|(?!\())")
 DATA_URI_REFERENCE_DEFINITION_PATTERN = re.compile(
-    r"^[ \t]{0,3}\[([^]\r\n]+)\]:[ \t]*(<?data:image/[^\r\n]*)$",
+    r"^[ \t]{0,3}\[([^]\r\n]+)\]:[ \t]*"
+    r"(<?data:image/[^\r\n]*(?:(?<!=)\r?\n[ \t]*[A-Za-z0-9+/]+={0,2})*)$",
     re.IGNORECASE | re.MULTILINE,
 )
+_RESIDUAL_DATA_URI_PREFIX_PATTERN = re.compile(r"data:image/", re.IGNORECASE)
 _VALID_DATA_URI_TARGET_PATTERN = re.compile(
     r"^(data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
     r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*)"
@@ -56,6 +58,7 @@ MIN_IMAGE_PIXELS = 784
 MAX_EMBEDDED_IMAGES = 50
 MAX_EMBEDDED_IMAGE_BYTES = 20 * 1024 * 1024
 MAX_EMBEDDED_TOTAL_BYTES = 100 * 1024 * 1024
+_URI_DELIMITERS = frozenset("\"'<>()[]{}")
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +136,86 @@ def _normalize_reference_label(label: str) -> str:
     return " ".join(label.split()).casefold()
 
 
+def _contextual_data_uri_end(text: str, start: int, closing_delimiter: str) -> int:
+    """Scan to a closing delimiter or blank-line paragraph boundary."""
+    cursor = start
+    while cursor < len(text):
+        if text[cursor] == closing_delimiter:
+            return cursor
+        if text[cursor] in "\r\n":
+            next_line = cursor + 1
+            if text[cursor] == "\r" and next_line < len(text) and text[next_line] == "\n":
+                next_line += 1
+            while next_line < len(text) and text[next_line] in " \t":
+                next_line += 1
+            if next_line < len(text) and text[next_line] in "\r\n":
+                return cursor
+        cursor += 1
+    return len(text)
+
+
+def _residual_data_uri_end(text: str, start: int, prefix_end: int) -> int:
+    """Find the end of an unhandled data URI without backtracking."""
+    if start > 0 and text[start - 1] in {'"', "'", "<", "("}:
+        closing_delimiter = {'"': '"', "'": "'", "<": ">", "(": ")"}[text[start - 1]]
+        return _contextual_data_uri_end(text, prefix_end, closing_delimiter)
+
+    end = prefix_end
+    while end < len(text) and text[end] != " " and text[end] not in _URI_DELIMITERS:
+        end += 1
+    return end
+
+
+def _scrub_unterminated_parenthesized_data_uris(text: str) -> tuple[str, int]:
+    """Remove unterminated parenthesized data URIs before Markdown regexes run."""
+    parts: list[str] = []
+    cursor = 0
+    search_from = 0
+    scrubbed = 0
+
+    while match := _RESIDUAL_DATA_URI_PREFIX_PATTERN.search(text, search_from):
+        opening_delimiter = match.start() - 1
+        if opening_delimiter >= 0 and text[opening_delimiter] == "<":
+            opening_delimiter -= 1
+        if opening_delimiter < 0 or text[opening_delimiter] != "(":
+            search_from = match.end()
+            continue
+
+        end = _contextual_data_uri_end(text, match.end(), ")")
+        if end < len(text) and text[end] == ")":
+            search_from = end + 1
+            continue
+
+        parts.append(text[cursor : match.start()])
+        parts.append("[Image]")
+        cursor = end
+        search_from = end
+        scrubbed += 1
+
+    if not scrubbed:
+        return text, 0
+    parts.append(text[cursor:])
+    return "".join(parts), scrubbed
+
+
+def _scrub_residual_data_uris(text: str) -> tuple[str, int]:
+    """Replace data URIs left by syntax-aware extraction using a linear scan."""
+    parts: list[str] = []
+    cursor = 0
+    scrubbed = 0
+
+    while match := _RESIDUAL_DATA_URI_PREFIX_PATTERN.search(text, cursor):
+        parts.append(text[cursor : match.start()])
+        parts.append("[Image]")
+        cursor = _residual_data_uri_end(text, match.start(), match.end())
+        scrubbed += 1
+
+    if not scrubbed:
+        return text, 0
+    parts.append(text[cursor:])
+    return "".join(parts), scrubbed
+
+
 def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[Any]:
     """Build ``ImageBlock``s for every ``![alt](data:image/...;base64,...)`` ref.
 
@@ -192,6 +275,7 @@ def normalize_data_uri_images(
 
     from core.models.document import ImageBlock
 
+    text, unterminated_scrubbed = _scrub_unterminated_parenthesized_data_uris(text)
     blocks: list[Any] = []
     matched = 0
     skipped = 0
@@ -262,8 +346,11 @@ def normalize_data_uri_images(
     sanitized = DATA_URI_REFERENCE_IMAGE_PATTERN.sub(replace_reference, sanitized)
     sanitized = DATA_URI_REFERENCE_DEFINITION_PATTERN.sub("", sanitized)
     sanitized = DATA_URI_LINK_PATTERN.sub(lambda match: match.group(1).strip() or "[Link]", sanitized)
+    sanitized, residual_scrubbed = _scrub_residual_data_uris(sanitized)
     if skipped:
         logger.bind(skipped=skipped, matched=matched).warning(
             "Skipped embedded image(s) while sanitizing document text"
         )
+    if scrubbed := unterminated_scrubbed + residual_scrubbed:
+        logger.bind(scrubbed=scrubbed).warning("Scrubbed residual embedded image data URI(s)")
     return sanitized, blocks

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -35,6 +35,9 @@ DATA_URI_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((data:image/[^;]+;base64,[^)]+
 
 # Qwen2.5-VL ``min_pixels`` threshold; images below this break the model.
 MIN_IMAGE_PIXELS = 784
+MAX_EMBEDDED_IMAGES = 50
+MAX_EMBEDDED_IMAGE_BYTES = 20 * 1024 * 1024
+MAX_EMBEDDED_TOTAL_BYTES = 100 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +76,7 @@ def decode_data_uri(data_uri: str) -> bytes | None:
     """Decode a ``data:image/...;base64,...`` URI into raw bytes. ``None`` on failure."""
     try:
         _, b64 = data_uri.split(",", 1)
-        return base64.b64decode(b64)
+        return base64.b64decode(b64, validate=True)
     except Exception as exc:
         logger.warning("Failed to decode data URI: %s", exc)
         return None
@@ -120,3 +123,71 @@ def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[An
             )
         )
     return blocks
+
+
+def normalize_data_uri_images(
+    text: str,
+    *,
+    page_number: int = 1,
+    max_images: int = MAX_EMBEDDED_IMAGES,
+    max_image_bytes: int = MAX_EMBEDDED_IMAGE_BYTES,
+    max_total_bytes: int = MAX_EMBEDDED_TOTAL_BYTES,
+) -> tuple[str, list[Any]]:
+    """Extract embedded images and remove their base64 payloads from Markdown.
+
+    Accepted images receive a compact deterministic placeholder that remains
+    compatible with the parser-to-caption replacement contract. Rejected or
+    malformed images are reduced to their alt text (or a small generic label),
+    so raw payloads never continue into chunking.
+    """
+    if not text:
+        return text, []
+
+    from ..models.document import ImageBlock
+
+    blocks: list[Any] = []
+    matched = 0
+    skipped = 0
+    total_bytes = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal matched, skipped, total_bytes
+        matched += 1
+        alt, data_uri = match.groups()
+        fallback = alt.strip() or "[Image]"
+
+        if matched > max_images:
+            skipped += 1
+            return fallback
+
+        encoded = data_uri.split(",", 1)[1] if "," in data_uri else ""
+        estimated_bytes = (len(encoded) * 3) // 4
+        if estimated_bytes > max_image_bytes or total_bytes + estimated_bytes > max_total_bytes:
+            skipped += 1
+            return fallback
+
+        payload = decode_data_uri(data_uri)
+        if payload is None or len(payload) > max_image_bytes or total_bytes + len(payload) > max_total_bytes:
+            skipped += 1
+            return fallback
+
+        placeholder = f"![{alt}](openrag-embedded-image-{matched})"
+        blocks.append(
+            ImageBlock(
+                image_bytes=payload,
+                page_number=page_number,
+                mime_type=mime_from_data_uri(data_uri),
+                metadata={"markdown_ref": placeholder, "alt": alt},
+            )
+        )
+        total_bytes += len(payload)
+        return placeholder
+
+    sanitized = DATA_URI_IMAGE_PATTERN.sub(replace, text)
+    if skipped:
+        logger.warning(
+            "Skipped %d of %d embedded image(s) while sanitizing document text",
+            skipped,
+            matched,
+        )
+    return sanitized, blocks

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,15 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[(.*?)\]\((data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,[^)]+)\)",
+    r"!\[(.*?)\]\((data:image/[^)]*)\)",
+    re.IGNORECASE,
+)
+DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(data:image/[^)]*\)", re.IGNORECASE)
+_VALID_DATA_URI_TARGET_PATTERN = re.compile(
+    r"^(data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
+    r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*)"
+    r"(?:[ \t\r\n\f\v]+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^\)\r\n]*\)))?"
+    r"[ \t\r\n\f\v]*$",
     re.IGNORECASE,
 )
 
@@ -98,6 +106,18 @@ def mime_from_data_uri(data_uri: str) -> str:
         return "image/png"
 
 
+def _data_uri_from_markdown_target(target: str) -> str | None:
+    """Return a validated data URI without an optional Markdown title."""
+    match = _VALID_DATA_URI_TARGET_PATTERN.fullmatch(target)
+    return match.group(1) if match else None
+
+
+def _estimated_base64_size(encoded: str) -> int:
+    """Estimate decoded bytes exactly for valid padded Base64."""
+    padding = min(len(encoded) - len(encoded.rstrip("=")), 2)
+    return max(0, (len(encoded) * 3) // 4 - padding)
+
+
 def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[Any]:
     """Build ``ImageBlock``s for every ``![alt](data:image/...;base64,...)`` ref.
 
@@ -115,7 +135,11 @@ def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[An
     from core.models.document import ImageBlock
 
     blocks: list[Any] = []
-    for alt, data_uri in DATA_URI_IMAGE_PATTERN.findall(text):
+    for match in DATA_URI_IMAGE_PATTERN.finditer(text):
+        alt, target = match.groups()
+        data_uri = _data_uri_from_markdown_target(target)
+        if data_uri is None:
+            continue
         payload = decode_data_uri(data_uri)
         if payload is None:
             continue
@@ -124,7 +148,7 @@ def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[An
                 image_bytes=payload,
                 page_number=page_number,
                 mime_type=mime_from_data_uri(data_uri),
-                metadata={"markdown_ref": f"![{alt}]({data_uri})", "alt": alt},
+                metadata={"markdown_ref": match.group(0), "alt": alt},
             )
         )
     return blocks
@@ -137,13 +161,15 @@ def normalize_data_uri_images(
     max_images: int = MAX_EMBEDDED_IMAGES,
     max_image_bytes: int = MAX_EMBEDDED_IMAGE_BYTES,
     max_total_bytes: int = MAX_EMBEDDED_TOTAL_BYTES,
+    reference_scope: str | None = None,
 ) -> tuple[str, list[Any]]:
-    """Extract embedded images and remove their base64 payloads from Markdown.
+    """Extract embedded images and remove image data URIs from Markdown.
 
     Accepted images receive a compact deterministic placeholder that remains
     compatible with the parser-to-caption replacement contract. Rejected or
-    malformed images are reduced to their alt text (or a small generic label),
-    so raw payloads never continue into chunking.
+    malformed images and data-URI links are reduced to their display text, so
+    raw payloads never continue into chunking. ``reference_scope`` keeps
+    placeholders unique when independently parsed documents are combined.
     """
     if not text:
         return text, []
@@ -160,15 +186,20 @@ def normalize_data_uri_images(
     def replace(match: re.Match[str]) -> str:
         nonlocal matched, skipped, total_bytes
         matched += 1
-        alt, data_uri = match.groups()
+        alt, target = match.groups()
         fallback = alt.strip() or "[Image]"
 
         if matched > max_images:
             skipped += 1
             return fallback
 
+        data_uri = _data_uri_from_markdown_target(target)
+        if data_uri is None:
+            skipped += 1
+            return fallback
+
         encoded = "".join(data_uri.split(",", 1)[1].split()) if "," in data_uri else ""
-        estimated_bytes = (len(encoded) * 3) // 4
+        estimated_bytes = _estimated_base64_size(encoded)
         if estimated_bytes > max_image_bytes or total_bytes + estimated_bytes > max_total_bytes:
             skipped += 1
             return fallback
@@ -178,7 +209,8 @@ def normalize_data_uri_images(
             skipped += 1
             return fallback
 
-        digest_builder = hashlib.sha256(f"{matched}:{alt}".encode())
+        digest_seed = f"{matched}:{alt}" if reference_scope is None else f"{reference_scope}:{matched}:{alt}"
+        digest_builder = hashlib.sha256(digest_seed.encode())
         digest_builder.update(payload)
         digest = digest_builder.hexdigest()[:16]
         suffix = 0
@@ -202,6 +234,7 @@ def normalize_data_uri_images(
         return placeholder
 
     sanitized = DATA_URI_IMAGE_PATTERN.sub(replace, text)
+    sanitized = DATA_URI_LINK_PATTERN.sub(lambda match: match.group(1).strip() or "[Link]", sanitized)
     if skipped:
         logger.bind(skipped=skipped, matched=matched).warning(
             "Skipped embedded image(s) while sanitizing document text"

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -15,19 +15,24 @@ migrated.
 from __future__ import annotations
 
 import base64
-import logging
+import hashlib
 import re
 from io import BytesIO
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from core.utils.logging import get_logger
+
+logger = get_logger()
 
 # ---------------------------------------------------------------------------
 # Markdown image-reference patterns (compile once; shared regex objects)
 # ---------------------------------------------------------------------------
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
-DATA_URI_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((data:image/[^;]+;base64,[^)]+)\)")
+DATA_URI_IMAGE_PATTERN = re.compile(
+    r"!\[(.*?)\]\((data:image/[^;,\s)]+(?:;[^;,\s)]+=[^;,\s)]*)*;base64,[^)]+)\)",
+    re.IGNORECASE,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -78,7 +83,7 @@ def decode_data_uri(data_uri: str) -> bytes | None:
         _, b64 = data_uri.split(",", 1)
         return base64.b64decode(b64, validate=True)
     except Exception as exc:
-        logger.warning("Failed to decode data URI: %s", exc)
+        logger.bind(error=str(exc)).warning("Failed to decode data URI")
         return None
 
 
@@ -107,7 +112,7 @@ def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[An
     if not text:
         return []
     # Local import to avoid a top-level cycle with ``core.models``.
-    from ..models.document import ImageBlock
+    from core.models.document import ImageBlock
 
     blocks: list[Any] = []
     for alt, data_uri in DATA_URI_IMAGE_PATTERN.findall(text):
@@ -143,12 +148,14 @@ def normalize_data_uri_images(
     if not text:
         return text, []
 
-    from ..models.document import ImageBlock
+    from core.models.document import ImageBlock
 
     blocks: list[Any] = []
     matched = 0
     skipped = 0
     total_bytes = 0
+    existing_targets = set(re.findall(r"\(openrag-embedded-image-[^)]+\)", text))
+    generated_targets: set[str] = set()
 
     def replace(match: re.Match[str]) -> str:
         nonlocal matched, skipped, total_bytes
@@ -171,7 +178,18 @@ def normalize_data_uri_images(
             skipped += 1
             return fallback
 
-        placeholder = f"![{alt}](openrag-embedded-image-{matched})"
+        digest_builder = hashlib.sha256(f"{matched}:{alt}".encode())
+        digest_builder.update(payload)
+        digest = digest_builder.hexdigest()[:16]
+        suffix = 0
+        while True:
+            disambiguator = f"-{suffix}" if suffix else ""
+            target = f"(openrag-embedded-image-{digest}{disambiguator})"
+            if target not in existing_targets and target not in generated_targets:
+                break
+            suffix += 1
+        generated_targets.add(target)
+        placeholder = f"![{alt}]{target}"
         blocks.append(
             ImageBlock(
                 image_bytes=payload,
@@ -185,9 +203,7 @@ def normalize_data_uri_images(
 
     sanitized = DATA_URI_IMAGE_PATTERN.sub(replace, text)
     if skipped:
-        logger.warning(
-            "Skipped %d of %d embedded image(s) while sanitizing document text",
-            skipped,
-            matched,
+        logger.bind(skipped=skipped, matched=matched).warning(
+            "Skipped embedded image(s) while sanitizing document text"
         )
     return sanitized, blocks

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -30,7 +30,7 @@ logger = get_logger()
 
 HTTP_IMAGE_PATTERN = re.compile(r"!\[(.*?)\]\((https?://[^)]+)\)")
 DATA_URI_IMAGE_PATTERN = re.compile(
-    r"!\[(.*?)\]\((data:image/[^;,\s)]+(?:;[^;,\s)]+=[^;,\s)]*)*;base64,[^)]+)\)",
+    r"!\[(.*?)\]\((data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,[^)]+)\)",
     re.IGNORECASE,
 )
 
@@ -81,7 +81,7 @@ def decode_data_uri(data_uri: str) -> bytes | None:
     """Decode a ``data:image/...;base64,...`` URI into raw bytes. ``None`` on failure."""
     try:
         _, b64 = data_uri.split(",", 1)
-        return base64.b64decode(b64, validate=True)
+        return base64.b64decode("".join(b64.split()), validate=True)
     except Exception as exc:
         logger.bind(error=str(exc)).warning("Failed to decode data URI")
         return None
@@ -167,7 +167,7 @@ def normalize_data_uri_images(
             skipped += 1
             return fallback
 
-        encoded = data_uri.split(",", 1)[1] if "," in data_uri else ""
+        encoded = "".join(data_uri.split(",", 1)[1].split()) if "," in data_uri else ""
         estimated_bytes = (len(encoded) * 3) // 4
         if estimated_bytes > max_image_bytes or total_bytes + estimated_bytes > max_total_bytes:
             skipped += 1

--- a/openrag/core/indexing/image_preprocessor.py
+++ b/openrag/core/indexing/image_preprocessor.py
@@ -34,6 +34,11 @@ DATA_URI_IMAGE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 DATA_URI_LINK_PATTERN = re.compile(r"(?<!!)\[([^]]*)\]\(<?data:image/[^)]*\)", re.IGNORECASE)
+DATA_URI_REFERENCE_IMAGE_PATTERN = re.compile(r"!\[([^]]+)\](?:\[([^]]*)\]|(?!\())")
+DATA_URI_REFERENCE_DEFINITION_PATTERN = re.compile(
+    r"^[ \t]{0,3}\[([^]\r\n]+)\]:[ \t]*(<?data:image/[^\r\n]*)$",
+    re.IGNORECASE | re.MULTILINE,
+)
 _VALID_DATA_URI_TARGET_PATTERN = re.compile(
     r"^(data:image/[^;,\s)]+(?:;[^;,=\s)]+=[^;,=\s)]*)*;base64,"
     r"[A-Za-z0-9+/=]+(?:[ \t\r\n\f\v]+[A-Za-z0-9+/=]+)*)"
@@ -123,6 +128,11 @@ def _estimated_base64_size(encoded: str) -> int:
     return max(0, (len(encoded) * 3) // 4 - padding)
 
 
+def _normalize_reference_label(label: str) -> str:
+    """Normalize a Markdown reference label for case-insensitive matching."""
+    return " ".join(label.split()).casefold()
+
+
 def extract_data_uri_image_blocks(text: str, *, page_number: int = 1) -> list[Any]:
     """Build ``ImageBlock``s for every ``![alt](data:image/...;base64,...)`` ref.
 
@@ -172,7 +182,8 @@ def normalize_data_uri_images(
 
     Accepted images receive a compact deterministic placeholder that remains
     compatible with the parser-to-caption replacement contract. Rejected or
-    malformed images and data-URI links are reduced to their display text, so
+    malformed images and data-URI links are reduced to their display text.
+    Inline and reference-style images share the same validation and limits, so
     raw payloads never continue into chunking. ``reference_scope`` keeps
     placeholders unique when independently parsed documents are combined.
     """
@@ -188,10 +199,9 @@ def normalize_data_uri_images(
     existing_targets = set(re.findall(r"\(openrag-embedded-image-[^)]+\)", text))
     generated_targets: set[str] = set()
 
-    def replace(match: re.Match[str]) -> str:
+    def replace_target(alt: str, target: str) -> str:
         nonlocal matched, skipped, total_bytes
         matched += 1
-        alt, target = match.groups()
         fallback = alt.strip() or "[Image]"
 
         if matched > max_images:
@@ -238,7 +248,19 @@ def normalize_data_uri_images(
         total_bytes += len(payload)
         return placeholder
 
-    sanitized = DATA_URI_IMAGE_PATTERN.sub(replace, text)
+    reference_targets: dict[str, str] = {}
+    for match in DATA_URI_REFERENCE_DEFINITION_PATTERN.finditer(text):
+        label, target = match.groups()
+        reference_targets.setdefault(_normalize_reference_label(label), target.strip())
+
+    def replace_reference(match: re.Match[str]) -> str:
+        alt, label = match.groups()
+        target = reference_targets.get(_normalize_reference_label(label or alt))
+        return match.group(0) if target is None else replace_target(alt, target)
+
+    sanitized = DATA_URI_IMAGE_PATTERN.sub(lambda match: replace_target(*match.groups()), text)
+    sanitized = DATA_URI_REFERENCE_IMAGE_PATTERN.sub(replace_reference, sanitized)
+    sanitized = DATA_URI_REFERENCE_DEFINITION_PATTERN.sub("", sanitized)
     sanitized = DATA_URI_LINK_PATTERN.sub(lambda match: match.group(1).strip() or "[Link]", sanitized)
     if skipped:
         logger.bind(skipped=skipped, matched=matched).warning(

--- a/openrag/core/indexing/parsers/eml_parser.py
+++ b/openrag/core/indexing/parsers/eml_parser.py
@@ -2,6 +2,8 @@
 
 Extracts the message body (``text/plain`` preferred, ``text/html``
 fallback) and dispatches each attachment to a parser supplied via DI.
+HTML-only bodies use the HTML parser so embedded images are extracted
+and their base64 payloads do not reach chunks.
 Email headers (subject, from, to, date, message-id) and an attachment
 manifest are merged into the output ``ProcessedDocument.metadata``.
 
@@ -34,6 +36,7 @@ from email.utils import parsedate_to_datetime
 
 from ...models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock
 from .document_parser import DocumentParser
+from .html_parser import HtmlParser
 from .registry import parser_registry
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,7 @@ class EmlParser(DocumentParser):
 
     def __init__(self, attachment_parsers: Mapping[str, DocumentParser] | None = None) -> None:
         self._attachment_parsers = dict(attachment_parsers or {})
+        self._body_html_parser = HtmlParser()
 
     def supported_types(self) -> list[str]:
         return [DocumentType.EML.value]
@@ -75,10 +79,12 @@ class EmlParser(DocumentParser):
             )
 
         headers = self._extract_headers(msg)
-        body, attachments = self._walk_parts(msg)
+        body, body_content_type, attachments = self._walk_parts_with_type(msg)
 
-        attachments_text, images = await self._render_attachments(attachments)
-        full_text = (body + attachments_text).strip()
+        body_text, body_images = await self._render_body(document, body, body_content_type)
+        attachments_text, attachment_images = await self._render_attachments(attachments)
+        full_text = (body_text + attachments_text).strip()
+        images = [*body_images, *attachment_images]
 
         metadata = dict(document.metadata)
         metadata.update(
@@ -129,7 +135,13 @@ class EmlParser(DocumentParser):
 
     @staticmethod
     def _walk_parts(msg: email.message.Message) -> tuple[str, list[dict]]:
+        body, _, attachments = EmlParser._walk_parts_with_type(msg)
+        return body, attachments
+
+    @staticmethod
+    def _walk_parts_with_type(msg: email.message.Message) -> tuple[str, str, list[dict]]:
         body = ""
+        body_content_type = ""
         attachments: list[dict] = []
         attachment_candidates = 0
 
@@ -168,8 +180,30 @@ class EmlParser(DocumentParser):
                 # text/plain wins; only use text/html if we have nothing yet
                 if content_type == "text/plain" or not body:
                     body = text
+                    body_content_type = content_type
 
-        return body.strip(), attachments
+        return body.strip(), body_content_type, attachments
+
+    async def _render_body(
+        self,
+        document: Document,
+        body: str,
+        content_type: str,
+    ) -> tuple[str, list[ImageBlock]]:
+        if not body or content_type != "text/html":
+            return body, []
+
+        processed = await self._body_html_parser.parse(
+            Document(
+                id=document.id,
+                filename=f"{document.filename or document.id}.html",
+                content_type=DocumentType.HTML,
+                text=body,
+                metadata=dict(document.metadata),
+            )
+        )
+        rendered = "\n\n".join(block.text for block in processed.text_blocks if block.text)
+        return rendered, list(processed.images)
 
     async def _render_attachments(self, attachments: list[dict]) -> tuple[str, list[ImageBlock]]:
         """Render the attachment-section text and collect any ImageBlocks.

--- a/openrag/core/indexing/parsers/html_parser.py
+++ b/openrag/core/indexing/parsers/html_parser.py
@@ -34,7 +34,7 @@ class HtmlParser(DocumentParser):
 
     async def parse(self, document: Document) -> ProcessedDocument:
         markdown = (await asyncio.to_thread(self._html_to_markdown, document)).strip()
-        markdown, images = normalize_data_uri_images(markdown, page_number=1)
+        markdown, images = normalize_data_uri_images(markdown, page_number=1, reference_scope=document.id)
         text_blocks = [TextBlock(text=markdown, page_number=1)] if markdown else []
         return ProcessedDocument(
             document_id=document.id,

--- a/openrag/core/indexing/parsers/html_parser.py
+++ b/openrag/core/indexing/parsers/html_parser.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import asyncio
 
-from ...models.document import Document, DocumentType, ProcessedDocument, TextBlock
-from ..image_preprocessor import normalize_data_uri_images
+from core.indexing.image_preprocessor import normalize_data_uri_images
+from core.models.document import Document, DocumentType, ProcessedDocument, TextBlock
+
 from ..text_preprocessor import decode_bytes
 from .document_parser import DocumentParser
 from .registry import parser_registry

--- a/openrag/core/indexing/parsers/html_parser.py
+++ b/openrag/core/indexing/parsers/html_parser.py
@@ -1,9 +1,10 @@
 """HTML ``DocumentParser`` implementation.
 
 Converts HTML to Markdown via the project's ``html_to_markdown`` dep
-(already used by the websearch and pptx pipelines), then emits a single
-text block. No file I/O, no JavaScript execution, no image fetching —
-purely structural conversion.
+(already used by the websearch and pptx pipelines), then emits a text
+block plus image blocks for embedded data-URI images. The base64 payloads
+are replaced with compact caption-compatible references before chunking.
+No file I/O, JavaScript execution, or image fetching is performed.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from __future__ import annotations
 import asyncio
 
 from ...models.document import Document, DocumentType, ProcessedDocument, TextBlock
+from ..image_preprocessor import normalize_data_uri_images
 from ..text_preprocessor import decode_bytes
 from .document_parser import DocumentParser
 from .registry import parser_registry
@@ -31,10 +33,12 @@ class HtmlParser(DocumentParser):
 
     async def parse(self, document: Document) -> ProcessedDocument:
         markdown = (await asyncio.to_thread(self._html_to_markdown, document)).strip()
+        markdown, images = normalize_data_uri_images(markdown, page_number=1)
         text_blocks = [TextBlock(text=markdown, page_number=1)] if markdown else []
         return ProcessedDocument(
             document_id=document.id,
             text_blocks=text_blocks,
+            images=images,
             metadata=dict(document.metadata),
             page_count=1 if markdown else 0,
         )

--- a/openrag/core/indexing/parsers/markdown_parser.py
+++ b/openrag/core/indexing/parsers/markdown_parser.py
@@ -3,8 +3,9 @@
 Decodes a Markdown document into a single :class:`TextBlock` and emits
 one :class:`ImageBlock` per image reference in the source:
 
-- Data-URI refs (``![alt](data:image/...;base64,...)``) are decoded and
-  the bytes stored on the block.
+- Data-URI refs (``![alt](data:image/...;base64,...)``) are decoded, the
+  bytes stored on the block, and the raw payload replaced by a compact
+  caption-compatible reference before chunking.
 - HTTP/HTTPS refs (``![alt](https://...)``) yield an :class:`ImageBlock`
   with empty ``image_bytes`` and ``source_url`` set; a downstream fetch
   stage can populate the bytes later. The :attr:`ImageBlock.image_url`
@@ -17,7 +18,7 @@ parser→caption contract.
 from __future__ import annotations
 
 from ...models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock
-from ..image_preprocessor import HTTP_IMAGE_PATTERN, extract_data_uri_image_blocks
+from ..image_preprocessor import HTTP_IMAGE_PATTERN, normalize_data_uri_images
 from ..text_preprocessor import decode_bytes
 from .document_parser import DocumentParser
 from .registry import parser_registry
@@ -35,7 +36,8 @@ class MarkdownParser(DocumentParser):
 
     async def parse(self, document: Document) -> ProcessedDocument:
         text = self._extract_text(document).strip()
-        images = self._extract_image_blocks(text)
+        text, images = normalize_data_uri_images(text, page_number=1)
+        images.extend(self._extract_http_image_blocks(text))
 
         text_blocks = [TextBlock(text=text, page_number=1)] if text else []
         return ProcessedDocument(
@@ -54,10 +56,10 @@ class MarkdownParser(DocumentParser):
         return ""
 
     @staticmethod
-    def _extract_image_blocks(text: str) -> list[ImageBlock]:
+    def _extract_http_image_blocks(text: str) -> list[ImageBlock]:
         if not text:
             return []
-        blocks: list[ImageBlock] = list(extract_data_uri_image_blocks(text, page_number=1))
+        blocks: list[ImageBlock] = []
         for alt, url in HTTP_IMAGE_PATTERN.findall(text):
             blocks.append(
                 ImageBlock(

--- a/openrag/core/indexing/parsers/markdown_parser.py
+++ b/openrag/core/indexing/parsers/markdown_parser.py
@@ -17,8 +17,9 @@ parser→caption contract.
 
 from __future__ import annotations
 
+from core.indexing.image_preprocessor import HTTP_IMAGE_PATTERN, normalize_data_uri_images
+
 from ...models.document import Document, DocumentType, ImageBlock, ProcessedDocument, TextBlock
-from ..image_preprocessor import HTTP_IMAGE_PATTERN, normalize_data_uri_images
 from ..text_preprocessor import decode_bytes
 from .document_parser import DocumentParser
 from .registry import parser_registry

--- a/openrag/core/indexing/parsers/markdown_parser.py
+++ b/openrag/core/indexing/parsers/markdown_parser.py
@@ -37,7 +37,7 @@ class MarkdownParser(DocumentParser):
 
     async def parse(self, document: Document) -> ProcessedDocument:
         text = self._extract_text(document).strip()
-        text, images = normalize_data_uri_images(text, page_number=1)
+        text, images = normalize_data_uri_images(text, page_number=1, reference_scope=document.id)
         images.extend(self._extract_http_image_blocks(text))
 
         text_blocks = [TextBlock(text=text, page_number=1)] if text else []

--- a/tests/unit/core/indexing/parsers/test_eml_parser.py
+++ b/tests/unit/core/indexing/parsers/test_eml_parser.py
@@ -7,6 +7,7 @@ import email.message
 
 import pytest
 from core.indexing.parsers.eml_parser import _MAX_EML_ATTACHMENTS, EmlParser
+from core.indexing.parsers.html_parser import HtmlParser
 from core.models.document import Document, DocumentType
 
 
@@ -95,6 +96,30 @@ async def test_plain_text_alternative_remains_preferred_over_html_body():
 
     assert processed.images == []
     assert processed.text_blocks[0].text == "Plain report"
+
+
+@pytest.mark.asyncio
+async def test_body_and_attachment_images_have_distinct_markdown_refs():
+    encoded = base64.b64encode(b"shared-logo").decode()
+    image_html = f'<img alt="logo" src="data:image/png;base64,{encoded}">'
+    msg = email.message.EmailMessage()
+    msg["Subject"] = "Logos"
+    msg.set_content(image_html, subtype="html")
+    msg.add_attachment(
+        image_html.encode(),
+        maintype="text",
+        subtype="html",
+        filename="inner.html",
+    )
+
+    processed = await EmlParser(attachment_parsers={"html": HtmlParser()}).parse(
+        Document(filename="logos.eml", content_type=DocumentType.EML, raw_bytes=msg.as_bytes())
+    )
+
+    refs = [image.metadata["markdown_ref"] for image in processed.images]
+    assert len(refs) == 2
+    assert len(set(refs)) == 2
+    assert all(processed.text_blocks[0].text.count(ref) == 1 for ref in refs)
 
 
 def test_eml_caps_attachment_candidates_before_decoding(monkeypatch):

--- a/tests/unit/core/indexing/parsers/test_eml_parser.py
+++ b/tests/unit/core/indexing/parsers/test_eml_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import email.message
 
 import pytest
@@ -56,6 +57,44 @@ async def test_eml_under_cap_processes_all():
     doc = Document(filename="ok.eml", content_type=DocumentType.EML, raw_bytes=raw)
     processed = await EmlParser().parse(doc)
     assert processed.metadata["email_attachment_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_html_only_body_extracts_images_without_leaking_base64():
+    encoded = base64.b64encode(b"email-image").decode()
+    msg = email.message.EmailMessage()
+    msg["Subject"] = "HTML report"
+    msg.set_content(
+        f'<p>Report</p><img alt="chart" src="data:image/png;base64,{encoded}">',
+        subtype="html",
+    )
+
+    processed = await EmlParser().parse(
+        Document(filename="report.eml", content_type=DocumentType.EML, raw_bytes=msg.as_bytes())
+    )
+
+    assert len(processed.images) == 1
+    assert processed.images[0].image_bytes == b"email-image"
+    assert "data:image" not in processed.text_blocks[0].text
+
+
+@pytest.mark.asyncio
+async def test_plain_text_alternative_remains_preferred_over_html_body():
+    encoded = base64.b64encode(b"unused-image").decode()
+    msg = email.message.EmailMessage()
+    msg["Subject"] = "Alternative report"
+    msg.set_content("Plain report")
+    msg.add_alternative(
+        f'<p>HTML report</p><img src="data:image/png;base64,{encoded}">',
+        subtype="html",
+    )
+
+    processed = await EmlParser().parse(
+        Document(filename="report.eml", content_type=DocumentType.EML, raw_bytes=msg.as_bytes())
+    )
+
+    assert processed.images == []
+    assert processed.text_blocks[0].text == "Plain report"
 
 
 def test_eml_caps_attachment_candidates_before_decoding(monkeypatch):

--- a/tests/unit/core/indexing/parsers/test_html_parser.py
+++ b/tests/unit/core/indexing/parsers/test_html_parser.py
@@ -66,3 +66,26 @@ async def test_html_parser_handles_parameterized_data_uri():
     assert "data:image" not in processed.text_blocks[0].text
     assert len(processed.images) == 1
     assert processed.images[0].mime_type == "image/svg+xml"
+
+
+@pytest.mark.asyncio
+async def test_html_parser_handles_an_embedded_image_with_a_title():
+    encoded = base64.b64encode(b"logo-image").decode()
+    html = f'<img alt="logo" title="Company logo" src="data:image/png;base64,{encoded}">'
+
+    processed = await HtmlParser().parse(Document(filename="logo.html", content_type=DocumentType.HTML, text=html))
+
+    assert "data:image" not in processed.text_blocks[0].text
+    assert len(processed.images) == 1
+    assert processed.images[0].image_bytes == b"logo-image"
+
+
+@pytest.mark.asyncio
+async def test_html_parser_sanitizes_data_uri_links():
+    encoded = base64.b64encode(b"logo-image").decode()
+    html = f'<a href="data:image/png;base64,{encoded}">logo</a>'
+
+    processed = await HtmlParser().parse(Document(filename="link.html", content_type=DocumentType.HTML, text=html))
+
+    assert processed.text_blocks[0].text == "logo"
+    assert processed.images == []

--- a/tests/unit/core/indexing/parsers/test_html_parser.py
+++ b/tests/unit/core/indexing/parsers/test_html_parser.py
@@ -54,3 +54,15 @@ async def test_html_without_images_is_unchanged():
 
     assert processed.images == []
     assert processed.text_blocks[0].text == "Hello **world**"
+
+
+@pytest.mark.asyncio
+async def test_html_parser_handles_parameterized_data_uri():
+    encoded = base64.b64encode(b"svg-image").decode()
+    html = f'<img alt="diagram" src="data:image/svg+xml;charset=utf-8;base64,{encoded}">'
+
+    processed = await HtmlParser().parse(Document(filename="diagram.html", content_type=DocumentType.HTML, text=html))
+
+    assert "data:image" not in processed.text_blocks[0].text
+    assert len(processed.images) == 1
+    assert processed.images[0].mime_type == "image/svg+xml"

--- a/tests/unit/core/indexing/parsers/test_html_parser.py
+++ b/tests/unit/core/indexing/parsers/test_html_parser.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from core.indexing.parsers.html_parser import HtmlParser
+from core.models.document import Document, DocumentType
+from services.workers.stages.caption import caption_stage
+
+
+def _html_with_image(payload: bytes = b"image-bytes") -> str:
+    encoded = base64.b64encode(payload).decode()
+    return f'<p>Report</p><img alt="chart" src="data:image/png;base64,{encoded}"><p>End</p>'
+
+
+@pytest.mark.asyncio
+async def test_html_parser_extracts_embedded_images_without_leaking_base64():
+    processed = await HtmlParser().parse(
+        Document(filename="report.html", content_type=DocumentType.HTML, text=_html_with_image())
+    )
+
+    assert len(processed.images) == 1
+    assert processed.images[0].image_bytes == b"image-bytes"
+    assert processed.images[0].metadata["alt"] == "chart"
+    assert "data:image" not in processed.text_blocks[0].text
+    assert processed.images[0].metadata["markdown_ref"] in processed.text_blocks[0].text
+
+
+@pytest.mark.asyncio
+async def test_html_image_placeholder_is_replaced_by_caption():
+    class FakeVLM:
+        async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+            assert image_bytes == b"image-bytes"
+            return "Quarterly sales chart"
+
+    processed = await HtmlParser().parse(
+        Document(filename="report.html", content_type=DocumentType.HTML, text=_html_with_image())
+    )
+    row = {"processed_document": processed}
+
+    await caption_stage(row, FakeVLM())
+
+    text = row["processed_document"].text_blocks[0].text
+    assert "Quarterly sales chart" in text
+    assert "openrag-embedded-image" not in text
+    assert "data:image" not in text
+
+
+@pytest.mark.asyncio
+async def test_html_without_images_is_unchanged():
+    processed = await HtmlParser().parse(
+        Document(filename="plain.html", content_type=DocumentType.HTML, text="<p>Hello <strong>world</strong></p>")
+    )
+
+    assert processed.images == []
+    assert processed.text_blocks[0].text == "Hello **world**"

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -65,6 +65,21 @@ async def test_markdown_parser_sanitizes_angle_bracketed_data_uri_images():
 
 
 @pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_reference_style_data_uri_images():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f"Before ![logo][asset] after\n\n[asset]: data:image/png;base64,{encoded}"
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert "data:image" not in processed.text_blocks[0].text
+    assert "[asset]:" not in processed.text_blocks[0].text
+    assert len(processed.images) == 1
+    assert processed.images[0].image_bytes == b"image-bytes"
+
+
+@pytest.mark.asyncio
 async def test_captioning_does_not_replace_a_preexisting_similar_reference():
     class FakeVLM:
         async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -5,6 +5,7 @@ import base64
 import pytest
 from core.indexing.parsers.markdown_parser import MarkdownParser
 from core.models.document import Document, DocumentType
+from services.workers.stages.caption import caption_stage
 
 
 @pytest.mark.asyncio
@@ -34,3 +35,24 @@ async def test_markdown_parser_preserves_http_image_behavior():
     assert processed.text_blocks[0].text == "Before ![chart](https://example.test/chart.png) after"
     assert len(processed.images) == 1
     assert processed.images[0].source_url == "https://example.test/chart.png"
+
+
+@pytest.mark.asyncio
+async def test_captioning_does_not_replace_a_preexisting_similar_reference():
+    class FakeVLM:
+        async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+            return "Generated caption"
+
+    encoded = base64.b64encode(b"image-bytes").decode()
+    existing = "![chart](openrag-embedded-image-1)"
+    source = f"{existing}\n\n![chart](data:image/png;base64,{encoded})"
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+    row = {"processed_document": processed}
+
+    await caption_stage(row, FakeVLM())
+
+    text = row["processed_document"].text_blocks[0].text
+    assert existing in text
+    assert "Generated caption" in text

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -80,6 +80,34 @@ async def test_markdown_parser_sanitizes_reference_style_data_uri_images():
 
 
 @pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_raw_html_data_uri_images():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f'Before <img alt="chart" src="data:image/png;base64,{encoded}"> after'
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert "data:image" not in processed.text_blocks[0].text.lower()
+    assert encoded not in processed.text_blocks[0].text
+    assert processed.images == []
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_unterminated_data_uri_images():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f"Before ![chart](data:image/png;base64,{encoded}"
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert "data:image" not in processed.text_blocks[0].text.lower()
+    assert encoded not in processed.text_blocks[0].text
+    assert processed.images == []
+
+
+@pytest.mark.asyncio
 async def test_captioning_does_not_replace_a_preexisting_similar_reference():
     class FakeVLM:
         async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from core.indexing.parsers.markdown_parser import MarkdownParser
+from core.models.document import Document, DocumentType
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_embedded_image_when_captioning_is_not_run():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f"Before ![chart](data:image/png;base64,{encoded}) after"
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert len(processed.images) == 1
+    assert "data:image" not in processed.text_blocks[0].text
+    assert processed.images[0].metadata["markdown_ref"] in processed.text_blocks[0].text
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_preserves_http_image_behavior():
+    processed = await MarkdownParser().parse(
+        Document(
+            filename="report.md",
+            content_type=DocumentType.MARKDOWN,
+            text="Before ![chart](https://example.test/chart.png) after",
+        )
+    )
+
+    assert processed.text_blocks[0].text == "Before ![chart](https://example.test/chart.png) after"
+    assert len(processed.images) == 1
+    assert processed.images[0].source_url == "https://example.test/chart.png"

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -51,6 +51,20 @@ async def test_markdown_parser_sanitizes_data_uri_links():
 
 
 @pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_angle_bracketed_data_uri_images():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f"Before ![chart](<data:image/png;base64,{encoded}>) after"
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert "data:image" not in processed.text_blocks[0].text
+    assert len(processed.images) == 1
+    assert processed.images[0].image_bytes == b"image-bytes"
+
+
+@pytest.mark.asyncio
 async def test_captioning_does_not_replace_a_preexisting_similar_reference():
     class FakeVLM:
         async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:

--- a/tests/unit/core/indexing/parsers/test_markdown_parser.py
+++ b/tests/unit/core/indexing/parsers/test_markdown_parser.py
@@ -38,6 +38,19 @@ async def test_markdown_parser_preserves_http_image_behavior():
 
 
 @pytest.mark.asyncio
+async def test_markdown_parser_sanitizes_data_uri_links():
+    encoded = base64.b64encode(b"image-bytes").decode()
+    source = f"See [the logo](data:image/png;base64,{encoded}) here"
+
+    processed = await MarkdownParser().parse(
+        Document(filename="report.md", content_type=DocumentType.MARKDOWN, text=source)
+    )
+
+    assert processed.text_blocks[0].text == "See the logo here"
+    assert processed.images == []
+
+
+@pytest.mark.asyncio
 async def test_captioning_does_not_replace_a_preexisting_similar_reference():
     class FakeVLM:
         async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -100,6 +100,16 @@ class TestExtractDataUriImageBlocks:
         text = "![](data:image/png;base64,!!!not-base64)"
         assert extract_data_uri_image_blocks(text) == []
 
+    def test_markdown_title_is_not_part_of_payload(self):
+        uri = self._data_uri(b"image")
+        text = f'![logo]({uri} "Company logo")'
+
+        blocks = extract_data_uri_image_blocks(text)
+
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+        assert blocks[0].metadata["markdown_ref"] == text
+
 
 class TestNormalizeDataUriImages:
     def _data_uri(self, payload: bytes = b"x", mime: str = "image/png") -> str:
@@ -138,12 +148,49 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == payload
 
-    def test_malformed_parameter_sequence_is_not_matched(self):
+    def test_markdown_title_is_excluded_from_the_data_uri(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f'before ![logo]({uri} "Company logo") after')
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
+    def test_data_uri_link_is_reduced_to_its_label(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f"before [logo]({uri}) after")
+
+        assert text == "before logo after"
+        assert blocks == []
+
+    def test_padded_payloads_are_accepted_at_exact_size_limits(self):
+        uri = self._data_uri(b"x")
+
+        text, blocks = normalize_data_uri_images(
+            f"![one]({uri}) ![two]({uri})",
+            max_image_bytes=1,
+            max_total_bytes=2,
+        )
+
+        assert "data:image" not in text
+        assert len(blocks) == 2
+
+    def test_reference_scope_prevents_cross_document_collisions(self):
+        uri = self._data_uri(b"same-image")
+
+        _, first = normalize_data_uri_images(f"![logo]({uri})", reference_scope="body")
+        _, second = normalize_data_uri_images(f"![logo]({uri})", reference_scope="attachment")
+
+        assert first[0].metadata["markdown_ref"] != second[0].metadata["markdown_ref"]
+
+    def test_malformed_parameter_sequence_is_sanitized(self):
         text = f"before ![bad](data:image/png;{'a=' * 10_000} nob64) after"
 
         sanitized, blocks = normalize_data_uri_images(text)
 
-        assert sanitized == text
+        assert sanitized == "before bad after"
         assert blocks == []
 
     def test_generated_reference_does_not_collide_with_existing_markdown(self):

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -197,6 +197,95 @@ class TestNormalizeDataUriImages:
         assert "logo" in text
         assert blocks == []
 
+    def test_line_wrapped_reference_definition_is_fully_sanitized(self):
+        payload = b"image payload" * 20
+        wrapped = base64.encodebytes(payload).decode().strip()
+        source = f"before ![logo][asset] after\n\n[asset]: data:image/png;base64,{wrapped}"
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert "data:image" not in text.lower()
+        assert "aW1hZ2" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == payload
+
+    def test_reference_definition_does_not_consume_following_text(self):
+        uri = self._data_uri(b"image")
+        source = f"before ![logo][asset] after\n\n[asset]: {uri}\nNext"
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert text.endswith("Next")
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
+    def test_residual_data_uris_are_scrubbed_in_unsupported_contexts(self):
+        uri = self._data_uri(b"image")
+        encoded = uri.split(",", 1)[1]
+        sources = (
+            f'before <img src="{uri}" alt="logo"> after',
+            f"before <img src='{uri}' alt='logo'> after",
+            f"before <img src={uri}> after",
+            f'before <span style="background-image:url({uri})">logo</span> after',
+            f"before {uri} after",
+        )
+
+        for source in sources:
+            text, blocks = normalize_data_uri_images(source)
+
+            assert "data:image" not in text.lower()
+            assert encoded not in text
+            assert "before" in text
+            assert "after" in text
+            assert blocks == []
+
+    def test_unterminated_data_uri_is_scrubbed_to_the_paragraph_boundary(self):
+        uri = self._data_uri(b"image")
+        source = f"before ![diagram]({uri} trailing payload\ncontinues here\n\nnext paragraph"
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert "data:image" not in text.lower()
+        assert uri.split(",", 1)[1] not in text
+        assert "trailing payload" not in text
+        assert text.endswith("next paragraph")
+        assert blocks == []
+
+    def test_repeated_unterminated_data_uris_are_sanitized_in_one_pass(self):
+        source = " ".join("![diagram](data:image/png;base64,AAAA" for _ in range(1_000))
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert "data:image" not in text.lower()
+        assert text == "![diagram]([Image]"
+        assert blocks == []
+
+    def test_residual_scrubber_handles_case_and_line_wrapping(self):
+        wrapped = base64.encodebytes(b"image payload" * 8).decode()
+        source = f'before <img src="DATA:IMAGE/PNG;BASE64,{wrapped}"> after'
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert "data:image" not in text.lower()
+        assert "aW1hZ2" not in text
+        assert text.startswith("before")
+        assert text.endswith("after")
+        assert blocks == []
+
+    def test_residual_scrubber_removes_malformed_data_uri_tokens(self):
+        sources = (
+            "before data:image/png;base64AAAA after",
+            "before data:image/png;base64,!!!!AAAA after",
+            "before data:image/svg+xml,%3Csvg%3E after",
+        )
+
+        for source in sources:
+            text, blocks = normalize_data_uri_images(source)
+
+            assert "data:image" not in text.lower()
+            assert text == "before [Image] after"
+            assert blocks == []
+
     def test_padded_payloads_are_accepted_at_exact_size_limits(self):
         uri = self._data_uri(b"x")
 

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -59,6 +59,12 @@ class TestDecodeDataUri:
         assert decode_data_uri("not-a-data-uri") is None
         assert decode_data_uri("data:image/png;base64,!!!not-base64") is None
 
+    def test_line_wrapped_payload(self):
+        payload = b"hello world " * 8
+        wrapped = base64.encodebytes(payload).decode()
+
+        assert decode_data_uri(f"data:image/png;base64,{wrapped}") == payload
+
 
 class TestMimeFromDataUri:
     def test_jpeg(self):
@@ -113,7 +119,7 @@ class TestNormalizeDataUriImages:
 
     def test_parameterized_data_uri_is_extracted_and_sanitized(self):
         payload = base64.b64encode(b"svg-image").decode()
-        uri = f"data:image/svg+xml;charset=utf-8;base64,{payload}"
+        uri = f"data:image/svg+xml;charset=utf-8;profile=compact;base64,{payload}"
 
         text, blocks = normalize_data_uri_images(f"before ![diagram]({uri}) after")
 
@@ -121,6 +127,24 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == b"svg-image"
         assert blocks[0].mime_type == "image/svg+xml"
+
+    def test_line_wrapped_data_uri_is_extracted_and_sanitized(self):
+        payload = b"hello world " * 8
+        wrapped = base64.encodebytes(payload).decode()
+
+        text, blocks = normalize_data_uri_images(f"before ![chart](data:image/png;base64,{wrapped}) after")
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == payload
+
+    def test_malformed_parameter_sequence_is_not_matched(self):
+        text = f"before ![bad](data:image/png;{'a=' * 10_000} nob64) after"
+
+        sanitized, blocks = normalize_data_uri_images(text)
+
+        assert sanitized == text
+        assert blocks == []
 
     def test_generated_reference_does_not_collide_with_existing_markdown(self):
         uri = self._data_uri(b"chart")

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -137,6 +137,17 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == b"embedded"
 
+    def test_image_alt_text_accepts_escaped_and_nested_brackets(self):
+        uri = self._data_uri(b"embedded")
+
+        for alt in (r"status \] chart", "status [draft] chart"):
+            text, blocks = normalize_data_uri_images(f"before ![{alt}]({uri}) after")
+
+            assert "data:image" not in text
+            assert len(blocks) == 1
+            assert blocks[0].metadata["alt"] == alt
+            assert blocks[0].image_bytes == b"embedded"
+
     def test_parameterized_data_uri_is_extracted_and_sanitized(self):
         payload = base64.b64encode(b"svg-image").decode()
         uri = f"data:image/svg+xml;charset=utf-8;profile=compact;base64,{payload}"

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 
 from core.indexing.image_preprocessor import (
     MIN_IMAGE_PIXELS,
@@ -105,10 +106,35 @@ class TestNormalizeDataUriImages:
         text, blocks = normalize_data_uri_images(f"before ![one]({first}) middle ![two]({second}) after")
 
         assert "data:image" not in text
-        assert "openrag-embedded-image-1" in text
-        assert "openrag-embedded-image-2" in text
+        assert text.count("openrag-embedded-image-") == 2
         assert [block.image_bytes for block in blocks] == [b"first", b"second"]
         assert all(block.metadata["markdown_ref"] in text for block in blocks)
+        assert blocks[0].metadata["markdown_ref"] != blocks[1].metadata["markdown_ref"]
+
+    def test_parameterized_data_uri_is_extracted_and_sanitized(self):
+        payload = base64.b64encode(b"svg-image").decode()
+        uri = f"data:image/svg+xml;charset=utf-8;base64,{payload}"
+
+        text, blocks = normalize_data_uri_images(f"before ![diagram]({uri}) after")
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"svg-image"
+        assert blocks[0].mime_type == "image/svg+xml"
+
+    def test_generated_reference_does_not_collide_with_existing_markdown(self):
+        uri = self._data_uri(b"chart")
+        digest_builder = hashlib.sha256(b"1:chart")
+        digest_builder.update(b"chart")
+        target = f"openrag-embedded-image-{digest_builder.hexdigest()[:16]}"
+        existing = f"![chart]({target})"
+
+        text, blocks = normalize_data_uri_images(f"{existing} ![chart]({uri})")
+
+        assert existing in text
+        assert len(blocks) == 1
+        assert blocks[0].metadata["markdown_ref"] != existing
+        assert blocks[0].metadata["markdown_ref"] in text
 
     def test_malformed_payload_is_removed_even_without_an_image_block(self):
         text, blocks = normalize_data_uri_images("before ![diagram](data:image/png;base64,!!!) after")

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -10,6 +10,7 @@ from core.indexing.image_preprocessor import (
     ensure_png_compatible_mode,
     extract_data_uri_image_blocks,
     mime_from_data_uri,
+    normalize_data_uri_images,
     pil_to_png_bytes,
 )
 from PIL import Image
@@ -91,6 +92,46 @@ class TestExtractDataUriImageBlocks:
     def test_skips_undecodable(self):
         text = "![](data:image/png;base64,!!!not-base64)"
         assert extract_data_uri_image_blocks(text) == []
+
+
+class TestNormalizeDataUriImages:
+    def _data_uri(self, payload: bytes = b"x", mime: str = "image/png") -> str:
+        return f"data:{mime};base64,{base64.b64encode(payload).decode()}"
+
+    def test_extracts_images_and_replaces_payloads_with_safe_refs(self):
+        first = self._data_uri(b"first")
+        second = self._data_uri(b"second", "image/jpeg")
+
+        text, blocks = normalize_data_uri_images(f"before ![one]({first}) middle ![two]({second}) after")
+
+        assert "data:image" not in text
+        assert "openrag-embedded-image-1" in text
+        assert "openrag-embedded-image-2" in text
+        assert [block.image_bytes for block in blocks] == [b"first", b"second"]
+        assert all(block.metadata["markdown_ref"] in text for block in blocks)
+
+    def test_malformed_payload_is_removed_even_without_an_image_block(self):
+        text, blocks = normalize_data_uri_images("before ![diagram](data:image/png;base64,!!!) after")
+
+        assert text == "before diagram after"
+        assert blocks == []
+
+    def test_rejected_payloads_are_still_sanitized(self):
+        uri = self._data_uri(b"too-large")
+
+        text, blocks = normalize_data_uri_images(f"before ![large]({uri}) after", max_image_bytes=1)
+
+        assert text == "before large after"
+        assert blocks == []
+
+    def test_image_count_limit_does_not_leave_payloads_behind(self):
+        uri = self._data_uri()
+
+        text, blocks = normalize_data_uri_images(f"![one]({uri}) ![two]({uri})", max_images=1)
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert text.endswith("two")
 
 
 def test_min_image_pixels_constant():

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -167,6 +167,17 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == b"image"
 
+    def test_parenthesized_title_does_not_end_the_image(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f"before ![chart]({uri} (sales draft)) after")
+
+        assert "data:image" not in text
+        assert text.startswith("before ![chart](openrag-embedded-image-")
+        assert text.endswith(" after")
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
     def test_angle_bracketed_destination_is_extracted_and_sanitized(self):
         uri = self._data_uri(b"image")
 

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -157,6 +157,15 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == b"image"
 
+    def test_angle_bracketed_destination_is_extracted_and_sanitized(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f'before ![logo](<{uri}> "Company logo") after')
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
     def test_data_uri_link_is_reduced_to_its_label(self):
         uri = self._data_uri(b"image")
 

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -174,6 +174,29 @@ class TestNormalizeDataUriImages:
         assert text == "before logo after"
         assert blocks == []
 
+    def test_reference_style_image_is_extracted_and_sanitized(self):
+        uri = self._data_uri(b"image")
+        for reference in ("![logo][asset]", "![asset][]", "![asset]"):
+            source = f"before {reference} after\n\n[asset]: {uri}"
+
+            text, blocks = normalize_data_uri_images(source)
+
+            assert "data:image" not in text
+            assert "[asset]:" not in text
+            assert len(blocks) == 1
+            assert blocks[0].image_bytes == b"image"
+            assert blocks[0].metadata["markdown_ref"] in text
+
+    def test_reference_style_image_uses_existing_size_limits(self):
+        uri = self._data_uri(b"too-large")
+        source = f"before ![logo][asset] after\n\n[asset]: {uri}"
+
+        text, blocks = normalize_data_uri_images(source, max_image_bytes=1)
+
+        assert "data:image" not in text
+        assert "logo" in text
+        assert blocks == []
+
     def test_padded_payloads_are_accepted_at_exact_size_limits(self):
         uri = self._data_uri(b"x")
 

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -176,7 +176,7 @@ class TestNormalizeDataUriImages:
 
     def test_reference_style_image_is_extracted_and_sanitized(self):
         uri = self._data_uri(b"image")
-        for reference in ("![logo][asset]", "![asset][]", "![asset]"):
+        for reference in ("![logo][asset]", "![][asset]", "![asset][]", "![asset]"):
             source = f"before {reference} after\n\n[asset]: {uri}"
 
             text, blocks = normalize_data_uri_images(source)
@@ -285,6 +285,14 @@ class TestNormalizeDataUriImages:
             assert "data:image" not in text.lower()
             assert text == "before [Image] after"
             assert blocks == []
+
+    def test_undelimited_data_uri_does_not_consume_the_next_line(self):
+        source = "before data:image/png;base64,QUJD\nafter-newline-text here"
+
+        text, blocks = normalize_data_uri_images(source)
+
+        assert text == "before [Image]\nafter-newline-text here"
+        assert blocks == []
 
     def test_padded_payloads_are_accepted_at_exact_size_limits(self):
         uri = self._data_uri(b"x")

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -127,6 +127,16 @@ class TestNormalizeDataUriImages:
         assert all(block.metadata["markdown_ref"] in text for block in blocks)
         assert blocks[0].metadata["markdown_ref"] != blocks[1].metadata["markdown_ref"]
 
+    def test_embedded_image_does_not_consume_an_earlier_markdown_image(self):
+        uri = self._data_uri(b"embedded")
+        remote = "![remote](https://example.test/image.png)"
+
+        text, blocks = normalize_data_uri_images(f"{remote} middle ![embedded]({uri})")
+
+        assert text.startswith(f"{remote} middle ")
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"embedded"
+
     def test_parameterized_data_uri_is_extracted_and_sanitized(self):
         payload = base64.b64encode(b"svg-image").decode()
         uri = f"data:image/svg+xml;charset=utf-8;profile=compact;base64,{payload}"

--- a/tests/unit/core/indexing/test_image_preprocessor.py
+++ b/tests/unit/core/indexing/test_image_preprocessor.py
@@ -176,6 +176,24 @@ class TestNormalizeDataUriImages:
         assert len(blocks) == 1
         assert blocks[0].image_bytes == b"image"
 
+    def test_title_containing_a_closing_paren_does_not_truncate_the_target(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f'before ![chart]({uri} "sales (draft)") after')
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
+    def test_single_quoted_title_containing_a_closing_paren_does_not_truncate_the_target(self):
+        uri = self._data_uri(b"image")
+
+        text, blocks = normalize_data_uri_images(f"before ![chart]({uri} 'sales (draft)') after")
+
+        assert "data:image" not in text
+        assert len(blocks) == 1
+        assert blocks[0].image_bytes == b"image"
+
     def test_data_uri_link_is_reduced_to_its_label(self):
         uri = self._data_uri(b"image")
 


### PR DESCRIPTION
## Context

HTML documents could carry inline base64 images into chunking without exposing those images to captioning. The same gap affected HTML-only email bodies, while Markdown could still leak the payload whenever captioning was disabled. This produced oversized, low-quality chunks and could make indexing fail at the embedding or storage stage.

## Fix

Embedded images are now extracted through one bounded normalization path. Their payload is replaced with a compact reference that remains compatible with caption insertion. Malformed, oversized, or excess images are removed from text even when they cannot be captioned. HTML-only email bodies now use the same HTML parsing behavior.

External image URLs remain unchanged and are not fetched by this work. Existing documents containing leaked payloads will need re-indexing.

## Validation

- Full unit suite: 1856 passed
- Focused indexing and parser suite: 179 passed
- Ruff lint: passed
- Ruff formatting: passed

Closes #711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded `data:image/...;base64,...` images in HTML/Markdown (including angle-bracket and reference-style variants) are extracted and the surrounding text is sanitized.
  * Deterministic, caption-friendly placeholders are inserted for embedded images.
  * HTML-only email bodies and HTML attachments now surface embedded images as indexed image data.
* **Bug Fixes**
  * Strict base64 validation rejects malformed payloads.
  * Per-image and total decoded size/count limits are enforced; skipped/over-limit payloads are safely removed.
  * `data:` links (e.g., `href`) are sanitized and won’t be misread as images.
* **Tests**
  * Expanded unit coverage across EML, HTML, Markdown, and image preprocessing, including edge/failure cases and limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->