### PR TITLE
fix(ci): make build.yml GA build fire on release tags under protected main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,34 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
-  build-and-push-image:
+  # GA images build for release tags (vX.Y.Z), never for RC tags (build_rc.yml
+  # owns those). This job also enforces "the tag is on main": we can't use
+  # github.event.base_ref for that — it is empty for a tag pushed to a
+  # branch-protected main (which only receives PR-merge commits, not client
+  # pushes), so the old base_ref guard silently skipped every release build.
+  # Instead we verify reachability from origin/main explicitly and fail loud.
+  verify-tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc.')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fail if the tagged commit is not on main
+        run: |
+          git fetch --no-tags origin main
+          if git merge-base --is-ancestor "${{ github.sha }}" FETCH_HEAD; then
+            echo "OK: ${{ github.ref_name }} (${{ github.sha }}) is on main"
+          else
+            echo "::error::Tag ${{ github.ref_name }} is not on main — refusing to build GA images."
+            exit 1
+          fi
+
+  build-and-push-image:
+    needs: verify-tag
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -68,8 +93,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   build-and-push-image-ray:
+    needs: verify-tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -116,8 +141,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   build-and-push-image-admin-ui:
+    needs: verify-tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.event.base_ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The v2.0.1 tag push triggered `build.yml` but **all three image-build jobs skipped** — a green run that built nothing.

## Cause

The jobs were guarded on `github.event.base_ref == 'refs/heads/main'`. That field is empty for a tag pushed to a **branch-protected** `main`: a protected `main` only receives PR-merge commits (created server-side), never client branch pushes, so GitHub records no branch association and `base_ref` arrives empty. The guard skipped everything, silently.

It worked for v2.0.0 only because `main` was still unprotected then (direct client pushes established the association). v2.0.1 is the first release since branch protection went on (2026-07-09), so it is the first to hit this.

## Fix

Add a `verify-tag` gate that the three build jobs `needs:`:
- fires for release tags (`v*`) but **not** RC tags (`build_rc.yml` owns `-rc.`)
- verifies the tagged commit is reachable from `origin/main` (`merge-base --is-ancestor`), failing **loud** (red) instead of skipping **silently** if a tag is ever off-main

Trigger matrix after this change:
| Event | Result |
|---|---|
| `vX.Y.Z` on main | verify passes → 3 images build |
| `vX.Y.Z` off main | verify **fails red** → builds skip |
| `vX.Y.Z-rc.N` | verify skipped → builds skip (handled by `build_rc.yml`) |
| `workflow_dispatch` | skipped (unchanged) |

Unblocks the v2.0.1 release. Must also back-merge to `develop` so future releases inherit the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now verify that tagged commits are included in the main branch before publishing Docker images.
  * Release candidate tags are excluded from this verification.
  * Prevents Docker images from being published for tags based on commits outside the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->