### PR TITLE
fix(retrieval): thread per-partition rrf_k into sub-query fusion (incl. websearch path)

### DIFF
--- a/openrag/core/retrieval/pipeline.py
+++ b/openrag/core/retrieval/pipeline.py
@@ -67,11 +67,17 @@ class RetrieverPipeline:
         reranker: Reranker | None = None,
         reranker_top_k: int = 5,
         allow_filterless_fallback: bool = True,
+        rrf_k: int = 60,
     ) -> None:
         self.retriever = retriever
         self.reranker = reranker
         self.reranker_top_k = reranker_top_k
         self.allow_filterless_fallback = allow_filterless_fallback
+        # RRF dampening for fusing this partition's multiQuery sub-query rankings
+        # (see get_relevant_docs). 60 is canonical; a preset can tune it via
+        # RetrievalPipelineConfig.rrf_k. Cross-partition fusion happens a layer
+        # up in RetrievalService.fuse, which is not partition-scoped.
+        self.rrf_k = rrf_k
 
     @property
     def reranker_enabled(self) -> bool:
@@ -146,7 +152,7 @@ class RetrieverPipeline:
             for q in search_queries.query_list
         ]
         ranked_lists = await asyncio.gather(*tasks)
-        fused = rrf_reranking(ranked_lists, key_fn=_chunk_key)
+        fused = rrf_reranking(ranked_lists, key_fn=_chunk_key, k=self.rrf_k)
         if top_k is not None:
             fused = fused[:top_k]
         return fused

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -321,8 +321,7 @@ class QueryService:
 
         web_results: list = []
         if partition is not None and use_websearch:
-            doc_lists, web_lists = await self._gather_rag_and_web(queries.query_list, partition, top_k, filter_params)
-            chunks = self._retrieval.fuse(doc_lists, top_k=top_k)
+            chunks, web_lists = await self._gather_rag_and_web(queries, partition, top_k, filter_params)
             web_results = _dedupe_web(web_lists)
         elif partition is not None:
             chunks = await self._retrieval.retrieve_multi(
@@ -380,13 +379,18 @@ class QueryService:
         payload["messages"] = new_messages
         return payload, docs, web_results
 
-    async def _gather_rag_and_web(self, query_list, partition, top_k, filter_params):
-        rag = self._retrieval.retrieve_per_query(
-            partitions=partition, queries=query_list, top_k=top_k, filter_params=filter_params
+    async def _gather_rag_and_web(self, queries, partition, top_k, filter_params):
+        # Fuse the doc branch through retrieve_multi so a partition's rrf_k drives
+        # its sub-query fusion here too (#707). Previously this used
+        # retrieve_per_query + fuse() at the hardcoded 60, so enabling websearch
+        # silently ignored rrf_k and the same preset fused differently depending
+        # on the websearch toggle.
+        rag = self._retrieval.retrieve_multi(
+            partitions=partition, search_queries=queries, top_k=top_k, filter_params=filter_params
         )
-        web = asyncio.gather(*[self._web.search(q.query) for q in query_list])
-        doc_lists, web_lists = await asyncio.gather(rag, web)
-        return doc_lists, web_lists
+        web = asyncio.gather(*[self._web.search(q.query) for q in queries.query_list])
+        chunks, web_lists = await asyncio.gather(rag, web)
+        return chunks, web_lists
 
     async def _prepare_completions(self, partition: list[str], payload: dict, llm: LLM | None = None):
         prompt = payload["prompt"]

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -207,6 +207,7 @@ class RetrievalService:
             reranker=reranker,
             reranker_top_k=pipeline_cfg.top_n,
             allow_filterless_fallback=self._legacy_retriever_value("allow_filterless_fallback", True),
+            rrf_k=pipeline_cfg.rrf_k,
         )
         return pipeline, pipeline_cfg.top_n
 
@@ -334,7 +335,13 @@ class RetrievalService:
 
     @staticmethod
     def fuse(doc_lists: list[list[Chunk]], top_k: int | None = None) -> list[Chunk]:
-        """RRF-fuse per-query ranked lists (same fusion the pipeline uses)."""
+        """RRF-fuse ranked lists across partitions (and doc+web).
+
+        Uses the canonical RRF constant (60) rather than a preset's ``rrf_k``:
+        this fuses lists from *different* partitions (and the web branch), so no
+        single partition's ``rrf_k`` applies. Per-partition ``rrf_k`` is honoured
+        one layer down, in ``RetrieverPipeline.get_relevant_docs`` (#707).
+        """
         fused = rrf_reranking(doc_lists, key_fn=_chunk_key)
         return fused[:top_k] if top_k is not None else fused
 

--- a/tests/unit/core/retrieval/test_pipeline.py
+++ b/tests/unit/core/retrieval/test_pipeline.py
@@ -203,3 +203,30 @@ async def test_retrieve_docs_top_k_zero_returns_empty():
     p = RetrieverPipeline(retriever=r)
     out = await p.retrieve_docs(partition=["p1"], query=Query(query="hi"), top_k=0)
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_get_relevant_docs_passes_configured_rrf_k(monkeypatch):
+    """The per-partition rrf_k must reach rrf_reranking, not the hardcoded 60 (#707)."""
+    import core.retrieval.pipeline as pipeline_mod
+
+    captured = {}
+    real = pipeline_mod.rrf_reranking
+
+    def spy(ranked_lists, key_fn=None, k=60):
+        captured["k"] = k
+        return real(ranked_lists, key_fn=key_fn, k=k)
+
+    monkeypatch.setattr(pipeline_mod, "rrf_reranking", spy)
+
+    r = FakeRetriever()
+    r.results_queue = [_chunks("a", "b"), _chunks("b", "c")]
+    p = RetrieverPipeline(retriever=r, rrf_k=17)
+    sq = SearchQueries(query_list=[Query(query="q1"), Query(query="q2")])
+    await p.get_relevant_docs(partition=["p1"], search_queries=sq)
+
+    assert captured["k"] == 17
+
+
+def test_rrf_k_defaults_to_canonical_60():
+    assert RetrieverPipeline(retriever=FakeRetriever()).rrf_k == 60

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -331,6 +331,43 @@ async def test_chat_with_partition_retrieves_and_filters_sources():
 
 
 @pytest.mark.asyncio
+async def test_websearch_with_partition_fuses_docs_via_retrieve_multi():
+    # #707/#740: with a partition AND websearch enabled, the document branch must
+    # fuse through retrieve_multi (which honors the partition's rrf_k), NOT the
+    # legacy retrieve_per_query + fuse()@60. Revert-proves _gather_rag_and_web:
+    # reverting it back to retrieve_per_query + fuse flips these counters and fails.
+    calls = {"multi": 0, "per_query": 0, "fuse": 0}
+    retrieval = FakeRetrieval()
+    base_multi = retrieval.retrieve_multi
+
+    async def _multi(**kwargs):
+        calls["multi"] += 1
+        return await base_multi(**kwargs)
+
+    async def _per_query(*, queries, **kwargs):
+        calls["per_query"] += 1
+        return [[] for _ in queries]
+
+    def _fuse(doc_lists, top_k=None):
+        calls["fuse"] += 1
+        return doc_lists[0] if doc_lists else []
+
+    retrieval.retrieve_multi = _multi
+    retrieval.retrieve_per_query = _per_query
+    retrieval.fuse = _fuse
+
+    web_result = SimpleNamespace(url="https://ex.com", title="T", content="web body", snippet="")
+    svc = _svc(retrieval=retrieval, web=FakeWeb(results=[web_result]))
+    _payload, _docs, web = await svc._prepare_chat(
+        ["p"], {"messages": [{"role": "user", "content": "q"}], "metadata": {"websearch": True}}
+    )
+    assert calls["multi"] == 1  # doc branch fused via the rrf_k-aware retrieve_multi
+    assert calls["per_query"] == 0  # legacy per-query path NOT used
+    assert calls["fuse"] == 0  # hardcoded-60 fuse NOT used
+    assert web and web[0].url == "https://ex.com"  # websearch branch actually taken
+
+
+@pytest.mark.asyncio
 async def test_complete_strips_and_filters():
     svc = _svc(llm=FakeLLM(gen_text="text body [Sources: none]"))
     out = await svc.complete(

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -280,3 +280,13 @@ async def test_retrieve_rejects_unknown_partition_when_partition_configs_exist()
 
     with pytest.raises(PartitionNotFoundError, match="tenant-b"):
         await svc.retrieve(partitions=["tenant-b"], query=Query(query="hello"))
+
+
+@pytest.mark.asyncio
+async def test_pipeline_for_partition_threads_rrf_k():
+    """A partition's rrf_k must reach its RetrieverPipeline (#707)."""
+    cfg = _config()
+    cfg.partitions = {"tenant-a": _partition(retrieval=RetrievalPipelineConfig(rrf_k=42))}
+    svc = RetrievalService(searcher=FakeSearcher(), reranker=None, llm=None, config=cfg)
+    pipeline, _ = svc._pipeline_for_partition("tenant-a")
+    assert pipeline.rrf_k == 42

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -282,8 +282,7 @@ async def test_retrieve_rejects_unknown_partition_when_partition_configs_exist()
         await svc.retrieve(partitions=["tenant-b"], query=Query(query="hello"))
 
 
-@pytest.mark.asyncio
-async def test_pipeline_for_partition_threads_rrf_k():
+def test_pipeline_for_partition_threads_rrf_k():
     """A partition's rrf_k must reach its RetrieverPipeline (#707)."""
     cfg = _config()
     cfg.partitions = {"tenant-a": _partition(retrieval=RetrievalPipelineConfig(rrf_k=42))}


### PR DESCRIPTION
Closes #707.

## Problem
`RetrievalPipelineConfig.rrf_k` (per-partition, UI-editable, validated) was never passed to `rrf_reranking` — the app-level RRF dampening constant was hardcoded to the function default 60, so per-partition tuning did nothing.

## Fix
- Thread `rrf_k` into `RetrieverPipeline` and use it in `get_relevant_docs`, where a partition's multiQuery sub-query rankings are fused (the fusion the per-partition field governs, and the sole fusion for a single-partition multiQuery search). Wired from `pipeline_cfg.rrf_k`.
- **websearch path** (found by adversarial review): the combined RAG+websearch branch fused sub-queries via `retrieve_per_query` + `fuse()` at the hardcoded 60, so enabling websearch silently ignored `rrf_k` — the same preset fused differently based on the toggle. Routed the doc branch through `retrieve_multi` so `rrf_k` applies consistently.

## Scope (documented, not silently narrowed)
- **Cross-partition / doc+web fusion** (`RetrievalService.fuse`) stays at canonical 60: it fuses lists from *different* partitions, so no single partition's `rrf_k` applies. Docstring corrected to match.
- **Legacy pipeline** (`"all"` / no-preset deployments) has no per-partition config, so `rrf_k` stays 60. There is no global `rrf_k` knob outside partition presets — noted as a limitation.
- **Milvus-native dense/BM25 hybrid fusion** (`RRFRanker(RRF_K=100)` in `milvus_store`) is a *separate* per-query fusion layer and is **not** governed by this per-partition field. An operator tuning `rrf_k` will not change the semantic-vs-keyword blend. Tracked as a follow-up (see below).

## Tests
- configured `rrf_k` reaches `rrf_reranking` (spy asserts `k=17`, fails against the hardcoded 60)
- a partition's `rrf_k` reaches its pipeline
- 34 query_service tests pass unchanged after the websearch reroute

Full suite: **1887 passed**; ruff/format/layer-guard green.

## Follow-up
Per-partition `rrf_k` does not reach the Milvus dense/BM25 `RRFRanker` (fixed at 100) — a separate cross-layer plumbing change. Will file a tracked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-partition configuration for result-fusion dampening, with the existing default preserved.
* **Bug Fixes**
  * Prevented duplicate result fusion in the combined retrieval + web search flow by ensuring fusion happens once using the partition’s configured settings.
* **Tests**
  * Added unit tests validating the default fusion setting and verifying per-partition configuration propagation through the retrieval pipeline and web search path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->