### PR TITLE
fix(streaming): flush answer tail and sources on any stream exit

### DIFF
--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -187,6 +187,17 @@ async def stream_with_source_filtering(
         # GeneratorExit are BaseException, not Exception, so a downstream client
         # disconnect propagates untouched and correctly skips the flush.
         stream_error = exc
+    finally:
+        # Release the upstream HTTP connection promptly. Breaking on `[DONE]`
+        # leaves the client's stream generator suspended inside its
+        # `async with response` (an `async for` does *not* close its iterator on
+        # break), so the pooled connection stays checked out until GC — which
+        # exhausts the httpx pool under concurrent traffic. Closing it here runs
+        # that cleanup now. Awaiting in a finally is safe (only *yielding* during
+        # teardown is forbidden); the guard tolerates iterables without `aclose`.
+        aclose = getattr(llm_stream, "aclose", None)
+        if aclose is not None:
+            await aclose()
 
     # The finish chunk needs *a* template; prefer the content/finish chunk, but
     # fall back to any earlier chunk so a preamble-only stream still gets flagged.

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -140,10 +140,15 @@ async def stream_with_source_filtering(
             if data.get("choices"):
                 last_chunk = data
 
+            # `content` and `finish_reason` are handled independently: some
+            # OpenAI-compatible providers pack the last token and the terminal
+            # `finish_reason` into the *same* chunk, so gating content on
+            # `elif finish_reason` would silently drop that final token.
             if finish_reason:
                 last_finish_reason = finish_reason
                 chunk_template = data
-            elif content:
+
+            if content:
                 chunk_template = data
                 pending += content
 
@@ -168,7 +173,11 @@ async def stream_with_source_filtering(
                     }
                     yield f"data: {json.dumps(out)}\n\n"
                     emitted_len = safe_end
-            else:
+            elif not finish_reason:
+                # Neither content nor finish_reason (role preamble, usage-only or
+                # keep-alive chunk): pass it through untouched. A finish-only chunk
+                # is intentionally *not* re-emitted here — the terminal flush emits
+                # the finish chunk so it can carry `extra.sources`.
                 data["extra"] = "{}"
                 yield f"data: {json.dumps(data)}\n\n"
     except Exception as exc:

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -84,45 +84,29 @@ async def stream_with_source_filtering(
     model_name: str,
     buffer_size: int | None = None,
 ):
-    """Process an LLM SSE stream, stripping line-terminal source tags."""
+    """Process an LLM SSE stream, stripping line-terminal source tags.
+
+    The terminal flush (tail content + ``extra.sources``) runs exactly once
+    after the loop, regardless of whether it exits via ``data: [DONE]`` or
+    the upstream simply closing the connection without it — otherwise a
+    dropped upstream stream silently loses the answer's tail and all
+    sources with no error surfaced to the caller.
+    """
     if buffer_size is None:
         buffer_size = max(_MIN_STREAM_LOOKAHEAD, _min_sources_tag_buffer_size(len(sources)))
     pending = ""
     emitted_len = 0
     chunk_template = None
     last_finish_reason = None
+    saw_done = False
 
     async for line in llm_stream:
         if not line.startswith("data:"):
             continue
 
         if line.strip() == "data: [DONE]":
-            final_clean, citations = extract_and_strip_sources_block(pending)
-            final_clean = final_clean.rstrip()
-
-            filtered = filter_sources_by_citations(sources, citations)
-            filtered_json = json.dumps({"sources": filtered})
-
-            if chunk_template and len(final_clean) > emitted_len:
-                tail_chunk = copy.deepcopy(chunk_template)
-                tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
-                # Content chunk must not carry finish_reason (template may be the
-                # finish chunk); clients treat such a chunk as terminal and drop its
-                # delta. The separate finish chunk below emits it with an empty delta.
-                tail_chunk["choices"][0]["finish_reason"] = None
-                tail_chunk["extra"] = filtered_json
-                yield f"data: {json.dumps(tail_chunk)}\n\n"
-
-            if chunk_template:
-                await asyncio.sleep(0.05)
-                finish_chunk = copy.deepcopy(chunk_template)
-                finish_chunk["choices"][0]["delta"] = {}
-                finish_chunk["choices"][0]["finish_reason"] = last_finish_reason or "stop"
-                finish_chunk["extra"] = filtered_json
-                yield f"data: {json.dumps(finish_chunk)}\n\n"
-
-            yield "data: [DONE]\n\n"
-            continue
+            saw_done = True
+            break
 
         data = json.loads(line[len("data: ") :])
         data["model"] = model_name
@@ -170,3 +154,38 @@ async def stream_with_source_filtering(
         else:
             data["extra"] = "{}"
             yield f"data: {json.dumps(data)}\n\n"
+
+    if not saw_done:
+        logger.warning(
+            "Upstream stream closed without [DONE]; flushing buffered tail",
+            pending_len=len(pending) - emitted_len,
+        )
+
+    final_clean, citations = extract_and_strip_sources_block(pending)
+    final_clean = final_clean.rstrip()
+
+    filtered = filter_sources_by_citations(sources, citations)
+    extra_payload = {"sources": filtered}
+    if not saw_done:
+        extra_payload["truncated"] = True
+    filtered_json = json.dumps(extra_payload)
+
+    if chunk_template and len(final_clean) > emitted_len:
+        tail_chunk = copy.deepcopy(chunk_template)
+        tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
+        # Content chunk must not carry finish_reason (template may be the
+        # finish chunk); clients treat such a chunk as terminal and drop its
+        # delta. The separate finish chunk below emits it with an empty delta.
+        tail_chunk["choices"][0]["finish_reason"] = None
+        tail_chunk["extra"] = filtered_json
+        yield f"data: {json.dumps(tail_chunk)}\n\n"
+
+    if chunk_template:
+        await asyncio.sleep(0.05)
+        finish_chunk = copy.deepcopy(chunk_template)
+        finish_chunk["choices"][0]["delta"] = {}
+        finish_chunk["choices"][0]["finish_reason"] = last_finish_reason or "stop"
+        finish_chunk["extra"] = filtered_json
+        yield f"data: {json.dumps(finish_chunk)}\n\n"
+
+    yield "data: [DONE]\n\n"

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -87,75 +87,114 @@ async def stream_with_source_filtering(
     """Process an LLM SSE stream, stripping line-terminal source tags.
 
     The terminal flush (tail content + ``extra.sources``) runs exactly once
-    after the loop, regardless of whether it exits via ``data: [DONE]`` or
-    the upstream simply closing the connection without it — otherwise a
-    dropped upstream stream silently loses the answer's tail and all
-    sources with no error surfaced to the caller.
+    after the loop on *every* termination path — a clean ``data: [DONE]``, the
+    upstream closing the connection without one, or the upstream generator
+    raising mid-stream (e.g. a read timeout surfaced as ``InferenceTimeoutError``).
+    Otherwise a dropped upstream stream silently loses the answer's tail and all
+    sources with no error surfaced to the caller. A non-clean exit is flagged
+    with ``extra.truncated = true`` so the client can tell a cut-off answer from
+    a clean completion; if nothing was ever streamed there is no tail to salvage,
+    so a mid-stream error is re-raised to surface the real failure instead of a
+    silent empty ``[DONE]``.
     """
     if buffer_size is None:
         buffer_size = max(_MIN_STREAM_LOOKAHEAD, _min_sources_tag_buffer_size(len(sources)))
     pending = ""
     emitted_len = 0
     chunk_template = None
+    # Fallback template for the truncated-finish chunk when the stream dies
+    # before any content/finish chunk (e.g. only a role-preamble arrived): any
+    # chunk with a usable `choices[0]` lets us still emit the `truncated` flag.
+    last_chunk = None
     last_finish_reason = None
     saw_done = False
+    stream_error = None
 
-    async for line in llm_stream:
-        if not line.startswith("data:"):
-            continue
-
-        if line.strip() == "data: [DONE]":
-            saw_done = True
-            break
-
-        data = json.loads(line[len("data: ") :])
-        data["model"] = model_name
-
-        # `choices` can be present but empty — e.g. the OpenAI/litellm final
-        # usage-report chunk sent when the caller requests
-        # `stream_options: {"include_usage": true}` has `"choices": []` and a
-        # top-level `"usage"` field. `.get("choices", [{}])` only falls back to
-        # the default when the key is *missing*, not when it's an empty list,
-        # so indexing straight into it raises IndexError on that chunk.
-        choices = data.get("choices") or [{}]
-        choice = choices[0]
-        delta = choice.get("delta", {})
-        content = delta.get("content", "") or ""
-        finish_reason = choice.get("finish_reason")
-
-        if finish_reason:
-            last_finish_reason = finish_reason
-            chunk_template = data
-        elif content:
-            chunk_template = data
-            pending += content
-
-            if len(pending) <= buffer_size:
+    try:
+        async for line in llm_stream:
+            if not line.startswith("data:"):
                 continue
 
-            cleaned, _, _ = _strip_sources_tags(pending)
-            safe_end = max(0, len(cleaned) - buffer_size)
-            if safe_end > emitted_len:
-                out = {
-                    **data,
-                    "choices": [
-                        {
-                            **choice,
-                            "delta": {
-                                **choice.get("delta", {}),
-                                "content": cleaned[emitted_len:safe_end],
-                            },
-                        }
-                    ],
-                    "extra": "{}",
-                }
-                yield f"data: {json.dumps(out)}\n\n"
-                emitted_len = safe_end
-        else:
-            data["extra"] = "{}"
-            yield f"data: {json.dumps(data)}\n\n"
+            if line.strip() == "data: [DONE]":
+                saw_done = True
+                break
 
-    if not saw_done:
+            data = json.loads(line[len("data: ") :])
+            data["model"] = model_name
+
+            # `choices` can be present but empty — e.g. the OpenAI/litellm final
+            # usage-report chunk sent when the caller requests
+            # `stream_options: {"include_usage": true}` has `"choices": []` and a
+            # top-level `"usage"` field. `.get("choices", [{}])` only falls back to
+            # the default when the key is *missing*, not when it's an empty list,
+            # so indexing straight into it raises IndexError on that chunk.
+            choices = data.get("choices") or [{}]
+            choice = choices[0]
+            delta = choice.get("delta", {})
+            content = delta.get("content", "") or ""
+            finish_reason = choice.get("finish_reason")
+
+            # Only chunks with a real `choices[0]` can template the finish chunk;
+            # skip usage-report chunks (`"choices": []`) whose deepcopy would
+            # IndexError in the flush below.
+            if data.get("choices"):
+                last_chunk = data
+
+            if finish_reason:
+                last_finish_reason = finish_reason
+                chunk_template = data
+            elif content:
+                chunk_template = data
+                pending += content
+
+                if len(pending) <= buffer_size:
+                    continue
+
+                cleaned, _, _ = _strip_sources_tags(pending)
+                safe_end = max(0, len(cleaned) - buffer_size)
+                if safe_end > emitted_len:
+                    out = {
+                        **data,
+                        "choices": [
+                            {
+                                **choice,
+                                "delta": {
+                                    **choice.get("delta", {}),
+                                    "content": cleaned[emitted_len:safe_end],
+                                },
+                            }
+                        ],
+                        "extra": "{}",
+                    }
+                    yield f"data: {json.dumps(out)}\n\n"
+                    emitted_len = safe_end
+            else:
+                data["extra"] = "{}"
+                yield f"data: {json.dumps(data)}\n\n"
+    except Exception as exc:
+        # Upstream raised mid-stream (timeout, connection drop, worker restart):
+        # capture it and fall through to the flush so the buffered tail + sources
+        # are still delivered instead of unwinding past it. CancelledError and
+        # GeneratorExit are BaseException, not Exception, so a downstream client
+        # disconnect propagates untouched and correctly skips the flush.
+        stream_error = exc
+
+    # The finish chunk needs *a* template; prefer the content/finish chunk, but
+    # fall back to any earlier chunk so a preamble-only stream still gets flagged.
+    template = chunk_template or last_chunk
+
+    if stream_error is not None:
+        logger.warning(
+            "Upstream stream raised before [DONE]; flushing buffered tail",
+            error=str(stream_error),
+            pending_len=len(pending) - emitted_len,
+        )
+        # Nothing was ever streamed to the client, so there is no partial answer
+        # to salvage. Re-raise so the router surfaces the real error rather than a
+        # silent, clean-looking empty `[DONE]`.
+        if template is None:
+            raise stream_error
+    elif not saw_done:
         logger.warning(
             "Upstream stream closed without [DONE]; flushing buffered tail",
             pending_len=len(pending) - emitted_len,
@@ -170,8 +209,8 @@ async def stream_with_source_filtering(
         extra_payload["truncated"] = True
     filtered_json = json.dumps(extra_payload)
 
-    if chunk_template and len(final_clean) > emitted_len:
-        tail_chunk = copy.deepcopy(chunk_template)
+    if template and len(final_clean) > emitted_len:
+        tail_chunk = copy.deepcopy(template)
         tail_chunk["choices"][0]["delta"] = {"content": final_clean[emitted_len:]}
         # Content chunk must not carry finish_reason (template may be the
         # finish chunk); clients treat such a chunk as terminal and drop its
@@ -180,9 +219,9 @@ async def stream_with_source_filtering(
         tail_chunk["extra"] = filtered_json
         yield f"data: {json.dumps(tail_chunk)}\n\n"
 
-    if chunk_template:
+    if template:
         await asyncio.sleep(0.05)
-        finish_chunk = copy.deepcopy(chunk_template)
+        finish_chunk = copy.deepcopy(template)
         finish_chunk["choices"][0]["delta"] = {}
         finish_chunk["choices"][0]["finish_reason"] = last_finish_reason or "stop"
         finish_chunk["extra"] = filtered_json

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -183,22 +183,12 @@ async def stream_with_source_filtering(
     # fall back to any earlier chunk so a preamble-only stream still gets flagged.
     template = chunk_template or last_chunk
 
-    if stream_error is not None:
-        logger.warning(
-            "Upstream stream raised before [DONE]; flushing buffered tail",
-            error=str(stream_error),
-            pending_len=len(pending) - emitted_len,
-        )
-        # Nothing was ever streamed to the client, so there is no partial answer
-        # to salvage. Re-raise so the router surfaces the real error rather than a
-        # silent, clean-looking empty `[DONE]`.
-        if template is None:
-            raise stream_error
-    elif not saw_done:
-        logger.warning(
-            "Upstream stream closed without [DONE]; flushing buffered tail",
-            pending_len=len(pending) - emitted_len,
-        )
+    # Nothing was ever streamed to the client, so there is no partial answer to
+    # salvage. Surface the real error instead of a silent, clean-looking empty
+    # `[DONE]` the caller can't distinguish from success.
+    if stream_error is not None and template is None:
+        logger.warning("Upstream stream raised before any content; surfacing error", error=str(stream_error))
+        raise stream_error
 
     final_clean, citations = extract_and_strip_sources_block(pending)
     final_clean = final_clean.rstrip()
@@ -207,6 +197,14 @@ async def stream_with_source_filtering(
     extra_payload = {"sources": filtered}
     if not saw_done:
         extra_payload["truncated"] = True
+        logger.warning(
+            "Answer truncated: upstream stream ended without [DONE] "
+            "(reason={reason}, model={model}, delivered_chars={chars}, sources={sources})",
+            reason=f"upstream error: {stream_error}" if stream_error is not None else "connection closed",
+            model=model_name,
+            chars=len(final_clean),
+            sources=len(filtered),
+        )
     filtered_json = json.dumps(extra_payload)
 
     if template and len(final_clean) > emitted_len:

--- a/openrag/core/utils/source_filtering.py
+++ b/openrag/core/utils/source_filtering.py
@@ -167,6 +167,12 @@ async def stream_with_source_filtering(
                                     **choice.get("delta", {}),
                                     "content": cleaned[emitted_len:safe_end],
                                 },
+                                # `choice` may carry finish_reason (a provider can pack
+                                # the last token + finish_reason into one chunk). Clear
+                                # it: a mid-stream chunk marked terminal makes spec
+                                # clients drop the delta and ignore the tail/finish
+                                # chunks. Same guard as the terminal tail chunk below.
+                                "finish_reason": None,
                             }
                         ],
                         "extra": "{}",

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -363,6 +363,65 @@ def test_min_sources_tag_buffer_size_fits_many_sources():
     assert _min_sources_tag_buffer_size(0) >= 1
 
 
+class TestStreamClosedWithoutDone:
+    """Regression for #715 — upstream closing without `data: [DONE]` must not
+    silently drop the answer tail or `extra.sources`."""
+
+    SOURCES = [{"file": "a.pdf"}, {"file": "b.pdf"}, {"file": "c.pdf"}]
+
+    @pytest.mark.asyncio
+    async def test_tail_and_sources_still_flushed_without_done(self):
+        lines = [
+            _make_chunk("Here is the answer."),
+            _make_chunk("\n[Sources: 1, 3]"),
+            _make_finish(),
+            # No DONE_LINE: upstream connection drops here.
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        assert _collect_content(result) == "Here is the answer."
+        assert _parse_finish_sources(result) == [{"file": "a.pdf"}, {"file": "c.pdf"}]
+        # A [DONE] marker is still emitted downstream so clients don't hang.
+        assert result[-1].strip() == "data: [DONE]"
+
+    @pytest.mark.asyncio
+    async def test_finish_chunk_flagged_truncated_without_done(self):
+        lines = [
+            _make_chunk("Partial answer only."),
+            _make_finish(),
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        finish_extra = None
+        for line in reversed(result):
+            if line.startswith("data: ") and line.strip() != "data: [DONE]":
+                data = json.loads(line[len("data: ") :])
+                extra = data.get("extra")
+                if extra and extra != "{}":
+                    finish_extra = json.loads(extra)
+                    break
+        assert finish_extra is not None
+        assert finish_extra.get("truncated") is True
+
+    @pytest.mark.asyncio
+    async def test_clean_done_stream_has_no_truncated_flag(self):
+        lines = [
+            _make_chunk("Here is the answer."),
+            _make_finish(),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        assert "truncated" not in _parse_finish_extra(result)
+
+
+def _parse_finish_extra(sse_lines: list[str]) -> dict:
+    for line in reversed(sse_lines):
+        if line.startswith("data: ") and line.strip() != "data: [DONE]":
+            data = json.loads(line[len("data: ") :])
+            extra = data.get("extra")
+            if extra and extra != "{}":
+                return json.loads(extra)
+    return {}
+
+
 class TestStreamWithManySources:
     @pytest.mark.asyncio
     async def test_60_source_citation_survives_buffer_eviction(self):

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -200,6 +200,17 @@ def _make_finish(chunk_id: str = "chatcmpl-1") -> str:
     return "data: " + json.dumps({"id": chunk_id, "choices": [{"delta": {}, "finish_reason": "stop"}]})
 
 
+def _make_content_finish(content: str, chunk_id: str = "chatcmpl-1") -> str:
+    """Build a terminal SSE line carrying both a content delta and finish_reason.
+
+    Some OpenAI-compatible providers pack the last token and the stop reason into
+    the same final chunk.
+    """
+    return "data: " + json.dumps(
+        {"id": chunk_id, "choices": [{"delta": {"content": content}, "finish_reason": "stop"}]}
+    )
+
+
 DONE_LINE = "data: [DONE]"
 
 
@@ -263,6 +274,18 @@ class TestStreamWithSourceFiltering:
         result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
         assert _collect_content(result) == "Here is the answer."
         assert _parse_finish_sources(result) == [{"file": "a.pdf"}, {"file": "c.pdf"}]
+
+    @pytest.mark.asyncio
+    async def test_content_and_finish_reason_in_same_chunk_keeps_last_token(self):
+        """A provider that packs the final token and finish_reason into one chunk
+        must not lose that token (regression: `Hello ` + final `world` → `Hello`)."""
+        lines = [
+            _make_chunk("Hello "),
+            _make_content_finish("world"),
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        assert _collect_content(result) == "Hello world"
 
     @pytest.mark.asyncio
     async def test_content_tail_chunk_has_null_finish_reason(self):

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -1,5 +1,6 @@
 """Tests for source citation extraction and filtering utilities."""
 
+import asyncio
 import json
 
 import pytest
@@ -202,9 +203,21 @@ def _make_finish(chunk_id: str = "chatcmpl-1") -> str:
 DONE_LINE = "data: [DONE]"
 
 
+def _make_preamble(chunk_id: str = "chatcmpl-1") -> str:
+    """Build an SSE line carrying only a role delta (no content, no finish_reason)."""
+    return "data: " + json.dumps({"id": chunk_id, "choices": [{"delta": {"role": "assistant"}, "finish_reason": None}]})
+
+
 async def _fake_stream(lines: list[str]):
     for line in lines:
         yield line
+
+
+async def _stream_then_raise(lines: list[str], exc: Exception):
+    """Yield the given lines, then raise — mimics an upstream that drops mid-stream."""
+    for line in lines:
+        yield line
+    raise exc
 
 
 async def _collect(async_gen) -> list[str]:
@@ -410,6 +423,54 @@ class TestStreamClosedWithoutDone:
         ]
         result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
         assert "truncated" not in _parse_finish_extra(result)
+
+    @pytest.mark.asyncio
+    async def test_preamble_only_close_still_flags_truncated(self):
+        # Upstream drops right after the role-preamble chunk, before any content
+        # or finish chunk arrives. There is no `chunk_template`, but the preamble
+        # must still let us surface `truncated` so the client can tell the stream
+        # was cut off rather than a clean empty completion.
+        lines = [_make_preamble()]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        assert result[-1].strip() == "data: [DONE]"
+        assert _parse_finish_extra(result).get("truncated") is True
+
+    @pytest.mark.asyncio
+    async def test_upstream_raises_after_content_flushes_tail_and_sources(self):
+        # A read timeout surfaces as the upstream generator raising mid-stream
+        # (not a clean close). The buffered tail + sources must still be flushed
+        # and flagged truncated, and no exception should propagate to the caller.
+        from core.utils.exceptions import InferenceTimeoutError
+
+        lines = [
+            _make_chunk("Here is the answer."),
+            _make_chunk("\n[Sources: 1, 3]"),
+        ]
+        stream = _stream_then_raise(lines, InferenceTimeoutError("LLM request timed out"))
+        result = await _collect(stream_with_source_filtering(stream, self.SOURCES, "test-model"))
+        assert _collect_content(result) == "Here is the answer."
+        assert _parse_finish_sources(result) == [{"file": "a.pdf"}, {"file": "c.pdf"}]
+        assert _parse_finish_extra(result).get("truncated") is True
+        assert result[-1].strip() == "data: [DONE]"
+
+    @pytest.mark.asyncio
+    async def test_upstream_raises_before_any_chunk_reraises(self):
+        # Nothing was ever streamed, so there is no partial answer to salvage:
+        # the real error must propagate instead of a silent, clean-looking [DONE].
+        from core.utils.exceptions import InferenceConnectionError
+
+        stream = _stream_then_raise([], InferenceConnectionError("Cannot reach LLM"))
+        with pytest.raises(InferenceConnectionError):
+            await _collect(stream_with_source_filtering(stream, self.SOURCES, "test-model"))
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_propagates_without_flush(self):
+        # CancelledError (client disconnect) is BaseException, not Exception, so it
+        # must propagate untouched rather than be captured as a truncation: no flush,
+        # no swallow, letting the router's cancellation handling run.
+        stream = _stream_then_raise([_make_chunk("partial")], asyncio.CancelledError())
+        with pytest.raises(asyncio.CancelledError):
+            await _collect(stream_with_source_filtering(stream, self.SOURCES, "test-model"))
 
 
 def _parse_finish_extra(sse_lines: list[str]) -> dict:

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -472,6 +472,36 @@ class TestStreamClosedWithoutDone:
         with pytest.raises(asyncio.CancelledError):
             await _collect(stream_with_source_filtering(stream, self.SOURCES, "test-model"))
 
+    @pytest.mark.asyncio
+    async def test_truncated_answer_is_logged(self):
+        # Truncation must surface an explicit, visible "Answer truncated" warning
+        # carrying the cause and context (model, delivered length, source count) —
+        # and must NOT fire on a clean, [DONE]-terminated stream.
+        from loguru import logger
+
+        # Truncated: the stream ends without [DONE].
+        records: list[str] = []
+        sink_id = logger.add(records.append, level="WARNING", format="{message}")
+        try:
+            lines = [_make_chunk("Partial answer only."), _make_finish()]
+            await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        finally:
+            logger.remove(sink_id)
+        truncation = [r for r in records if "Answer truncated" in r]
+        assert truncation, f"expected a truncation warning, got: {records}"
+        assert "model=test-model" in truncation[0]
+        assert "reason=connection closed" in truncation[0]
+
+        # Clean [DONE]-terminated stream: no truncation warning.
+        records = []
+        sink_id = logger.add(records.append, level="WARNING", format="{message}")
+        try:
+            lines = [_make_chunk("Complete answer."), _make_finish(), DONE_LINE]
+            await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        finally:
+            logger.remove(sink_id)
+        assert not any("Answer truncated" in r for r in records)
+
 
 def _parse_finish_extra(sse_lines: list[str]) -> dict:
     for line in reversed(sse_lines):

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -288,6 +288,29 @@ class TestStreamWithSourceFiltering:
         assert _collect_content(result) == "Hello world"
 
     @pytest.mark.asyncio
+    async def test_intermediate_content_chunk_never_marked_terminal(self):
+        """When the buffer has overflowed and the last token arrives packed with
+        finish_reason in one chunk, the mid-stream chunk emitted for it must NOT
+        carry finish_reason — else a spec client treats it as terminal, drops the
+        delta, and ignores the tail/finish chunks (truncating a long answer)."""
+        lines = [
+            _make_chunk("A" * 100),  # overflow the buffer (>80) so the next chunk emits mid-stream
+            _make_content_finish("B" * 100),  # last token + finish_reason in the same chunk
+            DONE_LINE,
+        ]
+        result = await _collect(stream_with_source_filtering(_fake_stream(lines), self.SOURCES, "test-model"))
+        # The whole answer is still delivered.
+        assert _collect_content(result) == "A" * 100 + "B" * 100
+        # No content-bearing chunk may be marked terminal — only the empty finish chunk.
+        for line in result:
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            data = json.loads(line[len("data: ") :])
+            choice = data.get("choices", [{}])[0]
+            if choice.get("delta", {}).get("content"):
+                assert choice.get("finish_reason") is None, f"content chunk marked terminal: {line}"
+
+    @pytest.mark.asyncio
     async def test_upstream_iterator_closed_after_done(self):
         """Breaking on [DONE] must close the upstream generator so the client's
         pooled HTTP connection is released now, not left suspended until GC (an

--- a/tests/unit/core/utils/test_source_filtering.py
+++ b/tests/unit/core/utils/test_source_filtering.py
@@ -288,6 +288,29 @@ class TestStreamWithSourceFiltering:
         assert _collect_content(result) == "Hello world"
 
     @pytest.mark.asyncio
+    async def test_upstream_iterator_closed_after_done(self):
+        """Breaking on [DONE] must close the upstream generator so the client's
+        pooled HTTP connection is released now, not left suspended until GC (an
+        `async for` does not close its iterator on break)."""
+        closed = {"value": False}
+
+        async def _tracking_stream():
+            try:
+                yield _make_chunk("Answer.")
+                yield _make_finish()
+                yield DONE_LINE
+                yield _make_chunk("after-done-never-consumed")
+            finally:
+                closed["value"] = True
+
+        # Hold a reference so a passing assertion can only mean an explicit
+        # aclose() ran — not that GC happened to reclaim the generator.
+        stream = _tracking_stream()
+        result = await _collect(stream_with_source_filtering(stream, self.SOURCES, "test-model"))
+        assert result[-1].strip() == "data: [DONE]"
+        assert closed["value"] is True, "upstream generator was not closed after [DONE]"
+
+    @pytest.mark.asyncio
     async def test_content_tail_chunk_has_null_finish_reason(self):
         """The content-bearing tail chunk must not carry finish_reason — the
         upstream finish chunk becomes the template, and a spec-compliant client


### PR DESCRIPTION
## Summary
- Closes #715: an upstream stream that ends without `data: [DONE]` (timeout, proxy drop, worker restart) silently dropped the buffered answer tail and all of `extra.sources`, with no error surfaced.
- `stream_with_source_filtering` now performs the terminal flush (tail content + `extra.sources`) in a single post-loop block that runs whether the loop exits via `[DONE]` or the upstream connection simply closing, instead of only inside the `data: [DONE]` branch.
- The generator always emits a downstream `data: [DONE]`, even if upstream never sent one, so clients (e.g. the OpenAI SDK) don't hang waiting for stream termination.
- When the stream ended without `[DONE]`, the final chunk's `extra` now includes `"truncated": true` so a silently-truncated answer is distinguishable from a normal completion instead of looking indistinguishable from a clean one.

## Test plan
- [x] Added regression tests in `tests/unit/core/utils/test_source_filtering.py::TestStreamClosedWithoutDone` covering: tail/sources still flushed without `[DONE]`, `truncated` flag set when `[DONE]` is missing, and no `truncated` flag on a normal `[DONE]`-terminated stream.
- [x] `uv run pytest tests/unit/core/utils/test_source_filtering.py` — 42 passed.
- [x] `uv run pytest tests/unit/` — 1888 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the streaming terminal “tail flush” runs exactly once across all upstream termination paths (clean `[DONE]`, upstream close without `[DONE]`, and mid-stream exceptions).
  * Preserves buffered answer tail and emits consistent final completion signals so clients don’t hang.
  * Filters and salvages cited sources from buffered output; sets `extra.truncated` and warning behavior based on whether termination was clean.

* **Tests**
  * Expanded SSE regression coverage for combined content+`finish_reason`, role-only preamble closes, missing `[DONE]`, upstream exceptions, and disconnect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->