### PR TITLE
chore(release): bump version to 2.0.2

### DIFF
--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.1"
+appVersion: "2.0.2"
 
 dependencies:
   - name: kuberay-operator

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -33,7 +33,7 @@ ray:
   image:
     repository: ghcr.io/linagora/openrag-ray
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.0.1"
+    tag: "v2.0.2"
 
 # === PostgreSQL (bitnami) ===
 postgresql:
@@ -262,7 +262,7 @@ adminUi:
     repository: linagoraai/openrag-admin-ui
     # Pin to a release tag (ideally a digest) for reproducible deploys. Must be a
     # build from infra/docker/ui.Dockerfile (nginx-unprivileged, listens :8080).
-    tag: "v2.0.1"
+    tag: "v2.0.2"
   imagePullPolicy: IfNotPresent
   replicaCount: 1
   service:
@@ -276,7 +276,7 @@ openrag:
   image:
     repository: linagoraai/openrag
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.0.1"
+    tag: "v2.0.2"
   service:
     type: ClusterIP
     port: 8080

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -18,7 +18,7 @@ x-openrag-env: &openrag_env
   FONT_PATH: ${FONT_PATH:-/app/data/fonts/GoNotoCurrent-Regular.ttf}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:v2.0.1
+  image: linagoraai/openrag:v2.0.2
   # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
   # writable dirs (data/, logs/, the HF cache) — which a non-root container
   # can't write when Docker auto-creates them root-owned — then it immediately
@@ -113,7 +113,7 @@ x-vllm: &vllm_template
 services:
   # ── Admin UI (React SPA + nginx, same-origin reverse proxy to the API) ──
   admin-ui:
-    image: linagoraai/openrag-admin-ui:v2.0.1
+    image: linagoraai/openrag-admin-ui:v2.0.2
     build:
       context: ../..
       dockerfile: infra/docker/ui.Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "2.0.1"
+version = "2.0.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2713,7 +2713,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
## Summary
- pyproject.toml + uv.lock: 2.0.1 -> 2.0.2
- compose: openrag and openrag-admin-ui pins -> v2.0.2
- chart: version 0.5.2 -> 0.5.3, appVersion -> 2.0.2
- chart values: ray, openrag, adminUi image tags -> v2.0.2

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 2.0.2.
  * Updated container images across supported deployment options to version 2.0.2.
  * Updated deployment metadata to reflect the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->