### PR TITLE
fix(ci): harden GA publish guard — exact tag format, no shell interpolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Fail if the tagged commit is not on main
+          persist-credentials: false
+      # Tag name and SHA are passed as env data, never interpolated into the
+      # script body: ${{ }} expands before the shell runs, and git permits
+      # ; $ ` " | & in ref names — so a crafted tag could otherwise execute
+      # arbitrary code in this privileged publishing workflow.
+      - name: Verify this is an exact GA release tag on main
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          TAG_SHA: ${{ github.sha }}
         run: |
+          # The job-level `if` only filters well-formed `-rc.` tags (owned by
+          # build_rc.yml). Anything else reaching here must be an exact GA tag:
+          # a near-miss like `v1.2.3-rc1` matches neither workflow's intent and
+          # would otherwise publish a prerelease as GA and move `latest`.
+          if ! printf '%s' "$TAG_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::$TAG_NAME is not an exact GA release tag (vMAJOR.MINOR.PATCH) — refusing to publish GA images."
+            exit 1
+          fi
           git fetch --no-tags origin main
-          if git merge-base --is-ancestor "${{ github.sha }}" FETCH_HEAD; then
-            echo "OK: ${{ github.ref_name }} (${{ github.sha }}) is on main"
+          if git merge-base --is-ancestor "$TAG_SHA" FETCH_HEAD; then
+            echo "OK: $TAG_NAME ($TAG_SHA) is an exact GA tag on main"
           else
-            echo "::error::Tag ${{ github.ref_name }} is not on main — refusing to build GA images."
+            echo "::error::$TAG_NAME is not on main — refusing to publish GA images."
             exit 1
           fi
 


### PR DESCRIPTION
Addresses the review findings on the `verify-tag` gate added in #764. Raised by @hedhoud on #765 and independently by CodeRabbit/zizmor. All three verified against the merged workflow.

Targets `main` rather than the back-merge branch (#765), because the affected guard is already **on main** — fixing it in the back-merge would leave `main` exposed while only `develop` got the fix.

## 1. GA tag format was too loose

The guard only rejected `-rc.`, so these all passed and would **publish GA images and move `:latest`**:

| Tag | Before | After |
|---|---|---|
| `v2.0.1` | builds | builds |
| `v2.0.1-rc.1` | skips → `build_rc.yml` | skips → `build_rc.yml` |
| **`v2.0.1-rc1`** | **publishes as GA** | fails loud |
| `v2.0.1-beta`, `v2.0.1-alpha.1` | publishes as GA | fails loud |
| `vfoo`, `v-test` | publishes as GA | fails loud |

The `-rc1` case is the sharp one: `build_rc.yml` triggers on `v*-rc.*`, which **requires** the dot — so a one-character typo matched neither workflow's intent and shipped a release candidate as GA.

Now validated against `^v[0-9]+\.[0-9]+\.[0-9]+$`.

## 2. Shell injection via `github.ref_name`

`${{ github.ref_name }}` was expanded into the `run` body before the shell executed. `git check-ref-format` permits `;`, `$`, backtick, `"`, `|`, `&` in ref names, so a crafted tag could execute arbitrary code — in a job holding `packages: write` and Docker Hub credentials.

Tag name and SHA are now passed via `env:` and referenced as `"$TAG_NAME"` / `"$TAG_SHA"`.

## 3. Checkout persisted credentials

`build_rc.yml` already sets `persist-credentials: false` on all three checkouts (hardened in `95fd86fc`); the new `verify-tag` checkout was inconsistent. Added. The repo is public, so the `origin/main` fetch still works without them.

## Validation

Regex checked against every case above (plus `v10.20.30`, `v2.0`, `v2.0.1.2`, `2.0.1`, and an injection-shaped tag — only exact `vMAJOR.MINOR.PATCH` passes). YAML re-parsed; confirmed no `${{ }}` remains in the `run` body and all three build jobs are still gated by `needs: verify-tag`.

Once merged, #765 will be re-synced from `main` so the back-merge carries this too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened release validation for GA publishing.
  * Releases now require an exact semantic version tag format (`vMAJOR.MINOR.PATCH`).
  * Added verification that tagged commits are included in the main development branch.
  * Improved release-check error and success messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->