### PR TITLE
Restore actor-pool acceptance when retirement is safely aborted

### DIFF
--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -136,6 +136,30 @@ Once running, **OpenRAG will auto-connect** to the Ray cluster using `RAY_ADDRES
 When `RAY_ADDRESS` is set, the app **attaches** to the external cluster and does **not** start its own embedded Ray dashboard — the head node owns it. Keep the dashboard bound to `127.0.0.1` by default because the dashboard API is unauthenticated ([CVE-2023-48022](https://nvd.nist.gov/vuln/detail/CVE-2023-48022)). If operators need remote dashboard access, expose it only through a private network, SSH tunnel, or authenticated proxy.
 :::
 
+### Retire an old indexer actor generation
+
+Detached indexer actors survive an API-only rollout when OpenRAG uses an external Ray cluster. When an upgrade changes the indexer actor protocol, stop traffic to API replicas using the old generation, then retire that generation from a checkout of the new release.
+
+The first transition is from the original unversioned actors to `v2`. Those actors cannot report whether they are idle, so verify that the old API replicas and indexing jobs have stopped before confirming their removal:
+
+```bash
+uv run python -m openrag.services.workers.retire_indexer_generation \
+  --ray-address "${RAY_ADDRESS}" \
+  --generation legacy \
+  --confirm-legacy-idle
+```
+
+Protocol-aware generations drain automatically. For example, a future `v2` retirement rejects new submissions, waits for all accepted jobs to settle, and only then removes the dispatcher and workers:
+
+```bash
+uv run python -m openrag.services.workers.retire_indexer_generation \
+  --ray-address "${RAY_ADDRESS}" \
+  --generation v2 \
+  --timeout 3600
+```
+
+If the timeout expires, the command leaves the actors running. Do not use the legacy confirmation while old API replicas can still submit indexing work. A complete Ray cluster restart also removes all detached generations.
+
 ---
 
 With this setup, your app is now fully distributed and ready to handle concurrent tasks across your Ray cluster.

--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -143,7 +143,7 @@ Detached indexer actors survive an API-only rollout when OpenRAG uses an externa
 The first transition is from the original unversioned actors to `v2`. Those actors cannot report whether they are idle, so verify that the old API replicas and indexing jobs have stopped before confirming their removal:
 
 ```bash
-uv run python -m openrag.services.workers.retire_indexer_generation \
+PYTHONPATH=openrag uv run python -m services.workers.retire_indexer_generation \
   --ray-address "${RAY_ADDRESS}" \
   --generation legacy \
   --confirm-legacy-idle
@@ -152,7 +152,7 @@ uv run python -m openrag.services.workers.retire_indexer_generation \
 Protocol-aware generations drain automatically. For example, a future `v2` retirement rejects new submissions, waits for all accepted jobs to settle, and only then removes the dispatcher and workers:
 
 ```bash
-uv run python -m openrag.services.workers.retire_indexer_generation \
+PYTHONPATH=openrag uv run python -m services.workers.retire_indexer_generation \
   --ray-address "${RAY_ADDRESS}" \
   --generation v2 \
   --timeout 3600

--- a/docs/content/docs/documentation/deploy_ray_cluster.md
+++ b/docs/content/docs/documentation/deploy_ray_cluster.md
@@ -158,7 +158,7 @@ PYTHONPATH=openrag uv run python -m services.workers.retire_indexer_generation \
   --timeout 3600
 ```
 
-If the timeout expires, the command leaves the actors running. Do not use the legacy confirmation while old API replicas can still submit indexing work. A complete Ray cluster restart also removes all detached generations.
+If `begin_drain` succeeds but a later timeout or drain check fails, the command leaves the actors running and restores submissions automatically. If that restoration also fails, the command logs that the pool may remain drained; stop API traffic and restart the Ray cluster to recreate the current generation. Do not use the legacy confirmation while old API replicas can still submit indexing work.
 
 ---
 

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -30,6 +30,7 @@ TERMINAL_TASK_STATES = frozenset({DocumentStatus.COMPLETED, DocumentStatus.FAILE
 # without replacing an already-running detached TaskStateManager actor.
 TASK_CREATED_AT_METADATA_KEY = "_openrag_job_created_at"
 TASK_FINISHED_AT_METADATA_KEY = "_openrag_job_finished_at"
+CONTENT_CLAIM_TOKEN_METADATA_KEY = "_openrag_content_claim_token"
 
 
 class JobStatus(str, Enum):

--- a/openrag/core/ports/document_repo.py
+++ b/openrag/core/ports/document_repo.py
@@ -51,9 +51,10 @@ class DocumentRepository(ABC):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
         replace: bool = False,
     ) -> str | None:
-        """Reserve content for indexing, returning a conflicting file id."""
+        """Reserve content for one indexing attempt, returning a conflicting file id."""
         ...
 
     @abstractmethod
@@ -63,8 +64,9 @@ class DocumentRepository(ABC):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
     ) -> bool:
-        """Extend an active content claim owned by this file."""
+        """Extend an active content claim owned by this indexing attempt."""
         ...
 
     @abstractmethod
@@ -74,6 +76,7 @@ class DocumentRepository(ABC):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
     ) -> None: ...
 
     @abstractmethod

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -275,6 +275,7 @@ class PgDocumentRepository(DocumentRepository):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
         replace: bool = False,
     ) -> str | None:
         """Atomically reserve content while it is being indexed."""
@@ -307,14 +308,15 @@ class PgDocumentRepository(DocumentRepository):
                 )
                 claimed = await conn.fetchval(
                     """
-                    INSERT INTO file_content_claims (partition_name, content_sha256, file_id)
-                    VALUES ($1, $2, $3)
+                    INSERT INTO file_content_claims (partition_name, content_sha256, file_id, claim_token)
+                    VALUES ($1, $2, $3, $4)
                     ON CONFLICT (partition_name, content_sha256) DO NOTHING
                     RETURNING file_id
                     """,
                     partition,
                     content_sha256,
                     file_id,
+                    claim_token,
                 )
                 if claimed is not None:
                     return None
@@ -333,16 +335,19 @@ class PgDocumentRepository(DocumentRepository):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
     ) -> bool:
         result = await self.pool.execute(
             """
             UPDATE file_content_claims
             SET expires_at = NOW() + interval '24 hours'
-            WHERE partition_name = $1 AND content_sha256 = $2 AND file_id = $3
+            WHERE partition_name = $1 AND content_sha256 = $2
+              AND file_id = $3 AND claim_token = $4
             """,
             partition,
             content_sha256,
             file_id,
+            claim_token,
         )
         return result.endswith(" 1")
 
@@ -352,6 +357,7 @@ class PgDocumentRepository(DocumentRepository):
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
     ) -> None:
         async with self.pool.acquire() as conn:
             async with conn.transaction():
@@ -363,11 +369,13 @@ class PgDocumentRepository(DocumentRepository):
                 await conn.execute(
                     """
                     DELETE FROM file_content_claims
-                    WHERE partition_name = $1 AND content_sha256 = $2 AND file_id = $3
+                    WHERE partition_name = $1 AND content_sha256 = $2
+                      AND file_id = $3 AND claim_token = $4
                     """,
                     partition,
                     content_sha256,
                     file_id,
+                    claim_token,
                 )
 
     # ── Legacy method names used by the Phase 7C shim ────────────────

--- a/openrag/services/persistence/migrations/alembic/versions/d4e5f6a7b8c9_add_content_claim_tokens.py
+++ b/openrag/services/persistence/migrations/alembic/versions/d4e5f6a7b8c9_add_content_claim_tokens.py
@@ -1,0 +1,38 @@
+"""add content claim ownership tokens
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from schema_helpers import column_exists, table_exists
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "c3d4e5f6a7b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not table_exists("file_content_claims") or column_exists("file_content_claims", "claim_token"):
+        return
+
+    op.add_column(
+        "file_content_claims",
+        sa.Column(
+            "claim_token",
+            sa.String(),
+            server_default=sa.text("md5(random()::text || clock_timestamp()::text)"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    if table_exists("file_content_claims") and column_exists("file_content_claims", "claim_token"):
+        op.drop_column("file_content_claims", "claim_token")

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -170,6 +170,12 @@ file_content_claims = Table(
     Column("content_sha256", String(64), primary_key=True),
     Column("file_id", String, nullable=False),
     Column(
+        "claim_token",
+        String,
+        server_default=text("md5(random()::text || clock_timestamp()::text)"),
+        nullable=False,
+    ),
+    Column(
         "expires_at",
         DateTime(timezone=True),
         server_default=text("now() + interval '24 hours'"),

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -6,7 +6,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 from core.indexing.dispatcher import IndexingDispatcher
-from core.models.catalog import TASK_CREATED_AT_METADATA_KEY, TASK_FINISHED_AT_METADATA_KEY
+from core.models.catalog import (
+    CONTENT_CLAIM_TOKEN_METADATA_KEY,
+    TASK_CREATED_AT_METADATA_KEY,
+    TASK_FINISHED_AT_METADATA_KEY,
+)
 from core.utils.conts import is_internal_metadata_key, strip_internal_metadata
 from core.utils.exceptions import ConflictError
 from core.utils.logging import get_logger
@@ -152,6 +156,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 file_id=file_id,
                 partition=partition,
                 content_sha256=content_sha256,
+                claim_token=task_id,
                 replace=replace,
             )
             if conflicting_file_id is not None:
@@ -182,6 +187,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=file_id,
                     partition=partition,
                     content_sha256=content_sha256,
+                    claim_token=task_id,
                 )
             raise
         if not accepted:
@@ -190,6 +196,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=file_id,
                     partition=partition,
                     content_sha256=content_sha256,
+                    claim_token=task_id,
                 )
             raise RuntimeError(
                 f"Task {task_id} was rejected because file {file_id!r} in partition {partition!r} is being deleted"
@@ -197,10 +204,13 @@ class WorkerDispatcher(IndexingDispatcher):
 
         task: Any | None = None
         try:
+            worker_metadata = dict(metadata)
+            if claimed_content:
+                worker_metadata[CONTENT_CLAIM_TOKEN_METADATA_KEY] = task_id
             submit_kwargs: dict[str, Any] = {
                 "task_id": task_id,
                 "path": path,
-                "metadata": metadata,
+                "metadata": worker_metadata,
                 "partition": partition,
                 "user": user,
                 "workspace_ids": workspace_ids,
@@ -239,6 +249,7 @@ class WorkerDispatcher(IndexingDispatcher):
                         file_id=file_id,
                         partition=partition,
                         content_sha256=content_sha256,
+                        claim_token=task_id,
                     )
             raise
         return task_id
@@ -453,11 +464,13 @@ class WorkerDispatcher(IndexingDispatcher):
         target_partition = metadata.get("partition", partition)
         content_sha256 = metadata.get("content_sha256")
         claimed_content = False
+        claim_token = uuid.uuid4().hex
         if content_sha256:
             conflicting_file_id = await self._document_repo.claim_content_sha256(
                 file_id=target_file_id,
                 partition=target_partition,
                 content_sha256=content_sha256,
+                claim_token=claim_token,
             )
             if conflicting_file_id is not None:
                 raise ConflictError(
@@ -503,6 +516,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=target_file_id,
                     partition=target_partition,
                     content_sha256=content_sha256,
+                    claim_token=claim_token,
                 )
 
     async def _upsert_entities(self, entities: list[dict[str, Any]]) -> None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -17,7 +17,16 @@ from openrag.core.config.root import Settings
 # of indexing throughput.
 _MODEL_REGISTRY_TTL_SECONDS = 60.0
 _CONTENT_CLAIM_RENEW_INTERVAL_SECONDS = 60 * 60
-_INDEXER_POOL_DISPATCHER_ACTOR_NAME = "IndexerPoolDispatcher"
+# Named detached actors survive API rolling deployments. Keep the dispatcher
+# and workers on the same protocol generation whenever their remote contract or
+# cross-process indexing semantics change, so new replicas cannot attach to a
+# partially compatible actor fleet left by the previous release.
+_INDEXER_ACTOR_PROTOCOL_VERSION = "v2"
+_INDEXER_POOL_DISPATCHER_ACTOR_NAME = f"IndexerPoolDispatcher-{_INDEXER_ACTOR_PROTOCOL_VERSION}"
+
+
+def _indexer_worker_actor_name(index: int) -> str:
+    return f"IndexerWorker-{_INDEXER_ACTOR_PROTOCOL_VERSION}-{index}"
 
 
 def _catalog_rdb_config(settings: Settings) -> Any:
@@ -290,13 +299,14 @@ class IndexerWorkerActor:
 class IndexerPool:
     """Single detached dispatcher actor over a fleet of ``IndexerWorkerActor``.
 
-    Exactly **one** instance exists cluster-wide — it is created named, detached
-    and with ``get_if_exists=True`` (see :func:`build_indexer_pool`). Every API
-    process and every Ray Serve replica therefore shares the *same* dispatcher,
-    so the least-loaded view is global. A per-replica client object would keep
-    its own ``_inflight`` counters, and since Ray Serve runs each replica as a
-    separate actor/process, those views would diverge and unbalance dispatch
-    across the shared workers under bursts.
+    Exactly **one** instance per protocol generation exists cluster-wide — it is
+    created named, detached and with ``get_if_exists=True`` (see
+    :func:`build_indexer_pool`). Every API process and every Ray Serve replica
+    on the current generation therefore shares the *same* dispatcher, so the
+    least-loaded view is global. A per-replica client object would keep its own
+    ``_inflight`` counters, and since Ray Serve runs each replica as a separate
+    actor/process, those views would diverge and unbalance dispatch across the
+    shared workers under bursts.
 
     It holds ``ray.indexer.pool_size`` worker actors and dispatches each file to
     the least-loaded one (fewest in-flight files). ``submit`` returns the
@@ -318,7 +328,7 @@ class IndexerPool:
         # are shared singletons too; only this dispatcher creates them.
         self._workers = [
             IndexerWorkerActor.options(  # type: ignore[attr-defined]
-                name=f"IndexerWorker-{i}",
+                name=_indexer_worker_actor_name(i),
                 namespace=namespace,
                 get_if_exists=True,
                 lifetime="detached",
@@ -327,12 +337,30 @@ class IndexerPool:
             for i in range(pool_size)
         ]
         self._inflight = [0] * len(self._workers)
+        self._accepting_tasks = True
         self._release_tasks: set[asyncio.Task[Any]] = set()
         self._claim_store: Any = None
         self._claim_store_lock = asyncio.Lock()
 
     async def size(self) -> int:
         return len(self._workers)
+
+    async def protocol_version(self) -> str:
+        """Return the remote contract generation implemented by this actor."""
+        return _INDEXER_ACTOR_PROTOCOL_VERSION
+
+    async def begin_drain(self) -> dict[str, Any]:
+        """Reject new submissions while allowing accepted work to settle."""
+        self._accepting_tasks = False
+        return await self.status()
+
+    async def status(self) -> dict[str, Any]:
+        """Expose the state a deployment controller needs before actor cleanup."""
+        return {
+            "protocol_version": _INDEXER_ACTOR_PROTOCOL_VERSION,
+            "accepting_tasks": self._accepting_tasks,
+            "inflight_jobs": sum(self._inflight),
+        }
 
     async def submit(self, **kwargs: Any) -> list[Any]:
         """Dispatch ``process_file`` to the least-loaded worker.
@@ -341,6 +369,8 @@ class IndexerPool:
         one-element list — see the class docstring); in-flight bookkeeping is
         released when the task settles (success, failure, or cancellation).
         """
+        if not self._accepting_tasks:
+            raise RuntimeError("IndexerPool is draining and cannot accept new tasks")
         idx = min(range(len(self._workers)), key=self._inflight.__getitem__)
         self._inflight[idx] += 1
         try:
@@ -448,8 +478,10 @@ def build_indexer_pool(namespace: str = "openrag") -> Any:
     # the whole fleet's capacity. The constructor args are honoured only on the
     # first creation; later get_if_exists calls reuse the existing dispatcher
     # and ignore them — which is correct, since every replica loads the same cfg.
-    # Do not reuse the old "IndexerPool" name: that detached actor exposed
-    # process_file(), while this dispatcher exposes submit().
+    # The protocol-generation suffix prevents a rolling deployment from
+    # reusing an older detached dispatcher or its workers. This matters even
+    # when the public submit() signature is unchanged: claim ownership and
+    # catalog routing are implemented inside those long-lived actor processes.
     return IndexerPool.options(  # type: ignore[attr-defined]
         name=_INDEXER_POOL_DISPATCHER_ACTOR_NAME,
         namespace=namespace,

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -339,6 +339,7 @@ class IndexerPool:
         self._worker_names = [_indexer_worker_actor_name(i) for i in range(pool_size)]
         self._inflight = [0] * len(self._workers)
         self._accepting_tasks = True
+        self._drain_operation_id: str | None = None
         self._release_tasks: set[asyncio.Task[Any]] = set()
         self._claim_store: Any = None
         self._claim_store_lock = asyncio.Lock()
@@ -350,9 +351,22 @@ class IndexerPool:
         """Return the remote contract generation implemented by this actor."""
         return _INDEXER_ACTOR_PROTOCOL_VERSION
 
-    async def begin_drain(self) -> dict[str, Any]:
+    async def begin_drain(self, operation_id: str) -> dict[str, Any]:
         """Reject new submissions while allowing accepted work to settle."""
+        if not self._accepting_tasks and self._drain_operation_id != operation_id:
+            raise RuntimeError("IndexerPool is already draining for another retirement operation")
         self._accepting_tasks = False
+        self._drain_operation_id = operation_id
+        return await self.status()
+
+    async def abort_drain(self, operation_id: str) -> dict[str, Any]:
+        """Resume submissions after this retirement operation is abandoned."""
+        if self._accepting_tasks and self._drain_operation_id is None:
+            return await self.status()
+        if self._drain_operation_id != operation_id:
+            raise RuntimeError("IndexerPool drain belongs to another retirement operation")
+        self._accepting_tasks = True
+        self._drain_operation_id = None
         return await self.status()
 
     async def status(self) -> dict[str, Any]:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import ray
+from core.models.catalog import CONTENT_CLAIM_TOKEN_METADATA_KEY
 from services.workers.indexer_actor import IndexerWorker, delete_uploaded_file
 
 from openrag.core.config.root import Settings
@@ -17,6 +18,14 @@ from openrag.core.config.root import Settings
 _MODEL_REGISTRY_TTL_SECONDS = 60.0
 _CONTENT_CLAIM_RENEW_INTERVAL_SECONDS = 60 * 60
 _INDEXER_POOL_DISPATCHER_ACTOR_NAME = "IndexerPoolDispatcher"
+
+
+def _catalog_rdb_config(settings: Settings) -> Any:
+    if settings.rdb.database is not None:
+        return settings.rdb
+    return settings.rdb.model_copy(
+        update={"database": f"partitions_for_collection_{settings.vectordb.collection_name}"}
+    )
 
 
 @ray.remote
@@ -91,8 +100,7 @@ class IndexerWorkerActor:
             topic_tagger_factory=topic_tagger_factory,
             defer_replace_cleanup=True,
         )
-        rdb_cfg = cfg.rdb.model_copy(update={"database": f"partitions_for_collection_{cfg.vectordb.collection_name}"})
-        self._catalog_store = PostgresStore(rdb_cfg, run_migrations=False)
+        self._catalog_store = PostgresStore(_catalog_rdb_config(cfg), run_migrations=False)
         self._catalog_initialized = False
         self._catalog_init_lock = asyncio.Lock()
         # Model-endpoint registry hydration. Unlike the API process, the indexer
@@ -227,13 +235,15 @@ class IndexerWorkerActor:
         embedder_name: str | None = None,
         require_existing_partition: bool = False,
     ) -> dict[str, Any]:
+        content_claim_token = metadata.get(CONTENT_CLAIM_TOKEN_METADATA_KEY)
+        worker_metadata = {key: value for key, value in metadata.items() if key != CONTENT_CLAIM_TOKEN_METADATA_KEY}
         try:
             await self._ensure_catalog()
             await self._ensure_registry_fresh(_required_model_endpoint_names(indexation_config, embedder_name))
             result = await self._worker.process_file(
                 task_id=task_id,
                 path=path,
-                metadata=metadata,
+                metadata=worker_metadata,
                 partition=partition,
                 user=user,
                 workspace_ids=workspace_ids,
@@ -257,13 +267,14 @@ class IndexerWorkerActor:
         finally:
             content_sha256 = metadata.get("content_sha256")
             file_id = metadata.get("file_id")
-            if content_sha256 and file_id:
+            if content_sha256 and file_id and content_claim_token:
                 try:
                     await self._ensure_catalog()
                     await self._catalog_store.document_repo.release_content_sha256_claim(
                         file_id=file_id,
                         partition=partition,
                         content_sha256=content_sha256,
+                        claim_token=content_claim_token,
                     )
                 except Exception as exc:  # noqa: BLE001 - stale claims expire automatically
                     self._logger.warning(f"Failed to release content deduplication claim for {file_id}: {exc}")
@@ -342,12 +353,14 @@ class IndexerPool:
         metadata = kwargs.get("metadata") or {}
         content_sha256 = metadata.get("content_sha256")
         file_id = metadata.get("file_id")
+        claim_token = metadata.get(CONTENT_CLAIM_TOKEN_METADATA_KEY)
         claim = None
-        if content_sha256 and file_id:
+        if content_sha256 and file_id and claim_token:
             claim = {
                 "file_id": str(file_id),
                 "partition": str(kwargs.get("partition") or ""),
                 "content_sha256": str(content_sha256),
+                "claim_token": str(claim_token),
             }
         task = asyncio.get_running_loop().create_task(self._release(idx, ref, claim=claim))
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
@@ -387,10 +400,7 @@ class IndexerPool:
                     from services.storage.postgres_store import PostgresStore
 
                     cfg = load_config()
-                    rdb_cfg = cfg.rdb.model_copy(
-                        update={"database": f"partitions_for_collection_{cfg.vectordb.collection_name}"}
-                    )
-                    store = PostgresStore(rdb_cfg, run_migrations=False)
+                    store = PostgresStore(_catalog_rdb_config(cfg), run_migrations=False)
                     await store.initialize()
                     self._claim_store = store
         return self._claim_store.document_repo
@@ -401,6 +411,7 @@ class IndexerPool:
         file_id: str,
         partition: str,
         content_sha256: str,
+        claim_token: str,
     ) -> None:
         while True:
             await asyncio.sleep(_CONTENT_CLAIM_RENEW_INTERVAL_SECONDS)
@@ -410,6 +421,7 @@ class IndexerPool:
                     file_id=file_id,
                     partition=partition,
                     content_sha256=content_sha256,
+                    claim_token=claim_token,
                 )
                 if not renewed:
                     return

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -336,6 +336,7 @@ class IndexerPool:
             ).remote()
             for i in range(pool_size)
         ]
+        self._worker_names = [_indexer_worker_actor_name(i) for i in range(pool_size)]
         self._inflight = [0] * len(self._workers)
         self._accepting_tasks = True
         self._release_tasks: set[asyncio.Task[Any]] = set()
@@ -360,6 +361,7 @@ class IndexerPool:
             "protocol_version": _INDEXER_ACTOR_PROTOCOL_VERSION,
             "accepting_tasks": self._accepting_tasks,
             "inflight_jobs": sum(self._inflight),
+            "worker_names": list(self._worker_names),
         }
 
     async def submit(self, **kwargs: Any) -> list[Any]:

--- a/openrag/services/workers/retire_indexer_generation.py
+++ b/openrag/services/workers/retire_indexer_generation.py
@@ -133,16 +133,22 @@ def retire_generation(
     )
     dispatcher_name, worker_names = _generation_actor_names(actors, generation)
     dispatcher = _get_actor(dispatcher_name, namespace)
-    if dispatcher is None:
-        return []
 
     if generation == _LEGACY_GENERATION:
-        if not confirm_legacy_idle:
+        if (dispatcher is not None or worker_names) and not confirm_legacy_idle:
             raise RuntimeError(
                 "The legacy indexer cannot report active work. Stop old API traffic, verify its jobs are idle, "
                 "then rerun with --confirm-legacy-idle."
             )
-    else:
+
+    removed: list[str] = []
+    if dispatcher is None:
+        for worker_name in worker_names:
+            if _kill_actor(worker_name, namespace):
+                removed.append(worker_name)
+        return removed
+
+    if generation != _LEGACY_GENERATION:
         status = asyncio.run(
             _drain_protocol_generation(
                 dispatcher,
@@ -153,7 +159,6 @@ def retire_generation(
         )
         worker_names = list(status.get("worker_names") or worker_names)
 
-    removed: list[str] = []
     if _kill_actor(dispatcher_name, namespace):
         removed.append(dispatcher_name)
     for worker_name in worker_names:

--- a/openrag/services/workers/retire_indexer_generation.py
+++ b/openrag/services/workers/retire_indexer_generation.py
@@ -13,15 +13,19 @@ import argparse
 import asyncio
 import re
 import time
+import uuid
 from typing import Any
 
 import ray
+from core.utils.logging import get_logger
 
 from .ray_utils import call_ray_actor_with_timeout
 
 _LEGACY_GENERATION = "legacy"
 _LEGACY_DISPATCHER_NAME = "IndexerPoolDispatcher"
 _LEGACY_WORKER_PATTERN = re.compile(r"^IndexerWorker-\d+$")
+_RECOVERY_TIMEOUT_SECONDS = 30.0
+logger = get_logger()
 
 
 def _actor_name(actor: Any) -> str:
@@ -88,31 +92,53 @@ async def _drain_protocol_generation(
 ) -> dict[str, Any]:
     """Drain one protocol-aware generation within one end-to-end deadline."""
     deadline = time.monotonic() + timeout
+    operation_id = uuid.uuid4().hex
+    drain_started = False
 
-    async def call_with_remaining_timeout(method: Any, description: str) -> dict[str, Any]:
+    async def call_with_remaining_timeout(method: Any, description: str, *args: Any) -> dict[str, Any]:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise _drain_timeout(generation, timeout)
-        future = method.remote()
+        future = method.remote(*args)
         try:
             return await call_ray_actor_with_timeout(future, remaining, description)
         except TimeoutError as exc:
             raise _drain_timeout(generation, timeout) from exc
 
-    status = await call_with_remaining_timeout(
-        dispatcher.begin_drain,
-        f"Begin draining indexer generation {generation}",
-    )
-    while int(status.get("inflight_jobs", 0)) > 0:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise _drain_timeout(generation, timeout)
-        await asyncio.sleep(min(max(poll_interval, 0.0), remaining))
+    try:
         status = await call_with_remaining_timeout(
-            dispatcher.status,
-            f"Check indexer generation {generation} drain status",
+            dispatcher.begin_drain,
+            f"Begin draining indexer generation {generation}",
+            operation_id,
         )
-    return status
+        drain_started = True
+        while int(status.get("inflight_jobs", 0)) > 0:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise _drain_timeout(generation, timeout)
+            await asyncio.sleep(min(max(poll_interval, 0.0), remaining))
+            status = await call_with_remaining_timeout(
+                dispatcher.status,
+                f"Check indexer generation {generation} drain status",
+            )
+        return status
+    except BaseException as exc:
+        if not drain_started:
+            raise
+        try:
+            await call_ray_actor_with_timeout(
+                dispatcher.abort_drain.remote(operation_id),
+                _RECOVERY_TIMEOUT_SECONDS,
+                f"Restore indexer generation {generation} after failed retirement",
+            )
+        except BaseException as recovery_exc:
+            logger.error(
+                "Failed to restore an indexer generation after retirement was abandoned; it may remain drained.",
+                generation=generation,
+                error=str(recovery_exc),
+                original_error=str(exc),
+            )
+        raise
 
 
 def retire_generation(

--- a/openrag/services/workers/retire_indexer_generation.py
+++ b/openrag/services/workers/retire_indexer_generation.py
@@ -3,7 +3,8 @@
 Run this only after traffic has stopped reaching API replicas that use the
 generation being retired. Protocol-aware generations are drained before they
 are removed. The original unversioned generation cannot report its state, so
-retiring it requires an explicit operator confirmation.
+retiring it requires an explicit operator confirmation. The same confirmation
+is required when a dispatcher is unavailable but its workers are still alive.
 """
 
 from __future__ import annotations
@@ -121,6 +122,7 @@ def retire_generation(
     timeout: float,
     poll_interval: float,
     confirm_legacy_idle: bool,
+    confirm_workers_idle: bool = False,
 ) -> list[str]:
     """Drain and remove one actor generation, returning removed actor names."""
     from ray.util.state import list_actors
@@ -143,6 +145,11 @@ def retire_generation(
 
     removed: list[str] = []
     if dispatcher is None:
+        if worker_names and not (confirm_legacy_idle or confirm_workers_idle):
+            raise RuntimeError(
+                "The indexer dispatcher is unavailable, so active worker jobs cannot be checked. "
+                "Verify the workers are idle, then rerun with --confirm-workers-idle."
+            )
         for worker_name in worker_names:
             if _kill_actor(worker_name, namespace):
                 removed.append(worker_name)
@@ -179,6 +186,11 @@ def main() -> int:
         action="store_true",
         help="Confirm old API traffic is stopped and the unversioned generation has no active work",
     )
+    parser.add_argument(
+        "--confirm-workers-idle",
+        action="store_true",
+        help="Confirm workers are idle when their dispatcher is unavailable",
+    )
     args = parser.parse_args()
 
     ray.init(address=args.ray_address, ignore_reinit_error=True)
@@ -188,6 +200,7 @@ def main() -> int:
         timeout=args.timeout,
         poll_interval=args.poll_interval,
         confirm_legacy_idle=args.confirm_legacy_idle,
+        confirm_workers_idle=args.confirm_workers_idle,
     )
     if removed:
         print("Removed indexer actors: " + ", ".join(removed))

--- a/openrag/services/workers/retire_indexer_generation.py
+++ b/openrag/services/workers/retire_indexer_generation.py
@@ -1,0 +1,151 @@
+"""Drain and remove a superseded detached indexer actor generation.
+
+Run this only after traffic has stopped reaching API replicas that use the
+generation being retired. Protocol-aware generations are drained before they
+are removed. The original unversioned generation cannot report its state, so
+retiring it requires an explicit operator confirmation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import time
+from typing import Any
+
+import ray
+
+_LEGACY_GENERATION = "legacy"
+_LEGACY_DISPATCHER_NAME = "IndexerPoolDispatcher"
+_LEGACY_WORKER_PATTERN = re.compile(r"^IndexerWorker-\d+$")
+
+
+def _actor_name(actor: Any) -> str:
+    if isinstance(actor, dict):
+        return str(actor.get("name") or "")
+    return str(getattr(actor, "name", ""))
+
+
+def _actor_state(actor: Any) -> str:
+    if isinstance(actor, dict):
+        return str(actor.get("state") or "")
+    return str(getattr(actor, "state", ""))
+
+
+def _generation_actor_names(actors: list[Any], generation: str) -> tuple[str, list[str]]:
+    if generation == _LEGACY_GENERATION:
+        dispatcher_name = _LEGACY_DISPATCHER_NAME
+        worker_names = sorted(
+            name
+            for actor in actors
+            if _actor_state(actor) == "ALIVE"
+            and (name := _actor_name(actor))
+            and _LEGACY_WORKER_PATTERN.fullmatch(name)
+        )
+        return dispatcher_name, worker_names
+
+    dispatcher_name = f"IndexerPoolDispatcher-{generation}"
+    worker_prefix = f"IndexerWorker-{generation}-"
+    worker_names = sorted(
+        name
+        for actor in actors
+        if _actor_state(actor) == "ALIVE" and (name := _actor_name(actor)) and name.startswith(worker_prefix)
+    )
+    return dispatcher_name, worker_names
+
+
+def _get_actor(name: str, namespace: str) -> Any | None:
+    try:
+        return ray.get_actor(name, namespace=namespace)
+    except ValueError:
+        return None
+
+
+def _kill_actor(name: str, namespace: str) -> bool:
+    actor = _get_actor(name, namespace)
+    if actor is None:
+        return False
+    ray.kill(actor, no_restart=True)
+    return True
+
+
+def retire_generation(
+    generation: str,
+    *,
+    namespace: str,
+    timeout: float,
+    poll_interval: float,
+    confirm_legacy_idle: bool,
+) -> list[str]:
+    """Drain and remove one actor generation, returning removed actor names."""
+    from ray.util.state import list_actors
+
+    actors = list(
+        list_actors(
+            filters=[("ray_namespace", "=", namespace)],
+            limit=10_000,
+        )
+    )
+    dispatcher_name, worker_names = _generation_actor_names(actors, generation)
+    dispatcher = _get_actor(dispatcher_name, namespace)
+    if dispatcher is None:
+        return []
+
+    if generation == _LEGACY_GENERATION:
+        if not confirm_legacy_idle:
+            raise RuntimeError(
+                "The legacy indexer cannot report active work. Stop old API traffic, verify its jobs are idle, "
+                "then rerun with --confirm-legacy-idle."
+            )
+    else:
+        status = ray.get(dispatcher.begin_drain.remote())
+        deadline = time.monotonic() + timeout
+        while int(status.get("inflight_jobs", 0)) > 0:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Indexer generation {generation!r} did not drain within {timeout:g} seconds; actors were kept."
+                )
+            time.sleep(poll_interval)
+            status = ray.get(dispatcher.status.remote())
+        worker_names = list(status.get("worker_names") or worker_names)
+
+    removed: list[str] = []
+    if _kill_actor(dispatcher_name, namespace):
+        removed.append(dispatcher_name)
+    for worker_name in worker_names:
+        if _kill_actor(worker_name, namespace):
+            removed.append(worker_name)
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--generation", required=True, help="Protocol generation to retire, for example v2 or legacy")
+    parser.add_argument("--namespace", default="openrag")
+    parser.add_argument("--ray-address", default="auto")
+    parser.add_argument("--timeout", type=float, default=3600.0)
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument(
+        "--confirm-legacy-idle",
+        action="store_true",
+        help="Confirm old API traffic is stopped and the unversioned generation has no active work",
+    )
+    args = parser.parse_args()
+
+    ray.init(address=args.ray_address, ignore_reinit_error=True)
+    removed = retire_generation(
+        args.generation,
+        namespace=args.namespace,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+        confirm_legacy_idle=args.confirm_legacy_idle,
+    )
+    if removed:
+        print("Removed indexer actors: " + ", ".join(removed))
+    else:
+        print(f"No live indexer actors found for generation {args.generation!r}.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/openrag/services/workers/retire_indexer_generation.py
+++ b/openrag/services/workers/retire_indexer_generation.py
@@ -9,11 +9,14 @@ retiring it requires an explicit operator confirmation.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import re
 import time
 from typing import Any
 
 import ray
+
+from .ray_utils import call_ray_actor_with_timeout
 
 _LEGACY_GENERATION = "legacy"
 _LEGACY_DISPATCHER_NAME = "IndexerPoolDispatcher"
@@ -69,6 +72,48 @@ def _kill_actor(name: str, namespace: str) -> bool:
     return True
 
 
+def _drain_timeout(generation: str, timeout: float) -> TimeoutError:
+    return TimeoutError(
+        f"Indexer generation {generation!r} did not drain within {timeout:g} seconds; actors were kept."
+    )
+
+
+async def _drain_protocol_generation(
+    dispatcher: Any,
+    generation: str,
+    *,
+    timeout: float,
+    poll_interval: float,
+) -> dict[str, Any]:
+    """Drain one protocol-aware generation within one end-to-end deadline."""
+    deadline = time.monotonic() + timeout
+
+    async def call_with_remaining_timeout(method: Any, description: str) -> dict[str, Any]:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _drain_timeout(generation, timeout)
+        future = method.remote()
+        try:
+            return await call_ray_actor_with_timeout(future, remaining, description)
+        except TimeoutError as exc:
+            raise _drain_timeout(generation, timeout) from exc
+
+    status = await call_with_remaining_timeout(
+        dispatcher.begin_drain,
+        f"Begin draining indexer generation {generation}",
+    )
+    while int(status.get("inflight_jobs", 0)) > 0:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _drain_timeout(generation, timeout)
+        await asyncio.sleep(min(max(poll_interval, 0.0), remaining))
+        status = await call_with_remaining_timeout(
+            dispatcher.status,
+            f"Check indexer generation {generation} drain status",
+        )
+    return status
+
+
 def retire_generation(
     generation: str,
     *,
@@ -98,15 +143,14 @@ def retire_generation(
                 "then rerun with --confirm-legacy-idle."
             )
     else:
-        status = ray.get(dispatcher.begin_drain.remote())
-        deadline = time.monotonic() + timeout
-        while int(status.get("inflight_jobs", 0)) > 0:
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"Indexer generation {generation!r} did not drain within {timeout:g} seconds; actors were kept."
-                )
-            time.sleep(poll_interval)
-            status = ray.get(dispatcher.status.remote())
+        status = asyncio.run(
+            _drain_protocol_generation(
+                dispatcher,
+                generation,
+                timeout=timeout,
+                poll_interval=poll_interval,
+            )
+        )
         worker_names = list(status.get("worker_names") or worker_names)
 
     removed: list[str] = []

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -57,6 +57,7 @@ async def test_claim_content_hash_reserves_new_content() -> None:
         file_id="new-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
     assert conflict is None
@@ -74,6 +75,7 @@ async def test_claim_content_hash_returns_completed_duplicate() -> None:
         file_id="new-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
     assert conflict == "existing-file"
@@ -91,6 +93,7 @@ async def test_claim_content_hash_returns_active_duplicate() -> None:
         file_id="new-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
     assert conflict == "active-file"
@@ -107,6 +110,7 @@ async def test_replacement_can_claim_its_own_existing_content() -> None:
         file_id="same-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
         replace=True,
     )
 
@@ -114,7 +118,7 @@ async def test_replacement_can_claim_its_own_existing_content() -> None:
 
 
 @pytest.mark.asyncio
-async def test_release_content_hash_claim_is_scoped_to_its_owner() -> None:
+async def test_release_content_hash_claim_is_scoped_to_its_indexing_attempt() -> None:
     from services.persistence.document_repo import PgDocumentRepository
 
     pool = _ClaimPool([])
@@ -124,13 +128,15 @@ async def test_release_content_hash_claim_is_scoped_to_its_owner() -> None:
         file_id="new-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
     query, params = next(
         (query, params) for query, params in pool.conn.executed if "DELETE FROM file_content_claims" in query
     )
     assert "file_id = $3" in query
-    assert params == ("tenant-a", "abc123", "new-file")
+    assert "claim_token = $4" in query
+    assert params == ("tenant-a", "abc123", "new-file", "attempt-1")
 
 
 @pytest.mark.asyncio
@@ -145,6 +151,7 @@ async def test_renew_content_hash_claim_extends_only_its_owner() -> None:
             file_id="new-file",
             partition="tenant-a",
             content_sha256="abc123",
+            claim_token="attempt-1",
         )
         is True
     )
@@ -152,7 +159,8 @@ async def test_renew_content_hash_claim_extends_only_its_owner() -> None:
     query, params = pool.executed[0]
     assert "SET expires_at" in query
     assert "file_id = $3" in query
-    assert params == ("tenant-a", "abc123", "new-file")
+    assert "claim_token = $4" in query
+    assert params == ("tenant-a", "abc123", "new-file", "attempt-1")
 
 
 def test_persistence_schema_enforces_partition_scoped_content_uniqueness() -> None:
@@ -163,3 +171,4 @@ def test_persistence_schema_enforces_partition_scoped_content_uniqueness() -> No
     assert index.unique is True
     assert [column.name for column in index.columns] == ["partition_name", "content_sha256"]
     assert set(file_content_claims.primary_key.columns.keys()) == {"partition_name", "content_sha256"}
+    assert file_content_claims.c.claim_token.nullable is False

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -273,6 +273,44 @@ async def test_dispatch_indexing_rejects_content_already_claimed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_indexing_passes_attempt_token_to_claim_and_worker() -> None:
+    from core.models.catalog import CONTENT_CLAIM_TOKEN_METADATA_KEY
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    pool = _pool_with_ref(object())
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=_task_state_manager(),
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    repo.claim_content_sha256.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="task-1",
+        replace=False,
+    )
+    assert pool.submit.remote.await_args.kwargs["metadata"][CONTENT_CLAIM_TOKEN_METADATA_KEY] == "task-1"
+
+
+@pytest.mark.asyncio
 async def test_dispatch_indexing_releases_claim_when_queueing_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
@@ -303,6 +341,7 @@ async def test_dispatch_indexing_releases_claim_when_queueing_fails() -> None:
         file_id="new-file",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token=repo.claim_content_sha256.await_args.kwargs["claim_token"],
     )
 
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -891,6 +891,7 @@ def _bare_pool(workers: list) -> object:
     actor_class = IndexerPool.__ray_metadata__.modified_class
     pool = actor_class.__new__(actor_class)
     pool._workers = list(workers)
+    pool._worker_names = [f"test-worker-{index}" for index in range(len(workers))]
     pool._inflight = [0] * len(workers)
     pool._accepting_tasks = True
     pool._release_tasks = set()
@@ -975,6 +976,7 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
         "protocol_version": "v2",
         "accepting_tasks": False,
         "inflight_jobs": 1,
+        "worker_names": ["test-worker-0"],
     }
     with pytest.raises(RuntimeError, match="draining"):
         await pool.submit(task_id="rejected-after-drain")
@@ -985,6 +987,7 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
         "protocol_version": "v2",
         "accepting_tasks": False,
         "inflight_jobs": 0,
+        "worker_names": ["test-worker-0"],
     }
 
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -894,6 +894,7 @@ def _bare_pool(workers: list) -> object:
     pool._worker_names = [f"test-worker-{index}" for index in range(len(workers))]
     pool._inflight = [0] * len(workers)
     pool._accepting_tasks = True
+    pool._drain_operation_id = None
     pool._release_tasks = set()
     pool._claim_store = None
     pool._claim_store_lock = asyncio.Lock()
@@ -972,7 +973,7 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
 
     await pool.submit(task_id="accepted-before-drain")
 
-    assert await pool.begin_drain() == {
+    assert await pool.begin_drain("retirement-a") == {
         "protocol_version": "v2",
         "accepting_tasks": False,
         "inflight_jobs": 1,
@@ -989,6 +990,37 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
         "inflight_jobs": 0,
         "worker_names": ["test-worker-0"],
     }
+
+
+@pytest.mark.asyncio
+async def test_pool_abort_drain_restores_submissions() -> None:
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+
+    await pool.begin_drain("retirement-a")
+    with pytest.raises(RuntimeError, match="draining"):
+        await pool.submit(task_id="rejected-while-draining")
+
+    assert await pool.abort_drain("retirement-a") == {
+        "protocol_version": "v2",
+        "accepting_tasks": True,
+        "inflight_jobs": 0,
+        "worker_names": ["test-worker-0"],
+    }
+    await pool.submit(task_id="accepted-after-abort")
+    assert [call["task_id"] for call in worker.calls] == ["accepted-after-abort"]
+    await _settle_pool_release_tasks(pool, worker.futures[0])
+
+
+@pytest.mark.asyncio
+async def test_pool_drain_operations_are_owned_and_abort_is_idempotent() -> None:
+    pool = _bare_pool([_FakeWorker()])
+
+    await pool.begin_drain("retirement-a")
+    with pytest.raises(RuntimeError, match="another retirement"):
+        await pool.begin_drain("retirement-b")
+    await pool.abort_drain("retirement-a")
+    assert (await pool.abort_drain("retirement-a"))["accepting_tasks"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -90,7 +90,7 @@ async def test_catalog_initialization_is_single_flight() -> None:
     assert pool._catalog_initialized is True
 
 
-def test_build_indexer_pool_uses_new_detached_dispatcher_name(
+def test_build_indexer_pool_uses_current_protocol_dispatcher_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import core.config
@@ -121,9 +121,9 @@ def test_build_indexer_pool_uses_new_detached_dispatcher_name(
     assert pool == "dispatcher-actor"
     assert len(options_calls) == 1
     opts = options_calls[0]
-    # The dispatcher has a different public interface from the old detached
-    # IndexerPool actor, so it must not reuse that actor name during upgrades.
-    assert opts["name"] == "IndexerPoolDispatcher"
+    # A protocol-specific name prevents a rolling deployment from attaching to
+    # a detached actor that still runs the previous claim implementation.
+    assert opts["name"] == "IndexerPoolDispatcher-v2"
     assert opts["namespace"] == "openrag"
     assert opts["get_if_exists"] is True
     assert opts["lifetime"] == "detached"
@@ -158,7 +158,11 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
 
     # One detached worker actor per pool_size slot, each capped at max_tasks_per_worker.
     assert len(pool._workers) == 3
-    assert {c["name"] for c in calls} == {"IndexerWorker-0", "IndexerWorker-1", "IndexerWorker-2"}
+    assert {c["name"] for c in calls} == {
+        "IndexerWorker-v2-0",
+        "IndexerWorker-v2-1",
+        "IndexerWorker-v2-2",
+    }
     for c in calls:
         assert c["lifetime"] == "detached"
         assert c["max_concurrency"] == 4
@@ -888,6 +892,7 @@ def _bare_pool(workers: list) -> object:
     pool = actor_class.__new__(actor_class)
     pool._workers = list(workers)
     pool._inflight = [0] * len(workers)
+    pool._accepting_tasks = True
     pool._release_tasks = set()
     pool._claim_store = None
     pool._claim_store_lock = asyncio.Lock()
@@ -957,6 +962,37 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
         workers[1].futures[0],
         workers[0].futures[1],
     )
+
+
+@pytest.mark.asyncio
+async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+
+    await pool.submit(task_id="accepted-before-drain")
+
+    assert await pool.begin_drain() == {
+        "protocol_version": "v2",
+        "accepting_tasks": False,
+        "inflight_jobs": 1,
+    }
+    with pytest.raises(RuntimeError, match="draining"):
+        await pool.submit(task_id="rejected-after-drain")
+    assert len(worker.calls) == 1
+
+    await _settle_pool_release_tasks(pool, worker.futures[0])
+    assert await pool.status() == {
+        "protocol_version": "v2",
+        "accepting_tasks": False,
+        "inflight_jobs": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pool_reports_current_protocol_version() -> None:
+    pool = _bare_pool([_FakeWorker()])
+
+    assert await pool.protocol_version() == "v2"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from core.config.model_endpoints import ModelEndpointConfig
+from core.models.catalog import CONTENT_CLAIM_TOKEN_METADATA_KEY
 
 
 class _NativeChunker:
@@ -902,6 +903,32 @@ async def _settle_pool_release_tasks(pool: object, *futures: asyncio.Future[obje
         await asyncio.gather(*release_tasks)
 
 
+@pytest.mark.asyncio
+async def test_claim_repo_preserves_configured_catalog_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.config
+    import services.storage.postgres_store as postgres_store
+
+    pool = _bare_pool([_FakeWorker()])
+    rdb = SimpleNamespace(database="custom_catalog")
+    cfg = SimpleNamespace(rdb=rdb, vectordb=SimpleNamespace(collection_name="ignored_collection"))
+    repo = object()
+    calls = []
+
+    class Store:
+        def __init__(self, config, *, run_migrations):
+            self.document_repo = repo
+            calls.append((config, run_migrations))
+
+        async def initialize(self) -> None:
+            calls.append("initialized")
+
+    monkeypatch.setattr(core.config, "load_config", lambda: cfg)
+    monkeypatch.setattr(postgres_store, "PostgresStore", Store)
+
+    assert await pool._claim_document_repo() is repo
+    assert calls == [(rdb, False), "initialized"]
+
+
 def test_pool_requires_positive_pool_size() -> None:
     from services.workers.indexer_pool import IndexerPool
 
@@ -1001,7 +1028,11 @@ async def test_pool_renews_content_claim_while_task_is_active(monkeypatch: pytes
     await pool.submit(
         task_id="task-1",
         partition="tenant-a",
-        metadata={"file_id": "file-1", "content_sha256": "abc123"},
+        metadata={
+            "file_id": "file-1",
+            "content_sha256": "abc123",
+            CONTENT_CLAIM_TOKEN_METADATA_KEY: "attempt-1",
+        },
     )
     await asyncio.wait_for(renewed.wait(), timeout=1)
     await _settle_pool_release_tasks(pool, worker.futures[0])
@@ -1011,11 +1042,13 @@ async def test_pool_renews_content_claim_while_task_is_active(monkeypatch: pytes
         "file_id": "file-1",
         "partition": "tenant-a",
         "content_sha256": "abc123",
+        "claim_token": "attempt-1",
     }
     repo.release_content_sha256_claim.assert_awaited_once_with(
         file_id="file-1",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
 
@@ -1032,7 +1065,11 @@ async def test_pool_keeps_content_claim_until_cancelled_task_settles() -> None:
     await pool.submit(
         task_id="task-1",
         partition="tenant-a",
-        metadata={"file_id": "file-1", "content_sha256": "abc123"},
+        metadata={
+            "file_id": "file-1",
+            "content_sha256": "abc123",
+            CONTENT_CLAIM_TOKEN_METADATA_KEY: "attempt-1",
+        },
     )
 
     worker.futures[0].cancel()
@@ -1043,6 +1080,7 @@ async def test_pool_keeps_content_claim_until_cancelled_task_settles() -> None:
         file_id="file-1",
         partition="tenant-a",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
 
 
@@ -1061,6 +1099,8 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
     vlm_factory = object()
 
     class RDBConfig:
+        database = "custom_catalog"
+
         def model_copy(self, *, update):
             return SimpleNamespace(**update)
 
@@ -1091,6 +1131,11 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
         captured.update(kwargs)
         return object()
 
+    def fake_postgres_store(config, *, run_migrations):
+        captured["catalog_config"] = config
+        captured["catalog_run_migrations"] = run_migrations
+        return Store()
+
     monkeypatch.setattr(core.config, "load_config", lambda: cfg)
     monkeypatch.setattr(module, "_build_chunker", lambda _cfg: object())
     monkeypatch.setattr(module, "_build_embedder_factory", lambda _cfg: object())
@@ -1099,7 +1144,7 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(module, "_build_topic_tagger_factory", lambda _cfg: topic_tagger_factory)
     monkeypatch.setattr(core.embeddings.embedder_registry, "create", lambda *args, **kwargs: object())
     monkeypatch.setattr(milvus_store, "MilvusVectorStore", lambda _cfg: object())
-    monkeypatch.setattr(postgres_store, "PostgresStore", lambda *args, **kwargs: Store())
+    monkeypatch.setattr(postgres_store, "PostgresStore", fake_postgres_store)
     monkeypatch.setattr(parser_dispatcher, "build_parser_dispatcher", lambda _cfg: object())
     monkeypatch.setattr(parser_dispatcher, "build_caption_vlm", lambda _cfg: object())
     monkeypatch.setattr(pipeline_builder, "build_indexing_pipeline", fake_build_pipeline)
@@ -1121,6 +1166,9 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
     assert captured["contextualizer_factory"] is contextualizer_factory
     assert captured["topic_tagger_factory"] is topic_tagger_factory
     assert captured["vlm_factory"] is vlm_factory
+    assert captured["catalog_config"] is cfg.rdb
+    assert captured["catalog_config"].database == "custom_catalog"
+    assert captured["catalog_run_migrations"] is False
 
 
 def test_indexer_pool_loads_caption_prompt_without_global_vlm_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1139,6 +1187,8 @@ def test_indexer_pool_loads_caption_prompt_without_global_vlm_default(monkeypatc
     captured = {}
 
     class RDBConfig:
+        database = None
+
         def model_copy(self, *, update):
             return SimpleNamespace(**update)
 
@@ -1208,9 +1258,11 @@ class _RecordingWorker:
     def __init__(self, *, error: Exception | None = None) -> None:
         self._error = error
         self.calls = 0
+        self.last_kwargs = None
 
-    async def process_file(self, **_kwargs) -> dict:
+    async def process_file(self, **kwargs) -> dict:
         self.calls += 1
+        self.last_kwargs = kwargs
         if self._error is not None:
             raise self._error
         return {"stored_count": 1, "stage": "stored"}
@@ -1255,12 +1307,17 @@ async def test_actor_keeps_upload_by_default(tmp_path) -> None:
 async def test_actor_releases_content_claim_after_indexing(tmp_path) -> None:
     path = tmp_path / "doc.txt"
     path.write_bytes(b"x")
-    actor = _bare_worker_actor(save_uploaded_files=True, worker=_RecordingWorker())
+    worker = _RecordingWorker()
+    actor = _bare_worker_actor(save_uploaded_files=True, worker=worker)
 
     await actor.process_file(
         task_id="t",
         path=str(path),
-        metadata={"file_id": "f", "content_sha256": "abc123"},
+        metadata={
+            "file_id": "f",
+            "content_sha256": "abc123",
+            CONTENT_CLAIM_TOKEN_METADATA_KEY: "attempt-1",
+        },
         partition="p",
     )
 
@@ -1268,7 +1325,9 @@ async def test_actor_releases_content_claim_after_indexing(tmp_path) -> None:
         file_id="f",
         partition="p",
         content_sha256="abc123",
+        claim_token="attempt-1",
     )
+    assert CONTENT_CLAIM_TOKEN_METADATA_KEY not in worker.last_kwargs["metadata"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_retire_indexer_generation.py
+++ b/tests/unit/services/workers/test_retire_indexer_generation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -54,7 +54,7 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
         {"name": "IndexerPoolDispatcher-v2", "state": "ALIVE"},
         {"name": "IndexerWorker-v2-0", "state": "ALIVE"},
     ]
-    ray_results = iter(
+    rpc_results = iter(
         [
             {"inflight_jobs": 1, "worker_names": ["IndexerWorker-v2-0"]},
             {"inflight_jobs": 0, "worker_names": ["IndexerWorker-v2-0"]},
@@ -64,8 +64,9 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: actors)
     monkeypatch.setattr(module, "_get_actor", lambda name, _namespace: dispatcher if "Dispatcher" in name else name)
-    monkeypatch.setattr(module.ray, "get", lambda _ref: next(ray_results))
-    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+    rpc = AsyncMock(side_effect=lambda *_args: next(rpc_results))
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(module, "_kill_actor", lambda name, _namespace: not killed.append(name))
 
     assert module.retire_generation(
@@ -78,16 +79,20 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
     assert killed == ["IndexerPoolDispatcher-v2", "IndexerWorker-v2-0"]
     begin_drain.assert_called_once_with()
     status.assert_called_once_with()
+    assert [call.args[2] for call in rpc.await_args_list] == [
+        "Begin draining indexer generation v2",
+        "Check indexer generation v2 drain status",
+    ]
 
 
-def test_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_begin_drain_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.workers.retire_indexer_generation as module
 
     dispatcher = SimpleNamespace(begin_drain=SimpleNamespace(remote=Mock()))
     monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
     monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
-    monkeypatch.setattr(module.ray, "get", lambda _ref: {"inflight_jobs": 1})
-    monkeypatch.setattr(module.time, "monotonic", Mock(side_effect=[0.0, 2.0]))
+    rpc = AsyncMock(side_effect=TimeoutError)
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
     kill = Mock()
     monkeypatch.setattr(module, "_kill_actor", kill)
 
@@ -100,3 +105,30 @@ def test_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None
             confirm_legacy_idle=False,
         )
     kill.assert_not_called()
+
+
+def test_status_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=Mock()),
+        status=SimpleNamespace(remote=Mock()),
+    )
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    rpc = AsyncMock(side_effect=[{"inflight_jobs": 1}, TimeoutError()])
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    kill = Mock()
+    monkeypatch.setattr(module, "_kill_actor", kill)
+
+    with pytest.raises(TimeoutError, match="actors were kept"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+    kill.assert_not_called()
+    assert rpc.await_count == 2

--- a/tests/unit/services/workers/test_retire_indexer_generation.py
+++ b/tests/unit/services/workers/test_retire_indexer_generation.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+def test_generation_actor_names_do_not_mix_protocols() -> None:
+    from services.workers.retire_indexer_generation import _generation_actor_names
+
+    actors = [
+        {"name": "IndexerWorker-0", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-0", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-1", "state": "ALIVE"},
+        {"name": "IndexerWorker-v3-0", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-2", "state": "DEAD"},
+    ]
+
+    assert _generation_actor_names(actors, "legacy") == ("IndexerPoolDispatcher", ["IndexerWorker-0"])
+    assert _generation_actor_names(actors, "v2") == (
+        "IndexerPoolDispatcher-v2",
+        ["IndexerWorker-v2-0", "IndexerWorker-v2-1"],
+    )
+
+
+def test_legacy_retirement_requires_explicit_idle_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = object()
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+
+    with pytest.raises(RuntimeError, match="confirm-legacy-idle"):
+        module.retire_generation(
+            "legacy",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+
+
+def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    begin_drain = Mock()
+    status = Mock()
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=begin_drain),
+        status=SimpleNamespace(remote=status),
+    )
+    actors = [
+        {"name": "IndexerPoolDispatcher-v2", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-0", "state": "ALIVE"},
+    ]
+    ray_results = iter(
+        [
+            {"inflight_jobs": 1, "worker_names": ["IndexerWorker-v2-0"]},
+            {"inflight_jobs": 0, "worker_names": ["IndexerWorker-v2-0"]},
+        ]
+    )
+    killed: list[str] = []
+
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: actors)
+    monkeypatch.setattr(module, "_get_actor", lambda name, _namespace: dispatcher if "Dispatcher" in name else name)
+    monkeypatch.setattr(module.ray, "get", lambda _ref: next(ray_results))
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(module, "_kill_actor", lambda name, _namespace: not killed.append(name))
+
+    assert module.retire_generation(
+        "v2",
+        namespace="openrag",
+        timeout=1,
+        poll_interval=0,
+        confirm_legacy_idle=False,
+    ) == ["IndexerPoolDispatcher-v2", "IndexerWorker-v2-0"]
+    assert killed == ["IndexerPoolDispatcher-v2", "IndexerWorker-v2-0"]
+    begin_drain.assert_called_once_with()
+    status.assert_called_once_with()
+
+
+def test_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = SimpleNamespace(begin_drain=SimpleNamespace(remote=Mock()))
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    monkeypatch.setattr(module.ray, "get", lambda _ref: {"inflight_jobs": 1})
+    monkeypatch.setattr(module.time, "monotonic", Mock(side_effect=[0.0, 2.0]))
+    kill = Mock()
+    monkeypatch.setattr(module, "_kill_actor", kill)
+
+    with pytest.raises(TimeoutError, match="actors were kept"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+    kill.assert_not_called()

--- a/tests/unit/services/workers/test_retire_indexer_generation.py
+++ b/tests/unit/services/workers/test_retire_indexer_generation.py
@@ -85,6 +85,29 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
     ]
 
 
+def test_missing_dispatcher_still_removes_discovered_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    actors = [
+        {"name": "IndexerWorker-v2-0", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-1", "state": "ALIVE"},
+    ]
+    killed: list[str] = []
+
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: actors)
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: None)
+    monkeypatch.setattr(module, "_kill_actor", lambda name, _namespace: not killed.append(name))
+
+    assert module.retire_generation(
+        "v2",
+        namespace="openrag",
+        timeout=1,
+        poll_interval=0,
+        confirm_legacy_idle=False,
+    ) == ["IndexerWorker-v2-0", "IndexerWorker-v2-1"]
+    assert killed == ["IndexerWorker-v2-0", "IndexerWorker-v2-1"]
+
+
 def test_begin_drain_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.workers.retire_indexer_generation as module
 

--- a/tests/unit/services/workers/test_retire_indexer_generation.py
+++ b/tests/unit/services/workers/test_retire_indexer_generation.py
@@ -85,7 +85,30 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
     ]
 
 
-def test_missing_dispatcher_still_removes_discovered_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_dispatcher_requires_idle_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    actors = [
+        {"name": "IndexerWorker-v2-0", "state": "ALIVE"},
+        {"name": "IndexerWorker-v2-1", "state": "ALIVE"},
+    ]
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: actors)
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: None)
+    kill = Mock()
+    monkeypatch.setattr(module, "_kill_actor", kill)
+
+    with pytest.raises(RuntimeError, match="confirm-workers-idle"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+    kill.assert_not_called()
+
+
+def test_missing_dispatcher_removes_confirmed_idle_workers(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.workers.retire_indexer_generation as module
 
     actors = [
@@ -104,6 +127,7 @@ def test_missing_dispatcher_still_removes_discovered_workers(monkeypatch: pytest
         timeout=1,
         poll_interval=0,
         confirm_legacy_idle=False,
+        confirm_workers_idle=True,
     ) == ["IndexerWorker-v2-0", "IndexerWorker-v2-1"]
     assert killed == ["IndexerWorker-v2-0", "IndexerWorker-v2-1"]
 

--- a/tests/unit/services/workers/test_retire_indexer_generation.py
+++ b/tests/unit/services/workers/test_retire_indexer_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -49,6 +50,7 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
     dispatcher = SimpleNamespace(
         begin_drain=SimpleNamespace(remote=begin_drain),
         status=SimpleNamespace(remote=status),
+        abort_drain=SimpleNamespace(remote=Mock()),
     )
     actors = [
         {"name": "IndexerPoolDispatcher-v2", "state": "ALIVE"},
@@ -77,7 +79,9 @@ def test_protocol_generation_drains_before_removal(monkeypatch: pytest.MonkeyPat
         confirm_legacy_idle=False,
     ) == ["IndexerPoolDispatcher-v2", "IndexerWorker-v2-0"]
     assert killed == ["IndexerPoolDispatcher-v2", "IndexerWorker-v2-0"]
-    begin_drain.assert_called_once_with()
+    begin_drain.assert_called_once()
+    assert isinstance(begin_drain.call_args.args[0], str)
+    dispatcher.abort_drain.remote.assert_not_called()
     status.assert_called_once_with()
     assert [call.args[2] for call in rpc.await_args_list] == [
         "Begin draining indexer generation v2",
@@ -135,7 +139,10 @@ def test_missing_dispatcher_removes_confirmed_idle_workers(monkeypatch: pytest.M
 def test_begin_drain_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.workers.retire_indexer_generation as module
 
-    dispatcher = SimpleNamespace(begin_drain=SimpleNamespace(remote=Mock()))
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=Mock()),
+        abort_drain=SimpleNamespace(remote=Mock()),
+    )
     monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
     monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
     rpc = AsyncMock(side_effect=TimeoutError)
@@ -152,6 +159,7 @@ def test_begin_drain_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.Monk
             confirm_legacy_idle=False,
         )
     kill.assert_not_called()
+    dispatcher.abort_drain.remote.assert_not_called()
 
 
 def test_status_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,10 +168,11 @@ def test_status_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPat
     dispatcher = SimpleNamespace(
         begin_drain=SimpleNamespace(remote=Mock()),
         status=SimpleNamespace(remote=Mock()),
+        abort_drain=SimpleNamespace(remote=Mock()),
     )
     monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
     monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
-    rpc = AsyncMock(side_effect=[{"inflight_jobs": 1}, TimeoutError()])
+    rpc = AsyncMock(side_effect=[{"inflight_jobs": 1}, TimeoutError(), {"accepting_tasks": True}])
     monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
     monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
     kill = Mock()
@@ -178,4 +187,148 @@ def test_status_rpc_timeout_keeps_generation_alive(monkeypatch: pytest.MonkeyPat
             confirm_legacy_idle=False,
         )
     kill.assert_not_called()
-    assert rpc.await_count == 2
+    assert rpc.await_count == 3
+    dispatcher.abort_drain.remote.assert_called_once()
+
+
+def test_status_failure_restores_acceptance_and_reraises_original_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=Mock()),
+        status=SimpleNamespace(remote=Mock()),
+        abort_drain=SimpleNamespace(remote=Mock()),
+    )
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    rpc = AsyncMock(side_effect=[{"inflight_jobs": 1}, RuntimeError("status failed"), {"accepting_tasks": True}])
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    kill = Mock()
+    monkeypatch.setattr(module, "_kill_actor", kill)
+
+    with pytest.raises(RuntimeError, match="status failed"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+
+    kill.assert_not_called()
+    dispatcher.abort_drain.remote.assert_called_once()
+
+
+def test_actor_kill_failure_does_not_restore_a_completed_drain(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=Mock()),
+        abort_drain=SimpleNamespace(remote=Mock()),
+    )
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", AsyncMock(return_value={"inflight_jobs": 0}))
+    monkeypatch.setattr(module, "_kill_actor", Mock(side_effect=RuntimeError("kill failed")))
+
+    with pytest.raises(RuntimeError, match="kill failed"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+
+    dispatcher.abort_drain.remote.assert_not_called()
+
+
+def test_recovery_failure_keeps_the_retirement_error_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=Mock()),
+        status=SimpleNamespace(remote=Mock()),
+        abort_drain=SimpleNamespace(remote=Mock()),
+    )
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    rpc = AsyncMock(side_effect=[{"inflight_jobs": 1}, TimeoutError(), RuntimeError("abort failed")])
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    logger = Mock()
+    monkeypatch.setattr(module, "logger", logger)
+
+    with pytest.raises(TimeoutError, match="actors were kept"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+
+    logger.error.assert_called_once()
+    assert logger.error.call_args.kwargs["error"] == "abort failed"
+
+
+def test_timeout_restores_acceptance_on_the_same_live_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.retire_indexer_generation as module
+    from services.workers.indexer_pool import IndexerPool
+
+    submitted: list[str] = []
+
+    def process_file(**kwargs):
+        future = asyncio.get_running_loop().create_future()
+        future.set_result(None)
+        submitted.append(kwargs["task_id"])
+        return future
+
+    actor_class = IndexerPool.__ray_metadata__.modified_class
+    pool = actor_class.__new__(actor_class)
+    pool._workers = [SimpleNamespace(process_file=SimpleNamespace(remote=process_file))]
+    pool._worker_names = ["IndexerWorker-v2-0"]
+    pool._inflight = [1]
+    pool._accepting_tasks = True
+    pool._drain_operation_id = None
+    pool._release_tasks = set()
+    pool._claim_store = None
+    pool._claim_store_lock = asyncio.Lock()
+
+    status_ref = object()
+    dispatcher = SimpleNamespace(
+        begin_drain=SimpleNamespace(remote=pool.begin_drain),
+        status=SimpleNamespace(remote=lambda: status_ref),
+        abort_drain=SimpleNamespace(remote=pool.abort_drain),
+    )
+
+    async def rpc(future, *_args):
+        if future is status_ref:
+            raise TimeoutError
+        return await future
+
+    monkeypatch.setattr("ray.util.state.list_actors", lambda **_kwargs: [])
+    monkeypatch.setattr(module, "_get_actor", lambda *_args: dispatcher)
+    monkeypatch.setattr(module, "call_ray_actor_with_timeout", rpc)
+    monkeypatch.setattr(module.asyncio, "sleep", AsyncMock())
+    kill = Mock()
+    monkeypatch.setattr(module, "_kill_actor", kill)
+
+    with pytest.raises(TimeoutError, match="actors were kept"):
+        module.retire_generation(
+            "v2",
+            namespace="openrag",
+            timeout=1,
+            poll_interval=0,
+            confirm_legacy_idle=False,
+        )
+
+    async def submit_after_timeout() -> None:
+        assert (await pool.status())["accepting_tasks"] is True
+        await pool.submit(task_id="accepted-after-timeout")
+        await asyncio.gather(*pool._release_tasks)
+
+    asyncio.run(submit_after_timeout())
+    kill.assert_not_called()
+    assert submitted == ["accepted-after-timeout"]


### PR DESCRIPTION
## Why

The report is confirmed: a successful drain followed by a timeout or status failure left the detached pool alive but permanently unable to accept new indexing submissions.

## Design

Each drain now has its own operation id. A failed retirement restores acceptance only when that same operation started the drain and actor termination has not begun. A second retirement cannot resume another operation’s drain. Once actor removal starts, the pool is intentionally left drained.

## Validation

Added coverage for normal retirement, timeout and status failures, recovery failure, ownership conflicts, retries, and continued submission on the same dispatcher after a failed retirement.

Focused worker tests, the full unit suite, repository Ruff checks, formatting checks, and the package build passed. The project has no configured type-check command.

## Recovery

If restoring acceptance fails, the original retirement error is preserved and the command logs that the pool may remain drained. Stop API traffic and restart the Ray cluster to recreate the generation.