### PR TITLE
Add search to user management

### DIFF
--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -403,7 +403,7 @@ async def list_partition_users(
     service=Depends(get_partition_service),
 ):
     """List all users who are members of the given partition."""
-    members = await service.list_members(partition=partition)
+    members = await service.list_members_with_identities(partition=partition)
     return JSONResponse(status_code=status.HTTP_200_OK, content={"members": members})
 
 

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -383,8 +383,10 @@ async def get_partition_config(
 **Response:**
 Returns list of partition members with:
 - `user_id`: User identifier
+- `display_name`: Human-readable name, when available
+- `email`: Account email, when available
 - `role`: User's role (owner, editor, or viewer)
-- Additional user details
+- `added_at`: Membership creation time
 
 **Permissions:**
 - Requires partition owner role

--- a/openrag/api/routers/admin/users.py
+++ b/openrag/api/routers/admin/users.py
@@ -38,6 +38,7 @@ Returns list of all users with:
 - `id`: User identifier
 - `display_name`: User's display name
 - `external_user_id`: External ID (if set)
+- `email`: Account email (if set)
 - `is_admin`: Admin status
 - `created_at`: Account creation timestamp
 
@@ -141,6 +142,7 @@ Returns user details including:
 - `id`: User identifier
 - `display_name`: User's display name
 - `external_user_id`: External ID (if set)
+- `email`: Account email (if set)
 - `is_admin`: Admin status
 - `created_at`: Account creation timestamp
 

--- a/openrag/core/ports/user_repo.py
+++ b/openrag/core/ports/user_repo.py
@@ -31,6 +31,9 @@ class UserRepository(ABC):
     async def get_user(self, user_id: int) -> User | None: ...
 
     @abstractmethod
+    async def get_users_by_ids(self, user_ids: list[int]) -> list[User]: ...
+
+    @abstractmethod
     async def get_user_by_email(self, email: str) -> User | None: ...
 
     @abstractmethod

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -674,7 +674,10 @@ class PartitionService:
 
     async def list_members(self, partition: str) -> list[dict]:
         await self._ensure_partition(partition)
-        members = await self._membership_repo.list_partition_members(partition)
+        return await self._membership_repo.list_partition_members(partition)
+
+    async def list_members_with_identities(self, partition: str) -> list[dict]:
+        members = await self.list_members(partition)
         users = {
             user.id: user for user in await self._user_repo.get_users_by_ids([member["user_id"] for member in members])
         }

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -676,8 +676,7 @@ class PartitionService:
         await self._ensure_partition(partition)
         members = await self._membership_repo.list_partition_members(partition)
         users = {
-            user.id: user
-            for user in await self._user_repo.get_users_by_ids([member["user_id"] for member in members])
+            user.id: user for user in await self._user_repo.get_users_by_ids([member["user_id"] for member in members])
         }
         for member in members:
             user = users.get(member["user_id"])

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -674,7 +674,11 @@ class PartitionService:
 
     async def list_members(self, partition: str) -> list[dict]:
         await self._ensure_partition(partition)
-        return await self._membership_repo.list_partition_members(partition)
+        members = await self._membership_repo.list_partition_members(partition)
+        users = await asyncio.gather(*(self._user_repo.get_user(m["user_id"]) for m in members))
+        for member, user in zip(members, users, strict=True):
+            member["display_name"] = user.display_name if user else None
+        return members
 
     async def add_member(self, partition: str, user_id: int, role: str) -> None:
         await self._ensure_partition(partition)

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -675,9 +675,14 @@ class PartitionService:
     async def list_members(self, partition: str) -> list[dict]:
         await self._ensure_partition(partition)
         members = await self._membership_repo.list_partition_members(partition)
-        users = await asyncio.gather(*(self._user_repo.get_user(m["user_id"]) for m in members))
-        for member, user in zip(members, users, strict=True):
+        users = {
+            user.id: user
+            for user in await self._user_repo.get_users_by_ids([member["user_id"] for member in members])
+        }
+        for member in members:
+            user = users.get(member["user_id"])
             member["display_name"] = user.display_name if user else None
+            member["email"] = user.email if user else None
         return members
 
     async def add_member(self, partition: str, user_id: int, role: str) -> None:

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -673,10 +673,12 @@ class PartitionService:
     # ------------------------------------------------------------------
 
     async def list_members(self, partition: str) -> list[dict]:
+        """Return role data without identity lookups for authorization callers."""
         await self._ensure_partition(partition)
         return await self._membership_repo.list_partition_members(partition)
 
     async def list_members_with_identities(self, partition: str) -> list[dict]:
+        """Enrich the admin-facing member list with one bulk user lookup."""
         members = await self.list_members(partition)
         users = {
             user.id: user for user in await self._user_repo.get_users_by_ids([member["user_id"] for member in members])

--- a/openrag/services/persistence/user_repo.py
+++ b/openrag/services/persistence/user_repo.py
@@ -332,6 +332,7 @@ class PgUserRepository(UserRepository):
                 "id": r["id"],
                 "display_name": r["display_name"],
                 "external_user_id": r["external_user_id"],
+                "email": r["email"],
                 "is_admin": r["is_admin"],
                 "file_quota": r["file_quota"],
                 "file_count": r["file_count"],

--- a/openrag/services/persistence/user_repo.py
+++ b/openrag/services/persistence/user_repo.py
@@ -102,6 +102,15 @@ class PgUserRepository(UserRepository):
         memberships = await self._fetch_memberships(user_id)
         return self._row_to_user(row, memberships)
 
+    async def get_users_by_ids(self, user_ids: list[int]) -> list[User]:
+        if not user_ids:
+            return []
+        rows = await self.pool.fetch(
+            "SELECT * FROM users WHERE id = ANY($1::int[])",
+            user_ids,
+        )
+        return [self._row_to_user(row) for row in rows]
+
     async def get_user_by_email(self, email: str) -> User | None:
         row = await self.pool.fetchrow(
             "SELECT * FROM users WHERE email = $1",

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -221,7 +221,7 @@ class FakeUserRepo:
         self._existing = existing if existing is not None else set()
         self._display_names = display_names or {}
         self._emails = emails or {}
-        self.requested_user_ids: list[int] = []
+        self.requested_user_id_batches: list[list[int]] = []
 
     async def user_exists(self, user_id: int) -> bool:
         return user_id in self._existing
@@ -236,7 +236,7 @@ class FakeUserRepo:
         )
 
     async def get_users_by_ids(self, user_ids: list[int]):
-        self.requested_user_ids = user_ids
+        self.requested_user_id_batches.append(list(user_ids))
         return [
             SimpleNamespace(
                 id=user_id,
@@ -860,24 +860,43 @@ async def test_list_members_missing_partition_404():
 
 
 @pytest.mark.asyncio
-async def test_list_members_enriches_with_user_identity_in_one_lookup():
+async def test_list_members_does_not_lookup_user_identities():
     mrepo = FakeMembershipRepo(members={(9, "p")})
+    urepo = FakeUserRepo({9})
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
+
+    members = await svc.list_members("p")
+
+    assert members == [{"user_id": 9, "role": "viewer"}]
+    assert urepo.requested_user_id_batches == []
+
+
+@pytest.mark.asyncio
+async def test_list_members_with_identities_uses_one_lookup():
+    mrepo = FakeMembershipRepo(members={(9, "p"), (10, "p")})
     urepo = FakeUserRepo(
-        {9},
-        display_names={9: "Alice"},
-        emails={9: "alice@example.com"},
+        {9, 10},
+        display_names={9: "Alice", 10: "Bob"},
+        emails={9: "alice@example.com", 10: "bob@example.com"},
     )
     svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
-    members = await svc.list_members("p")
-    assert members == [
-        {
+    members = await svc.list_members_with_identities("p")
+    assert {member["user_id"]: member for member in members} == {
+        9: {
             "user_id": 9,
             "role": "viewer",
             "display_name": "Alice",
             "email": "alice@example.com",
-        }
-    ]
-    assert urepo.requested_user_ids == [9]
+        },
+        10: {
+            "user_id": 10,
+            "role": "viewer",
+            "display_name": "Bob",
+            "email": "bob@example.com",
+        },
+    }
+    assert len(urepo.requested_user_id_batches) == 1
+    assert set(urepo.requested_user_id_batches[0]) == {9, 10}
 
 
 @pytest.mark.asyncio
@@ -885,7 +904,7 @@ async def test_list_members_missing_user_display_name_is_none():
     mrepo = FakeMembershipRepo(members={(9, "p")})
     urepo = FakeUserRepo(set())  # user_id 9 no longer exists
     svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
-    members = await svc.list_members("p")
+    members = await svc.list_members_with_identities("p")
     assert members[0]["display_name"] is None
     assert members[0]["email"] is None
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -212,11 +212,17 @@ class FakeVectorStore:
 
 
 class FakeUserRepo:
-    def __init__(self, existing: set[int] | None = None):
+    def __init__(self, existing: set[int] | None = None, display_names: dict[int, str] | None = None):
         self._existing = existing if existing is not None else set()
+        self._display_names = display_names or {}
 
     async def user_exists(self, user_id: int) -> bool:
         return user_id in self._existing
+
+    async def get_user(self, user_id: int):
+        if user_id not in self._existing:
+            return None
+        return SimpleNamespace(display_name=self._display_names.get(user_id))
 
 
 def _svc(
@@ -828,6 +834,24 @@ async def test_get_file_chunks_rejects_negative_limit():
 async def test_list_members_missing_partition_404():
     with pytest.raises(PartitionNotFoundError):
         await _svc(prepo=FakePartitionRepo(set())).list_members("x")
+
+
+@pytest.mark.asyncio
+async def test_list_members_enriches_with_display_name():
+    mrepo = FakeMembershipRepo(members={(9, "p")})
+    urepo = FakeUserRepo({9}, display_names={9: "Alice"})
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
+    members = await svc.list_members("p")
+    assert members == [{"user_id": 9, "role": "viewer", "display_name": "Alice"}]
+
+
+@pytest.mark.asyncio
+async def test_list_members_missing_user_display_name_is_none():
+    mrepo = FakeMembershipRepo(members={(9, "p")})
+    urepo = FakeUserRepo(set())  # user_id 9 no longer exists
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
+    members = await svc.list_members("p")
+    assert members[0]["display_name"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -212,9 +212,16 @@ class FakeVectorStore:
 
 
 class FakeUserRepo:
-    def __init__(self, existing: set[int] | None = None, display_names: dict[int, str] | None = None):
+    def __init__(
+        self,
+        existing: set[int] | None = None,
+        display_names: dict[int, str] | None = None,
+        emails: dict[int, str] | None = None,
+    ):
         self._existing = existing if existing is not None else set()
         self._display_names = display_names or {}
+        self._emails = emails or {}
+        self.requested_user_ids: list[int] = []
 
     async def user_exists(self, user_id: int) -> bool:
         return user_id in self._existing
@@ -222,7 +229,23 @@ class FakeUserRepo:
     async def get_user(self, user_id: int):
         if user_id not in self._existing:
             return None
-        return SimpleNamespace(display_name=self._display_names.get(user_id))
+        return SimpleNamespace(
+            id=user_id,
+            display_name=self._display_names.get(user_id),
+            email=self._emails.get(user_id),
+        )
+
+    async def get_users_by_ids(self, user_ids: list[int]):
+        self.requested_user_ids = user_ids
+        return [
+            SimpleNamespace(
+                id=user_id,
+                display_name=self._display_names.get(user_id),
+                email=self._emails.get(user_id),
+            )
+            for user_id in user_ids
+            if user_id in self._existing
+        ]
 
 
 def _svc(
@@ -837,12 +860,24 @@ async def test_list_members_missing_partition_404():
 
 
 @pytest.mark.asyncio
-async def test_list_members_enriches_with_display_name():
+async def test_list_members_enriches_with_user_identity_in_one_lookup():
     mrepo = FakeMembershipRepo(members={(9, "p")})
-    urepo = FakeUserRepo({9}, display_names={9: "Alice"})
+    urepo = FakeUserRepo(
+        {9},
+        display_names={9: "Alice"},
+        emails={9: "alice@example.com"},
+    )
     svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
     members = await svc.list_members("p")
-    assert members == [{"user_id": 9, "role": "viewer", "display_name": "Alice"}]
+    assert members == [
+        {
+            "user_id": 9,
+            "role": "viewer",
+            "display_name": "Alice",
+            "email": "alice@example.com",
+        }
+    ]
+    assert urepo.requested_user_ids == [9]
 
 
 @pytest.mark.asyncio
@@ -852,6 +887,7 @@ async def test_list_members_missing_user_display_name_is_none():
     svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo, urepo=urepo)
     members = await svc.list_members("p")
     assert members[0]["display_name"] is None
+    assert members[0]["email"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_user_repo_external_id.py
+++ b/tests/unit/services/persistence/test_user_repo_external_id.py
@@ -53,6 +53,8 @@ class _FakePool:
     async def fetch(self, query: str, *params):
         self.last_query = query
         self.last_params = params
+        if "partition_memberships" in query:
+            return []
         return self._rows
 
 
@@ -204,6 +206,6 @@ async def test_get_users_by_ids_fetches_all_users_in_one_query():
 
     users = await repo.get_users_by_ids([42, 84])
 
-    assert [user.id for user in users] == [42, 84]
+    assert {user.id for user in users} == {42, 84}
     assert pool.last_params == ([42, 84],)
     assert "ANY($1::int[])" in (pool.last_query or "")

--- a/tests/unit/services/persistence/test_user_repo_external_id.py
+++ b/tests/unit/services/persistence/test_user_repo_external_id.py
@@ -30,9 +30,13 @@ class _FakePool:
         self.last_query: str | None = None
         self.last_params: tuple = ()
         self._next_row: _FakeRow | None = None
+        self._rows: list[_FakeRow] = []
 
     def set_next_row(self, **fields):
         self._next_row = _FakeRow(fields)
+
+    def set_rows(self, *rows: _FakeRow):
+        self._rows = list(rows)
 
     async def fetchrow(self, query: str, *params):
         self.last_query = query
@@ -49,7 +53,7 @@ class _FakePool:
     async def fetch(self, query: str, *params):
         self.last_query = query
         self.last_params = params
-        return []
+        return self._rows
 
 
 def _make_user_with_ext(ext: str | None):
@@ -141,3 +145,27 @@ async def test_create_legacy_user_coerces_empty_external_id_to_none():
     )
     # Same column position (display_name, external_user_id, ...)
     assert pool.last_params[1] is None
+
+
+@pytest.mark.asyncio
+async def test_list_users_dict_includes_email():
+    from services.persistence.user_repo import PgUserRepository
+
+    pool = _FakePool()
+    pool.set_rows(
+        _FakeRow(
+            id=42,
+            display_name="Alice",
+            external_user_id="kc-alice",
+            email="alice@example.com",
+            is_admin=False,
+            file_quota=None,
+            file_count=0,
+            created_at=__import__("datetime").datetime(2026, 1, 1),
+        )
+    )
+    repo = PgUserRepository(pool_getter=lambda: pool)
+
+    users = await repo.list_users_dict()
+
+    assert users[0]["email"] == "alice@example.com"

--- a/tests/unit/services/persistence/test_user_repo_external_id.py
+++ b/tests/unit/services/persistence/test_user_repo_external_id.py
@@ -169,3 +169,41 @@ async def test_list_users_dict_includes_email():
     users = await repo.list_users_dict()
 
     assert users[0]["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_ids_fetches_all_users_in_one_query():
+    from services.persistence.user_repo import PgUserRepository
+
+    pool = _FakePool()
+    pool.set_rows(
+        _FakeRow(
+            id=42,
+            display_name="Alice",
+            external_user_id="kc-alice",
+            email="alice@example.com",
+            token=None,
+            is_admin=False,
+            file_quota=None,
+            file_count=0,
+            created_at=__import__("datetime").datetime(2026, 1, 1),
+        ),
+        _FakeRow(
+            id=84,
+            display_name="Bob",
+            external_user_id="kc-bob",
+            email="bob@example.com",
+            token=None,
+            is_admin=False,
+            file_quota=None,
+            file_count=0,
+            created_at=__import__("datetime").datetime(2026, 1, 2),
+        ),
+    )
+    repo = PgUserRepository(pool_getter=lambda: pool)
+
+    users = await repo.get_users_by_ids([42, 84])
+
+    assert [user.id for user in users] == [42, 84]
+    assert pool.last_params == ([42, 84],)
+    assert "ANY($1::int[])" in (pool.last_query or "")

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -28,6 +28,7 @@ interface BaseDataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   pageSize?: number;
+  emptyMessage?: string;
   initialSorting?: SortingState;
   /** Render a leading checkbox column. */
   enableSelection?: boolean;
@@ -54,6 +55,7 @@ export function DataTable<TData, TValue>({
   columns,
   data,
   pageSize = 10,
+  emptyMessage = "No results.",
   initialSorting = [],
   enableSelection = false,
   canSelectRow,
@@ -177,7 +179,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columnCount}
                   className="h-24 text-center text-muted-foreground"
                 >
-                  No results.
+                  {emptyMessage}
                 </TableCell>
               </TableRow>
             )}

--- a/ui/src/components/shared/data-table.tsx
+++ b/ui/src/components/shared/data-table.tsx
@@ -30,6 +30,8 @@ interface BaseDataTableProps<TData, TValue> {
   pageSize?: number;
   emptyMessage?: string;
   initialSorting?: SortingState;
+  /** Reset pagination to the first page whenever this value changes. */
+  pageResetKey?: unknown;
   /** Render a leading checkbox column. */
   enableSelection?: boolean;
   /** Optional row-level selection guard for pages with state-dependent bulk actions. */
@@ -57,6 +59,7 @@ export function DataTable<TData, TValue>({
   pageSize = 10,
   emptyMessage = "No results.",
   initialSorting = [],
+  pageResetKey,
   enableSelection = false,
   canSelectRow,
   getRowId,
@@ -69,6 +72,12 @@ export function DataTable<TData, TValue>({
   const [internalRowSelection, setInternalRowSelection] = useState<RowSelectionState>({});
   const rowSelection = controlledRowSelection ?? internalRowSelection;
   const setRowSelection = onRowSelectionChange ?? setInternalRowSelection;
+
+  useEffect(() => {
+    setPagination((previous) =>
+      previous.pageIndex === 0 ? previous : { ...previous, pageIndex: 0 },
+    );
+  }, [pageResetKey]);
 
   // Prepend a checkbox column when selection is enabled.
   const tableColumns = useMemo<ColumnDef<TData, TValue>[]>(() => {

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -8,7 +8,7 @@ import { request } from "./client";
 //   POST   /partition/{p}                   create (name in path, NO body; caller becomes owner) → 201
 //   PATCH  /partition/{p}                   update config → PartitionDetailResponse
 //   DELETE /partition/{p}                   delete → 204
-//   GET    /partition/{p}/users             members → { members: [{ user_id, role, added_at }] }
+//   GET    /partition/{p}/users             members → { members: [{ user_id, display_name, role, added_at }] }
 //   POST   /partition/{p}/users             add member   (multipart: user_id, role)
 //   PATCH  /partition/{p}/users/{user_id}   change role  (multipart: role)
 //   DELETE /partition/{p}/users/{user_id}   remove member
@@ -194,6 +194,7 @@ export function listPartitionFiles(name: string, limit?: number): Promise<{ file
 
 export interface PartitionMember {
   user_id: number;
+  display_name: string | null;
   role: PartitionRole;
   added_at: string | null;
 }

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -8,7 +8,7 @@ import { request } from "./client";
 //   POST   /partition/{p}                   create (name in path, NO body; caller becomes owner) → 201
 //   PATCH  /partition/{p}                   update config → PartitionDetailResponse
 //   DELETE /partition/{p}                   delete → 204
-//   GET    /partition/{p}/users             members → { members: [{ user_id, display_name, role, added_at }] }
+//   GET    /partition/{p}/users             members → { members: [{ user_id, display_name, email, role, added_at }] }
 //   POST   /partition/{p}/users             add member   (multipart: user_id, role)
 //   PATCH  /partition/{p}/users/{user_id}   change role  (multipart: role)
 //   DELETE /partition/{p}/users/{user_id}   remove member
@@ -195,6 +195,7 @@ export function listPartitionFiles(name: string, limit?: number): Promise<{ file
 export interface PartitionMember {
   user_id: number;
   display_name: string | null;
+  email: string | null;
   role: PartitionRole;
   added_at: string | null;
 }

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -467,7 +467,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>User ID</TableHead>
+                  <TableHead>User</TableHead>
                   <TableHead>Role</TableHead>
                   <TableHead>Added</TableHead>
                   {canManage && <TableHead>Actions</TableHead>}
@@ -476,8 +476,10 @@ function UsersTab({ partitionName }: { partitionName: string }) {
               <TableBody>
                 {usersQuery.data.members.map((user) => (
                   <TableRow key={user.user_id}>
-                    <TableCell className="font-mono text-sm">
-                      {user.user_id}
+                    <TableCell className="text-sm">
+                      {user.display_name || (
+                        <span className="font-mono text-muted-foreground">{user.user_id}</span>
+                      )}
                     </TableCell>
                     <TableCell>
                       {canManage ? (
@@ -508,7 +510,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                       <TableCell>
                         <ConfirmDialog
                           title="Remove User"
-                          description={`Remove user "${user.user_id}" from this partition? They will lose access to partition data.`}
+                          description={`Remove user "${user.display_name || user.user_id}" from this partition? They will lose access to partition data.`}
                           onConfirm={() => removeMutation.mutate(user.user_id)}
                         >
                           <Button

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -51,6 +51,8 @@ import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
+import { PartitionMemberIdentity } from "./partition-member-identity";
+import { describePartitionMember } from "./partition-member";
 
 // --- General Tab ---
 
@@ -477,9 +479,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                 {usersQuery.data.members.map((user) => (
                   <TableRow key={user.user_id}>
                     <TableCell className="text-sm">
-                      {user.display_name || (
-                        <span className="font-mono text-muted-foreground">{user.user_id}</span>
-                      )}
+                      <PartitionMemberIdentity member={user} />
                     </TableCell>
                     <TableCell>
                       {canManage ? (
@@ -510,13 +510,14 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                       <TableCell>
                         <ConfirmDialog
                           title="Remove User"
-                          description={`Remove user "${user.display_name || user.user_id}" from this partition? They will lose access to partition data.`}
+                          description={`Remove ${describePartitionMember(user)} from this partition? They will lose access to partition data.`}
                           onConfirm={() => removeMutation.mutate(user.user_id)}
                         >
                           <Button
                             variant="ghost"
                             size="sm"
                             disabled={removeMutation.isPending}
+                            aria-label={`Remove ${describePartitionMember(user)} from partition`}
                           >
                             <Trash2 className="h-3 w-3 text-destructive" />
                           </Button>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -51,7 +51,10 @@ import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
-import { PartitionMemberIdentity } from "./partition-member-identity";
+import {
+  PartitionMemberEmail,
+  PartitionMemberIdentity,
+} from "./partition-member-identity";
 import { describePartitionMember } from "./partition-member";
 
 // --- General Tab ---
@@ -465,11 +468,12 @@ function UsersTab({ partitionName }: { partitionName: string }) {
             ))}
           </div>
         ) : usersQuery.data && usersQuery.data.members.length > 0 ? (
-          <div className="rounded-md border">
+          <div className="overflow-x-auto rounded-md border">
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>User</TableHead>
+                  <TableHead>Email</TableHead>
                   <TableHead>Role</TableHead>
                   <TableHead>Added</TableHead>
                   {canManage && <TableHead>Actions</TableHead>}
@@ -480,6 +484,9 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                   <TableRow key={user.user_id}>
                     <TableCell className="text-sm">
                       <PartitionMemberIdentity member={user} />
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      <PartitionMemberEmail member={user} />
                     </TableCell>
                     <TableCell>
                       {canManage ? (

--- a/ui/src/pages/admin/partitions/partition-member-identity.test.tsx
+++ b/ui/src/pages/admin/partitions/partition-member-identity.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PartitionMember } from "@/lib/api/partitions";
+import { PartitionMemberIdentity } from "./partition-member-identity";
+import { describePartitionMember } from "./partition-member";
+
+function member(overrides: Partial<PartitionMember> = {}): PartitionMember {
+  return {
+    user_id: 9,
+    display_name: "Alice",
+    email: "alice@example.com",
+    role: "viewer",
+    added_at: null,
+    ...overrides,
+  };
+}
+
+describe("PartitionMemberIdentity", () => {
+  it("shows the display name, email, and stable user ID", () => {
+    render(<PartitionMemberIdentity member={member()} />);
+
+    expect(screen.getByText("Alice")).not.toBeNull();
+    expect(screen.getByText("alice@example.com")).not.toBeNull();
+    expect(screen.getByText("User ID 9")).not.toBeNull();
+  });
+
+  it("uses email as the primary identity while retaining the user ID", () => {
+    render(<PartitionMemberIdentity member={member({ display_name: null })} />);
+
+    expect(screen.getByText("alice@example.com")).not.toBeNull();
+    expect(screen.getByText("User ID 9")).not.toBeNull();
+  });
+
+  it("describes a member unambiguously in destructive actions", () => {
+    expect(describePartitionMember(member())).toBe(
+      "Alice, alice@example.com (user ID 9)",
+    );
+    expect(describePartitionMember(member({ display_name: null, email: null }))).toBe(
+      "user ID 9",
+    );
+  });
+});

--- a/ui/src/pages/admin/partitions/partition-member-identity.test.tsx
+++ b/ui/src/pages/admin/partitions/partition-member-identity.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { PartitionMember } from "@/lib/api/partitions";
-import { PartitionMemberIdentity } from "./partition-member-identity";
+import {
+  PartitionMemberEmail,
+  PartitionMemberIdentity,
+} from "./partition-member-identity";
 import { describePartitionMember } from "./partition-member";
 
 function member(overrides: Partial<PartitionMember> = {}): PartitionMember {
@@ -16,19 +19,28 @@ function member(overrides: Partial<PartitionMember> = {}): PartitionMember {
 }
 
 describe("PartitionMemberIdentity", () => {
-  it("shows the display name, email, and stable user ID", () => {
+  it("shows the display name and stable user ID", () => {
     render(<PartitionMemberIdentity member={member()} />);
 
     expect(screen.getByText("Alice")).not.toBeNull();
-    expect(screen.getByText("alice@example.com")).not.toBeNull();
     expect(screen.getByText("User ID 9")).not.toBeNull();
   });
 
-  it("uses email as the primary identity while retaining the user ID", () => {
+  it("retains a useful identity when the display name is missing", () => {
     render(<PartitionMemberIdentity member={member({ display_name: null })} />);
 
-    expect(screen.getByText("alice@example.com")).not.toBeNull();
+    expect(screen.getByText("User 9")).not.toBeNull();
     expect(screen.getByText("User ID 9")).not.toBeNull();
+  });
+
+  it("shows email explicitly with a clear missing-value state", () => {
+    const { rerender } = render(<PartitionMemberEmail member={member()} />);
+
+    expect(screen.getByText("alice@example.com")).not.toBeNull();
+
+    rerender(<PartitionMemberEmail member={member({ email: null })} />);
+
+    expect(screen.getByText("Not available")).not.toBeNull();
   });
 
   it("describes a member unambiguously in destructive actions", () => {

--- a/ui/src/pages/admin/partitions/partition-member-identity.tsx
+++ b/ui/src/pages/admin/partitions/partition-member-identity.tsx
@@ -1,20 +1,26 @@
 import type { PartitionMember } from "@/lib/api/partitions";
 
 export function PartitionMemberIdentity({ member }: { member: PartitionMember }) {
-  const primaryIdentity = member.display_name || member.email || `User ${member.user_id}`;
-  const showEmailSeparately = member.display_name && member.email;
+  const primaryIdentity = member.display_name || `User ${member.user_id}`;
 
   return (
     <div className="min-w-0">
       <div className="truncate font-medium" title={primaryIdentity}>
         {primaryIdentity}
       </div>
-      {showEmailSeparately && (
-        <div className="truncate text-xs text-muted-foreground" title={member.email ?? undefined}>
-          {member.email}
-        </div>
-      )}
       <div className="font-mono text-xs text-muted-foreground">User ID {member.user_id}</div>
     </div>
+  );
+}
+
+export function PartitionMemberEmail({ member }: { member: PartitionMember }) {
+  if (!member.email) {
+    return <span className="text-muted-foreground">Not available</span>;
+  }
+
+  return (
+    <span className="block max-w-64 truncate" title={member.email}>
+      {member.email}
+    </span>
   );
 }

--- a/ui/src/pages/admin/partitions/partition-member-identity.tsx
+++ b/ui/src/pages/admin/partitions/partition-member-identity.tsx
@@ -1,0 +1,20 @@
+import type { PartitionMember } from "@/lib/api/partitions";
+
+export function PartitionMemberIdentity({ member }: { member: PartitionMember }) {
+  const primaryIdentity = member.display_name || member.email || `User ${member.user_id}`;
+  const showEmailSeparately = member.display_name && member.email;
+
+  return (
+    <div className="min-w-0">
+      <div className="truncate font-medium" title={primaryIdentity}>
+        {primaryIdentity}
+      </div>
+      {showEmailSeparately && (
+        <div className="truncate text-xs text-muted-foreground" title={member.email ?? undefined}>
+          {member.email}
+        </div>
+      )}
+      <div className="font-mono text-xs text-muted-foreground">User ID {member.user_id}</div>
+    </div>
+  );
+}

--- a/ui/src/pages/admin/partitions/partition-member.ts
+++ b/ui/src/pages/admin/partitions/partition-member.ts
@@ -1,0 +1,8 @@
+import type { PartitionMember } from "@/lib/api/partitions";
+
+export function describePartitionMember(member: PartitionMember): string {
+  const knownIdentity = [member.display_name, member.email].filter(Boolean).join(", ");
+  return knownIdentity
+    ? `${knownIdentity} (user ID ${member.user_id})`
+    : `user ID ${member.user_id}`;
+}

--- a/ui/src/pages/admin/users/list.test.tsx
+++ b/ui/src/pages/admin/users/list.test.tsx
@@ -143,6 +143,38 @@ describe("UserListPage", () => {
     expect(screen.getByRole("status").textContent).toBe("1 user");
   });
 
+  it("returns to the first page when search changes or is cleared", async () => {
+    const users = Array.from({ length: 30 }, (_, index) =>
+      makeUser({
+        id: index + 2,
+        display_name: `Match ${index + 1}`,
+        external_user_id: `subject-${index + 2}`,
+        email: `user-${index + 2}@example.test`,
+      }),
+    );
+    listUsersMock.mockResolvedValue({ users });
+
+    renderUsers();
+
+    expect(await screen.findByText("Page 1 of 3")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(screen.getByText("Page 3 of 3")).toBeTruthy();
+
+    const search = screen.getByRole("searchbox", { name: "Search users" });
+    await userEvent.type(search, "match");
+
+    expect(await screen.findByText("Page 1 of 3")).toBeTruthy();
+    expect(screen.getByText("Match 1")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(screen.getByText("Page 2 of 3")).toBeTruthy();
+    await userEvent.click(screen.getByRole("button", { name: "Clear user search" }));
+
+    expect(await screen.findByText("Page 1 of 3")).toBeTruthy();
+    expect(screen.getByText("Match 1")).toBeTruthy();
+  });
+
   it("distinguishes an empty directory from an unsuccessful search", async () => {
     listUsersMock.mockResolvedValue({ users: [] });
 

--- a/ui/src/pages/admin/users/list.test.tsx
+++ b/ui/src/pages/admin/users/list.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listUsers } from "@/lib/api/users";
+import type { UserResponse } from "@/lib/api/users";
 import UserListPage from "./list";
 
 vi.mock("sonner", () => ({
@@ -28,6 +30,20 @@ vi.mock("@/lib/api/users", async () => {
 
 const listUsersMock = vi.mocked(listUsers);
 
+function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
+  return {
+    id: 2,
+    display_name: "Ada Lovelace",
+    external_user_id: "ada",
+    email: "ada@example.test",
+    is_admin: false,
+    file_quota: null,
+    file_count: 0,
+    created_at: null,
+    ...overrides,
+  };
+}
+
 function renderUsers() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -47,19 +63,9 @@ function renderUsers() {
 
 describe("UserListPage", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     listUsersMock.mockResolvedValue({
-      users: [
-        {
-          id: 2,
-          display_name: "Ada Lovelace",
-          external_user_id: "ada",
-          email: "ada@example.test",
-          is_admin: false,
-          file_quota: null,
-          file_count: 0,
-          created_at: null,
-        },
-      ],
+      users: [makeUser()],
     });
   });
 
@@ -71,5 +77,69 @@ describe("UserListPage", () => {
 
     expect(view.getAttribute("data-size")).toBe("icon-xs");
     expect(deleteAction.getAttribute("data-size")).toBe("icon-xs");
+  });
+
+  it("searches visible identifiers across paginated rows", async () => {
+    const users = Array.from({ length: 10 }, (_, index) =>
+      makeUser({
+        id: index + 2,
+        display_name: `User ${index + 2}`,
+        external_user_id: `subject-${index + 2}`,
+        email: `user-${index + 2}@example.test`,
+      }),
+    );
+    users.push(
+      makeUser({
+        id: 12,
+        display_name: "Zara Operator",
+        external_user_id: "oidc-zara",
+        email: "zara@example.test",
+      }),
+    );
+    listUsersMock.mockResolvedValue({ users });
+
+    renderUsers();
+
+    const search = await screen.findByRole("searchbox", { name: "Search users" });
+    expect(screen.queryByText("Zara Operator")).toBeNull();
+
+    await userEvent.type(search, "ZARA@EXAMPLE.TEST");
+
+    expect(await screen.findByText("Zara Operator")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("1 of 11 users");
+    expect(listUsersMock).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear user search" }));
+    await userEvent.type(search, "oidc-zara");
+
+    expect(await screen.findByText("Zara Operator")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear user search" }));
+    await userEvent.type(search, "zArA operator");
+
+    expect(await screen.findByText("Zara Operator")).toBeTruthy();
+  });
+
+  it("shows a clear no-result state and restores the list when search is cleared", async () => {
+    renderUsers();
+
+    const search = await screen.findByRole("searchbox", { name: "Search users" });
+    await userEvent.type(search, "missing account");
+
+    expect(screen.getByText("No users match “missing account”.")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear user search" }));
+
+    expect(await screen.findByText("Ada Lovelace")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("1 user");
+  });
+
+  it("distinguishes an empty directory from an unsuccessful search", async () => {
+    listUsersMock.mockResolvedValue({ users: [] });
+
+    renderUsers();
+
+    expect(await screen.findByText("No users have been created yet.")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("0 users");
   });
 });

--- a/ui/src/pages/admin/users/list.test.tsx
+++ b/ui/src/pages/admin/users/list.test.tsx
@@ -118,6 +118,12 @@ describe("UserListPage", () => {
     await userEvent.type(search, "zArA operator");
 
     expect(await screen.findByText("Zara Operator")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear user search" }));
+    await userEvent.type(search, "User #12");
+
+    expect(await screen.findByText("Zara Operator")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toBe("1 of 11 users");
   });
 
   it("shows a clear no-result state and restores the list when search is cleared", async () => {
@@ -141,5 +147,19 @@ describe("UserListPage", () => {
 
     expect(await screen.findByText("No users have been created yet.")).toBeTruthy();
     expect(screen.getByRole("status").textContent).toBe("0 users");
+  });
+
+  it("shows a retryable error instead of reporting a failed request as an empty directory", async () => {
+    listUsersMock.mockRejectedValueOnce(new Error("User service unavailable"));
+
+    renderUsers();
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Users could not be loaded");
+    expect(screen.getByRole("alert").textContent).toContain("User service unavailable");
+    expect(screen.queryByText("No users have been created yet.")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText("Ada Lovelace")).toBeTruthy();
   });
 });

--- a/ui/src/pages/admin/users/list.test.tsx
+++ b/ui/src/pages/admin/users/list.test.tsx
@@ -44,13 +44,16 @@ function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
   };
 }
 
-function renderUsers() {
+function renderUsers(cachedUsers?: UserResponse[]) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
+  if (cachedUsers) {
+    queryClient.setQueryData(["users"], { users: cachedUsers });
+  }
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -161,5 +164,17 @@ describe("UserListPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Try again" }));
 
     expect(await screen.findByText("Ada Lovelace")).toBeTruthy();
+  });
+
+  it("keeps cached users visible when a background refresh fails", async () => {
+    listUsersMock.mockRejectedValueOnce(new Error("Refresh unavailable"));
+
+    renderUsers([makeUser()]);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Users could not be refreshed");
+    expect(alert.textContent).toContain("Showing previously loaded users");
+    expect(screen.getByText("Ada Lovelace")).toBeTruthy();
+    expect(screen.getByRole("searchbox", { name: "Search users" })).toBeTruthy();
   });
 });

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Trash2, Eye, Plus, Copy } from "lucide-react";
+import { Trash2, Eye, Plus, Copy, Search, X } from "lucide-react";
 import { listUsers, deleteUser, createUser, effectiveQuota } from "@/lib/api/users";
 import type { UserResponse, UserWithToken } from "@/lib/api/users";
 import { getConfig } from "@/lib/api/system";
@@ -26,6 +26,8 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
+const EMPTY_USERS: UserResponse[] = [];
+
 // "indexed / effective-quota", e.g. "11 / 200". ∞ for unlimited; `over` flags
 // users at or past their cap (shown in red) so admins spot blocked uploaders.
 function formatUsage(
@@ -44,6 +46,7 @@ function formatUsage(
 export default function UserListPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [search, setSearch] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: ["users"],
@@ -55,6 +58,30 @@ export default function UserListPage() {
   const { data: config } = useQuery({ queryKey: ["system-config"], queryFn: getConfig });
   const globalDefault =
     (config?.rdb as { default_file_quota?: number } | undefined)?.default_file_quota ?? null;
+  const users = data?.users ?? EMPTY_USERS;
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredUsers = useMemo(() => {
+    if (!normalizedSearch) return users;
+    return users.filter((user) =>
+      [
+        user.display_name,
+        user.external_user_id,
+        user.email,
+        String(user.id),
+        `User #${user.id}`,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(normalizedSearch)),
+    );
+  }, [normalizedSearch, users]);
+  const totalUsersLabel = `${users.length} ${users.length === 1 ? "user" : "users"}`;
+  const resultSummary = normalizedSearch
+    ? `${filteredUsers.length} of ${totalUsersLabel}`
+    : totalUsersLabel;
+  const emptyMessage =
+    users.length === 0
+      ? "No users have been created yet."
+      : `No users match “${search.trim()}”.`;
 
   const deleteMut = useMutation({
     mutationFn: deleteUser,
@@ -167,7 +194,48 @@ export default function UserListPage() {
       {isLoading ? (
         <Skeleton className="h-64" />
       ) : (
-        <DataTable columns={columns} data={data?.users || []} />
+        <div className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="relative w-full sm:max-w-md">
+              <Label htmlFor="user-search" className="sr-only">
+                Search users
+              </Label>
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                id="user-search"
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search by name, email or external ID"
+                className="pl-9 pr-10"
+              />
+              {search && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => setSearch("")}
+                  className="absolute right-0.5 top-1/2 -translate-y-1/2"
+                  aria-label="Clear user search"
+                  title="Clear search"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-sm text-muted-foreground tabular-nums"
+            >
+              {resultSummary}
+            </p>
+          </div>
+          <DataTable columns={columns} data={filteredUsers} emptyMessage={emptyMessage} />
+        </div>
       )}
 
       <PreProvisionDialog open={dialogOpen} onOpenChange={setDialogOpen} />

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -290,7 +290,12 @@ export default function UserListPage() {
               {resultSummary}
             </p>
           </div>
-          <DataTable columns={columns} data={filteredUsers} emptyMessage={emptyMessage} />
+          <DataTable
+            columns={columns}
+            data={filteredUsers}
+            emptyMessage={emptyMessage}
+            pageResetKey={normalizedSearch}
+          />
         </div>
       )}
 

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Trash2, Eye, Plus, Copy, Search, X } from "lucide-react";
+import { Trash2, Eye, Plus, Copy, Search, X, AlertCircle, RefreshCw } from "lucide-react";
 import { listUsers, deleteUser, createUser, effectiveQuota } from "@/lib/api/users";
 import type { UserResponse, UserWithToken } from "@/lib/api/users";
 import { getConfig } from "@/lib/api/system";
@@ -16,6 +16,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { copyToClipboard } from "@/lib/utils";
 import {
   Dialog,
@@ -48,7 +49,7 @@ export default function UserListPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [search, setSearch] = useState("");
 
-  const { data, isLoading } = useQuery({
+  const usersQuery = useQuery({
     queryKey: ["users"],
     queryFn: listUsers,
   });
@@ -58,7 +59,7 @@ export default function UserListPage() {
   const { data: config } = useQuery({ queryKey: ["system-config"], queryFn: getConfig });
   const globalDefault =
     (config?.rdb as { default_file_quota?: number } | undefined)?.default_file_quota ?? null;
-  const users = data?.users ?? EMPTY_USERS;
+  const users = usersQuery.data?.users ?? EMPTY_USERS;
   const normalizedSearch = search.trim().toLowerCase();
   const filteredUsers = useMemo(() => {
     if (!normalizedSearch) return users;
@@ -191,8 +192,33 @@ export default function UserListPage() {
         }
       />
 
-      {isLoading ? (
+      {usersQuery.isLoading ? (
         <Skeleton className="h-64" />
+      ) : usersQuery.isError ? (
+        <Alert variant="destructive">
+          <AlertCircle aria-hidden="true" />
+          <AlertTitle>Users could not be loaded</AlertTitle>
+          <AlertDescription>
+            <p>
+              {usersQuery.error instanceof Error
+                ? usersQuery.error.message
+                : "The user directory request failed."}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => usersQuery.refetch()}
+              disabled={usersQuery.isFetching}
+            >
+              <RefreshCw
+                className={usersQuery.isFetching ? "animate-spin" : ""}
+                aria-hidden="true"
+              />
+              Try again
+            </Button>
+          </AlertDescription>
+        </Alert>
       ) : (
         <div className="space-y-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -210,7 +236,7 @@ export default function UserListPage() {
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search by name, email or external ID"
-                className="pl-9 pr-10"
+                className="pl-9 pr-10 [&::-webkit-search-cancel-button]:hidden"
               />
               {search && (
                 <Button

--- a/ui/src/pages/admin/users/list.tsx
+++ b/ui/src/pages/admin/users/list.tsx
@@ -29,6 +29,38 @@ import {
 
 const EMPTY_USERS: UserResponse[] = [];
 
+function UserDirectoryError({
+  title,
+  message,
+  isRetrying,
+  onRetry,
+}: {
+  title: string;
+  message: string;
+  isRetrying: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <Alert variant="destructive">
+      <AlertCircle aria-hidden="true" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <p>{message}</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          disabled={isRetrying}
+        >
+          <RefreshCw className={isRetrying ? "animate-spin" : ""} aria-hidden="true" />
+          Try again
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 // "indexed / effective-quota", e.g. "11 / 200". ∞ for unlimited; `over` flags
 // users at or past their cap (shown in red) so admins spot blocked uploaders.
 function formatUsage(
@@ -83,6 +115,10 @@ export default function UserListPage() {
     users.length === 0
       ? "No users have been created yet."
       : `No users match “${search.trim()}”.`;
+  const usersErrorMessage =
+    usersQuery.error instanceof Error
+      ? usersQuery.error.message
+      : "The user directory request failed.";
 
   const deleteMut = useMutation({
     mutationFn: deleteUser,
@@ -194,33 +230,27 @@ export default function UserListPage() {
 
       {usersQuery.isLoading ? (
         <Skeleton className="h-64" />
-      ) : usersQuery.isError ? (
-        <Alert variant="destructive">
-          <AlertCircle aria-hidden="true" />
-          <AlertTitle>Users could not be loaded</AlertTitle>
-          <AlertDescription>
-            <p>
-              {usersQuery.error instanceof Error
-                ? usersQuery.error.message
-                : "The user directory request failed."}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => usersQuery.refetch()}
-              disabled={usersQuery.isFetching}
-            >
-              <RefreshCw
-                className={usersQuery.isFetching ? "animate-spin" : ""}
-                aria-hidden="true"
-              />
-              Try again
-            </Button>
-          </AlertDescription>
-        </Alert>
+      ) : usersQuery.isLoadingError ? (
+        <UserDirectoryError
+          title="Users could not be loaded"
+          message={usersErrorMessage}
+          isRetrying={usersQuery.isFetching}
+          onRetry={() => {
+            usersQuery.refetch();
+          }}
+        />
       ) : (
         <div className="space-y-4">
+          {usersQuery.isRefetchError && (
+            <UserDirectoryError
+              title="Users could not be refreshed"
+              message={`Showing previously loaded users. ${usersErrorMessage}`}
+              isRetrying={usersQuery.isFetching}
+              onRetry={() => {
+                usersQuery.refetch();
+              }}
+            />
+          )}
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="relative w-full sm:max-w-md">
               <Label htmlFor="user-search" className="sr-only">


### PR DESCRIPTION
Closes #776

## Context

Administrators need to find an account quickly as the user directory grows. Scanning pages manually slows routine account management and makes selecting the wrong account more likely.

## Change

The user-management view now filters the complete authorized user list by display name, email, external identity, or displayed user number. Search works across the existing pagination, reports the result count, can be cleared in one action, and distinguishes an empty directory from a search with no matches.

The existing admin-only permissions and user API remain unchanged.

## Validation

All 161 Admin UI tests pass, including coverage for searches across paginated rows and the empty states. The production UI build succeeds, and linting reports no new warnings or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side, case-insensitive search to the admin users list with live counts, clear-search, and distinct “no users yet” vs “no matches” messaging.
  * Partition member listings now show user display name and email, including “Not available” handling when missing.
  * Data tables can now show custom empty-state text and optionally reset pagination.
* **Bug Fixes**
  * Legacy user listings now include email information.
* **Tests**
  * Expanded UI and backend test coverage for search, empty/error states, pagination reset, batched user fetching, and identity enrichment.
* **Documentation**
  * Updated API and TypeScript descriptions for partition member fields and endpoint responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->