### PR TITLE
fix(entrypoint): grant GID-0 write on chainlit translations mount

### DIFF
--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -16,7 +16,12 @@
 # membership plus the image's group-writable paths already cover it.
 APP_UID="${APP_UID:-10001}"
 if [ "$(id -u)" = "0" ]; then
-  for d in /app/data /app/logs /app/model_weights; do
+  # /app/openrag/.chainlit/translations can be a bind mount (compose maps the
+  # host i8n/ folder there for custom translations). Like the dirs below, a
+  # host-owned mount keeps its host ownership, so Chainlit — which writes any
+  # bundled language file missing from the mount on startup — hits
+  # PermissionError as the non-root app user. Grant GID-0 write here too.
+  for d in /app/data /app/logs /app/model_weights /app/openrag/.chainlit/translations; do
     mkdir -p "$d" 2>/dev/null || true
     chgrp -R 0 "$d" 2>/dev/null || true
     chmod -R g+rwX "$d" 2>/dev/null || true


### PR DESCRIPTION
## Problem

Starting the API container fails with:

```
PermissionError: [Errno 13] Permission denied: '/app/openrag/.chainlit/translations/zh-TW.json'
```

Compose bind-mounts the host `i8n/` folder onto `/app/openrag/.chainlit/translations`. On startup Chainlit's `init_config()` writes every bundled language file missing from that folder (e.g. `zh-TW.json`). Because the mount keeps its host ownership, the non-root app user (GID 0) can't write into it.

`entrypoint.sh` already fixes GID-0 write on the other host-owned bind mounts (`data/`, `logs/`, `model_weights/`) during its root phase, but the translations mount was left out.

## Fix

Add `/app/openrag/.chainlit/translations` to the root-phase permission-fix loop, mirroring the existing pattern. Works regardless of the host folder's UID.

## Testing

`docker compose up -d --build --force-recreate openrag` — Chainlit starts without the PermissionError and populates the mounted translations folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup permissions for the translations directory.
  * Ensured the application can write translation files when running in a container as a non-root user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->