### PR TITLE
fix(indexation): default preset follows the global chunking config (CHUNK_SIZE/CHUNKER)

### DIFF
--- a/openrag/core/config/chunking.py
+++ b/openrag/core/config/chunking.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from .base import ConfigMixin
 
 
@@ -12,5 +14,8 @@ class ChunkerConfig(ConfigMixin):
     contextual_retrieval: bool = True
     contextualization_timeout: int = 120
     max_concurrent_contextualization: int = 10
-    chunk_size: int = 512
-    chunk_overlap_rate: float = 0.2
+    chunk_size: int = Field(default=512, gt=0)
+    # Bounded to [0, 1): an overlap >= chunk_size makes the recursive splitter
+    # raise at construction ("larger chunk overlap than chunk size"), so a bad
+    # CHUNK_OVERLAP_RATE must fail at config load, not per-file at index time.
+    chunk_overlap_rate: float = Field(default=0.2, ge=0.0, lt=1.0)

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -309,14 +309,38 @@ class PresetService:
 
     def _validate_config(self, preset_type: str, config: dict[str, Any]) -> None:
         """Instantiate the Pydantic pipeline model to validate the config dict."""
+        indexation_model: IndexationPipelineConfig | None = None
         try:
             match preset_type:
                 case "indexation":
-                    IndexationPipelineConfig(**config)
+                    indexation_model = IndexationPipelineConfig(**config)
                 case "retrieval":
                     RetrievalPipelineConfig(**config)
         except Exception as exc:
             raise ValidationError(f"Invalid {preset_type} preset config: {exc}") from exc
+
+        # Structural validation accepts any chunker *name* (ChunkerConfig.name is a
+        # free string), but only registered strategies can actually be built. Reject
+        # an unknown name here — at seed time (startup) and on the admin CRUD path —
+        # so a typo fails fast instead of letting every document explode at chunker
+        # build during indexing. #709 wired the global CHUNKER into the default
+        # preset, so a bad env value now reaches this seed instead of being ignored.
+        if indexation_model is not None:
+            self._ensure_chunker_registered(indexation_model.chunking.name)
+
+    @staticmethod
+    def _ensure_chunker_registered(name: str) -> None:
+        """Raise ``ValidationError`` if *name* is not a registered chunking strategy."""
+        # Importing the factory triggers chunker registration (import side-effect),
+        # so the registry is populated before the membership check. Mirrors the
+        # trigger used by ``create_chunker`` itself.
+        import core.chunking.factory  # noqa: F401
+        from core.chunking.registry import chunking_registry
+
+        if name not in chunking_registry:
+            raise ValidationError(
+                f"Unknown chunker '{name}'. Available chunkers: {chunking_registry.list_registered()}"
+            )
 
 
 __all__ = ["PresetService"]

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -149,8 +149,20 @@ class PresetService:
         if preset_type == "retrieval":
             return {**config, "enable_reranker": self._config.reranker.enabled}
         if preset_type == "indexation" and name == "default":
+            chunker = self._config.chunker
             return {
                 **config,
+                # The default preset follows the deployment's global chunking
+                # knobs (CHUNKER / CHUNK_SIZE / CHUNK_OVERLAP_RATE). Without this
+                # the seeded 512/0.2 was hardcoded and the operator's global
+                # values were silently ignored for every document (#709). Named
+                # presets keep their explicit, deliberate chunk sizes.
+                "chunking": {
+                    **config.get("chunking", {}),
+                    "name": chunker.name,
+                    "chunk_size": chunker.chunk_size,
+                    "chunk_overlap_rate": chunker.chunk_overlap_rate,
+                },
                 "enable_contextualization": self._config.chunker.contextual_retrieval,
                 "enable_image_captioning": self._config.loader.image_captioning,
             }

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -122,7 +122,16 @@ class PresetService:
             if existing:
                 continue
             for name, config in presets.items():
-                await self._repo.upsert(name, preset_type, self._finalize_seed(name, preset_type, config))
+                finalized = self._finalize_seed(name, preset_type, config)
+                # Validate the finalized seed the same way the CRUD path does, so
+                # a structurally-invalid global override folded in here is rejected
+                # at seeding rather than persisted and exploded later. (An
+                # out-of-range CHUNK_OVERLAP_RATE is already rejected earlier at
+                # config load via ChunkerConfig's bounds; a bad CHUNKER *name* is
+                # an unvalidated string here but fails fast at chunker build — this
+                # call is defense-in-depth over both.)
+                self._validate_config(preset_type, finalized)
+                await self._repo.upsert(name, preset_type, finalized)
                 logger.info(f"Seeded default {preset_type} preset '{name}'.")
 
     def _finalize_seed(self, name: str, preset_type: str, config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/core/config/test_pipeline_configs.py
+++ b/tests/unit/core/config/test_pipeline_configs.py
@@ -57,3 +57,17 @@ def test_retrieval_pipeline_rejects_out_of_range_similarity_threshold(threshold:
     """Retrieval presets keep similarity thresholds in the normalized range."""
     with pytest.raises(ValidationError):
         RetrievalPipelineConfig(similarity_threshold=threshold)
+
+
+@pytest.mark.parametrize("rate", [1.0, 1.5, -0.1])
+def test_indexation_pipeline_rejects_out_of_range_chunk_overlap_rate(rate: float):
+    """overlap must be in [0, 1): >= chunk_size makes the splitter raise at
+    construction, so it has to fail at config load, not per-file (#709)."""
+    with pytest.raises(ValidationError):
+        IndexationPipelineConfig(chunking={"chunk_size": 512, "chunk_overlap_rate": rate})
+
+
+@pytest.mark.parametrize("rate", [0.0, 0.2, 0.99])
+def test_indexation_pipeline_accepts_in_range_chunk_overlap_rate(rate: float):
+    cfg = IndexationPipelineConfig(chunking={"chunk_size": 512, "chunk_overlap_rate": rate})
+    assert cfg.chunking.chunk_overlap_rate == rate

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -593,3 +593,44 @@ async def test_seed_defaults_default_chunk_size_falls_back_to_seed_when_global_u
     default_chunking = repo._store[("default", "indexation")]["config"]["chunking"]
     assert default_chunking["chunk_size"] == 512
     assert default_chunking["chunk_overlap_rate"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_does_not_update_existing_default_chunk_size():
+    """KNOWN LIMITATION (documented, not a bug): the global chunk-size overlay
+    is a *seed-time* default. Once a `default` indexation row exists, a changed
+    CHUNK_SIZE does NOT rewrite it — `seed_defaults` skips a type that already
+    has rows. Existing deployments change chunking by editing the preset. This
+    test pins that behaviour so it isn't 'fixed' accidentally without a
+    reconciliation design (see the #709 follow-up)."""
+    from core.config.root import Settings
+
+    current = _make_row(
+        "default",
+        "indexation",
+        {**_VALID_IDX_CONFIG, "chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 0.2}},
+    )
+    repo = _FakePresetRepo(rows=[current])
+    settings = Settings(chunker={"chunk_size": 1024})  # operator raised it after first seed
+    svc = _make_service(repo, settings=settings)
+
+    await svc.seed_defaults()
+
+    # Unchanged: the stored 512 is the source of truth once the row exists.
+    assert repo._store[("default", "indexation")]["config"]["chunking"]["chunk_size"] == 512
+    upserts = [c for c in repo.calls if c[0] == "upsert"]
+    assert all(args[1] != "indexation" for _, args in upserts)
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_rejects_invalid_overlap_in_default_chunking():
+    """A structurally-invalid finalized seed is rejected at seeding, not
+    persisted (defense-in-depth on the seed path). Overlap out of [0,1) can't
+    even be built into Settings, so validate the seed-path guard directly."""
+    from core.utils.exceptions import ValidationError as OpenRAGValidationError
+
+    repo = _FakePresetRepo()
+    svc = _make_service(repo)
+    bad = {"chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 1.5}}
+    with pytest.raises(OpenRAGValidationError):
+        svc._validate_config("indexation", bad)

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -622,8 +622,7 @@ async def test_seed_defaults_does_not_update_existing_default_chunk_size():
     assert all(args[1] != "indexation" for _, args in upserts)
 
 
-@pytest.mark.asyncio
-async def test_seed_defaults_rejects_invalid_overlap_in_default_chunking():
+def test_seed_defaults_rejects_invalid_overlap_in_default_chunking():
     """A structurally-invalid finalized seed is rejected at seeding, not
     persisted (defense-in-depth on the seed path). Overlap out of [0,1) can't
     even be built into Settings, so validate the seed-path guard directly."""
@@ -634,3 +633,32 @@ async def test_seed_defaults_rejects_invalid_overlap_in_default_chunking():
     bad = {"chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 1.5}}
     with pytest.raises(OpenRAGValidationError):
         svc._validate_config("indexation", bad)
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_rejects_unknown_global_chunker():
+    """A typo'd global CHUNKER must fail at seeding (startup), not per-file at
+    chunker build during indexing. #709 wired CHUNKER into the default preset,
+    so an unknown name now propagates here instead of being silently ignored."""
+    from core.config.root import Settings
+    from core.utils.exceptions import ValidationError as OpenRAGValidationError
+
+    repo = _FakePresetRepo()
+    settings = Settings(chunker={"name": "definitely_not_a_chunker"})
+    svc = _make_service(repo, settings=settings)
+    with pytest.raises(OpenRAGValidationError, match="Unknown chunker"):
+        await svc.seed_defaults()
+    # Nothing was persisted — the bad name is rejected before any upsert.
+    assert not any(c[0] == "upsert" for c in repo.calls)
+
+
+@pytest.mark.asyncio
+async def test_create_preset_rejects_unknown_chunker():
+    """The admin CRUD path also rejects an unregistered chunker name, so a bad
+    preset fails at create time rather than at chunker build during indexing."""
+    from core.utils.exceptions import ValidationError as OpenRAGValidationError
+
+    svc = _make_service()
+    bad = {"chunking": {"name": "nope_splitter", "chunk_size": 512, "chunk_overlap_rate": 0.2}}
+    with pytest.raises(OpenRAGValidationError, match="Unknown chunker"):
+        await svc.create_preset("bad", "indexation", bad)

--- a/tests/unit/services/orchestrators/test_preset_service.py
+++ b/tests/unit/services/orchestrators/test_preset_service.py
@@ -544,3 +544,52 @@ async def test_delete_preset_removes_row():
     await svc.delete_preset("legal", "indexation")
 
     assert ("legal", "indexation") not in repo._store
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_default_indexation_inherits_global_chunk_size():
+    """The default preset must follow the global CHUNK_SIZE / CHUNK_OVERLAP_RATE
+    / CHUNKER, not the hardcoded 512/0.2 seed (#709)."""
+    from core.config.root import Settings
+
+    settings = Settings(chunker={"chunk_size": 1024, "chunk_overlap_rate": 0.3, "name": "recursive_splitter"})
+    repo = _FakePresetRepo()
+    svc = _make_service(repo, settings=settings)
+    await svc.seed_defaults()
+
+    default_chunking = repo._store[("default", "indexation")]["config"]["chunking"]
+    assert default_chunking["chunk_size"] == 1024
+    assert default_chunking["chunk_overlap_rate"] == 0.3
+    assert default_chunking["name"] == "recursive_splitter"
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_named_presets_keep_explicit_chunk_size():
+    """Named presets carry deliberate per-domain chunk sizes and must NOT be
+    overridden by the global chunker knob."""
+    from core.config.root import Settings
+
+    settings = Settings(chunker={"chunk_size": 1024})
+    repo = _FakePresetRepo()
+    svc = _make_service(repo, settings=settings)
+    await svc.seed_defaults()
+
+    # finance seeds 768 explicitly; global is 1024 — finance must stay 768.
+    finance_chunking = repo._store[("finance", "indexation")]["config"]["chunking"]
+    assert finance_chunking["chunk_size"] == 768
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_default_chunk_size_falls_back_to_seed_when_global_unset():
+    """With the global chunker at its own default (512/0.2), the default preset
+    reflects that — no behavioural change for a deployment that didn't tune it."""
+    from core.config.root import Settings
+
+    settings = Settings()
+    repo = _FakePresetRepo()
+    svc = _make_service(repo, settings=settings)
+    await svc.seed_defaults()
+
+    default_chunking = repo._store[("default", "indexation")]["config"]["chunking"]
+    assert default_chunking["chunk_size"] == 512
+    assert default_chunking["chunk_overlap_rate"] == 0.2


### PR DESCRIPTION
Closes #709 (fresh-install scope — see "Scope & known limitation" below).

## Problem

The seeded `default` indexation preset hardcodes chunking (512 / 0.2), and the preset always wins at runtime (`pipeline_builder._select_chunker`), so a deployment's global `CHUNKER` / `CHUNK_SIZE` / `CHUNK_OVERLAP_RATE` (env → `config.chunker`) was silently ignored — the value loaded, showed in config introspection, and never reached the splitter.

## Fix

`_finalize_seed` now overlays the global chunker's `name` / `chunk_size` / `chunk_overlap_rate` onto the `default` preset — mirroring how `enable_contextualization` / `enable_image_captioning` are already folded in. Only the 3 shape fields, only for `default`; named presets (legal/finance) keep their deliberate sizes.

## Hardening (added after an adversarial pre-merge review)

- **`chunk_overlap_rate` bounded to [0, 1)** and `chunk_size > 0` on `ChunkerConfig`. An overlap ≥ size makes the recursive splitter raise at construction, so a bad `CHUNK_OVERLAP_RATE` now fails at **config load** (earliest gate) instead of per-file — closing both the surface this overlay newly exposed on the default preset and the pre-existing eager-global-build crash, at the source.
- **Seed path now runs `_validate_config`** (the same validation the CRUD path uses) as defense-in-depth, so a structurally-invalid overlaid seed is rejected at seeding, not persisted.
- **Unknown chunker *name* now rejected** in `_validate_config` against the chunking registry. Previously the name was a free string that passed structural validation and only failed later at chunker build — once per document, at index time. Since this PR makes `CHUNKER` actually reach the default preset, a typo would now propagate to the seed; it instead fails fast at **seed time (startup)** and on the **admin CRUD path**, listing the available chunkers. (Added after review — same "a configured value is now actually consumed, so validate it" pattern as the bounds above.)

## Scope & known limitations (important)

This makes a **fresh, never-seeded** deployment honour the global chunking config. It does **not** retroactively change an **already-seeded** deployment: `seed_defaults` skips a type that already has rows, so a stored `default` preset keeps its `chunk_size` even if `CHUNK_SIZE` changes. This is **consistent with the existing `_finalize_seed` contract** — the sibling `enable_contextualization` / `enable_image_captioning` overlays behave identically. Existing deployments change chunking by editing the `default` preset (admin UI / `update_preset`).

Reconciliation for existing deployments is tracked in #739 (it can't be done safely without provenance — a stored 512 is indistinguishable from a deliberate choice).

**Upgrade caveat (bounds are global, not fresh-install-only):** the new `chunk_size > 0` / `chunk_overlap_rate ∈ [0, 1)` bounds apply at **global config load for every deployment**. A deployment that had set a genuinely-invalid-but-previously-tolerated value (e.g. `CHUNK_OVERLAP_RATE=1.0`, which the old hardcoded preset ignored) will now fail fast at **startup** with a clear Pydantic error instead of silently ignoring it. This is deliberate (fail loud on invalid config, don't let it reach the splitter per-file), but it is a boot-time behaviour change on upgrade — flagged here so it isn't a surprise.

## Tests (each meaningful; the guard tests fail on revert)

- `default` preset reflects global `CHUNK_SIZE=1024` / overlap `0.3` — **fails against pre-fix code** (stays 512)
- named `finance` keeps its explicit 768 despite global 1024
- overlap out of [0,1) rejected at config load — **fails without the new bound**
- **documents the limitation**: an already-seeded `default` is NOT rewritten by a changed `CHUNK_SIZE`
- seed-path validation rejects a structurally-invalid finalized chunking
- unknown global `CHUNKER` rejected at `seed_defaults` (startup) and unknown chunker name rejected on the CRUD path — both **fail on revert** of the new registry check

Full suite (merged with latest develop): green; ruff check / format / layer-import-guard green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default indexation presets now inherit configured chunking settings.
  * Existing default preset settings are preserved during seeding.
* **Bug Fixes**
  * Invalid chunk sizes, overlap rates, and unknown chunker names are rejected before saving.
  * Preset creation and default seeding now validate configurations consistently.
* **Tests**
  * Added coverage for global chunker settings, preset preservation, fallback values, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->