### PR TITLE
fix(models): carry sampling params into DB-backed LLM/VLM endpoints

### DIFF
--- a/openrag/services/inference/ollama_client.py
+++ b/openrag/services/inference/ollama_client.py
@@ -58,8 +58,13 @@ class OllamaClient(LLM):
         model_name: str,
         *,
         timeout: float = 240.0,
+        max_retries: int = 2,
         **kwargs,
     ) -> None:
+        # See VLLMClient.__init__: accepted here purely so it doesn't fall into
+        # **kwargs and leak into the request body — retry attempts are fixed by
+        # the @with_retry decorator on each method, not by a per-instance value.
+        del max_retries
         self._endpoint = endpoint.rstrip("/")
         if not self._endpoint.endswith("/v1"):
             self._endpoint = f"{self._endpoint}/v1"

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -65,8 +65,17 @@ class VLLMClient(LLM):
         api_key: str = "",
         timeout: float = 240.0,
         enable_thinking: bool | None = None,
+        max_retries: int = 2,
         **kwargs,
     ) -> None:
+        # max_retries is accepted (not forwarded into self._defaults) purely to
+        # stop it from leaking into the request body: LLMParamsConfig carries it
+        # as a config field, but retry attempts are fixed by the @with_retry
+        # decorator on each method, not by a per-instance value. Without this
+        # param it would fall into **kwargs like an unknown sampling field and
+        # get sent to the backend on every call — the same class of bug fixed
+        # for batch_size in di/factories.py (#712).
+        del max_retries
         self._endpoint = endpoint.rstrip("/")
         self._model = model_name
         self._api_key = api_key

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 _VALID_TYPES = frozenset({"embedder", "reranker", "llm", "vlm"})
+_SAMPLING_TYPES = frozenset({"llm", "vlm"})
 
 
 def _slug(model_name: str) -> str:
@@ -46,6 +47,15 @@ def _with_enable_thinking(extra: dict[str, Any], enable_thinking: bool | None) -
     return {**extra, "enable_thinking": enable_thinking}
 
 
+def _sampling_params(llm_cfg: Any) -> dict[str, Any]:
+    """Extract the shared LLM/VLM sampling params (``LLMParamsConfig``) as a dict."""
+    return {
+        "temperature": llm_cfg.temperature,
+        "max_retries": llm_cfg.max_retries,
+        "logprobs": llm_cfg.logprobs,
+    }
+
+
 def _with_sampling_params(extra: dict[str, Any], llm_cfg: Any) -> dict[str, Any]:
     """Add the shared LLM/VLM sampling params (``LLMParamsConfig``) to endpoint extras.
 
@@ -56,12 +66,7 @@ def _with_sampling_params(extra: dict[str, Any], llm_cfg: Any) -> dict[str, Any]
     Mirrors the fallback config built in
     ``indexer_pool._global_llm_endpoint_config``.
     """
-    return {
-        **extra,
-        "temperature": llm_cfg.temperature,
-        "max_retries": llm_cfg.max_retries,
-        "logprobs": llm_cfg.logprobs,
-    }
+    return {**extra, **_sampling_params(llm_cfg)}
 
 
 class ModelEndpointService:
@@ -90,12 +95,20 @@ class ModelEndpointService:
         Seeds are derived from existing Settings / env-var values so that
         existing deployments continue working after the Phase 14 upgrade
         without any admin intervention.
+
+        For ``llm``/``vlm``, a type with existing rows is *not* skipped
+        outright: those rows are backfilled with any sampling params missing
+        from their ``extra`` first (see ``_backfill_sampling_params``), since
+        endpoints created before #720's fix never had them written and would
+        otherwise keep silently running at the provider default forever.
         """
         seeds = self._build_default_seeds()
         now = datetime.now(UTC)
         for model_type, data in seeds.items():
             existing = await self._repo.list_all(model_type=model_type)
             if existing:
+                if model_type in _SAMPLING_TYPES:
+                    await self._backfill_sampling_params(existing, getattr(self._config, model_type))
                 continue
             endpoint: str = data["endpoint"]
             model_name: str = data["model_name"]
@@ -168,6 +181,26 @@ class ModelEndpointService:
                 "extra": _with_api_key({"implementation": s.reranker.provider}, s.reranker.api_key),
             },
         }
+
+    async def _backfill_sampling_params(self, rows: list[ModelEndpointRow], llm_cfg: Any) -> None:
+        """Fill in sampling params missing from pre-existing llm/vlm rows' ``extra``.
+
+        ``seed_defaults()`` only seeds a type when the DB has no rows for it,
+        so an endpoint created before #720's fix keeps whatever ``extra`` it
+        was given — which never included ``temperature``/``max_retries``/
+        ``logprobs`` (see ``_with_sampling_params``). Only keys *absent* from
+        ``extra`` are filled in here, so a value an admin explicitly set (or a
+        prior backfill already wrote) is never overwritten.
+        """
+        for row in rows:
+            missing = {k: v for k, v in _sampling_params(llm_cfg).items() if k not in row.extra}
+            if not missing:
+                continue
+            await self._repo.update(row.name, row.model_type, extra={**row.extra, **missing})
+            logger.info(
+                f"Backfilled sampling params on existing {row.model_type} endpoint '{row.name}'.",
+                keys=sorted(missing),
+            )
 
     async def load_all(self) -> None:
         """Fetch all endpoints from DB, rebuild config.models dicts atomically.

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -46,6 +46,24 @@ def _with_enable_thinking(extra: dict[str, Any], enable_thinking: bool | None) -
     return {**extra, "enable_thinking": enable_thinking}
 
 
+def _with_sampling_params(extra: dict[str, Any], llm_cfg: Any) -> dict[str, Any]:
+    """Add the shared LLM/VLM sampling params (``LLMParamsConfig``) to endpoint extras.
+
+    Without this, a named LLM/VLM endpoint built via the DB-backed registry
+    (di/factories.py's ``make_component_factory``, which splats ``extra``
+    straight into the client constructor) never receives ``temperature`` /
+    ``max_retries`` / ``logprobs`` and silently runs at the provider default.
+    Mirrors the fallback config built in
+    ``indexer_pool._global_llm_endpoint_config``.
+    """
+    return {
+        **extra,
+        "temperature": llm_cfg.temperature,
+        "max_retries": llm_cfg.max_retries,
+        "logprobs": llm_cfg.logprobs,
+    }
+
+
 class ModelEndpointService:
     """CRUD and lifecycle management for named model endpoints."""
 
@@ -124,7 +142,7 @@ class ModelEndpointService:
                 "model_name": os.getenv("LLM_MODEL", s.llm.model),
                 "timeout": s.llm.timeout,
                 "extra": _with_enable_thinking(
-                    _with_api_key({"implementation": "vllm"}, s.llm.api_key),
+                    _with_sampling_params(_with_api_key({"implementation": "vllm"}, s.llm.api_key), s.llm),
                     s.llm.enable_thinking,
                 ),
             },
@@ -133,7 +151,7 @@ class ModelEndpointService:
                 "model_name": os.getenv("VLM_MODEL", s.vlm.model),
                 "timeout": s.vlm.timeout,
                 "extra": _with_enable_thinking(
-                    _with_api_key({"implementation": "vllm"}, s.vlm.api_key),
+                    _with_sampling_params(_with_api_key({"implementation": "vllm"}, s.vlm.api_key), s.vlm),
                     s.vlm.enable_thinking,
                 ),
             },

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -846,7 +846,7 @@ def _global_llm_endpoint_config(cfg: Any) -> Any | None:
         "api_key": getattr(llm_cfg, "api_key", ""),
         "temperature": getattr(llm_cfg, "temperature", 0.1),
         "max_retries": getattr(llm_cfg, "max_retries", 2),
-        "logprobs": getattr(llm_cfg, "logprobs", True),
+        "logprobs": getattr(llm_cfg, "logprobs", False),
     }
     enable_thinking = getattr(llm_cfg, "enable_thinking", None)
     if enable_thinking is not None:
@@ -892,6 +892,9 @@ def _global_vlm_endpoint_config(cfg: Any) -> Any | None:
     extra = {
         "implementation": "vllm",
         "api_key": getattr(vlm_cfg, "api_key", ""),
+        "temperature": getattr(vlm_cfg, "temperature", 0.1),
+        "max_retries": getattr(vlm_cfg, "max_retries", 2),
+        "logprobs": getattr(vlm_cfg, "logprobs", False),
     }
     enable_thinking = getattr(vlm_cfg, "enable_thinking", None)
     if enable_thinking is not None:

--- a/tests/unit/services/inference/test_ollama_client.py
+++ b/tests/unit/services/inference/test_ollama_client.py
@@ -153,6 +153,24 @@ class TestOllamaClient:
         )
 
     @pytest.mark.asyncio
+    async def test_max_retries_is_not_forwarded_to_request_body(self):
+        """max_retries is a config field (LLMParamsConfig), not a sampling param —
+        it must not leak into **kwargs/self._defaults and end up in the outgoing
+        chat payload the way batch_size once did for the embedder (#712)."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        client = self._make_client(capture, max_retries=9)
+        assert "max_retries" not in client._defaults
+
+        await client.chat([{"role": "user", "content": "hi"}])
+
+        assert "max_retries" not in captured
+
+    @pytest.mark.asyncio
     async def test_metadata_stripped_from_payload(self):
         def handler(request: httpx.Request) -> httpx.Response:
             body = json.loads(request.content)

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -208,6 +208,24 @@ class TestVLLMClient:
         await self._make_client(handler).chat([{"role": "user", "content": "hi"}], temperature=0.9, max_tokens=100)
 
     @pytest.mark.asyncio
+    async def test_max_retries_is_not_forwarded_to_request_body(self):
+        """max_retries is a config field (LLMParamsConfig), not a sampling param —
+        it must not leak into **kwargs/self._defaults and end up in the outgoing
+        chat payload the way batch_size once did for the embedder (#712)."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        client = self._make_client(capture, max_retries=9)
+        assert "max_retries" not in client._defaults
+
+        await client.chat([{"role": "user", "content": "hi"}])
+
+        assert "max_retries" not in captured
+
+    @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
         c = VLLMClient(endpoint="http://vllm:8000/v1/", model_name="m")
         assert c._endpoint == "http://vllm:8000/v1"
@@ -527,6 +545,17 @@ class TestVLLMVision:
             return _chat_response("ok")
 
         await self._make_vision(handler, max_tokens=512).caption_image(b"img")
+
+    @pytest.mark.asyncio
+    async def test_max_retries_is_not_forwarded_to_request_body(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert "max_retries" not in json.loads(request.content)
+            return _chat_response("ok")
+
+        vision = self._make_vision(handler, max_retries=9)
+        assert "max_retries" not in vision._defaults
+
+        await vision.caption_image(b"img")
 
     @pytest.mark.asyncio
     async def test_caption_image_sends_enable_thinking_as_chat_template_kwargs_when_configured(self):

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -258,6 +258,47 @@ async def test_seed_defaults_preserves_llm_and_vlm_enable_thinking(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_seed_defaults_carries_llm_and_vlm_sampling_params(monkeypatch):
+    """temperature/max_retries/logprobs must reach the seeded ``extra`` so a
+    named LLM/VLM endpoint (built by di/factories.py splatting ``extra``) does
+    not silently fall back to the provider's default sampling params (#720).
+    """
+    from core.config.root import Settings
+
+    monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    settings = Settings(
+        llm={
+            "base_url": "http://llm:8000/v1",
+            "model": "qwen",
+            "temperature": 0.3,
+            "max_retries": 5,
+            "logprobs": True,
+        },
+        vlm={
+            "base_url": "http://vlm:8000/v1",
+            "model": "qwen-vl",
+            "temperature": 0.7,
+            "max_retries": 1,
+            "logprobs": False,
+        },
+    )
+    repo = _FakeEndpointRepo()
+    svc = _make_service(repo, settings=settings)
+
+    await svc.seed_defaults()
+
+    rows = {row.model_type: row for row in repo._store.values()}
+    assert rows["llm"].extra["temperature"] == 0.3
+    assert rows["llm"].extra["max_retries"] == 5
+    assert rows["llm"].extra["logprobs"] is True
+    assert rows["vlm"].extra["temperature"] == 0.7
+    assert rows["vlm"].extra["max_retries"] == 1
+    assert rows["vlm"].extra["logprobs"] is False
+
+
+@pytest.mark.asyncio
 async def test_seed_defaults_skips_reranker_when_unconfigured(monkeypatch):
     from core.config.root import Settings
 

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -299,6 +299,114 @@ async def test_seed_defaults_carries_llm_and_vlm_sampling_params(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_seed_defaults_backfills_missing_sampling_params_on_existing_llm_row(monkeypatch):
+    """Regression test for the upgrade path (#720 review): endpoints created
+    before the sampling-params fix never had temperature/max_retries/logprobs
+    written to ``extra``. seed_defaults() must backfill the existing row
+    instead of skipping the type outright, or upgraded deployments keep
+    silently running at the provider default forever.
+    """
+    from core.config.root import Settings
+
+    monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    pre_fix_row = _make_row(
+        name="default",
+        model_type="llm",
+        is_default=True,
+        extra={"implementation": "vllm", "api_key": "llm-key"},
+    )
+    settings = Settings(
+        llm={
+            "base_url": "http://llm:8000/v1",
+            "model": "mistral",
+            "temperature": 0.3,
+            "max_retries": 5,
+            "logprobs": True,
+        },
+    )
+    repo = _FakeEndpointRepo(rows=[pre_fix_row])
+    svc = _make_service(repo, settings=settings)
+
+    await svc.seed_defaults()
+
+    row = repo._store[("default", "llm")]
+    assert row.extra["temperature"] == 0.3
+    assert row.extra["max_retries"] == 5
+    assert row.extra["logprobs"] is True
+    assert row.extra["api_key"] == "llm-key"
+    assert row.extra["implementation"] == "vllm"
+    # No duplicate row was created — the existing one was updated in place.
+    creates = [c for c in repo.calls if c[0] == "create"]
+    assert not any(name_type[1] == "llm" for _, name_type in creates)
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_preserves_explicit_sampling_param_while_backfilling_others(monkeypatch):
+    """Backfilling missing keys must not clobber a value already present on the
+    row, even when other sampling keys on that same row are still missing.
+    """
+    from core.config.root import Settings
+
+    monkeypatch.delenv("VLM_ENDPOINT", raising=False)
+    monkeypatch.delenv("VLM_MODEL", raising=False)
+
+    partially_fixed_row = _make_row(
+        name="default",
+        model_type="vlm",
+        is_default=True,
+        extra={"implementation": "vllm", "temperature": 0.9},
+    )
+    settings = Settings(
+        vlm={
+            "base_url": "http://vlm:8000/v1",
+            "model": "pixtral",
+            "temperature": 0.7,
+            "max_retries": 1,
+            "logprobs": False,
+        },
+    )
+    repo = _FakeEndpointRepo(rows=[partially_fixed_row])
+    svc = _make_service(repo, settings=settings)
+
+    await svc.seed_defaults()
+
+    row = repo._store[("default", "vlm")]
+    assert row.extra["temperature"] == 0.9  # explicit value left untouched
+    assert row.extra["max_retries"] == 1  # missing key filled in
+    assert row.extra["logprobs"] is False  # missing key filled in
+
+
+@pytest.mark.asyncio
+async def test_seed_defaults_backfill_does_not_clobber_fully_configured_row(monkeypatch):
+    """A row that already has all three sampling keys must be left exactly as
+    stored, even when current Settings would compute a different value.
+    """
+    from core.config.root import Settings
+
+    monkeypatch.delenv("LLM_ENDPOINT", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    already_fixed_row = _make_row(
+        name="default",
+        model_type="llm",
+        is_default=True,
+        extra={"implementation": "vllm", "temperature": 0.5, "max_retries": 3, "logprobs": True},
+    )
+    settings = Settings(llm={"base_url": "http://llm:8000/v1", "model": "mistral", "temperature": 0.9})
+    repo = _FakeEndpointRepo(rows=[already_fixed_row])
+    svc = _make_service(repo, settings=settings)
+
+    await svc.seed_defaults()
+
+    row = repo._store[("default", "llm")]
+    assert row.extra["temperature"] == 0.5
+    assert row.extra["max_retries"] == 3
+    assert row.extra["logprobs"] is True
+
+
+@pytest.mark.asyncio
 async def test_seed_defaults_skips_reranker_when_unconfigured(monkeypatch):
     from core.config.root import Settings
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -767,6 +767,68 @@ def test_contextualizer_factory_rebuilds_on_api_key_rotation(tmp_path) -> None:
         llm_registry._registry.pop("key-probe-llm", None)
 
 
+def test_global_llm_endpoint_config_carries_sampling_params() -> None:
+    """The fallback LLM endpoint config must carry temperature/max_retries/
+    logprobs so it behaves the same as a named endpoint (#720) — and
+    ``logprobs`` must default to False (LLMParamsConfig's real default), not
+    True.
+    """
+    from services.workers.indexer_pool import _global_llm_endpoint_config
+
+    cfg = SimpleNamespace(
+        llm=SimpleNamespace(
+            base_url="http://llm.example/v1",
+            model="mistral",
+            api_key="llm-key",
+            temperature=0.42,
+            max_retries=9,
+            logprobs=True,
+            timeout=60,
+        )
+    )
+
+    endpoint_cfg = _global_llm_endpoint_config(cfg)
+
+    assert endpoint_cfg.extra["temperature"] == 0.42
+    assert endpoint_cfg.extra["max_retries"] == 9
+    assert endpoint_cfg.extra["logprobs"] is True
+
+
+def test_global_llm_endpoint_config_logprobs_defaults_false() -> None:
+    from services.workers.indexer_pool import _global_llm_endpoint_config
+
+    cfg = SimpleNamespace(llm=SimpleNamespace(base_url="http://llm.example/v1", model="mistral"))
+
+    endpoint_cfg = _global_llm_endpoint_config(cfg)
+
+    assert endpoint_cfg.extra["logprobs"] is False
+
+
+def test_global_vlm_endpoint_config_carries_sampling_params() -> None:
+    """Mirrors the LLM fallback: the VLM fallback must also carry sampling
+    params instead of dropping temperature/max_retries/logprobs entirely.
+    """
+    from services.workers.indexer_pool import _global_vlm_endpoint_config
+
+    cfg = SimpleNamespace(
+        vlm=SimpleNamespace(
+            base_url="http://vlm.example/v1",
+            model="pixtral",
+            api_key="vlm-key",
+            temperature=0.55,
+            max_retries=4,
+            logprobs=True,
+            timeout=60,
+        )
+    )
+
+    endpoint_cfg = _global_vlm_endpoint_config(cfg)
+
+    assert endpoint_cfg.extra["temperature"] == 0.55
+    assert endpoint_cfg.extra["max_retries"] == 4
+    assert endpoint_cfg.extra["logprobs"] is True
+
+
 def test_build_contextualizer_factory_uses_global_llm_fallback(tmp_path) -> None:
     from services.workers.indexer_pool import _build_contextualizer_factory
 


### PR DESCRIPTION
## Summary

- `ModelEndpointService._build_default_seeds` seeded `extra` with only `{implementation, api_key, enable_thinking}` for `llm`/`vlm`, so a named LLM/VLM endpoint built through the DB-backed registry (`di/factories.py`'s `make_component_factory`, which splats `model_cfg.extra` straight into the client constructor) never received `temperature`, `max_retries`, or `logprobs` — it silently ran at the provider's default sampling params instead of the configured values.
- Added `_with_sampling_params()` to carry `temperature`/`max_retries`/`logprobs` from `LLMParamsConfig` into both the `llm` and `vlm` seed `extra`, mirroring the pattern already used correctly in `indexer_pool._global_llm_endpoint_config`.
- Fixed the same class of bug in `indexer_pool.py`'s global fallback configs:
  - `_global_llm_endpoint_config` defaulted `logprobs` to `True`, inverting `LLMParamsConfig.logprobs`'s deliberate `False` default (requesting logprobs unsolicited breaks streaming on some backends).
  - `_global_vlm_endpoint_config` dropped `temperature`/`max_retries`/`logprobs` entirely — now mirrors its LLM sibling.
- **Follow-up fix (found in review):** carrying `max_retries` through to `VLLMClient`/`VLLMVision`/`OllamaClient` exposed a separate pre-existing bug — those clients absorb unknown constructor kwargs into `self._defaults` and splat them into every outgoing chat/completion/caption request body. `max_retries` is never actually consumed as retry config anywhere (retry attempts are fixed per-method by the `@with_retry` decorator), so it was leaking as a bogus field on the wire — the same class of bug already fixed for `batch_size` in `di/factories.py` (#712). Gave both clients an explicit `max_retries` parameter so it's captured and discarded before reaching `self._defaults`, closing the leak at the client constructor regardless of which factory/call site builds it. Real vLLM (`OpenAIBaseModel`, `extra="allow"`) tolerates unknown fields and just logs them at DEBUG, so this wasn't causing hard failures against the default backend, but it's still not something we want on the wire. Tracked in #747.

Fixes #720

## Test plan

- [x] `uv run pytest tests/unit/services/orchestrators/test_model_endpoint_service.py tests/unit/services/workers/test_indexer_pool.py tests/unit/services/inference/test_vllm_client.py tests/unit/services/inference/test_ollama_client.py -q` — new tests covering seeded sampling params, global-fallback configs, and the max_retries leak
- [x] `uv run pytest tests/unit/ -q` — full unit suite (1891 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved configured LLM/VLM sampling settings (temperature, retry limits, log-probabilities) when seeding and when generating fallback endpoint configs.
  * Ensured log-probabilities default to **disabled** when not explicitly set.
  * Prevented the internal `max_retries` setting from being forwarded into Ollama/vLLM request payloads.
* **Tests**
  * Added unit tests covering sampling-param retention during endpoint seeding/fallback configuration.
  * Added unit tests confirming `max_retries` is not included in outgoing request bodies for both chat and vision requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->