### PR TITLE
fix(storage): fail closed on an empty partition scope (cross-partition leak)

### DIFF
--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -469,11 +469,14 @@ class MilvusVectorStore(VectorStore):
 
         Rules:
             * ``filters['partition']`` builds the partition_key clause.
-              Value ``"all"`` (or ``["all"]``) skips the clause. List/tuple
-              values become ``partition in [...]``. Mixing a wildcard with
-              explicit partitions in the same list raises ``ValueError`` —
-              that combination is rejected rather than silently widened to
-              every partition.
+              Value ``"all"`` (or ``["all"]``) is the explicit wildcard and
+              skips the clause. A non-empty list/tuple becomes
+              ``partition in [...]``. An **empty** list/tuple means "no
+              accessible partition" and short-circuits to
+              :data:`_MATCH_NOTHING_EXPR` (fail closed) — it must never widen
+              to every partition. Mixing a wildcard with explicit partitions
+              in the same list raises ``ValueError`` — that combination is
+              rejected rather than silently widened to every partition.
             * ``filters['expr']`` is appended verbatim as an escape hatch
               for callers that need operators the dict form cannot express.
             * Any other key with a scalar value becomes ``key == <literal>``.
@@ -494,7 +497,18 @@ class MilvusVectorStore(VectorStore):
             has_wildcard = any(p in self._PARTITION_WILDCARDS for p in partition)
             if has_wildcard and len(partition) > 1:
                 raise ValueError("`partition` cannot mix wildcard with explicit values.")
-            if not has_wildcard and partition:
+            if has_wildcard:
+                pass  # explicit "all" wildcard → intentionally unscoped, no clause
+            elif not partition:
+                # SECURITY (fail closed): an empty partition list means the
+                # caller resolved to *no* accessible partition (e.g. a user
+                # with zero memberships hitting `openrag-all`). It must match
+                # NOTHING, never every partition. Failing open here dropped the
+                # clause entirely and leaked cross-tenant rows — a query scoped
+                # to one partition returning another tenant's chunks. Restore
+                # the pre-refactor behaviour (`partition in []` matched nothing).
+                return self._MATCH_NOTHING_EXPR
+            else:
                 quoted = ", ".join(self._format_value(p) for p in partition)
                 parts.append(f"partition in [{quoted}]")
         elif partition is not None and partition not in self._PARTITION_WILDCARDS:

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -130,9 +130,31 @@ class TestBuildFilterExpr:
         with pytest.raises(ValueError, match="cannot mix wildcard"):
             store._build_filter_expr({"partition": ["all", "p1"]})
 
-    def test_empty_partition_list_is_skipped(self, store: MilvusVectorStore) -> None:
-        # No partitions means no partition clause (not match-nothing).
-        assert store._build_filter_expr({"partition": []}) == ""
+    def test_empty_partition_list_matches_nothing(self, store: MilvusVectorStore) -> None:
+        # SECURITY (fail closed): an empty partition list means the caller
+        # resolved to NO accessible partition (e.g. a user with zero
+        # memberships hitting `openrag-all`). It must match nothing, never
+        # every partition. Failing open here dropped the clause and leaked
+        # cross-tenant rows — a query scoped to one partition returning
+        # another tenant's chunks. Reverting the fix yields "" (unfiltered →
+        # all partitions), so this test guards the regression.
+        assert store._build_filter_expr({"partition": []}) == "1 == 0"
+
+    def test_empty_partition_tuple_matches_nothing(self, store: MilvusVectorStore) -> None:
+        # Same fail-closed guarantee for a tuple (both list and tuple are
+        # accepted partition-scope shapes).
+        assert store._build_filter_expr({"partition": ()}) == "1 == 0"
+
+    def test_empty_partition_scope_dominates_other_filters(self, store: MilvusVectorStore) -> None:
+        # An empty partition scope must dominate: even with a permissive raw
+        # expr present, the result stays match-nothing — a caller cannot widen
+        # an empty scope back to every partition through another filter.
+        assert store._build_filter_expr({"partition": [], "expr": "text != ''"}) == "1 == 0"
+
+    def test_empty_partition_scope_dominates_file_id_filter(self, store: MilvusVectorStore) -> None:
+        # Same dominance against a scalar/IN co-filter — an empty partition
+        # scope short-circuits before any other key is rendered.
+        assert store._build_filter_expr({"partition": [], "file_id": ["f1"]}) == "1 == 0"
 
     def test_scalar_field(self, store: MilvusVectorStore) -> None:
         assert store._build_filter_expr({"file_id": "abc"}) == 'file_id == "abc"'


### PR DESCRIPTION
Closes #759.

## Problem

`MilvusVectorStore._build_filter_expr` **failed open** on an empty partition scope: `{"partition": []}` dropped the partition clause and returned an empty expression, so the search ran **unfiltered across every partition** — a cross-tenant read. A scope that resolves to no accessible partition (e.g. a user with zero memberships hitting `openrag-all`) got other tenants' documents back, where the pre-refactor line failed **closed** (`partition in []` matched nothing). The fail-open was even enshrined in a test.

## Fix

An empty (non-wildcard) partition list/tuple now short-circuits to `_MATCH_NOTHING_EXPR` (`1 == 0`) — fail closed — and dominates any co-filter (early return before `expr`/other keys are read). The explicit `"all"` wildcard remains the only way to run an intentionally unscoped search.

- One shared chokepoint: `_build_filter_expr` is the sole filter builder for **all** read/delete paths (dense + hybrid search, scalar query, delete), so the guarantee holds everywhere. Verified the hybrid path applies the expr to **both** the dense and BM25 sparse legs.
- `None`/missing partition is deliberately left unscoped: the search routers already 403 an empty scope upstream (`get_partition_name`, `search.py`), and the partition-less path is required by the authz-gated global-`_id` lookup in `ConversionService.get_chunk` (extractText/download). Closing it there would break that flow with no isolation benefit.
- No regression: the "everything" wildcard is `["all"]`, never `[]`; no caller passes an empty partition list meaning all. `delete_by_filter({"partition": []})` now safely no-ops instead of erroring.

## Tests

Rewrote the test that had enshrined the fail-open into a revert-prove (`test_empty_partition_list_matches_nothing` asserts `1 == 0`; reverting the fix yields `""` and fails). Added empty-tuple and two co-filter-dominance cases (`expr` and `file_id`).

- Revert-prove confirmed (3 tests fail on the reverted code).
- `uv run pytest tests/unit/` green; full `test_milvus_store.py` (78) green; ruff check/format + layer-import-guard clean.

## Scope / follow-ups (separate, noted in #759)

- Defense-in-depth: reject an empty `user_partitions` scope even earlier at the resolution layer.
- Unrelated but real: `vector_store_searcher.search`/`multi_query_search` accept but never read `filter_params`, so #706 workspace file-scoping doesn't reach Milvus (within-partition over-retrieval, not this cross-partition leak).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty partition filters now safely return no results instead of unintentionally querying across all partitions.
  * This behavior is enforced even when additional search conditions are provided.
* **Documentation**
  * Clarified how wildcard and explicitly specified partitions are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->