### PR TITLE
fix(retrieval): enforce workspace file scoping through to Milvus search (#706)

### DIFF
--- a/openrag/api/routers/user/search.py
+++ b/openrag/api/routers/user/search.py
@@ -164,10 +164,14 @@ async def search_multiple_partitions(
 
     filter_params = None
     if workspace:
-        ws = await workspaces.get_workspace(workspace)
-        if not ws or ws["partition_name"] not in partitions:
+        scope = await workspaces.resolve_scope(workspace, partitions)
+        if scope is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
-        filter_params = {"workspace_id": workspace}
+        # A workspace belongs to exactly one partition — narrow the search to
+        # it, otherwise file_id-only filtering could match a same-named file
+        # in another partition the caller also has access to (#706).
+        partitions = [scope.partition]
+        filter_params = {"file_id": scope.file_ids}
 
     results = await service.search(
         text=search_params.text,
@@ -249,10 +253,10 @@ async def search_one_partition(
     )
     filter_params = None
     if workspace:
-        ws = await workspaces.get_workspace(workspace)
-        if not ws or ws["partition_name"] != partition:
+        scope = await workspaces.resolve_scope(workspace, [partition])
+        if scope is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
-        filter_params = {"workspace_id": workspace}
+        filter_params = {"file_id": scope.file_ids}
 
     results = await service.search(
         text=search_params.text,
@@ -322,19 +326,18 @@ async def search_file(
         partition=partition, file_id=file_id, query_len=len(search_params.text), top_k=search_params.top_k
     )
 
-    # Parenthesise the caller filter so it stays a single AND-operand and can't
-    # break out of the file scope (e.g. ``page > 5 OR 1==1`` must not widen the
-    # ``file_id ==`` constraint). It is already validated by CommonSearchParams.
-    filter = "file_id == {_file_id}" + (f" AND ({search_params.filter})" if search_params.filter else "")
-    params = {"_file_id": file_id}
-
+    # The file_id restriction goes through filter_params (parameterized), not
+    # string-templated into `filter` — the store ANDs every filter_params key
+    # with the raw `filter` expr and parenthesises each operand, so a caller
+    # filter like ``page > 5 OR 1==1`` cannot widen the file_id scope. It is
+    # already validated by CommonSearchParams.
     results = await service.search(
         text=search_params.text,
         partitions=partition,
         top_k=search_params.top_k,
         similarity_threshold=search_params.similarity_threshold,
-        filter=filter,
-        filter_params=params,
+        filter=search_params.filter,
+        filter_params={"file_id": file_id},
     )
     log.info("Semantic search on specific file completed.", result_count=len(results))
 

--- a/openrag/core/models/workspace.py
+++ b/openrag/core/models/workspace.py
@@ -22,4 +22,18 @@ class Workspace(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
-__all__ = ["Workspace"]
+class WorkspaceScope(BaseModel):
+    """Authorization-checked search scope resolved from a workspace_id.
+
+    ``file_ids`` is the authoritative Milvus ``file_id`` allowlist — an
+    empty list is a valid state (a workspace with no files yet) and must
+    restrict a search to zero results, never fall back to the full
+    ``partition``.
+    """
+
+    workspace_id: str
+    partition: str
+    file_ids: list[str] = Field(default_factory=list)
+
+
+__all__ = ["Workspace", "WorkspaceScope"]

--- a/openrag/core/retrieval/pipeline.py
+++ b/openrag/core/retrieval/pipeline.py
@@ -118,7 +118,7 @@ class RetrieverPipeline:
         if self.expansion_enabled:
             limit = self.reranker_top_k if top_k is None else max(self.reranker_top_k, top_k)
             head = copy.deepcopy(chunks[:limit])
-            expanded = await self.retriever.expand_search_results(results=head)
+            expanded = await self.retriever.expand_search_results(results=head, filter_params=filter_params)
             if len(expanded) > len(head):
                 chunks = expanded
                 if self.reranker_enabled:

--- a/openrag/core/retrieval/retriever.py
+++ b/openrag/core/retrieval/retriever.py
@@ -29,7 +29,7 @@ from core.prompts.query_rewriter import (
     build_multi_query_prompt,
     split_multi_query_response,
 )
-from core.retrieval.searcher import RetrievalSearcher
+from core.retrieval.searcher import RetrievalSearcher, file_id_restriction
 from core.utils.registry import Registry
 
 logger = logging.getLogger(__name__)
@@ -50,8 +50,13 @@ class Retriever(ABC):
         ...
 
     @abstractmethod
-    async def expand_search_results(self, results: list[Chunk]) -> list[Chunk]:
-        """Optionally enrich a result set with related/ancestor chunks."""
+    async def expand_search_results(self, results: list[Chunk], filter_params: dict | None = None) -> list[Chunk]:
+        """Optionally enrich a result set with related/ancestor chunks.
+
+        ``filter_params`` carries the same restriction (e.g. a workspace's
+        ``file_id`` allowlist) the initial search was scoped by — expansion
+        must never surface a chunk that restriction would have excluded.
+        """
         ...
 
 
@@ -97,7 +102,7 @@ class BaseRetriever(Retriever):
             with_surrounding_chunks=self.with_surrounding_chunks,
         )
 
-    async def expand_search_results(self, results: list[Chunk]) -> list[Chunk]:
+    async def expand_search_results(self, results: list[Chunk], filter_params: dict | None = None) -> list[Chunk]:
         return await _expand_with_related_chunks(
             searcher=self.searcher,
             results=results,
@@ -105,6 +110,7 @@ class BaseRetriever(Retriever):
             include_ancestors=self.include_ancestors,
             related_limit=self.related_limit,
             max_ancestor_depth=self.max_ancestor_depth,
+            filter_params=filter_params,
         )
 
 
@@ -214,16 +220,23 @@ async def _expand_with_related_chunks(
     include_ancestors: bool,
     related_limit: int = 10,
     max_ancestor_depth: int | None = None,
+    filter_params: dict | None = None,
 ) -> list[Chunk]:
     """Append related and/or ancestor chunks to a result set, deduplicated by id.
 
     Failures on individual related/ancestor lookups are logged and treated
     as empty results, matching legacy behavior so retrieval remains
     resilient to per-document errors.
+
+    ``filter_params`` carries the same restriction the initial search was
+    scoped by (e.g. a workspace's ``file_id`` allowlist) — passed through so
+    related/ancestor expansion cannot surface a chunk outside that scope
+    (#706).
     """
     if not results or (not include_related and not include_ancestors):
         return results
 
+    allowed_file_ids = file_id_restriction(filter_params)
     seen_ids = {c.id for c in results if c.id}
     expanded: list[Chunk] = list(results)
 
@@ -240,7 +253,9 @@ async def _expand_with_related_chunks(
 
     async def _safe_related(part: str, rel_id: str) -> list[Chunk]:
         try:
-            return await searcher.get_related_chunks(partition=part, relationship_id=rel_id, limit=related_limit)
+            return await searcher.get_related_chunks(
+                partition=part, relationship_id=rel_id, limit=related_limit, allowed_file_ids=allowed_file_ids
+            )
         except Exception:
             logger.warning("get_related_chunks failed (partition=%s, relationship_id=%s)", part, rel_id, exc_info=True)
             return []
@@ -252,6 +267,7 @@ async def _expand_with_related_chunks(
                 file_id=file_id,
                 limit=related_limit,
                 max_ancestor_depth=max_ancestor_depth,
+                allowed_file_ids=allowed_file_ids,
             )
         except Exception:
             logger.warning("get_ancestor_chunks failed (partition=%s, file_id=%s)", part, file_id, exc_info=True)

--- a/openrag/core/retrieval/searcher.py
+++ b/openrag/core/retrieval/searcher.py
@@ -28,6 +28,23 @@ from abc import ABC, abstractmethod
 from core.models.chunk import Chunk
 
 
+def file_id_restriction(filter_params: dict | None) -> list[str] | None:
+    """Extract a ``file_id`` allowlist from a ``filter_params`` dict, if any.
+
+    Normalises both shapes callers use: a list (workspace scoping —
+    ``{"file_id": [...]}``) and a scalar (single-file search —
+    ``{"file_id": "abc123"}``). Returns ``None`` when no ``file_id``
+    restriction is present, which callers must treat as "unrestricted" —
+    an empty list means "restricted to nothing" and is a different thing.
+    """
+    if not filter_params or "file_id" not in filter_params:
+        return None
+    value = filter_params["file_id"]
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
 class RetrievalSearcher(ABC):
     """Operations a retriever needs from the chunk store."""
 
@@ -65,8 +82,14 @@ class RetrievalSearcher(ABC):
         partition: str,
         relationship_id: str,
         limit: int,
+        allowed_file_ids: list[str] | None = None,
     ) -> list[Chunk]:
-        """Fetch other chunks belonging to the same relationship group."""
+        """Fetch other chunks belonging to the same relationship group.
+
+        ``allowed_file_ids``, when not ``None``, restricts results to that
+        file-id set (workspace scoping) — expansion must never surface a
+        related file outside the caller's authorized scope.
+        """
         ...
 
     @abstractmethod
@@ -76,6 +99,12 @@ class RetrievalSearcher(ABC):
         file_id: str,
         limit: int,
         max_ancestor_depth: int | None = None,
+        allowed_file_ids: list[str] | None = None,
     ) -> list[Chunk]:
-        """Walk parent links up the document tree from a file."""
+        """Walk parent links up the document tree from a file.
+
+        ``allowed_file_ids``, when not ``None``, restricts results to that
+        file-id set (workspace scoping) — expansion must never surface an
+        ancestor file outside the caller's authorized scope.
+        """
         ...

--- a/openrag/core/utils/exceptions.py
+++ b/openrag/core/utils/exceptions.py
@@ -16,6 +16,7 @@ The hierarchy is organised by concern:
     |   +-- DocumentNotFoundError
     |   +-- PartitionNotFoundError
     |   +-- UserNotFoundError
+    |   +-- WorkspaceNotFoundError
     +-- ConflictError                    (409)
     +-- QuotaExceededError               (429)
     +-- ServiceUnavailableError          (503)
@@ -166,6 +167,18 @@ class PartitionNotFoundError(NotFoundError):
 class UserNotFoundError(NotFoundError):
     def __init__(self, message: str, **kwargs):
         super().__init__(message, code="USER_NOT_FOUND", **kwargs)
+
+
+class WorkspaceNotFoundError(NotFoundError):
+    """Workspace missing or not accessible in the requested partition(s).
+
+    Used for both "no such workspace" and "workspace exists in a partition
+    the caller cannot access" — the two are intentionally indistinguishable
+    so an inaccessible workspace never reveals its existence.
+    """
+
+    def __init__(self, message: str, **kwargs):
+        super().__init__(message, code="WORKSPACE_NOT_FOUND", **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/openrag/services/orchestrators/mcp_service.py
+++ b/openrag/services/orchestrators/mcp_service.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import asyncio
 import difflib
 import ipaddress
-import json
 import mimetypes
 import socket
 import tempfile
@@ -222,19 +221,14 @@ class MCPService:
             raise ValueError("top_k must be greater than 0")
         effective_top_k = min(effective_top_k, self.max_top_k)
 
-        # Inline the file_id as a literal Milvus expression rather than using
-        # the templated ``filter_params`` form: the shared VectorStoreSearcher
-        # forwards the raw ``filter`` string to Milvus but drops
-        # ``filter_params``, so a ``{var}`` placeholder would never be bound.
-        # ``json.dumps`` yields a correctly quoted/escaped string literal.
-        search_filter = f"file_id == {json.dumps(file_id)}" if file_id is not None else None
+        filter_params = {"file_id": file_id} if file_id is not None else None
 
         chunks = await self._retrieval.search(
             text=normalized_query,
             partitions=scoped,
             top_k=effective_top_k,
             similarity_threshold=self.similarity_threshold,
-            filter=search_filter,
+            filter_params=filter_params,
         )
         documents = [self._shape_chunk(c) for c in chunks]
         return {

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -49,6 +49,7 @@ from core.prompts import (
     format_web_context,
     load_template_by_key,
 )
+from core.utils.exceptions import WorkspaceNotFoundError
 from core.utils.logging import get_logger
 from core.utils.source_filtering import (
     extract_and_strip_sources_block,
@@ -330,12 +331,17 @@ class QueryService:
 
         top_k = self._mr_max if use_map_reduce else None
 
-        if workspace:
-            ws = await self._workspace.get_workspace(workspace)
-            if not ws or ("all" not in partition and ws["partition_name"] not in partition):
-                logger.warning("Workspace not found in partition(s) — ignoring", workspace=workspace)
-                workspace = None
-        filter_params = {"workspace_id": workspace} if workspace else None
+        filter_params = None
+        if workspace and partition:
+            scope = await self._workspace.resolve_scope(workspace, partition)
+            if scope is None:
+                raise WorkspaceNotFoundError(f"Workspace '{workspace}' not found.")
+            # A workspace belongs to exactly one partition — narrow retrieval to
+            # it even for an "openrag-all" / multi-partition request, otherwise
+            # file_id-only filtering could match a same-named file in another
+            # partition the caller also has access to (#706).
+            partition = [scope.partition]
+            filter_params = {"file_id": scope.file_ids}
 
         web_results: list = []
         if partition is not None and use_websearch:

--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -263,6 +263,7 @@ class RetrievalService:
                 include_ancestors=include_ancestors,
                 related_limit=related_limit,
                 max_ancestor_depth=max_ancestor_depth,
+                filter_params=filter_params,
             )
         return chunks
 

--- a/openrag/services/orchestrators/workspace_service.py
+++ b/openrag/services/orchestrators/workspace_service.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from core.models.workspace import WorkspaceScope
 from core.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -93,6 +94,35 @@ class WorkspaceService:
 
     async def get_file_workspaces(self, file_id: str, partition: str) -> list[str]:
         return await self._workspace_repo.get_file_workspaces(file_id, partition)
+
+    # ------------------------------------------------------------------
+    # Search-scope resolution (single source of truth for workspace-scoped
+    # search / chat — issue #706)
+    # ------------------------------------------------------------------
+
+    async def resolve_scope(self, workspace_id: str, allowed_partitions: list[str]) -> WorkspaceScope | None:
+        """Resolve ``workspace_id`` to its owning partition and file allowlist.
+
+        Returns ``None`` when the workspace does not exist *or* exists in a
+        partition outside ``allowed_partitions`` — the two cases are
+        intentionally indistinguishable to the caller so a workspace living
+        in another tenant's partition is never revealed to exist. ``"all"``
+        in ``allowed_partitions`` (the ``openrag-all`` / multi-partition
+        sentinel) accepts a workspace from any partition, matching how
+        partition access is resolved elsewhere.
+
+        The returned ``file_ids`` may be empty — a workspace with no files
+        yet is valid and must scope the search to zero results, not fall
+        back to the full partition.
+        """
+        ws = await self._workspace_repo.get_workspace_dict(workspace_id)
+        if not ws:
+            return None
+        partition = ws["partition_name"]
+        if "all" not in allowed_partitions and partition not in allowed_partitions:
+            return None
+        file_ids = await self._workspace_repo.list_workspace_files(workspace_id)
+        return WorkspaceScope(workspace_id=workspace_id, partition=partition, file_ids=file_ids)
 
     # ------------------------------------------------------------------
     # Cross-cutting: delete workspace + clean up orphaned files

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -445,6 +445,11 @@ class MilvusVectorStore(VectorStore):
     # must go through :meth:`drop_collection`.
     _TAUTOLOGICAL_EXPRS = frozenset({"true", "1==1"})
 
+    # Always-false predicate for an empty ``IN`` list. Milvus 2.6 rejects a
+    # bare ``false`` literal ("predicate is not a boolean expression"), so the
+    # match-nothing sentinel must be a comparison it can plan.
+    _MATCH_NOTHING_EXPR = "1 == 0"
+
     @staticmethod
     def _format_value(value: Any) -> str:
         """Render a scalar as a Milvus filter literal.
@@ -473,7 +478,9 @@ class MilvusVectorStore(VectorStore):
               for callers that need operators the dict form cannot express.
             * Any other key with a scalar value becomes ``key == <literal>``.
             * Any other key with a list/tuple value becomes ``key in [...]``.
-              Empty list/tuple short-circuits to ``"false"`` (matches no row).
+              Empty list/tuple short-circuits to :data:`_MATCH_NOTHING_EXPR`
+              (an always-false comparison Milvus can plan — a bare ``false``
+              literal is rejected).
 
         Workspace-id resolution, role checks, and other PG concerns are
         upstream concerns — they resolve to ``file_id`` lists before reaching
@@ -500,7 +507,7 @@ class MilvusVectorStore(VectorStore):
                 continue  # already handled above
             if isinstance(value, (list, tuple)):
                 if not value:
-                    return "false"  # empty IN list — match nothing
+                    return self._MATCH_NOTHING_EXPR  # empty IN list — match nothing
                 quoted = ", ".join(self._format_value(v) for v in value)
                 parts.append(f"{key} in [{quoted}]")
             else:

--- a/openrag/services/storage/vector_store_searcher.py
+++ b/openrag/services/storage/vector_store_searcher.py
@@ -13,7 +13,7 @@ from typing import Any
 from core.embeddings import Embedder
 from core.models.chunk import Chunk, _coerce_chunk_type
 from core.ports.document_repo import DocumentRepository
-from core.retrieval.searcher import RetrievalSearcher
+from core.retrieval.searcher import RetrievalSearcher, file_id_restriction
 from core.utils.conts import is_internal_metadata_key
 from core.vector_stores import VectorStore
 
@@ -73,6 +73,8 @@ class VectorStoreSearcher(RetrievalSearcher):
         filters: dict[str, Any] = {"partition": partition}
         if filter:
             filters["expr"] = filter
+        if filter_params:
+            filters.update(filter_params)
         results = await self._store.search(
             embedding=embedding,
             query_text=query,
@@ -83,7 +85,7 @@ class VectorStoreSearcher(RetrievalSearcher):
         )
         chunks = [_dict_to_chunk(r) for r in results]
         if with_surrounding_chunks and chunks:
-            surrounding = await self._fetch_surrounding(chunks)
+            surrounding = await self._fetch_surrounding(chunks, allowed_file_ids=file_id_restriction(filter_params))
             seen = {c.id for c in chunks}
             chunks.extend(c for c in surrounding if c.id not in seen)
         return chunks
@@ -102,6 +104,8 @@ class VectorStoreSearcher(RetrievalSearcher):
         filters: dict[str, Any] = {"partition": partition}
         if filter:
             filters["expr"] = filter
+        if filter_params:
+            filters.update(filter_params)
         per_query = await asyncio.gather(
             *[
                 self._store.search(
@@ -124,7 +128,7 @@ class VectorStoreSearcher(RetrievalSearcher):
                     seen_ids.add(c.id)
                     chunks.append(c)
         if with_surrounding_chunks and chunks:
-            surrounding = await self._fetch_surrounding(chunks)
+            surrounding = await self._fetch_surrounding(chunks, allowed_file_ids=file_id_restriction(filter_params))
             chunks.extend(c for c in surrounding if c.id not in seen_ids)
         return chunks
 
@@ -133,10 +137,14 @@ class VectorStoreSearcher(RetrievalSearcher):
         partition: str,
         relationship_id: str,
         limit: int,
+        allowed_file_ids: list[str] | None = None,
     ) -> list[Chunk]:
         file_ids = await self._document_repo.get_file_ids_by_relationship(
             partition=partition, relationship_id=relationship_id
         )
+        if allowed_file_ids is not None:
+            allowed = set(allowed_file_ids)
+            file_ids = [f for f in file_ids if f in allowed]
         if not file_ids:
             return []
         rows = await self._store.query_chunks_by_filter(
@@ -151,10 +159,14 @@ class VectorStoreSearcher(RetrievalSearcher):
         file_id: str,
         limit: int,
         max_ancestor_depth: int | None = None,
+        allowed_file_ids: list[str] | None = None,
     ) -> list[Chunk]:
         ancestor_ids = await self._document_repo.get_ancestor_file_ids(
             partition=partition, file_id=file_id, max_ancestor_depth=max_ancestor_depth
         )
+        if allowed_file_ids is not None:
+            allowed = set(allowed_file_ids)
+            ancestor_ids = [f for f in ancestor_ids if f in allowed]
         if not ancestor_ids:
             return []
         rows = await self._store.query_chunks_by_filter(
@@ -163,7 +175,7 @@ class VectorStoreSearcher(RetrievalSearcher):
         )
         return [_dict_to_chunk(r) for r in rows[:limit]]
 
-    async def _fetch_surrounding(self, chunks: list[Chunk]) -> list[Chunk]:
+    async def _fetch_surrounding(self, chunks: list[Chunk], allowed_file_ids: list[str] | None = None) -> list[Chunk]:
         # section_id is only unique within a partition, so the lookup MUST be
         # scoped to each source chunk's partition; otherwise a neighbouring
         # section_id could resolve to another tenant's chunk (cross-tenant leak,
@@ -178,12 +190,18 @@ class VectorStoreSearcher(RetrievalSearcher):
                     by_partition.setdefault(c.partition, []).append(sid)
         if not by_partition:
             return []
+        allowed = set(allowed_file_ids) if allowed_file_ids is not None else None
         results: list[Chunk] = []
         for partition, section_ids in by_partition.items():
             rows = await self._store.query_chunks_by_filter(
                 self._collection,
                 {"section_id": section_ids, "partition": partition},
             )
+            if allowed is not None:
+                # A neighbouring section can belong to an adjacent file that sits
+                # outside the caller's workspace/file scope — filter it out rather
+                # than trusting section adjacency alone (workspace scoping, #706).
+                rows = [r for r in rows if r.get("file_id") in allowed]
             results.extend(_dict_to_chunk(r) for r in rows)
         return results
 

--- a/tests/integration/repos/test_workspace_scoping_e2e.py
+++ b/tests/integration/repos/test_workspace_scoping_e2e.py
@@ -1,0 +1,186 @@
+"""End-to-end regression test for issue #706 — workspace scoping.
+
+Exercises the real fix across the two systems that matter: Postgres (workspace
+membership, via ``WorkspaceService.resolve_scope``) and Milvus (the actual
+vector search, via ``VectorStoreSearcher``). No LLM/embedder service is
+needed — embeddings are hand-crafted and deterministic, same pattern as
+``test_milvus_store_integration.py``.
+
+Scenario (matches the issue's end-to-end verification plan):
+    * partition A contains ``included-file`` and ``excluded-file``
+    * partition B contains a *different* file sharing the same ``file_id`` as
+      the included one — proving file_id-only filtering can't leak across
+      partitions once the workspace's owning partition is enforced
+    * a workspace in partition A contains only ``included-file``
+
+A workspace-scoped, cross-partition ("all") search must return only the
+included file's chunks. Removing the file from the workspace must then
+return zero results — never fall back to the full partition.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from core.config.infrastructure import VectorDBConfig
+from core.embeddings.embedder import Embedder
+from core.models.catalog import DocumentRecord
+from core.models.chunk import Chunk
+from core.models.workspace import Workspace
+from services.orchestrators.workspace_service import WorkspaceService
+from services.storage.milvus_store import MilvusVectorStore
+from services.storage.postgres_store import PostgresStore
+from services.storage.vector_store_searcher import VectorStoreSearcher
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+_DIM = 4
+_QUERY_VEC = [1.0, 0.0, 0.0, 0.0]
+
+
+class _FixedEmbedder(Embedder):
+    """Always embeds to the same vector — this test is about scoping, not
+    ranking quality, so every chunk is an equally-good nearest neighbor and
+    filtering is the only thing that can exclude one."""
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [list(_QUERY_VEC) for _ in texts]
+
+    async def embed_single(self, text: str) -> list[float]:
+        return list(_QUERY_VEC)
+
+    @property
+    def dimension(self) -> int:
+        return _DIM
+
+
+def _milvus_reachable(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.fixture(scope="module")
+def milvus_host_port() -> tuple[str, int]:
+    host = os.getenv("OPENRAG_TEST_VDB_HOST", "localhost")
+    port = int(os.getenv("OPENRAG_TEST_VDB_PORT", "19530"))
+    return host, port
+
+
+@pytest.fixture(scope="module")
+def _live_milvus(milvus_host_port: tuple[str, int]) -> None:
+    host, port = milvus_host_port
+    if not _milvus_reachable(host, port):
+        pytest.skip(f"Milvus not reachable at {host}:{port} — skipping integration tests")
+
+
+@pytest.fixture
+async def milvus_store(_live_milvus: None, milvus_host_port: tuple[str, int]) -> Iterator[MilvusVectorStore]:
+    host, port = milvus_host_port
+    collection = f"itest_ws706_{uuid.uuid4().hex[:12]}"
+    config = VectorDBConfig(host=host, port=port, collection_name=collection, hybrid_search=False, schema_version=1)
+    store = MilvusVectorStore(config)
+    await store.initialize(_DIM)
+    try:
+        yield store
+    finally:
+        await store.drop_collection(collection)
+
+
+@pytest.fixture
+def searcher(milvus_store: MilvusVectorStore) -> VectorStoreSearcher:
+    return VectorStoreSearcher(
+        vector_store=milvus_store,
+        embedder=_FixedEmbedder(),
+        document_repo=None,  # not exercised — no related/ancestor expansion here
+        collection=milvus_store._collection_name,
+    )
+
+
+def _chunk(partition: str, file_id: str, text: str) -> Chunk:
+    return Chunk(document_id=file_id, text=text, partition=partition, embedding=list(_QUERY_VEC))
+
+
+async def _seed_document(postgres_store: PostgresStore, partition: str, file_id: str) -> None:
+    await postgres_store.document_repo.create_document(
+        DocumentRecord(id=f"{partition}-{file_id}", file_id=file_id, partition=partition, filename=f"{file_id}.txt"),
+    )
+
+
+class TestWorkspaceScopingAcrossPartitions:
+    async def test_workspace_scoped_search_excludes_sibling_and_cross_partition_file(
+        self,
+        postgres_store: PostgresStore,
+        milvus_store: MilvusVectorStore,
+        searcher: VectorStoreSearcher,
+    ):
+        part_a, part_b = f"a-{uuid.uuid4().hex[:8]}", f"b-{uuid.uuid4().hex[:8]}"
+        await postgres_store.partition_repo.create_partition(part_a)
+        await postgres_store.partition_repo.create_partition(part_b)
+        for fid in ("included-file", "excluded-file"):
+            await _seed_document(postgres_store, part_a, fid)
+        await _seed_document(postgres_store, part_b, "included-file")  # same file_id, different partition
+
+        await milvus_store.upsert(
+            [
+                _chunk(part_a, "included-file", "the one that should come back"),
+                _chunk(part_a, "excluded-file", "must never be returned"),
+                _chunk(part_b, "included-file", "same file_id, wrong partition — must never leak"),
+            ]
+        )
+
+        workspace_service = WorkspaceService(
+            workspace_repo=postgres_store.workspace_repo,
+            document_repo=postgres_store.document_repo,
+            vector_store=milvus_store,
+            collection=milvus_store._collection_name,
+        )
+        ws_id = f"ws-{uuid.uuid4().hex[:8]}"
+        await postgres_store.workspace_repo.create_workspace(Workspace(workspace_id=ws_id, partition=part_a))
+        missing = await workspace_service.add_files(ws_id, ["included-file"])
+        assert missing == []
+
+        # A caller with access to both partitions searches "all" with the workspace set.
+        scope = await workspace_service.resolve_scope(ws_id, [part_a, part_b])
+        assert scope is not None
+        assert scope.partition == part_a  # narrowed to the workspace's own partition
+
+        results = await searcher.search(
+            query="anything",
+            partition=[scope.partition],  # production code narrows to this, not [part_a, part_b]
+            top_k=10,
+            filter_params={"file_id": scope.file_ids},
+            with_surrounding_chunks=False,
+        )
+        texts = {c.text for c in results}
+        assert texts == {"the one that should come back"}
+
+        # Now unassign the file — the workspace is valid but empty.
+        assert await workspace_service.remove_file(ws_id, "included-file") is True
+        empty_scope = await workspace_service.resolve_scope(ws_id, [part_a, part_b])
+        assert empty_scope.file_ids == []
+
+        empty_results = await searcher.search(
+            query="anything",
+            partition=[empty_scope.partition],
+            top_k=10,
+            filter_params={"file_id": empty_scope.file_ids},
+            with_surrounding_chunks=False,
+        )
+        # Must be empty — never fall back to every document in the partition.
+        assert empty_results == []
+
+    async def test_resolve_scope_none_for_unknown_workspace(self, postgres_store: PostgresStore):
+        workspace_service = WorkspaceService(
+            workspace_repo=postgres_store.workspace_repo,
+            document_repo=postgres_store.document_repo,
+            vector_store=None,
+            collection="unused",
+        )
+        assert await workspace_service.resolve_scope("does-not-exist", ["all"]) is None

--- a/tests/unit/api/routers/user/test_search.py
+++ b/tests/unit/api/routers/user/test_search.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from api.dependencies.auth import (
     current_user,
     current_user_or_admin_partitions_list,
@@ -65,9 +67,12 @@ def test_search_rejects_cross_tenant_filter_injection():
     assert "INVALID_FILTER" in response.json()["detail"]
 
 
-def test_search_file_parenthesises_caller_filter():
-    # The by-file route must wrap the caller filter so an OR predicate cannot
-    # widen the file_id scope (``page > 5 OR 1==1`` must stay a single operand).
+def test_search_file_binds_file_id_via_filter_params():
+    # The by-file route must bind file_id through filter_params (parameterized),
+    # not by string-templating it into `filter` — the store ANDs each
+    # filter_params key with the raw filter expr and parenthesises every
+    # operand, so a caller filter like ``page > 5 OR 1==1`` cannot widen the
+    # file_id scope.
     from api.dependencies.auth import require_partition_viewer
     from api.dependencies.files import validate_file_id
 
@@ -90,4 +95,131 @@ def test_search_file_parenthesises_caller_filter():
     )
 
     assert resp.status_code == 200
-    assert captured["filter"] == "file_id == {_file_id} AND (page > 5 OR page < 2)"
+    assert captured["filter"] == "page > 5 OR page < 2"
+    assert captured["filter_params"] == {"file_id": "abc123"}
+
+
+# --------------------------------------------------------------------------- #
+# Workspace scoping (issue #706)
+# --------------------------------------------------------------------------- #
+
+
+class _CapturingRetrieval:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def search(self, **kwargs):
+        self.calls.append(kwargs)
+        return []
+
+
+class _FakeWorkspaces:
+    def __init__(self, scope=None):
+        self._scope = scope
+        self.resolve_scope_calls: list[tuple] = []
+
+    async def resolve_scope(self, workspace_id, allowed_partitions):
+        self.resolve_scope_calls.append((workspace_id, list(allowed_partitions)))
+        return self._scope
+
+
+def _client_with_workspace(*, user_partitions, workspaces, retrieval):
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[current_user] = lambda: {"id": 7, "is_admin": False}
+    app.dependency_overrides[current_user_partitions] = lambda: user_partitions
+    app.dependency_overrides[current_user_or_admin_partitions_list] = lambda: [
+        row["partition"] for row in user_partitions
+    ]
+    app.dependency_overrides[get_auth_service] = lambda: _AuthService
+    app.dependency_overrides[get_partition_service] = lambda: _PartitionService()
+    app.dependency_overrides[get_retrieval_service] = lambda: retrieval
+    app.dependency_overrides[get_workspace_service] = lambda: workspaces
+    return TestClient(app)
+
+
+def test_search_multiple_partitions_valid_workspace_scopes_partition_and_files():
+    scope = SimpleNamespace(workspace_id="w1", partition="mine", file_ids=["fa", "fb"])
+    retrieval = _CapturingRetrieval()
+    client = _client_with_workspace(
+        user_partitions=[{"partition": "mine", "role": "viewer"}, {"partition": "other", "role": "viewer"}],
+        workspaces=_FakeWorkspaces(scope),
+        retrieval=retrieval,
+    )
+    resp = client.get("/search", params={"text": "hello", "workspace": "w1"})
+
+    assert resp.status_code == 200
+    call = retrieval.calls[0]
+    # Must narrow to the workspace's own partition, not the full accessible set.
+    assert call["partitions"] == ["mine"]
+    assert call["filter_params"] == {"file_id": ["fa", "fb"]}
+
+
+def test_search_multiple_partitions_invalid_workspace_404s_and_skips_search():
+    retrieval = _CapturingRetrieval()
+    client = _client_with_workspace(
+        user_partitions=[{"partition": "mine", "role": "viewer"}],
+        workspaces=_FakeWorkspaces(None),
+        retrieval=retrieval,
+    )
+    resp = client.get("/search", params={"text": "hello", "workspace": "ghost"})
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Workspace not found"
+    assert retrieval.calls == []  # never falls back to an unscoped search
+
+
+def test_search_one_partition_valid_workspace_scopes_files():
+    from api.dependencies.auth import require_partition_viewer
+
+    scope = SimpleNamespace(workspace_id="w1", partition="mine", file_ids=["fa"])
+    retrieval = _CapturingRetrieval()
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[require_partition_viewer] = lambda: None
+    app.dependency_overrides[get_retrieval_service] = lambda: retrieval
+    app.dependency_overrides[get_workspace_service] = lambda: _FakeWorkspaces(scope)
+
+    resp = TestClient(app).get("/search/partition/mine", params={"text": "hello", "workspace": "w1"})
+
+    assert resp.status_code == 200
+    assert retrieval.calls[0]["filter_params"] == {"file_id": ["fa"]}
+
+
+def test_search_one_partition_empty_workspace_forwards_empty_file_ids():
+    from api.dependencies.auth import require_partition_viewer
+
+    scope = SimpleNamespace(workspace_id="w1", partition="mine", file_ids=[])
+    retrieval = _CapturingRetrieval()
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[require_partition_viewer] = lambda: None
+    app.dependency_overrides[get_retrieval_service] = lambda: retrieval
+    app.dependency_overrides[get_workspace_service] = lambda: _FakeWorkspaces(scope)
+
+    resp = TestClient(app).get("/search/partition/mine", params={"text": "hello", "workspace": "w1"})
+
+    assert resp.status_code == 200
+    # Must stay an explicit empty allowlist (fails closed), never omitted/None.
+    assert retrieval.calls[0]["filter_params"] == {"file_id": []}
+
+
+def test_search_one_partition_invalid_workspace_404s():
+    from api.dependencies.auth import require_partition_viewer
+
+    retrieval = _CapturingRetrieval()
+    app = FastAPI()
+    register_error_handlers(app)
+    app.include_router(search_router, prefix="/search")
+    app.dependency_overrides[require_partition_viewer] = lambda: None
+    app.dependency_overrides[get_retrieval_service] = lambda: retrieval
+    app.dependency_overrides[get_workspace_service] = lambda: _FakeWorkspaces(None)
+
+    resp = TestClient(app).get("/search/partition/mine", params={"text": "hello", "workspace": "ghost"})
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Workspace not found"
+    assert retrieval.calls == []

--- a/tests/unit/core/retrieval/test_pipeline.py
+++ b/tests/unit/core/retrieval/test_pipeline.py
@@ -17,6 +17,7 @@ class FakeRetriever(Retriever):
         self.results_queue: list[list[Chunk]] = []
         self.expand_input: list[Chunk] | None = None
         self.expand_result: list[Chunk] | None = None
+        self.expand_filter_params: dict | None = None
         self.expansion_enabled = expansion_enabled
 
     async def retrieve(self, partition, query, filter=None, filter_params=None):
@@ -25,8 +26,9 @@ class FakeRetriever(Retriever):
             return self.results_queue.pop(0)
         return []
 
-    async def expand_search_results(self, results):
+    async def expand_search_results(self, results, filter_params=None):
         self.expand_input = list(results)
+        self.expand_filter_params = filter_params
         return list(self.expand_result) if self.expand_result is not None else list(results)
 
 

--- a/tests/unit/services/orchestrators/test_mcp_service.py
+++ b/tests/unit/services/orchestrators/test_mcp_service.py
@@ -254,9 +254,9 @@ async def test_search_file_id_builds_filter():
     svc = _service(retrieval=retrieval)
     await svc.search_documents(query="hi", partitions=["a"], top_k=3, allowed_partitions=["a"], file_id="f1")
     call = retrieval.calls[0]
-    # Inlined as a literal expr (the shared searcher drops filter_params).
-    assert call["filter"] == 'file_id == "f1"'
-    assert "filter_params" not in call
+    # Bound through filter_params (parameterized), not a hand-built literal expr.
+    assert call["filter_params"] == {"file_id": "f1"}
+    assert call.get("filter") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -17,6 +17,8 @@ import pytest
 import services.orchestrators.query_service as qs
 from core.config import load_config
 from core.models.chunk import Chunk
+from core.models.workspace import WorkspaceScope
+from core.utils.exceptions import WorkspaceNotFoundError
 from services.orchestrators.query_service import QueryService
 
 # Real prompt-template config (dir + key->filename mapping) so QueryService
@@ -60,11 +62,15 @@ class FakeLLM:
 class FakeRetrieval:
     def __init__(self, chunks=None):
         self._chunks = chunks if chunks is not None else [Chunk(id="c1", text="ctx", metadata={"_id": "c1"})]
+        self.retrieve_multi_calls: list[dict] = []
+        self.retrieve_per_query_calls: list[dict] = []
 
     async def retrieve_multi(self, **kwargs):
+        self.retrieve_multi_calls.append(kwargs)
         return list(self._chunks)
 
     async def retrieve_per_query(self, *, queries, **kwargs):
+        self.retrieve_per_query_calls.append({"queries": queries, **kwargs})
         return [list(self._chunks) for _ in queries]
 
     @staticmethod
@@ -83,8 +89,14 @@ class FakeWeb:
 
 
 class FakeWorkspace:
+    def __init__(self, scope=None):
+        self._scope = scope
+
     async def get_workspace(self, wid):
         return None
+
+    async def resolve_scope(self, workspace_id, allowed_partitions):
+        return self._scope
 
 
 def _config(mode="SimpleRag"):
@@ -99,13 +111,13 @@ def _config(mode="SimpleRag"):
     )
 
 
-def _svc(*, llm=None, retrieval=None, web=None, mode="SimpleRag", llm_factory=None) -> QueryService:
+def _svc(*, llm=None, retrieval=None, web=None, mode="SimpleRag", llm_factory=None, workspace=None) -> QueryService:
     return QueryService(
         retrieval_service=retrieval or FakeRetrieval(),
         llm=llm or FakeLLM(),
         config=_config(mode),
         web_search_service=web or FakeWeb(),
-        workspace_service=FakeWorkspace(),
+        workspace_service=workspace or FakeWorkspace(),
         llm_factory=llm_factory,
     )
 
@@ -347,6 +359,104 @@ async def test_chat_with_partition_retrieves_and_filters_sources():
     )
     filtered = json.loads(out["extra"])["sources"]
     assert filtered == [{"source_type": "document", "n": 1}]  # only cited source 1
+
+
+@pytest.mark.asyncio
+async def test_chat_with_valid_workspace_scopes_search_to_file_ids():
+    scope = WorkspaceScope(workspace_id="w1", partition="p1", file_ids=["fa", "fb"])
+    retrieval = FakeRetrieval()
+    svc = _svc(
+        retrieval=retrieval, llm=FakeLLM(chat_responses=["answer [Sources: none]"]), workspace=FakeWorkspace(scope)
+    )
+    await svc.chat(
+        partitions=["p1"],
+        payload={"messages": [{"role": "user", "content": "q"}], "metadata": {"workspace": "w1"}},
+        prepare_sources=lambda d, w: [],
+        model_name="m",
+    )
+    assert len(retrieval.retrieve_multi_calls) == 1
+    call = retrieval.retrieve_multi_calls[0]
+    assert call["partitions"] == ["p1"]
+    assert call["filter_params"] == {"file_id": ["fa", "fb"]}
+
+
+@pytest.mark.asyncio
+async def test_chat_workspace_restricts_openrag_all_to_owning_partition():
+    # "openrag-all" reaches _prepare_chat as partitions=["all"] — a workspace
+    # must narrow retrieval to its single owning partition, never search
+    # every accessible partition with just a file_id filter (#706).
+    scope = WorkspaceScope(workspace_id="w1", partition="only-this-one", file_ids=["fa"])
+    retrieval = FakeRetrieval()
+    svc = _svc(
+        retrieval=retrieval, llm=FakeLLM(chat_responses=["answer [Sources: none]"]), workspace=FakeWorkspace(scope)
+    )
+    await svc.chat(
+        partitions=["all"],
+        payload={"messages": [{"role": "user", "content": "q"}], "metadata": {"workspace": "w1"}},
+        prepare_sources=lambda d, w: [],
+        model_name="m",
+    )
+    call = retrieval.retrieve_multi_calls[0]
+    assert call["partitions"] == ["only-this-one"]
+
+
+@pytest.mark.asyncio
+async def test_chat_empty_workspace_scopes_to_zero_files_not_full_partition():
+    scope = WorkspaceScope(workspace_id="w1", partition="p1", file_ids=[])
+    retrieval = FakeRetrieval()
+    svc = _svc(
+        retrieval=retrieval, llm=FakeLLM(chat_responses=["answer [Sources: none]"]), workspace=FakeWorkspace(scope)
+    )
+    await svc.chat(
+        partitions=["p1"],
+        payload={"messages": [{"role": "user", "content": "q"}], "metadata": {"workspace": "w1"}},
+        prepare_sources=lambda d, w: [],
+        model_name="m",
+    )
+    call = retrieval.retrieve_multi_calls[0]
+    assert call["filter_params"] == {"file_id": []}  # must stay explicit, never None/omitted
+
+
+@pytest.mark.asyncio
+async def test_chat_invalid_workspace_raises_instead_of_falling_back():
+    # Fail closed: an unknown/inaccessible workspace must error, never
+    # silently widen the search to the full partition (#706).
+    svc = _svc(workspace=FakeWorkspace(None))
+    with pytest.raises(WorkspaceNotFoundError):
+        await svc.chat(
+            partitions=["p1"],
+            payload={"messages": [{"role": "user", "content": "q"}], "metadata": {"workspace": "ghost"}},
+            prepare_sources=lambda d, w: [],
+            model_name="m",
+        )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_invalid_workspace_raises_instead_of_falling_back():
+    svc = _svc(workspace=FakeWorkspace(None))
+    with pytest.raises(WorkspaceNotFoundError):
+        async for _ in svc.chat_stream(
+            partitions=["p1"],
+            payload={"messages": [{"role": "user", "content": "q"}], "metadata": {"workspace": "ghost"}},
+            prepare_sources=lambda d, w: [],
+            model_name="m",
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_without_workspace_unaffected():
+    retrieval = FakeRetrieval()
+    svc = _svc(retrieval=retrieval, llm=FakeLLM(chat_responses=["answer [Sources: none]"]))
+    await svc.chat(
+        partitions=["p1"],
+        payload={"messages": [{"role": "user", "content": "q"}], "metadata": {}},
+        prepare_sources=lambda d, w: [],
+        model_name="m",
+    )
+    call = retrieval.retrieve_multi_calls[0]
+    assert call["partitions"] == ["p1"]
+    assert call["filter_params"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_workspace_service.py
+++ b/tests/unit/services/orchestrators/test_workspace_service.py
@@ -7,9 +7,10 @@ from services.orchestrators.workspace_service import WorkspaceService
 
 
 class FakeWorkspaceRepo:
-    def __init__(self, *, workspace=None, orphaned=None):
+    def __init__(self, *, workspace=None, orphaned=None, files=None):
         self._workspace = workspace
         self._orphaned = orphaned if orphaned is not None else []
+        self._files = files if files is not None else ["f1", "f2"]
         self.created: list[tuple] = []
         self.added: list[tuple[str, list[str]]] = []
         self.removed: list[tuple[str, str]] = []
@@ -37,7 +38,7 @@ class FakeWorkspaceRepo:
         return True
 
     async def list_workspace_files(self, workspace_id: str) -> list[str]:
-        return ["f1", "f2"]
+        return list(self._files)
 
     async def get_file_workspaces(self, file_id: str, partition: str) -> list[str]:
         return ["w1", "w2"]
@@ -151,3 +152,51 @@ async def test_delete_workspace_collects_per_file_failures():
 
     assert out["orphaned_files_deleted"] == 1
     assert out["orphaned_files_failed"] == ["bad"]
+
+
+# --------------------------------------------------------------------------- #
+# resolve_scope — the workspace scope resolver (issue #706)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_returns_partition_and_file_ids():
+    wrepo = FakeWorkspaceRepo(
+        workspace={"workspace_id": "w1", "partition_name": "p1"},
+        files=["f1", "f2"],
+    )
+    scope = await _svc(wrepo=wrepo).resolve_scope("w1", ["p1"])
+    assert scope is not None
+    assert scope.workspace_id == "w1"
+    assert scope.partition == "p1"
+    assert scope.file_ids == ["f1", "f2"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_none_when_workspace_missing():
+    wrepo = FakeWorkspaceRepo(workspace=None)
+    assert await _svc(wrepo=wrepo).resolve_scope("ghost", ["p1"]) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_none_when_partition_not_allowed():
+    # Workspace exists but belongs to a partition the caller has no access
+    # to — must look identical to "not found", never reveal the partition.
+    wrepo = FakeWorkspaceRepo(workspace={"workspace_id": "w1", "partition_name": "other"})
+    assert await _svc(wrepo=wrepo).resolve_scope("w1", ["p1"]) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_accepts_all_sentinel():
+    wrepo = FakeWorkspaceRepo(workspace={"workspace_id": "w1", "partition_name": "any-partition"}, files=["f1"])
+    scope = await _svc(wrepo=wrepo).resolve_scope("w1", ["all"])
+    assert scope is not None
+    assert scope.partition == "any-partition"
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_empty_workspace_returns_empty_file_ids():
+    wrepo = FakeWorkspaceRepo(workspace={"workspace_id": "w1", "partition_name": "p1"}, files=[])
+    scope = await _svc(wrepo=wrepo).resolve_scope("w1", ["p1"])
+    assert scope is not None
+    assert scope.file_ids == []

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -143,9 +143,10 @@ class TestBuildFilterExpr:
 
     def test_empty_list_field_matches_nothing(self, store: MilvusVectorStore) -> None:
         # An empty IN list cannot be expressed in Milvus, so short-circuit to
-        # the explicit no-match literal — callers get an empty result set
-        # instead of a syntax error.
-        assert store._build_filter_expr({"file_id": []}) == "false"
+        # an always-false comparison — callers get an empty result set instead
+        # of a syntax error. A bare ``false`` literal is rejected by Milvus 2.6
+        # ("predicate is not a boolean expression"), so it must be ``1 == 0``.
+        assert store._build_filter_expr({"file_id": []}) == "1 == 0"
 
     def test_raw_expr_appended(self, store: MilvusVectorStore) -> None:
         expr = store._build_filter_expr({"expr": "created_at > ISO '2025-01-01'"})

--- a/tests/unit/services/storage/test_vector_store_searcher.py
+++ b/tests/unit/services/storage/test_vector_store_searcher.py
@@ -118,6 +118,94 @@ async def test_search_passes_filter_expr():
 
 
 @pytest.mark.asyncio
+async def test_search_merges_filter_params_into_store_filters():
+    """#706: filter_params must actually reach the store, not be dropped."""
+    searcher, store, *_ = _make_searcher(search_results=[])
+    await searcher.search(
+        query="q",
+        partition=["p1"],
+        top_k=3,
+        filter_params={"file_id": ["a", "b"]},
+        with_surrounding_chunks=False,
+    )
+    call_kwargs = store.search.call_args.kwargs
+    assert call_kwargs["filters"]["file_id"] == ["a", "b"]
+    assert call_kwargs["filters"]["partition"] == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_empty_file_id_allowlist():
+    """An empty workspace's file_id restriction must reach the store as `[]`,
+    never be treated as falsy/absent — that's the fail-closed path."""
+    searcher, store, *_ = _make_searcher(search_results=[])
+    await searcher.search(
+        query="q",
+        partition=["p1"],
+        top_k=3,
+        filter_params={"file_id": []},
+        with_surrounding_chunks=False,
+    )
+    call_kwargs = store.search.call_args.kwargs
+    assert call_kwargs["filters"]["file_id"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_combines_filter_and_filter_params():
+    searcher, store, *_ = _make_searcher(search_results=[])
+    await searcher.search(
+        query="q",
+        partition=["p1"],
+        top_k=3,
+        filter="page > 1",
+        filter_params={"file_id": ["a"]},
+        with_surrounding_chunks=False,
+    )
+    call_kwargs = store.search.call_args.kwargs
+    assert call_kwargs["filters"]["expr"] == "page > 1"
+    assert call_kwargs["filters"]["file_id"] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_multi_query_search_merges_filter_params():
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[_EMBED_VEC, _EMBED_VEC])
+    store = MagicMock()
+    store.search = AsyncMock(return_value=[])
+    store.query_chunks_by_filter = AsyncMock(return_value=[])
+    searcher = VectorStoreSearcher(vector_store=store, embedder=embedder, document_repo=MagicMock(), collection="col")
+    await searcher.multi_query_search(
+        queries=["q1", "q2"],
+        partition=["p1"],
+        top_k_per_query=3,
+        filter_params={"file_id": ["a"]},
+        with_surrounding_chunks=False,
+    )
+    for call in store.search.call_args_list:
+        assert call.kwargs["filters"]["file_id"] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_search_scopes_surrounding_chunks_to_allowed_file_ids():
+    """#706: surrounding-chunk hydration must not leak a neighbouring file
+    outside the workspace/file-id restriction the main search was scoped by."""
+    main_row = _make_row("1", file_id="in-scope", prev_section_id="s0")
+    surrounding_rows = [
+        {**_make_row("0"), "file_id": "in-scope"},
+        {**_make_row("2"), "file_id": "outside-scope"},
+    ]
+    searcher, store, _, _ = _make_searcher(search_results=[main_row], filter_results=surrounding_rows)
+    chunks = await searcher.search(
+        query="q",
+        partition=["p1"],
+        top_k=5,
+        filter_params={"file_id": ["in-scope"]},
+        with_surrounding_chunks=True,
+    )
+    ids = {c.id for c in chunks}
+    assert ids == {"1", "0"}  # "2" (outside-scope) must be dropped
+
+
+@pytest.mark.asyncio
 async def test_search_with_surrounding_chunks_deduplicates():
     main_row = _make_row("1", prev_section_id="s0", next_section_id="s2")
     surrounding_rows = [_make_row("0"), _make_row("1")]  # "1" is a duplicate
@@ -228,6 +316,29 @@ async def test_get_related_chunks_queries_store_with_file_ids():
     assert call_args.args[1]["file_id"] == ["f1", "f2"]
 
 
+@pytest.mark.asyncio
+async def test_get_related_chunks_intersects_allowed_file_ids():
+    """#706: related-file expansion must not escape a workspace's file allowlist."""
+    rows = [_make_row("1")]
+    searcher, store, _, doc_repo = _make_searcher(
+        file_ids_by_rel=["f1", "f2", "f3"],
+        filter_results=rows,
+    )
+    await searcher.get_related_chunks(partition="p1", relationship_id="r1", limit=10, allowed_file_ids=["f1", "f3"])
+    call_args = store.query_chunks_by_filter.call_args
+    assert call_args.args[1]["file_id"] == ["f1", "f3"]  # "f2" excluded
+
+
+@pytest.mark.asyncio
+async def test_get_related_chunks_empty_intersection_skips_query():
+    searcher, store, _, doc_repo = _make_searcher(file_ids_by_rel=["f1", "f2"])
+    result = await searcher.get_related_chunks(
+        partition="p1", relationship_id="r1", limit=10, allowed_file_ids=["unrelated"]
+    )
+    assert result == []
+    store.query_chunks_by_filter.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # get_ancestor_chunks()
 # ---------------------------------------------------------------------------
@@ -260,6 +371,24 @@ async def test_get_ancestor_chunks_passes_max_depth():
 
 
 @pytest.mark.asyncio
+async def test_get_ancestor_chunks_intersects_allowed_file_ids():
+    """#706: ancestor-file expansion must not escape a workspace's file allowlist."""
+    rows = [_make_row("1")]
+    searcher, store, _, doc_repo = _make_searcher(ancestor_ids=["a1", "a2"], filter_results=rows)
+    await searcher.get_ancestor_chunks(partition="p1", file_id="f1", limit=10, allowed_file_ids=["a2"])
+    call_args = store.query_chunks_by_filter.call_args
+    assert call_args.args[1]["file_id"] == ["a2"]
+
+
+@pytest.mark.asyncio
+async def test_get_ancestor_chunks_empty_intersection_skips_query():
+    searcher, store, _, _ = _make_searcher(ancestor_ids=["a1", "a2"])
+    result = await searcher.get_ancestor_chunks(partition="p1", file_id="f1", limit=10, allowed_file_ids=["unrelated"])
+    assert result == []
+    store.query_chunks_by_filter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_fetch_surrounding_scopes_section_lookup_to_partition():
     """N6: section_id is only unique within a partition, so neighbour lookups
     must be scoped to each source chunk's partition (no cross-tenant leak)."""
@@ -283,3 +412,26 @@ async def test_fetch_surrounding_drops_refs_without_partition():
     c.partition = ""  # source chunk with no partition → dropped, not queried unscoped
     assert await searcher._fetch_surrounding([c]) == []
     store.query_chunks_by_filter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_surrounding_filters_out_disallowed_file_ids():
+    """#706: neighbouring-section hydration must respect the allowed_file_ids
+    restriction even though the lookup itself is only scoped by partition."""
+    rows = [
+        {**_make_row("0"), "file_id": "allowed"},
+        {**_make_row("9"), "file_id": "not-allowed"},
+    ]
+    searcher, store, _, _ = _make_searcher(filter_results=rows)
+    c = _dict_to_chunk(_make_row("1", partition="p1", prev_section_id="s0"))
+    out = await searcher._fetch_surrounding([c], allowed_file_ids=["allowed"])
+    assert [o.id for o in out] == ["0"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_surrounding_no_restriction_when_allowed_file_ids_none():
+    rows = [{**_make_row("0"), "file_id": "anything"}]
+    searcher, store, _, _ = _make_searcher(filter_results=rows)
+    c = _dict_to_chunk(_make_row("1", partition="p1", prev_section_id="s0"))
+    out = await searcher._fetch_surrounding([c], allowed_file_ids=None)
+    assert [o.id for o in out] == ["0"]


### PR DESCRIPTION
## Summary

Fixes #706 — workspace-scoped search and chat validated the workspace but never actually restricted results to it. `filter_params` was threaded through every layer of retrieval but silently dropped at `VectorStoreSearcher`, the one place that builds the Milvus query — so a "workspace search" quietly ran against the whole partition. Root cause and fix details are in the issue.

- Add a single workspace scope resolver (`WorkspaceService.resolve_scope`) that resolves `workspace_id → (partition, file_ids)` via Postgres and fails closed on missing/inaccessible workspaces
- Fix `VectorStoreSearcher.search`/`multi_query_search` to actually merge `filter_params` into the Milvus query (dense + both legs of hybrid)
- Narrow the effective search partition to the workspace's own partition, so `openrag-all` + workspace can't match a same-named file in another partition
- Scope surrounding/related/ancestor chunk expansion to the same file-id allowlist so it can't reintroduce out-of-workspace documents
- Replace "log a warning and search unscoped" with a proper `WorkspaceNotFoundError` (404 for REST search, structured error for both streaming and non-streaming chat)
- Remove the MCP and by-file-search workarounds that hand-built raw Milvus expressions because `filter_params` didn't work; both now bind through it properly
- Fix a real Milvus bug found via integration testing: the empty-file-list short-circuit emitted a bare `false` literal, which Milvus 2.6 rejects outright — changed to `1 == 0`

## Test plan

- [x] `uv run pytest tests/unit/` — 1872 passed
- [x] `uv run pytest tests/integration/repos/` against a real Postgres + Milvus stack — all workspace/Milvus-related suites pass (2 pre-existing, unrelated failures in `test_partition_repo.py`)
- [x] New end-to-end test (`test_workspace_scoping_e2e.py`): two partitions, a file sharing the same `file_id` across both, a workspace scoped to one — confirms cross-partition search returns only the in-scope file, and that removing the file returns zero results rather than falling back to the full partition
- [x] `uv run ruff check` / `uv run ruff format --check` — clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace-scoped searches now fail closed using an authorization-checked resolved scope, returning consistent 404 behavior when the workspace is unresolved or inaccessible.
  * Related/ancestor/surrounding expansion is now constrained by the same authorized file allowlist, including correct zero results for empty allowlists.
  * File-scoped routes bind `file_id` using parameterized scoping (no hard-coded filter strings), while preserving any caller filter.
  * Milvus empty-scope filtering now uses an always-false predicate to prevent accidental broad matches.
* **Tests**
  * Added end-to-end and unit coverage for workspace scoping, fail-closed empty scopes, and restricted expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->