### PR TITLE
fix(retrieval): expand "all" to per-partition pipelines (right embedder + top_n), bounded

### DIFF
--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -305,6 +305,7 @@ The retriever fetches relevant documents from the vector database based on query
 | `RELATED_LIMIT` | `int` | 10 | Maximum number of related/ancestor chunks fetched per matched result when expansion is enabled. |
 | `MAX_DEPTH` | `int` | 10 | Maximum ancestor depth traversed when `INCLUDE_ANCESTORS` is enabled. |
 | `RETRIEVER_ALLOW_FILTERLESS_FALLBACK` | `bool` | true | When a temporally-filtered retrieval returns no documents, re-run the query without the filter. Set to `false` for strict temporal retrieval. |
+| `RETRIEVER_MAX_PARTITION_CONCURRENCY` | `int` | 16 | Upper bound on how many per-partition retrievals run concurrently within a single request. Bounds fan-out for multi-partition / `openrag-all` searches; small fan-outs stay fully parallel. |
 
 #### Retrieval Strategies
 

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -306,7 +306,7 @@ The retriever fetches relevant documents from the vector database based on query
 | `RELATED_LIMIT` | `int` | 10 | Maximum number of related/ancestor chunks fetched per matched result when expansion is enabled. |
 | `MAX_DEPTH` | `int` | 10 | Maximum ancestor depth traversed when `INCLUDE_ANCESTORS` is enabled. |
 | `RETRIEVER_ALLOW_FILTERLESS_FALLBACK` | `bool` | true | When a temporally-filtered retrieval returns no documents, re-run the query without the filter. Set to `false` for strict temporal retrieval. |
-| `RETRIEVER_MAX_PARTITION_CONCURRENCY` | `int` | 16 | Upper bound on how many per-partition retrievals run concurrently within a single request. Bounds fan-out for multi-partition / `openrag-all` searches; small fan-outs stay fully parallel. |
+| `RETRIEVER_MAX_PARTITION_CONCURRENCY` | `int` | 16 | Upper bound on how many per-partition retrievals run concurrently **per retrieval call**. Bounds fan-out for multi-partition / `openrag-all` searches; small fan-outs stay fully parallel. Note: a multi-query request (multiQuery/hyde) issues one such call per sub-query, so peak concurrency can reach `N × this value`, not a flat per-request cap. |
 
 #### Retrieval Strategies
 

--- a/openrag/core/config/loader.py
+++ b/openrag/core/config/loader.py
@@ -154,6 +154,7 @@ _ENV_OVERRIDES: list[tuple[str, str, type]] = [
     ("RELATED_LIMIT", "retriever.related_limit", int),
     ("MAX_DEPTH", "retriever.max_ancestor_depth", int),
     ("RETRIEVER_ALLOW_FILTERLESS_FALLBACK", "retriever.allow_filterless_fallback", bool),
+    ("RETRIEVER_MAX_PARTITION_CONCURRENCY", "retriever.max_partition_concurrency", int),
     # RAG
     ("RAG_MODE", "rag.mode", str),
     # WebSearch

--- a/openrag/core/config/retrieval.py
+++ b/openrag/core/config/retrieval.py
@@ -67,6 +67,13 @@ class _BaseRetrieverConfig(ConfigMixin):
     # document hierarchies.
     max_ancestor_depth_cap: int = 1000
     allow_filterless_fallback: bool = True
+    # Upper bound on how many per-partition retrievals run concurrently within a
+    # single request. A multi-partition search (notably a SUPER_ADMIN_MODE
+    # ``openrag-all`` that expands to every partition) fans out one embed+search
+    # per partition; without a cap that is proportional to the partition count
+    # and can exhaust the Milvus/embedder pools from one request. Small fan-outs
+    # (the common case) stay fully parallel — the cap only engages past it.
+    max_partition_concurrency: int = Field(default=16, gt=0)
 
 
 class SingleRetrieverConfig(_BaseRetrieverConfig):

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -213,7 +213,21 @@ class RetrievalService:
     def _pipeline_groups_for_partitions(
         self, partitions: list[str]
     ) -> list[tuple[list[str], RetrieverPipeline, int | None]]:
-        if not partitions or "all" in partitions or not self._partition_configs():
+        configs = self._partition_configs()
+        # Expand the "all" sentinel to concrete partitions so each is retrieved
+        # with its own embedder and top_n, via the same per-partition fan-out the
+        # named-partition path already uses (#708). Collapsing to self._pipeline
+        # embedded the query with the deployment-default embedder — near-random
+        # recall for any partition indexed with a different one — and dropped the
+        # reranker top_n (its default_top_k was None). "all" only reaches this
+        # layer post-authorization (a SUPER_ADMIN_MODE admin; regular users are
+        # already expanded to their memberships upstream), so every hydrated
+        # partition is in scope.
+        if "all" in partitions and configs:
+            partitions = list(configs.keys())
+        elif not partitions or not configs:
+            # Nothing to expand (no partitions exist yet) — keep the single
+            # legacy pipeline; there is no per-partition config to honour.
             return [(["all"] if "all" in partitions else partitions, self._pipeline, None)]
         return [
             ([partition], pipeline, default_top_k)

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -165,7 +165,10 @@ class RetrievalService:
         return getattr(self._config.retriever, name, default)
 
     def _pipeline_for_partition(self, partition: str) -> tuple[RetrieverPipeline, int | None]:
-        if partition == "all" or not self._partition_configs():
+        # Callers only ever pass a concrete partition name — the "all" sentinel is
+        # expanded to concrete keys by _pipeline_groups_for_partitions before this
+        # runs. With no per-partition configs at all, fall back to the legacy pipeline.
+        if not self._partition_configs():
             return self._pipeline, None
 
         partition_cfg = self._require_partition_config(partition)
@@ -300,7 +303,7 @@ class RetrievalService:
         its own leaves; the coroutines being awaited hold no permit while
         waiting for one, so there is no cross-level deadlock).
         """
-        limit = getattr(self._config.retriever, "max_partition_concurrency", 16) or 16
+        limit = self._config.retriever.max_partition_concurrency
         if len(coros) <= limit:
             return await asyncio.gather(*coros)
 

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -284,6 +284,34 @@ class RetrievalService:
     # Pipeline retrieval (powers QueryService — 8C.2)
     # ------------------------------------------------------------------
 
+    async def _gather_partition_groups(self, coros: list) -> list:
+        """Await one coroutine per partition group, bounding concurrency.
+
+        Small fan-outs (the common case: a handful of partitions) run fully
+        parallel via a plain gather — no added overhead, byte-identical to the
+        prior behaviour. Only a fan-out larger than ``max_partition_concurrency``
+        (e.g. a SUPER_ADMIN_MODE ``openrag-all`` expanded to every partition) is
+        throttled through a per-call semaphore, so one request cannot launch a
+        partition-count-proportional flood of embed+Milvus calls (#708).
+
+        The semaphore is per-call, not shared: it caps this request's own fan-out
+        without coupling concurrent requests, and the caps compose safely across
+        the ``retrieve_per_query`` → ``retrieve`` nesting (each inner call bounds
+        its own leaves; the coroutines being awaited hold no permit while
+        waiting for one, so there is no cross-level deadlock).
+        """
+        limit = getattr(self._config.retriever, "max_partition_concurrency", 16) or 16
+        if len(coros) <= limit:
+            return await asyncio.gather(*coros)
+
+        semaphore = asyncio.Semaphore(limit)
+
+        async def _bounded(coro):
+            async with semaphore:
+                return await coro
+
+        return await asyncio.gather(*(_bounded(c) for c in coros))
+
     async def retrieve(
         self,
         *,
@@ -293,8 +321,8 @@ class RetrievalService:
         filter_params: dict | None = None,
     ) -> list[Chunk]:
         """Single ``Query`` through retrieve → expand → rerank."""
-        ranked_lists = await asyncio.gather(
-            *[
+        ranked_lists = await self._gather_partition_groups(
+            [
                 pipeline.retrieve_docs(
                     partition=partition_group,
                     query=query,
@@ -315,8 +343,8 @@ class RetrievalService:
         filter_params: dict | None = None,
     ) -> list[Chunk]:
         """Every sub-query in parallel, fused with RRF."""
-        ranked_lists = await asyncio.gather(
-            *[
+        ranked_lists = await self._gather_partition_groups(
+            [
                 pipeline.get_relevant_docs(
                     partition=partition_group,
                     search_queries=search_queries,

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -61,6 +61,7 @@ def _config(rtype: str = "single", reranker_enabled: bool = False) -> SimpleName
             allow_filterless_fallback=True,
             k_queries=3,
             combine=False,
+            max_partition_concurrency=16,
         ),
         reranker=SimpleNamespace(enabled=reranker_enabled, top_k=5),
         partitions={},

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -280,3 +280,99 @@ async def test_retrieve_rejects_unknown_partition_when_partition_configs_exist()
 
     with pytest.raises(PartitionNotFoundError, match="tenant-b"):
         await svc.retrieve(partitions=["tenant-b"], query=Query(query="hello"))
+
+
+# --- #708: "all" must expand to per-partition pipelines (right embedder + top_n) ---
+
+
+@pytest.mark.asyncio
+async def test_retrieve_all_expands_to_per_partition_embedders():
+    """Super-admin `openrag-all` reaches this layer as the literal ["all"].
+
+    It previously collapsed to the default-embedder legacy pipeline and searched
+    partition=["all"], so a partition indexed with a named embedder was queried
+    with the wrong model. It must instead fan out to one pipeline per partition,
+    each using that partition's embedder — the path named-partition search
+    already uses.
+    """
+    per_embedder: dict[str, FakeSearcher] = {}
+
+    def factory(name: str) -> FakeSearcher:
+        s = per_embedder.setdefault(name, FakeSearcher())
+        s.search_result = [_chunk(f"{name}-hit")]
+        return s
+
+    default_searcher = FakeSearcher()
+    cfg = _config()
+    cfg.partitions = {
+        "p1": _partition(name="p1", embedder="embed-1"),
+        "p2": _partition(name="p2", embedder="embed-2"),
+    }
+    svc = RetrievalService(
+        searcher=default_searcher,
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=factory,
+    )
+
+    out = await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+    # Each partition searched with its OWN embedder, scoped to itself — never the
+    # default searcher, never partition=["all"].
+    assert set(per_embedder) == {"embed-1", "embed-2"}
+    assert default_searcher.search_calls == []
+    assert per_embedder["embed-1"].search_calls[0]["partition"] == ["p1"]
+    assert per_embedder["embed-2"].search_calls[0]["partition"] == ["p2"]
+    assert {c.id for c in out} == {"embed-1-hit", "embed-2-hit"}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_all_applies_partition_top_n():
+    """The reranker top_n was dropped on the `all` path (default_top_k was None).
+    With expansion, each partition's top_n truncates its results."""
+    s = FakeSearcher()
+    s.search_result = [_chunk("a"), _chunk("b"), _chunk("c")]
+    reranker = FakeReranker()
+    cfg = _config()
+    cfg.partitions = {
+        "solo": _partition(
+            name="solo",
+            retrieval=RetrievalPipelineConfig(top_k=3, top_n=2, enable_reranker=True, reranker="r"),
+        )
+    }
+    svc = RetrievalService(
+        searcher=s,
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=lambda name: s,
+        reranker_factory=lambda name: reranker,
+    )
+
+    out = await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+    assert [c.id for c in out] == ["a", "b"]  # truncated to top_n=2, not the full 3
+    assert s.search_calls[0]["partition"] == ["solo"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_all_falls_back_to_legacy_when_no_partitions_exist():
+    """On a fresh system with zero hydrated partitions there is nothing to
+    expand — keep the single legacy pipeline searching ["all"]."""
+    default_searcher = FakeSearcher()
+    default_searcher.search_result = [_chunk("x")]
+    cfg = _config()
+    cfg.partitions = {}
+    svc = RetrievalService(
+        searcher=default_searcher,
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=lambda name: (_ for _ in ()).throw(AssertionError("factory must not be used")),
+    )
+
+    out = await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+    assert [c.id for c in out] == ["x"]
+    assert default_searcher.search_calls[0]["partition"] == ["all"]

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -9,6 +9,7 @@ without inference services.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -376,3 +377,70 @@ async def test_retrieve_all_falls_back_to_legacy_when_no_partitions_exist():
 
     assert [c.id for c in out] == ["x"]
     assert default_searcher.search_calls[0]["partition"] == ["all"]
+
+
+# --- #708: the "all" fan-out must be concurrency-bounded (production safety) ---
+
+
+def _tracking_factory(state: dict):
+    """searcher_factory whose searchers share a live-concurrency tracker."""
+
+    def factory(_name: str) -> FakeSearcher:
+        s = FakeSearcher()
+
+        async def tracked_search(**kwargs):
+            state["live"] += 1
+            state["max"] = max(state["max"], state["live"])
+            for _ in range(5):  # yield so queued searches get a chance to start
+                await asyncio.sleep(0)
+            state["live"] -= 1
+            return [_chunk("hit")]
+
+        s.search = tracked_search
+        return s
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_retrieve_all_bounds_partition_fanout():
+    """A large `all` fan-out must not launch one search per partition at once.
+    With the cap at 2 over 6 partitions, no more than 2 run concurrently."""
+    state = {"live": 0, "max": 0}
+    cfg = _config()
+    cfg.retriever.max_partition_concurrency = 2
+    cfg.partitions = {f"p{i}": _partition(name=f"p{i}", embedder=f"e{i}") for i in range(6)}
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_tracking_factory(state),
+    )
+
+    await svc.retrieve(partitions=["all"], query=Query(query="hi"))
+
+    assert state["max"] <= 2, f"fan-out exceeded the cap: {state['max']}"
+    assert state["max"] == 2, "the cap should still allow parallelism up to the limit"
+    assert state["live"] == 0
+
+
+@pytest.mark.asyncio
+async def test_retrieve_small_fanout_stays_fully_parallel():
+    """The fast path: a fan-out within the cap runs fully parallel — regular
+    multi-partition users are not throttled and keep the prior behaviour."""
+    state = {"live": 0, "max": 0}
+    cfg = _config()
+    cfg.retriever.max_partition_concurrency = 16
+    cfg.partitions = {f"p{i}": _partition(name=f"p{i}", embedder=f"e{i}") for i in range(3)}
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_tracking_factory(state),
+    )
+
+    await svc.retrieve(partitions=["all"], query=Query(query="hi"))
+
+    assert state["max"] == 3, "all 3 partitions should run concurrently under the cap"


### PR DESCRIPTION
Closes #708.

Two commits: the correctness fix, then a production-safety cap found by an adversarial pre-PR audit.

## 1. Wrong embedder + dropped top_n on the `all` path

`_pipeline_groups_for_partitions` collapsed the `"all"` case to the default-embedder legacy pipeline (`self._pipeline`, `default_top_k=None`). So a partition indexed with a named embedder was queried with a **different model's vector** (near-random recall — the collection is COSINE, so results still come back), and the reranker `top_n` was silently dropped (a token heuristic decided the count instead).

Fix: expand `"all"` to the hydrated partition set and reuse the **existing** per-partition fan-out + `fuse()` — the same path regular multi-partition users already run — so each partition is retrieved with its own embedder and `top_n`. The single-legacy-pipeline fallback is kept only when zero partitions exist.

### Scope / security (verified, not assumed)
`"all"` only reaches this layer **post-authorization**: `get_partition_name` (`api/dependencies/llm.py:103-110`) expands `openrag-all` to a regular user's concrete membership list upstream, so they already take the per-partition branch. The literal `["all"]` is a **SUPER_ADMIN_MODE** admin, for whom every partition is legitimately in scope — so expanding to all hydrated partitions is correct and leaks nothing. The `/search` route uses a separate raw-search path and is unaffected. `config.partitions` is hydrated from DB presets by `PartitionService.load_partitions()`, so per-partition config exists for every partition; the legacy collapse only fires on a fresh system with zero partitions.

## 2. Bounded fan-out (production safety)

The expansion is correct but, without a cap, a super-admin `openrag-all` launched **one embed+Milvus search per partition** in a single unbounded `asyncio.gather` — proportional to the partition count, and ×sub-queries for multiQuery/hyde. On a large multi-tenant deployment (the SaaS-orgs direction), one admin request could exhaust the Milvus/embedder pools and starve the event loop (~4,500 concurrent ops at 500 partitions × 3 sub-queries × 3).

Fix: a per-call semaphore over the per-partition leaf coroutines — `retriever.max_partition_concurrency` (default 16, env `RETRIEVER_MAX_PARTITION_CONCURRENCY`). A fast path keeps fan-outs **within** the cap fully parallel and byte-identical to before, so regular multi-partition users are untouched; only oversized fan-outs are throttled.

Design notes:
- The cap is **per-call, not a shared instance semaphore** — it bounds a single `retrieve()` call's partition fan-out without coupling concurrent requests. Under `retrieve_per_query` (multiQuery/hyde) the N sub-queries each get their own cap, so worst-case concurrency is `N × max_partition_concurrency` — deliberately not a flat per-request cap, but still bounded and no longer partition-count-proportional (the blowup being fixed); N is small (`k_queries`, default 3).
- It wraps only the **leaf** coroutines, so it composes across the `retrieve_per_query → retrieve` nesting: the awaited coroutines hold no permit while waiting for one → no cross-level deadlock.

## Verified

- Security: no cross-tenant leak (traced every caller of the `["all"]` path).
- Concurrency race: snapshot-and-build is fully synchronous (no `await` between `list(configs.keys())` and pipeline construction), so a concurrent `load_partitions`/`pop` cannot interleave — no `PartitionNotFoundError`, no "dict changed size".
- Tests assert the *effects*, and each fails against its pre-fix code:
  - each partition searched with its **own** embedder, scoped to itself (never the default searcher, never `partition=["all"]`)
  - `top_n` truncates on the `all` path
  - the cap engages (max concurrent == limit over a larger fan-out) and within-cap fan-outs stay fully parallel
  - zero-partition fallback unchanged
- Full suite: **1846 passed**; ruff check / format / layer-import-guard green.

## Deliberately out of scope (tracked follow-ups)

- **Group by embedder+config** (#735) — in a homogeneous deployment the N per-partition searches could collapse to one `partition=[list]` query. Bigger change that also touches the regular-user path.
- **`return_exceptions` on the fan-out** (#736) — one failing partition currently aborts the whole `all`-search (pre-existing for regular multi-partition users too).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “All partitions” retrieval now expands into per-partition searches using each partition’s configured settings.
  * Added `RETRIEVER_MAX_PARTITION_CONCURRENCY` (default: 16) to cap concurrent per-partition retrievals within a request.
  * The concurrency cap is enforced for both single-query and multi-query retrieval.
* **Bug Fixes**
  * Partition-specific `top_n` truncation is applied correctly when searching across all partitions.
  * Legacy fallback behavior remains unchanged when no partition configurations are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
