### PR TITLE
fix: make file count deletion atomic

### DIFF
--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Any
 
 from core.models.catalog import DocumentRecord, DocumentStatus
 from core.ports.document_repo import DocumentRepository
+from core.utils.logging import get_logger
+from services.persistence.file_count import decrement_file_counts
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -37,6 +39,8 @@ if TYPE_CHECKING:
 # on every connection, so reading a JSON column yields a Python dict and
 # binding a dict to a JSON parameter is encoded transparently. The repo
 # therefore never calls ``json.dumps`` itself.
+
+logger = get_logger()
 
 
 class PgDocumentRepository(DocumentRepository):
@@ -192,47 +196,45 @@ class PgDocumentRepository(DocumentRepository):
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 row = await conn.fetchrow(
-                    "SELECT id, created_by FROM files WHERE file_id = $1 LIMIT 1",
+                    """
+                    WITH target AS (
+                        SELECT id
+                        FROM files
+                        WHERE file_id = $1
+                        ORDER BY id
+                        LIMIT 1
+                    )
+                    DELETE FROM files AS file
+                    USING target
+                    WHERE file.id = target.id
+                    RETURNING file.created_by
+                    """,
                     document_id,
                 )
-                if row is None:
-                    return False
-                await conn.execute("DELETE FROM files WHERE id = $1", row["id"])
-                if row["created_by"] is not None:
-                    await conn.execute(
-                        "UPDATE users SET file_count = GREATEST(file_count - 1, 0) WHERE id = $1",
-                        row["created_by"],
-                    )
-                return True
+                deleted_rows = [row] if row is not None else []
+                counters_adjusted = await decrement_file_counts(conn, deleted_rows)
+                logger.bind(
+                    operation="delete_document",
+                    deleted_rows=len(deleted_rows),
+                    counters_adjusted=counters_adjusted,
+                ).debug("Catalog file deletion accounted")
+                return row is not None
 
     async def delete_documents_by_partition(self, partition: str) -> int:
         """Bulk-delete every file in a partition and decrement uploader counts."""
         async with self.pool.acquire() as conn:
             async with conn.transaction():
-                uploader_rows = await conn.fetch(
-                    """
-                    SELECT created_by, COUNT(*)::int AS n
-                    FROM files
-                    WHERE partition_name = $1 AND created_by IS NOT NULL
-                    GROUP BY created_by
-                    """,
+                deleted_rows = await conn.fetch(
+                    "DELETE FROM files WHERE partition_name = $1 RETURNING created_by",
                     partition,
                 )
-                result = await conn.execute(
-                    "DELETE FROM files WHERE partition_name = $1",
-                    partition,
-                )
-                for r in uploader_rows:
-                    await conn.execute(
-                        "UPDATE users SET file_count = GREATEST(file_count - $1, 0) WHERE id = $2",
-                        r["n"],
-                        r["created_by"],
-                    )
-        # asyncpg returns 'DELETE <n>' as the command tag.
-        try:
-            return int(result.split()[-1])
-        except (ValueError, IndexError):
-            return 0
+                counters_adjusted = await decrement_file_counts(conn, deleted_rows)
+                logger.bind(
+                    operation="delete_documents_by_partition",
+                    deleted_rows=len(deleted_rows),
+                    counters_adjusted=counters_adjusted,
+                ).debug("Catalog file deletion accounted")
+                return len(deleted_rows)
 
     async def count_documents(
         self,
@@ -481,19 +483,22 @@ class PgDocumentRepository(DocumentRepository):
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 row = await conn.fetchrow(
-                    "SELECT id, created_by FROM files WHERE file_id = $1 AND partition_name = $2",
+                    """
+                    DELETE FROM files
+                    WHERE file_id = $1 AND partition_name = $2
+                    RETURNING created_by
+                    """,
                     file_id,
                     partition,
                 )
-                if row is None:
-                    return False
-                await conn.execute("DELETE FROM files WHERE id = $1", row["id"])
-                if row["created_by"] is not None:
-                    await conn.execute(
-                        "UPDATE users SET file_count = GREATEST(file_count - 1, 0) WHERE id = $1",
-                        row["created_by"],
-                    )
-                return True
+                deleted_rows = [row] if row is not None else []
+                counters_adjusted = await decrement_file_counts(conn, deleted_rows)
+                logger.bind(
+                    operation="remove_file_from_partition",
+                    deleted_rows=len(deleted_rows),
+                    counters_adjusted=counters_adjusted,
+                ).debug("Catalog file deletion accounted")
+                return row is not None
 
     async def update_file_metadata_in_db(
         self,

--- a/openrag/services/persistence/file_count.py
+++ b/openrag/services/persistence/file_count.py
@@ -1,0 +1,25 @@
+"""Shared file-count accounting for catalog deletion transactions."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import asyncpg
+
+
+async def decrement_file_counts(
+    conn: asyncpg.Connection,
+    deleted_rows: Iterable[Mapping[str, Any]],
+) -> int:
+    """Decrement counters for rows deleted by the current transaction."""
+    counts = Counter(row["created_by"] for row in deleted_rows if row["created_by"] is not None)
+    for user_id in sorted(counts):
+        await conn.execute(
+            "UPDATE users SET file_count = GREATEST(file_count - $1, 0) WHERE id = $2",
+            counts[user_id],
+            user_id,
+        )
+    return len(counts)

--- a/openrag/services/persistence/partition_repo.py
+++ b/openrag/services/persistence/partition_repo.py
@@ -7,10 +7,9 @@ collections. The legacy
 ``partition_exists``, ``get_partition_file_count``, ``get_total_file_count``
 here; all six map onto this class.
 
-Deleting a partition cascades to ``files``, ``partition_memberships``,
-and ``workspaces`` via the FK ``ON DELETE CASCADE`` rules in the schema.
-Per-uploader ``file_count`` is decremented in application code (no SQL
-trigger) so the books stay balanced.
+Deleting a partition explicitly removes ``files`` before the partition row;
+memberships and workspaces use FK cascades. Per-uploader ``file_count`` is
+decremented in application code (no SQL trigger) so the books stay balanced.
 """
 
 from __future__ import annotations
@@ -21,6 +20,8 @@ from typing import TYPE_CHECKING
 
 from core.ports.partition_repo import PartitionRepository
 from core.utils.exceptions import ValidationError
+from core.utils.logging import get_logger
+from services.persistence.file_count import decrement_file_counts
 
 if TYPE_CHECKING:
     import asyncpg
@@ -47,6 +48,8 @@ _PARTITION_UPDATE_COLUMNS = frozenset(
     }
 )
 _PARTITION_OPERATION_LOCK_NAMESPACE = 20260720
+
+logger = get_logger()
 
 
 def _partition_updates(fields: dict[str, object]) -> dict[str, object]:
@@ -203,44 +206,39 @@ class PgPartitionRepository(PartitionRepository):
         ``partition_memberships`` and ``workspaces`` cascade from the
         partition row.
 
-        Mirrors the legacy bookkeeping: before deleting we count files per
-        uploader and decrement each uploader's ``file_count`` by that
-        amount (clamped at zero) so quotas stay accurate.
+        Counter updates are derived from the rows actually deleted and remain
+        clamped at zero so retries and concurrent deletion paths stay safe.
         """
         async with self.pool.acquire() as conn:
             return await self._delete_partition_on_conn(conn, name)
 
     async def _delete_partition_on_conn(self, conn: asyncpg.Connection, name: str) -> bool:
         async with conn.transaction():
-            exists = await conn.fetchval(
-                "SELECT 1 FROM partitions WHERE partition = $1",
+            partition = await conn.fetchrow(
+                "SELECT partition FROM partitions WHERE partition = $1 FOR UPDATE",
                 name,
             )
-            if not exists:
+            if partition is None:
+                logger.bind(
+                    operation="delete_partition",
+                    deleted_rows=0,
+                    counters_adjusted=0,
+                ).debug("Catalog partition deletion accounted")
                 return False
-            uploader_counts = await conn.fetch(
-                """
-                SELECT created_by, COUNT(*)::int AS n
-                FROM files
-                WHERE partition_name = $1 AND created_by IS NOT NULL
-                GROUP BY created_by
-                """,
+            deleted_rows = await conn.fetch(
+                "DELETE FROM files WHERE partition_name = $1 RETURNING created_by",
                 name,
             )
-            await conn.execute(
-                "DELETE FROM files WHERE partition_name = $1",
-                name,
-            )
+            counters_adjusted = await decrement_file_counts(conn, deleted_rows)
             await conn.execute(
                 "DELETE FROM partitions WHERE partition = $1",
                 name,
             )
-            for r in uploader_counts:
-                await conn.execute(
-                    "UPDATE users SET file_count = GREATEST(file_count - $1, 0) WHERE id = $2",
-                    r["n"],
-                    r["created_by"],
-                )
+            logger.bind(
+                operation="delete_partition",
+                deleted_rows=len(deleted_rows),
+                counters_adjusted=counters_adjusted,
+            ).debug("Catalog partition deletion accounted")
             return True
 
     async def partition_exists(self, name: str) -> bool:

--- a/tests/integration/repos/test_atomic_file_count_deletion.py
+++ b/tests/integration/repos/test_atomic_file_count_deletion.py
@@ -1,0 +1,222 @@
+"""Concurrency coverage for atomic catalog deletion accounting."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import asyncpg
+import pytest
+from core.models.catalog import DocumentRecord
+from services.storage.postgres_store import PostgresStore
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+
+async def _run_while_user_locked(
+    store: PostgresStore,
+    user_id: int,
+    *operations: Callable[[], Awaitable[Any]],
+) -> list[Any]:
+    """Release both deletes only after PostgreSQL reports both lock waits."""
+    tasks: list[asyncio.Task[Any]] = []
+    try:
+        async with store.pool.acquire() as blocker:
+            async with blocker.transaction():
+                await blocker.fetchval("SELECT 1 FROM users WHERE id = $1 FOR UPDATE", user_id)
+                tasks = [asyncio.create_task(operation()) for operation in operations]
+                try:
+                    async with asyncio.timeout(10):
+                        while True:
+                            # This only yields to the tasks; progress is gated by database locks, not elapsed time.
+                            await asyncio.sleep(0)
+                            waiters = await blocker.fetchval(
+                                """
+                                SELECT COUNT(DISTINCT pid)::int
+                                FROM pg_locks
+                                WHERE granted = false
+                                  AND pid <> pg_backend_pid()
+                                """
+                            )
+                            if waiters >= len(operations):
+                                break
+                except TimeoutError as exc:
+                    task_state = [
+                        {
+                            "done": task.done(),
+                            "stack": [f"{frame.f_code.co_name}:{frame.f_lineno}" for frame in task.get_stack()],
+                        }
+                        for task in tasks
+                    ]
+                    raise AssertionError({"tasks": task_state}) from exc
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+async def _create_user(store: PostgresStore, name: str) -> int:
+    user = await store.user_repo.create_legacy_user(
+        display_name=name,
+        external_user_id=None,
+        email=None,
+        is_admin=False,
+        file_quota=None,
+    )
+    return user["id"]
+
+
+async def _add_file(store: PostgresStore, file_id: str, partition: str, user_id: int) -> None:
+    if not await store.partition_repo.partition_exists(partition):
+        await store.partition_repo.create_partition(partition)
+    assert await store.document_repo.add_file_to_partition(file_id, partition, user_id=user_id) is True
+
+
+async def _file_count(store: PostgresStore, user_id: int) -> int:
+    user = await store.user_repo.get_user_dict_by_id(user_id)
+    assert user is not None
+    return user["file_count"]
+
+
+async def test_concurrent_delete_of_the_same_file_decrements_once(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "same-file")
+    await _add_file(postgres_store, "target", "race", user_id)
+    await _add_file(postgres_store, "control", "control", user_id)
+
+    results = await _run_while_user_locked(
+        postgres_store,
+        user_id,
+        lambda: postgres_store.document_repo.remove_file_from_partition("target", "race"),
+        lambda: postgres_store.document_repo.remove_file_from_partition("target", "race"),
+    )
+
+    assert sorted(results) == [False, True]
+    assert await _file_count(postgres_store, user_id) == 1
+
+
+async def test_single_file_and_partition_delete_decrement_once(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "single-partition")
+    await _add_file(postgres_store, "target", "race", user_id)
+    await _add_file(postgres_store, "control", "control", user_id)
+
+    await _run_while_user_locked(
+        postgres_store,
+        user_id,
+        lambda: postgres_store.document_repo.remove_file_from_partition("target", "race"),
+        lambda: postgres_store.partition_repo.delete_partition("race"),
+    )
+
+    assert await postgres_store.partition_repo.partition_exists("race") is False
+    assert await _file_count(postgres_store, user_id) == 1
+
+
+async def test_single_file_and_bulk_delete_decrement_once(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "single-bulk")
+    await _add_file(postgres_store, "target", "race", user_id)
+    await _add_file(postgres_store, "control", "control", user_id)
+
+    single_result, bulk_count = await _run_while_user_locked(
+        postgres_store,
+        user_id,
+        lambda: postgres_store.document_repo.remove_file_from_partition("target", "race"),
+        lambda: postgres_store.document_repo.delete_documents_by_partition("race"),
+    )
+
+    assert int(single_result) + bulk_count == 1
+    assert await _file_count(postgres_store, user_id) == 1
+
+
+async def test_concurrent_partition_deletes_lock_users_in_stable_order(postgres_store: PostgresStore):
+    first_user = await _create_user(postgres_store, "first")
+    second_user = await _create_user(postgres_store, "second")
+    for partition in ("first-partition", "second-partition"):
+        await _add_file(postgres_store, f"{partition}-first", partition, first_user)
+        await _add_file(postgres_store, f"{partition}-second", partition, second_user)
+    await _add_file(postgres_store, "first-control", "control", first_user)
+    await _add_file(postgres_store, "second-control", "control", second_user)
+
+    results = await _run_while_user_locked(
+        postgres_store,
+        first_user,
+        lambda: postgres_store.partition_repo.delete_partition("first-partition"),
+        lambda: postgres_store.partition_repo.delete_partition("second-partition"),
+    )
+
+    assert results == [True, True]
+    assert await _file_count(postgres_store, first_user) == 1
+    assert await _file_count(postgres_store, second_user) == 1
+
+
+async def test_concurrent_delete_of_the_same_partition_decrements_once(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "same-partition")
+    await _add_file(postgres_store, "target", "race", user_id)
+    await _add_file(postgres_store, "control", "control", user_id)
+
+    results = await _run_while_user_locked(
+        postgres_store,
+        user_id,
+        lambda: postgres_store.partition_repo.delete_partition("race"),
+        lambda: postgres_store.partition_repo.delete_partition("race"),
+    )
+
+    assert sorted(results) == [False, True]
+    assert await _file_count(postgres_store, user_id) == 1
+
+
+async def test_unscoped_delete_removes_one_matching_row_per_call(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "unscoped")
+    await _add_file(postgres_store, "shared", "first", user_id)
+    await _add_file(postgres_store, "shared", "second", user_id)
+
+    assert await postgres_store.document_repo.delete_document("shared") is True
+    assert await _file_count(postgres_store, user_id) == 1
+    assert await postgres_store.document_repo.delete_document("shared") is True
+    assert await postgres_store.document_repo.delete_document("shared") is False
+    assert await _file_count(postgres_store, user_id) == 0
+
+
+async def test_bulk_delete_ignores_rows_without_an_uploader(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "mixed")
+    await _add_file(postgres_store, "owned", "mixed", user_id)
+    await postgres_store.document_repo.create_document(DocumentRecord(id="legacy", file_id="legacy", partition="mixed"))
+
+    assert await postgres_store.document_repo.delete_documents_by_partition("mixed") == 2
+    assert await _file_count(postgres_store, user_id) == 0
+
+
+async def test_counter_failure_rolls_back_file_delete(postgres_store: PostgresStore):
+    user_id = await _create_user(postgres_store, "rollback")
+    await _add_file(postgres_store, "target", "race", user_id)
+    await _add_file(postgres_store, "control", "control", user_id)
+
+    async with postgres_store.pool.acquire() as conn:
+        await conn.execute(
+            """
+            CREATE FUNCTION issue724_reject_file_count_update() RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION 'injected file-count failure';
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TRIGGER issue724_reject_file_count_update
+            BEFORE UPDATE OF file_count ON users
+            FOR EACH ROW EXECUTE FUNCTION issue724_reject_file_count_update()
+            """
+        )
+
+    try:
+        with pytest.raises(asyncpg.PostgresError, match="injected file-count failure"):
+            await postgres_store.document_repo.remove_file_from_partition("target", "race")
+    finally:
+        async with postgres_store.pool.acquire() as conn:
+            await conn.execute("DROP TRIGGER issue724_reject_file_count_update ON users")
+            await conn.execute("DROP FUNCTION issue724_reject_file_count_update()")
+
+    assert await postgres_store.document_repo.file_exists_in_partition("target", "race") is True
+    assert await _file_count(postgres_store, user_id) == 2

--- a/tests/unit/services/persistence/test_atomic_file_count_deletion.py
+++ b/tests/unit/services/persistence/test_atomic_file_count_deletion.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Transaction(_AsyncContext):
+    async def __aexit__(self, exc_type, exc, tb):
+        self.value.transaction_exits.append(exc_type)
+        return False
+
+
+class _DeleteConn:
+    def __init__(
+        self,
+        *,
+        single_row=None,
+        deleted_rows=None,
+        partition_row=None,
+        fail_counter_update: bool = False,
+    ):
+        self.single_row = single_row
+        self.deleted_rows = deleted_rows or []
+        self.partition_row = partition_row
+        self.fail_counter_update = fail_counter_update
+        self.operations: list[tuple[str, tuple]] = []
+        self.transaction_exits: list[type[BaseException] | None] = []
+
+    def transaction(self):
+        self.operations.append(("BEGIN", ()))
+        return _Transaction(self)
+
+    async def fetchrow(self, query: str, *params):
+        self.operations.append((query, params))
+        if "SELECT partition FROM partitions" in query:
+            return self.partition_row
+        return self.single_row
+
+    async def fetch(self, query: str, *params):
+        self.operations.append((query, params))
+        return self.deleted_rows
+
+    async def execute(self, query: str, *params):
+        self.operations.append((query, params))
+        if self.fail_counter_update and "UPDATE users SET file_count" in query:
+            raise RuntimeError("counter update failed")
+        return "UPDATE 1"
+
+
+class _DeletePool:
+    def __init__(self, conn: _DeleteConn):
+        self.conn = conn
+
+    def acquire(self):
+        return _AsyncContext(self.conn)
+
+
+def _queries(conn: _DeleteConn) -> list[str]:
+    return [query for query, _params in conn.operations if query != "BEGIN"]
+
+
+def _counter_updates(conn: _DeleteConn) -> list[tuple]:
+    return [params for query, params in conn.operations if "UPDATE users SET file_count" in query]
+
+
+@pytest.mark.asyncio
+async def test_scoped_delete_accounts_only_for_the_returned_row():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    conn = _DeleteConn(single_row={"created_by": 7})
+    repo = PgDocumentRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.remove_file_from_partition("file-1", "tenant-a") is True
+    assert "DELETE FROM files" in _queries(conn)[0]
+    assert "RETURNING created_by" in _queries(conn)[0]
+    assert not any(query.lstrip().startswith("SELECT") for query in _queries(conn))
+    assert _counter_updates(conn) == [(1, 7)]
+
+
+@pytest.mark.asyncio
+async def test_scoped_delete_retry_is_a_noop():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    conn = _DeleteConn(single_row=None)
+    repo = PgDocumentRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.remove_file_from_partition("missing", "tenant-a") is False
+    assert _counter_updates(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_unscoped_delete_keeps_one_row_semantics_in_one_statement():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    conn = _DeleteConn(single_row={"created_by": None})
+    repo = PgDocumentRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.delete_document("shared-file-id") is True
+    assert len(_queries(conn)) == 1
+    assert "WITH target AS" in _queries(conn)[0]
+    assert "ORDER BY id" in _queries(conn)[0]
+    assert "DELETE FROM files" in _queries(conn)[0]
+    assert _counter_updates(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_uses_returned_rows_and_stable_user_order():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    conn = _DeleteConn(
+        deleted_rows=[
+            {"created_by": 9},
+            {"created_by": None},
+            {"created_by": 2},
+            {"created_by": 9},
+        ]
+    )
+    repo = PgDocumentRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.delete_documents_by_partition("tenant-a") == 4
+    assert "DELETE FROM files" in _queries(conn)[0]
+    assert "RETURNING created_by" in _queries(conn)[0]
+    assert not any("GROUP BY created_by" in query for query in _queries(conn))
+    assert _counter_updates(conn) == [(1, 2), (2, 9)]
+
+
+@pytest.mark.asyncio
+async def test_partition_delete_locks_then_accounts_for_returned_rows():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _DeleteConn(
+        partition_row={"partition": "tenant-a"},
+        deleted_rows=[{"created_by": 9}, {"created_by": 2}],
+    )
+    repo = PgPartitionRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.delete_partition("tenant-a") is True
+    queries = _queries(conn)
+    assert "FOR UPDATE" in queries[0]
+    assert "DELETE FROM files" in queries[1]
+    assert "RETURNING created_by" in queries[1]
+    assert _counter_updates(conn) == [(1, 2), (1, 9)]
+    assert queries[-1] == "DELETE FROM partitions WHERE partition = $1"
+
+
+@pytest.mark.asyncio
+async def test_partition_delete_retry_is_a_noop():
+    from services.persistence.partition_repo import PgPartitionRepository
+
+    conn = _DeleteConn(partition_row=None)
+    repo = PgPartitionRepository(pool_getter=lambda: _DeletePool(conn))
+
+    assert await repo.delete_partition("missing") is False
+    assert len(_queries(conn)) == 1
+    assert _counter_updates(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_counter_failure_escapes_the_delete_transaction():
+    from services.persistence.document_repo import PgDocumentRepository
+
+    conn = _DeleteConn(single_row={"created_by": 7}, fail_counter_update=True)
+    repo = PgDocumentRepository(pool_getter=lambda: _DeletePool(conn))
+
+    with pytest.raises(RuntimeError, match="counter update failed"):
+        await repo.remove_file_from_partition("file-1", "tenant-a")
+
+    assert conn.transaction_exits == [RuntimeError]


### PR DESCRIPTION
## Context

Concurrent file, bulk, and partition deletion could decrement a user's file count more than once for the same file. The zero clamp hid the drift, leaving quota decisions based on incorrect data.

## Fix

Deletion accounting now follows only rows actually removed by the transaction. Partition deletion is serialized, uploader counters are updated consistently, and retries remain no-ops.

Closes #724

## Validation

- Full unit suite: 1854 passed
- PostgreSQL concurrency and rollback coverage: 8 passed
- Ruff lint and formatting checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-user `file_count` tracking during document, file, and partition deletions.
  * Prevented duplicate counter decrements when deletions overlap or run concurrently.
  * Ensured deletions roll back safely if updating usage counts fails.
  * Clamped counter decrements to avoid negative `file_count`.
  * Improved bulk and unscoped deletion handling, including entries without uploader information.
* **Reliability**
  * Strengthened atomic deletion behavior under concurrent activity.
* **Tests**
  * Added new integration and unit coverage for counter correctness and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->