### PR TITLE
fix(chunking): match canonical GFM table delimiters (| --- | --- |)

### DIFF
--- a/openrag/core/chunking/markdown_utils.py
+++ b/openrag/core/chunking/markdown_utils.py
@@ -17,9 +17,14 @@ from typing import Literal
 
 from core.utils.text import clean_markdown_table_spacing
 
-# Header + delimiter + at least one row.
+# Header + delimiter + at least one row. The delimiter row is one or more cells
+# of ``:?-+:?`` with optional surrounding whitespace — this matches canonical GFM
+# spacing (``| --- | --- |``), alignment colons (``| :--- | ---: |``, ``| :---: |``)
+# and the tight form (``|---|---|``) alike. A previous ``\s*[:-]+(?:\s*\|[:-]+)*``
+# allowed whitespace only *before* each pipe, so a space *after* a pipe (the
+# canonical form) failed to match and the table fell through to plain text (#710).
 TABLE_RE = re.compile(
-    r"((?:^|\n)\|.*?\|\r?\n\|\s*[:-]+(?:\s*\|[:-]+)*\|\r?\n(?:\|.*?\|\r?\n)+)",
+    r"((?:^|\n)\|.*?\|\r?\n\|(?:\s*:?-+:?\s*\|)+\r?\n(?:\|.*?\|\r?\n)+)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/openrag/core/chunking/markdown_utils.py
+++ b/openrag/core/chunking/markdown_utils.py
@@ -24,10 +24,12 @@ from core.utils.text import clean_markdown_table_spacing
 # allowed whitespace only *before* each pipe, so a space *after* a pipe (the
 # canonical form) failed to match and the table fell through to plain text (#710).
 # In-cell whitespace is ``[ \t]`` (not ``\s``) so a delimiter can't span line
-# breaks and swallow following rows as one multi-line "delimiter".
+# breaks and swallow following rows as one multi-line "delimiter". No re.DOTALL,
+# so a row's ``.*?`` stays on its line (a pipe-looking text line can't be pulled
+# into a later table); the final row may end at a newline OR EOF.
 TABLE_RE = re.compile(
-    r"((?:^|\n)\|.*?\|\r?\n\|(?:[ \t]*:?-+:?[ \t]*\|)+\r?\n(?:\|.*?\|\r?\n)+)",
-    re.DOTALL | re.MULTILINE,
+    r"((?:^|\n)\|.*?\|\r?\n\|(?:[ \t]*:?-+:?[ \t]*\|)+\r?\n(?:\|.*?\|(?:\r?\n|$))+)",
+    re.MULTILINE,
 )
 
 # `<image_description>...</image_description>` block injected by the VLM step.

--- a/openrag/core/chunking/markdown_utils.py
+++ b/openrag/core/chunking/markdown_utils.py
@@ -18,13 +18,15 @@ from typing import Literal
 from core.utils.text import clean_markdown_table_spacing
 
 # Header + delimiter + at least one row. The delimiter row is one or more cells
-# of ``:?-+:?`` with optional surrounding whitespace — this matches canonical GFM
+# of ``:?-+:?`` with optional surrounding spaces/tabs — this matches canonical GFM
 # spacing (``| --- | --- |``), alignment colons (``| :--- | ---: |``, ``| :---: |``)
 # and the tight form (``|---|---|``) alike. A previous ``\s*[:-]+(?:\s*\|[:-]+)*``
 # allowed whitespace only *before* each pipe, so a space *after* a pipe (the
 # canonical form) failed to match and the table fell through to plain text (#710).
+# In-cell whitespace is ``[ \t]`` (not ``\s``) so a delimiter can't span line
+# breaks and swallow following rows as one multi-line "delimiter".
 TABLE_RE = re.compile(
-    r"((?:^|\n)\|.*?\|\r?\n\|(?:\s*:?-+:?\s*\|)+\r?\n(?:\|.*?\|\r?\n)+)",
+    r"((?:^|\n)\|.*?\|\r?\n\|(?:[ \t]*:?-+:?[ \t]*\|)+\r?\n(?:\|.*?\|\r?\n)+)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/openrag/core/chunking/markdown_utils.py
+++ b/openrag/core/chunking/markdown_utils.py
@@ -26,9 +26,12 @@ from core.utils.text import clean_markdown_table_spacing
 # In-cell whitespace is ``[ \t]`` (not ``\s``) so a delimiter can't span line
 # breaks and swallow following rows as one multi-line "delimiter". No re.DOTALL,
 # so a row's ``.*?`` stays on its line (a pipe-looking text line can't be pulled
-# into a later table); the final row may end at a newline OR EOF.
+# into a later table); the final row may end at a newline OR EOF. Each row's
+# closing pipe may be followed by ``[ \t]*`` before the line ends — GFM permits
+# trailing line whitespace, and without this a stray space after ``|`` would drop
+# the whole table back to plain text (the same failure class as #710).
 TABLE_RE = re.compile(
-    r"((?:^|\n)\|.*?\|\r?\n\|(?:[ \t]*:?-+:?[ \t]*\|)+\r?\n(?:\|.*?\|(?:\r?\n|$))+)",
+    r"((?:^|\n)\|.*?\|[ \t]*\r?\n\|(?:[ \t]*:?-+:?[ \t]*\|)+[ \t]*\r?\n(?:\|.*?\|[ \t]*(?:\r?\n|$))+)",
     re.MULTILINE,
 )
 

--- a/tests/unit/core/chunking/test_markdown_utils.py
+++ b/tests/unit/core/chunking/test_markdown_utils.py
@@ -69,6 +69,22 @@ class TestSplitMdElements:
         elems = split_md_elements(md)
         assert any(e.type == "table" for e in elems)
 
+    def test_table_at_eof_without_trailing_newline(self):
+        """A table whose last row ends at EOF (no trailing newline) is detected."""
+        md = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        elems = split_md_elements(md)
+        assert any(e.type == "table" for e in elems)
+
+    def test_pipe_text_line_before_blank_not_swallowed_into_later_table(self):
+        """A pipe-looking text line before a blank line must not be pulled into a
+        later table by ``.*?`` crossing line breaks (hedhoud review on #710)."""
+        md = "| just some | inline pipes |\n\nintro\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n"
+        elems = split_md_elements(md)
+        tables = [e for e in elems if e.type == "table"]
+        assert len(tables) == 1
+        assert "just some" not in tables[0].content
+        assert "A" in tables[0].content
+
     def test_delimiter_cannot_span_line_breaks(self):
         """In-cell whitespace is spaces/tabs only — a "delimiter" broken across
         physical lines is not a valid GFM delimiter and must not match (hedhoud

--- a/tests/unit/core/chunking/test_markdown_utils.py
+++ b/tests/unit/core/chunking/test_markdown_utils.py
@@ -93,6 +93,25 @@ class TestSplitMdElements:
         elems = split_md_elements(md)
         assert all(e.type != "table" for e in elems)
 
+    @pytest.mark.parametrize(
+        "md",
+        [
+            "| A | B |  \n| --- | --- |\n| 1 | 2 |\n",  # after header pipe
+            "| A | B |\n| --- | --- |   \n| 1 | 2 |\n",  # after delimiter pipe
+            "| A | B |\n| --- | --- |\n| 1 | 2 |  \n",  # after data-row pipe
+            "| A | B |\t\n| --- | --- |\t\n| 1 | 2 |\t\n",  # trailing tabs
+            "| A | B |  \n| --- | --- |  \n| 1 | 2 |  ",  # trailing whitespace + EOF
+        ],
+    )
+    def test_trailing_line_whitespace_still_detected_as_table(self, md):
+        """GFM permits trailing whitespace after a row's closing pipe; a stray
+        space/tab before the line end must not drop the table to plain text
+        (same failure class as #710)."""
+        elems = split_md_elements(md)
+        tables = [e for e in elems if e.type == "table"]
+        assert len(tables) == 1
+        assert "A" in tables[0].content and "1" in tables[0].content
+
     def test_single_image(self):
         md = (
             "\nText before image.\n\n<image_description>\nA beautiful sunset over the ocean.\n"

--- a/tests/unit/core/chunking/test_markdown_utils.py
+++ b/tests/unit/core/chunking/test_markdown_utils.py
@@ -6,6 +6,7 @@ preserved through the move into core/.
 
 from __future__ import annotations
 
+import pytest
 from core.chunking.markdown_utils import (
     MDElement,
     chunk_table,
@@ -37,6 +38,36 @@ class TestSplitMdElements:
         elems = split_md_elements(md)
         assert [e.type for e in elems] == ["text", "table", "text"]
         assert "Header 1" in elems[1].content
+
+    @pytest.mark.parametrize(
+        "delimiter",
+        [
+            "| --- | --- |",  # canonical GFM (spaced)
+            "|---|---|",  # tight
+            "| :--- | ---: |",  # aligned, spaced
+            "|:---|---:|",  # aligned, tight
+            "| :---: | :---: |",  # centered
+            "| - | - |",  # single dash
+        ],
+    )
+    def test_delimiter_spacing_variants_detected_as_table(self, delimiter):
+        """Canonical GFM delimiter spacing (| --- | --- |) must be recognised as a
+        table, not fall through to plain text (#710)."""
+        md = f"before\n\n| A | B |\n{delimiter}\n| 1 | 2 |\n| 3 | 4 |\n\nafter"
+        elems = split_md_elements(md)
+        assert [e.type for e in elems] == ["text", "table", "text"]
+        assert "A" in elems[1].content and "1" in elems[1].content
+
+    def test_data_rows_without_delimiter_are_not_a_table(self):
+        """A pipe block with no delimiter row must NOT be treated as a table."""
+        md = "| a | b |\n| c | d |\n| e | f |\n"
+        elems = split_md_elements(md)
+        assert all(e.type != "table" for e in elems)
+
+    def test_crlf_spaced_delimiter_detected(self):
+        md = "| A | B |\r\n| --- | --- |\r\n| 1 | 2 |\r\n"
+        elems = split_md_elements(md)
+        assert any(e.type == "table" for e in elems)
 
     def test_single_image(self):
         md = (

--- a/tests/unit/core/chunking/test_markdown_utils.py
+++ b/tests/unit/core/chunking/test_markdown_utils.py
@@ -69,6 +69,14 @@ class TestSplitMdElements:
         elems = split_md_elements(md)
         assert any(e.type == "table" for e in elems)
 
+    def test_delimiter_cannot_span_line_breaks(self):
+        """In-cell whitespace is spaces/tabs only — a "delimiter" broken across
+        physical lines is not a valid GFM delimiter and must not match (hedhoud
+        review on #710)."""
+        md = "| A | B |\n| ---\n | --- |\n| 1 | 2 |\n"
+        elems = split_md_elements(md)
+        assert all(e.type != "table" for e in elems)
+
     def test_single_image(self):
         md = (
             "\nText before image.\n\n<image_description>\nA beautiful sunset over the ocean.\n"


### PR DESCRIPTION
Closes #710.

## Problem
`TABLE_RE`'s delimiter row was `\|\s*[:-]+(?:\s*\|[:-]+)*\|` — whitespace was allowed only *before* each pipe. A space *after* a pipe (canonical GFM `| --- | --- |`, plus aligned `| :--- | ---: |` and centered `| :---: |`) failed to match, so those tables fell through to the plain-text splitter: no header replay across chunks, no table-aware handling, `chunk_type` mislabelled as text. Only the tight `|---|---|` form worked.

## Fix
Delimiter row → `\|(?:\s*:?-+:?\s*\|)+`: one or more `:?-+:?` cells with optional surrounding whitespace. Matches spaced / tight / aligned / centered / single-dash delimiters and CRLF, and still rejects non-tables (`-+` is required, so `| a | b |` data rows are not misread as a delimiter).

## Verified (no false positives, no regressions)
Ran old vs new across 9 cases: fixes spaced/aligned/centered/single-dash/CRLF, preserves tight forms, rejects delimiter-less pipe blocks and text-cell false delimiters.

## Tests
Parametrized over all 6 delimiter variants + a false-positive guard + CRLF. Reverting the regex fails the 5 spaced-variant cases.

Full suite: **1892 passed**; ruff/format/layer-guard green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of GitHub Flavored Markdown tables across more pipe-delimiter spacing variants (including aligned/compact forms).
  * Fixed an edge case where whitespace right after a pipe could prevent table recognition.
  * Ensured tables with Windows-style line endings and delimiter rows ending at EOF (no trailing newline) are handled correctly.
* **Tests**
  * Added unit tests for valid and invalid table delimiter patterns, including malformed multi-line cases and trailing whitespace within rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->