### PR TITLE
Select partition members by user name

### DIFF
--- a/docs/content/docs/documentation/API.mdx
+++ b/docs/content/docs/documentation/API.mdx
@@ -383,9 +383,12 @@ Manage who can access a partition and with which role — all **owner** only.
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/partition/{partition}/users` | GET | List members → `{ "members": [...] }` |
-| `/partition/{partition}/users` | POST | Add a member — form fields `user_id` (int), `role` (default `viewer`) → `201` |
+| `/partition/{partition}/users/candidates` | GET | Search non-members by display-name prefix or exact user ID → paginated identities |
+| `/partition/{partition}/users` | POST | Add a new member → `201`; returns `409` if already present |
 | `/partition/{partition}/users/{user_id}` | PATCH | Update a member's role — form field `role` → `200` |
 | `/partition/{partition}/users/{user_id}` | DELETE | Remove a member → `204` |
+
+`POST` no longer updates an existing member's role. Use the `PATCH` endpoint when changing a role.
 
 #### Document Relationships
 

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -418,7 +418,8 @@ async def list_partition_users(
 - `limit`: Page size (maximum 100)
 
 **Response:**
-Returns a bounded page of non-member users and continuation metadata.
+Returns a bounded page of non-member users with their display name and email,
+plus continuation metadata.
 
 **Permissions:**
 - Requires partition owner role

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -405,6 +405,30 @@ async def list_partition_users(
     return JSONResponse(status_code=status.HTTP_200_OK, content={"members": members})
 
 
+@router.get(
+    "/{partition}/users/candidates",
+    description="""List users who can be added to a partition.
+
+**Parameters:**
+- `partition`: The partition name
+
+**Response:**
+Returns non-member users with their display name and stable user ID.
+
+**Permissions:**
+- Requires partition owner role
+""",
+)
+async def list_partition_user_candidates(
+    partition: str,
+    partition_owner=Depends(require_partition_owner),
+    service=Depends(get_partition_service),
+):
+    """List users who are not already members of the given partition."""
+    candidates = await service.list_member_candidates(partition=partition)
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"candidates": candidates})
+
+
 @router.post(
     "/{partition}/users",
     description="""Add a user to a partition with a specific role.

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -411,9 +411,12 @@ async def list_partition_users(
 
 **Parameters:**
 - `partition`: The partition name
+- `search`: Optional display name or user ID fragment
+- `offset`: Page offset
+- `limit`: Page size (maximum 100)
 
 **Response:**
-Returns non-member users with their display name and stable user ID.
+Returns a bounded page of non-member users and continuation metadata.
 
 **Permissions:**
 - Requires partition owner role
@@ -421,12 +424,20 @@ Returns non-member users with their display name and stable user ID.
 )
 async def list_partition_user_candidates(
     partition: str,
+    search: str | None = Query(default=None, max_length=200),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=25, ge=1, le=100),
     partition_owner=Depends(require_partition_owner),
     service=Depends(get_partition_service),
 ):
-    """List users who are not already members of the given partition."""
-    candidates = await service.list_member_candidates(partition=partition)
-    return JSONResponse(status_code=status.HTTP_200_OK, content={"candidates": candidates})
+    """List a searchable page of users who are not partition members."""
+    page = await service.list_member_candidates(
+        partition=partition,
+        search=search,
+        offset=offset,
+        limit=limit,
+    )
+    return JSONResponse(status_code=status.HTTP_200_OK, content=page)
 
 
 @router.post(

--- a/openrag/api/routers/admin/partitions.py
+++ b/openrag/api/routers/admin/partitions.py
@@ -411,8 +411,8 @@ async def list_partition_users(
 
 **Parameters:**
 - `partition`: The partition name
-- `search`: Optional display name or user ID fragment
-- `offset`: Page offset
+- `search`: Display-name prefix (at least 3 characters) or exact user ID
+- `cursor`: Last user ID from the previous page
 - `limit`: Page size (maximum 100)
 
 **Response:**
@@ -424,8 +424,8 @@ Returns a bounded page of non-member users and continuation metadata.
 )
 async def list_partition_user_candidates(
     partition: str,
-    search: str | None = Query(default=None, max_length=200),
-    offset: int = Query(default=0, ge=0),
+    search: str = Query(..., max_length=200),
+    cursor: int | None = Query(default=None, ge=0, le=2_147_483_647),
     limit: int = Query(default=25, ge=1, le=100),
     partition_owner=Depends(require_partition_owner),
     service=Depends(get_partition_service),
@@ -434,7 +434,7 @@ async def list_partition_user_candidates(
     page = await service.list_member_candidates(
         partition=partition,
         search=search,
-        offset=offset,
+        cursor=cursor,
         limit=limit,
     )
     return JSONResponse(status_code=status.HTTP_200_OK, content=page)
@@ -459,6 +459,7 @@ async def list_partition_user_candidates(
 
 **Response:**
 Returns 201 Created on successful addition.
+Returns 409 Conflict if the user is already a member; use the role endpoint to change an existing member.
 """,
 )
 async def add_partition_user(

--- a/openrag/core/ports/partition_membership_repo.py
+++ b/openrag/core/ports/partition_membership_repo.py
@@ -40,7 +40,8 @@ class PartitionMembershipRepository(ABC):
         self,
         partition: str,
         *,
-        search: str | None,
-        offset: int,
+        search_prefix: str | None,
+        search_user_id: int | None,
+        after_id: int | None,
         limit: int,
     ) -> list[dict]: ...

--- a/openrag/core/ports/partition_membership_repo.py
+++ b/openrag/core/ports/partition_membership_repo.py
@@ -34,3 +34,13 @@ class PartitionMembershipRepository(ABC):
 
     @abstractmethod
     async def count_partition_users(self, partition: str) -> int: ...
+
+    @abstractmethod
+    async def list_partition_member_candidates(
+        self,
+        partition: str,
+        *,
+        search: str | None,
+        offset: int,
+        limit: int,
+    ) -> list[dict]: ...

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -704,7 +704,7 @@ class PartitionService:
 
         search_user_id: int | None = None
         search_prefix: str | None = None
-        if normalized_search.isdecimal():
+        if normalized_search.isascii() and normalized_search.isdecimal():
             search_user_id = int(normalized_search)
             if search_user_id > _MAX_POSTGRES_INTEGER:
                 raise ValidationError("User ID is outside the supported range.")
@@ -749,7 +749,10 @@ class PartitionService:
         created = await self._membership_repo.add_partition_member(partition, user_id, role)
         if not created:
             raise ConflictError(
-                f"User {user_id} is already a member of partition '{partition}'.",
+                (
+                    f"User {user_id} is already a member of partition '{partition}'. "
+                    f"Use PATCH /partition/{partition}/users/{user_id} to change their role."
+                ),
                 code="PARTITION_MEMBER_EXISTS",
             )
         logger.info(f"User_id {user_id} added to partition '{partition}'.")

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -705,9 +705,11 @@ class PartitionService:
         search_user_id: int | None = None
         search_prefix: str | None = None
         if normalized_search.isascii() and normalized_search.isdecimal():
-            search_user_id = int(normalized_search)
-            if search_user_id > _MAX_POSTGRES_INTEGER:
-                raise ValidationError("User ID is outside the supported range.")
+            numeric_search = int(normalized_search)
+            if numeric_search <= _MAX_POSTGRES_INTEGER:
+                search_user_id = numeric_search
+            if len(normalized_search) >= _MIN_MEMBER_CANDIDATE_SEARCH_LENGTH:
+                search_prefix = normalized_search
         elif len(normalized_search) < _MIN_MEMBER_CANDIDATE_SEARCH_LENGTH:
             raise ValidationError(
                 f"Enter at least {_MIN_MEMBER_CANDIDATE_SEARCH_LENGTH} characters or an exact user ID.",

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -61,6 +61,7 @@ logger = get_logger()
 # and the admin partition-list route would expand it to *every* partition — see
 # ``list_existant_partitions``. Matched case-insensitively.
 _RESERVED_PARTITION_NAMES = frozenset({"all"})
+_USER_PAGE_SIZE = 100
 
 # Columns where an explicit ``None`` in a PATCH is a real value (SQL NULL =
 # "reset to default"), not the omitted-field sentinel that the None-filter
@@ -675,6 +676,30 @@ class PartitionService:
     async def list_members(self, partition: str) -> list[dict]:
         await self._ensure_partition(partition)
         return await self._membership_repo.list_partition_members(partition)
+
+    async def list_member_candidates(self, partition: str) -> list[dict]:
+        """Return non-member user identities suitable for a membership picker."""
+        await self._ensure_partition(partition)
+        members = await self._membership_repo.list_partition_members(partition)
+        member_ids = {member["user_id"] for member in members}
+
+        candidates: list[dict] = []
+        offset = 0
+        while True:
+            users = await self._user_repo.list_users(offset=offset, limit=_USER_PAGE_SIZE)
+            candidates.extend(
+                {
+                    "user_id": user.id,
+                    "display_name": user.display_name,
+                }
+                for user in users
+                if user.id not in member_ids
+            )
+            if len(users) < _USER_PAGE_SIZE:
+                break
+            offset += _USER_PAGE_SIZE
+
+        return candidates
 
     async def add_member(self, partition: str, user_id: int, role: str) -> None:
         await self._ensure_partition(partition)

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -38,6 +38,7 @@ from core.models.preset import PartitionConfig
 from core.utils.conts import is_internal_metadata_key
 from core.utils.exceptions import (
     ConfigError,
+    ConflictError,
     NotFoundError,
     PartitionNotFoundError,
     UserNotFoundError,
@@ -62,6 +63,8 @@ logger = get_logger()
 # ``list_existant_partitions``. Matched case-insensitively.
 _RESERVED_PARTITION_NAMES = frozenset({"all"})
 _MAX_MEMBER_CANDIDATE_PAGE_SIZE = 100
+_MAX_POSTGRES_INTEGER = 2_147_483_647
+_MIN_MEMBER_CANDIDATE_SEARCH_LENGTH = 3
 
 # Columns where an explicit ``None`` in a PATCH is a real value (SQL NULL =
 # "reset to default"), not the omitted-field sentinel that the None-filter
@@ -681,40 +684,61 @@ class PartitionService:
         self,
         partition: str,
         *,
-        search: str | None = None,
-        offset: int = 0,
+        search: str | None,
+        cursor: int | None = None,
         limit: int = 25,
     ) -> dict:
-        """Return a bounded, searchable page for the membership picker."""
-        if offset < 0:
-            raise ValidationError("Offset must be non-negative.")
+        """Return matching non-members without exposing the full user directory."""
+        if cursor is not None and (cursor < 0 or cursor > _MAX_POSTGRES_INTEGER):
+            raise ValidationError("Cursor is outside the supported user ID range.")
         if limit < 1 or limit > _MAX_MEMBER_CANDIDATE_PAGE_SIZE:
             raise ValidationError(
                 f"Limit must be between 1 and {_MAX_MEMBER_CANDIDATE_PAGE_SIZE}.",
             )
 
         await self._ensure_partition(partition)
-        normalized_search = search.strip() if search and search.strip() else None
+        normalized_search = search.strip() if search else ""
+        if not normalized_search:
+            raise ValidationError("Search is required to find users.")
+
+        search_user_id: int | None = None
+        search_prefix: str | None = None
+        if normalized_search.isdecimal():
+            search_user_id = int(normalized_search)
+            if search_user_id > _MAX_POSTGRES_INTEGER:
+                raise ValidationError("User ID is outside the supported range.")
+        elif len(normalized_search) < _MIN_MEMBER_CANDIDATE_SEARCH_LENGTH:
+            raise ValidationError(
+                f"Enter at least {_MIN_MEMBER_CANDIDATE_SEARCH_LENGTH} characters or an exact user ID.",
+            )
+        else:
+            search_prefix = normalized_search
+
         rows = await self._membership_repo.list_partition_member_candidates(
             partition,
-            search=normalized_search,
-            offset=offset,
+            search_prefix=search_prefix,
+            search_user_id=search_user_id,
+            after_id=cursor,
             limit=limit + 1,
         )
         has_more = len(rows) > limit
         candidates = rows[:limit]
         return {
             "candidates": candidates,
-            "offset": offset,
             "limit": limit,
             "has_more": has_more,
-            "next_offset": offset + len(candidates) if has_more else None,
+            "next_cursor": candidates[-1]["user_id"] if has_more and candidates else None,
         }
 
     async def add_member(self, partition: str, user_id: int, role: str) -> None:
         await self._ensure_partition(partition)
         await self._ensure_user_exists(user_id)
-        await self._membership_repo.add_partition_member(partition, user_id, role)
+        created = await self._membership_repo.add_partition_member(partition, user_id, role)
+        if not created:
+            raise ConflictError(
+                f"User {user_id} is already a member of partition '{partition}'.",
+                code="PARTITION_MEMBER_EXISTS",
+            )
         logger.info(f"User_id {user_id} added to partition '{partition}'.")
 
     async def remove_member(self, partition: str, user_id: int) -> None:

--- a/openrag/services/orchestrators/partition_service.py
+++ b/openrag/services/orchestrators/partition_service.py
@@ -61,7 +61,7 @@ logger = get_logger()
 # and the admin partition-list route would expand it to *every* partition — see
 # ``list_existant_partitions``. Matched case-insensitively.
 _RESERVED_PARTITION_NAMES = frozenset({"all"})
-_USER_PAGE_SIZE = 100
+_MAX_MEMBER_CANDIDATE_PAGE_SIZE = 100
 
 # Columns where an explicit ``None`` in a PATCH is a real value (SQL NULL =
 # "reset to default"), not the omitted-field sentinel that the None-filter
@@ -677,29 +677,39 @@ class PartitionService:
         await self._ensure_partition(partition)
         return await self._membership_repo.list_partition_members(partition)
 
-    async def list_member_candidates(self, partition: str) -> list[dict]:
-        """Return non-member user identities suitable for a membership picker."""
-        await self._ensure_partition(partition)
-        members = await self._membership_repo.list_partition_members(partition)
-        member_ids = {member["user_id"] for member in members}
-
-        candidates: list[dict] = []
-        offset = 0
-        while True:
-            users = await self._user_repo.list_users(offset=offset, limit=_USER_PAGE_SIZE)
-            candidates.extend(
-                {
-                    "user_id": user.id,
-                    "display_name": user.display_name,
-                }
-                for user in users
-                if user.id not in member_ids
+    async def list_member_candidates(
+        self,
+        partition: str,
+        *,
+        search: str | None = None,
+        offset: int = 0,
+        limit: int = 25,
+    ) -> dict:
+        """Return a bounded, searchable page for the membership picker."""
+        if offset < 0:
+            raise ValidationError("Offset must be non-negative.")
+        if limit < 1 or limit > _MAX_MEMBER_CANDIDATE_PAGE_SIZE:
+            raise ValidationError(
+                f"Limit must be between 1 and {_MAX_MEMBER_CANDIDATE_PAGE_SIZE}.",
             )
-            if len(users) < _USER_PAGE_SIZE:
-                break
-            offset += _USER_PAGE_SIZE
 
-        return candidates
+        await self._ensure_partition(partition)
+        normalized_search = search.strip() if search and search.strip() else None
+        rows = await self._membership_repo.list_partition_member_candidates(
+            partition,
+            search=normalized_search,
+            offset=offset,
+            limit=limit + 1,
+        )
+        has_more = len(rows) > limit
+        candidates = rows[:limit]
+        return {
+            "candidates": candidates,
+            "offset": offset,
+            "limit": limit,
+            "has_more": has_more,
+            "next_offset": offset + len(candidates) if has_more else None,
+        }
 
     async def add_member(self, partition: str, user_id: int, role: str) -> None:
         await self._ensure_partition(partition)

--- a/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
+++ b/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
@@ -22,13 +22,15 @@ _INDEX_NAME = "ix_users_lower_display_name_pattern"
 
 def upgrade() -> None:
     if table_exists("users") and not index_exists("users", _INDEX_NAME):
-        op.execute(
-            sa.text(
-                f"CREATE INDEX {_INDEX_NAME} ON users (LOWER(display_name) text_pattern_ops)",
-            ),
-        )
+        with op.get_context().autocommit_block():
+            op.execute(
+                sa.text(
+                    f"CREATE INDEX CONCURRENTLY {_INDEX_NAME} ON users (LOWER(display_name) text_pattern_ops)",
+                ),
+            )
 
 
 def downgrade() -> None:
     if table_exists("users") and index_exists("users", _INDEX_NAME):
-        op.drop_index(_INDEX_NAME, table_name="users")
+        with op.get_context().autocommit_block():
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY {_INDEX_NAME}"))

--- a/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
+++ b/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
-from schema_helpers import index_exists, table_exists
+from schema_helpers import table_exists
 
 revision: str = "e5f6a7b8c9d0"
 down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
@@ -20,8 +20,40 @@ depends_on: str | Sequence[str] | None = None
 _INDEX_NAME = "ix_users_lower_display_name_pattern"
 
 
+def _index_validity() -> bool | None:
+    result = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT i.indisvalid
+            FROM pg_catalog.pg_class index_class
+            JOIN pg_catalog.pg_index i ON i.indexrelid = index_class.oid
+            JOIN pg_catalog.pg_class table_class ON table_class.oid = i.indrelid
+            JOIN pg_catalog.pg_namespace namespace ON namespace.oid = index_class.relnamespace
+            WHERE namespace.nspname = current_schema()
+              AND table_class.relname = 'users'
+              AND index_class.relname = :index_name
+            """,
+        ),
+        {"index_name": _INDEX_NAME},
+    )
+    validity = result.scalar()
+    return bool(validity) if validity is not None else None
+
+
+def _drop_index_concurrently() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY {_INDEX_NAME}"))
+
+
 def upgrade() -> None:
-    if table_exists("users") and not index_exists("users", _INDEX_NAME):
+    if not table_exists("users"):
+        return
+
+    validity = _index_validity()
+    if validity is False:
+        _drop_index_concurrently()
+
+    if validity is not True:
         with op.get_context().autocommit_block():
             op.execute(
                 sa.text(
@@ -31,6 +63,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    if table_exists("users") and index_exists("users", _INDEX_NAME):
-        with op.get_context().autocommit_block():
-            op.execute(sa.text(f"DROP INDEX CONCURRENTLY {_INDEX_NAME}"))
+    if table_exists("users") and _index_validity() is not None:
+        _drop_index_concurrently()

--- a/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
+++ b/openrag/services/persistence/migrations/alembic/versions/e5f6a7b8c9d0_add_user_display_name_prefix_index.py
@@ -1,0 +1,34 @@
+"""add user display name prefix index
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from schema_helpers import index_exists, table_exists
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX_NAME = "ix_users_lower_display_name_pattern"
+
+
+def upgrade() -> None:
+    if table_exists("users") and not index_exists("users", _INDEX_NAME):
+        op.execute(
+            sa.text(
+                f"CREATE INDEX {_INDEX_NAME} ON users (LOWER(display_name) text_pattern_ops)",
+            ),
+        )
+
+
+def downgrade() -> None:
+    if table_exists("users") and index_exists("users", _INDEX_NAME):
+        op.drop_index(_INDEX_NAME, table_name="users")

--- a/openrag/services/persistence/partition_membership_repo.py
+++ b/openrag/services/persistence/partition_membership_repo.py
@@ -127,11 +127,16 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
         self,
         partition: str,
         *,
-        search: str | None,
-        offset: int,
+        search_prefix: str | None,
+        search_user_id: int | None,
+        after_id: int | None,
         limit: int,
     ) -> list[dict]:
-        """Return a bounded page of users who are not partition members."""
+        """Return matching users after the cursor who are not partition members."""
+        escaped_prefix = None
+        if search_prefix is not None:
+            escaped_prefix = search_prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
         rows = await self.pool.fetch(
             """
             SELECT u.id AS user_id, u.display_name
@@ -143,17 +148,21 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
                   AND m.user_id = u.id
             )
               AND (
-                $2::text IS NULL
-                OR STRPOS(LOWER(COALESCE(u.display_name, '')), LOWER($2)) > 0
-                OR STRPOS(u.id::text, $2) > 0
+                ($2::integer IS NOT NULL AND u.id = $2)
+                OR (
+                    $3::text IS NOT NULL
+                    AND LOWER(u.display_name) LIKE LOWER($3) || '%' ESCAPE '\\'
+                )
               )
+              AND ($4::integer IS NULL OR u.id > $4)
             ORDER BY u.id
-            LIMIT $3 OFFSET $4
+            LIMIT $5
             """,
             partition,
-            search,
+            search_user_id,
+            escaped_prefix,
+            after_id,
             limit,
-            offset,
         )
         return [
             {
@@ -208,19 +217,19 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
                     """,
                     partition,
                 )
-                await conn.execute(
+                result = await conn.execute(
                     """
                     INSERT INTO partition_memberships
                         (partition_name, user_id, role, added_at)
                     VALUES ($1, $2, $3, NOW())
                     ON CONFLICT (partition_name, user_id)
-                      DO UPDATE SET role = EXCLUDED.role
+                      DO NOTHING
                     """,
                     partition,
                     user_id,
                     role,
                 )
-        return True
+        return result.endswith(" 1")
 
     async def remove_partition_member(self, partition: str, user_id: int) -> bool:
         """TODO(phase-9): remove."""

--- a/openrag/services/persistence/partition_membership_repo.py
+++ b/openrag/services/persistence/partition_membership_repo.py
@@ -139,7 +139,7 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
 
         rows = await self.pool.fetch(
             """
-            SELECT u.id AS user_id, u.display_name
+            SELECT u.id AS user_id, u.display_name, u.email
             FROM users u
             WHERE NOT EXISTS (
                 SELECT 1
@@ -168,6 +168,7 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
             {
                 "user_id": row["user_id"],
                 "display_name": row["display_name"],
+                "email": row["email"],
             }
             for row in rows
         ]
@@ -217,19 +218,20 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
                     """,
                     partition,
                 )
-                result = await conn.execute(
+                created = await conn.fetchval(
                     """
                     INSERT INTO partition_memberships
                         (partition_name, user_id, role, added_at)
                     VALUES ($1, $2, $3, NOW())
                     ON CONFLICT (partition_name, user_id)
                       DO NOTHING
+                    RETURNING 1
                     """,
                     partition,
                     user_id,
                     role,
                 )
-        return result.endswith(" 1")
+        return created is not None
 
     async def remove_partition_member(self, partition: str, user_id: int) -> bool:
         """TODO(phase-9): remove."""

--- a/openrag/services/persistence/partition_membership_repo.py
+++ b/openrag/services/persistence/partition_membership_repo.py
@@ -123,6 +123,46 @@ class PgPartitionMembershipRepository(PartitionMembershipRepository):
             partition,
         )
 
+    async def list_partition_member_candidates(
+        self,
+        partition: str,
+        *,
+        search: str | None,
+        offset: int,
+        limit: int,
+    ) -> list[dict]:
+        """Return a bounded page of users who are not partition members."""
+        rows = await self.pool.fetch(
+            """
+            SELECT u.id AS user_id, u.display_name
+            FROM users u
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM partition_memberships m
+                WHERE m.partition_name = $1
+                  AND m.user_id = u.id
+            )
+              AND (
+                $2::text IS NULL
+                OR STRPOS(LOWER(COALESCE(u.display_name, '')), LOWER($2)) > 0
+                OR STRPOS(u.id::text, $2) > 0
+              )
+            ORDER BY u.id
+            LIMIT $3 OFFSET $4
+            """,
+            partition,
+            search,
+            limit,
+            offset,
+        )
+        return [
+            {
+                "user_id": row["user_id"],
+                "display_name": row["display_name"],
+            }
+            for row in rows
+        ]
+
     # ── Legacy method names used by the Phase 7C shim ────────────────
 
     async def list_partition_members(self, partition: str) -> list[dict]:

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
+    func,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -222,6 +223,12 @@ users = Table(
     Column("created_at", DateTime, default=datetime.now, nullable=False),
     Column("file_quota", Integer, nullable=True, default=None),
     Column("file_count", Integer, nullable=False, default=0),
+)
+
+Index(
+    "ix_users_lower_display_name_pattern",
+    func.lower(users.c.display_name).label("display_name_lower"),
+    postgresql_ops={"display_name_lower": "text_pattern_ops"},
 )
 
 

--- a/tests/integration/repos/test_partition_membership_repo.py
+++ b/tests/integration/repos/test_partition_membership_repo.py
@@ -59,3 +59,52 @@ class TestPartitionMemberships:
         )
         assert await postgres_store.membership_repo.remove_partition(user.id, "docs") is True
         assert await postgres_store.membership_repo.list_user_partitions(user.id) == []
+
+    async def test_candidate_search_is_paginated_and_excludes_members(
+        self,
+        postgres_store: PostgresStore,
+    ):
+        member = await postgres_store.user_repo.create_user(
+            _user(display_name="Sam Lee", email="member@example.com"),
+        )
+        candidate = await postgres_store.user_repo.create_user(
+            _user(display_name="Sam Lee", email="candidate@example.com"),
+        )
+        third = await postgres_store.user_repo.create_user(
+            _user(display_name="Taylor", email="taylor@example.com"),
+        )
+        fourth = await postgres_store.user_repo.create_user(
+            _user(display_name="Jordan", email="jordan@example.com"),
+        )
+        await postgres_store.partition_repo.create_partition("docs")
+        await postgres_store.membership_repo.assign_partition(
+            UserPartition(user_id=member.id, partition="docs"),
+        )
+
+        matches = await postgres_store.membership_repo.list_partition_member_candidates(
+            "docs",
+            search="SAM",
+            offset=0,
+            limit=10,
+        )
+        assert matches == [
+            {
+                "user_id": candidate.id,
+                "display_name": "Sam Lee",
+            }
+        ]
+
+        first_page = await postgres_store.membership_repo.list_partition_member_candidates(
+            "docs",
+            search=None,
+            offset=0,
+            limit=2,
+        )
+        second_page = await postgres_store.membership_repo.list_partition_member_candidates(
+            "docs",
+            search=str(fourth.id),
+            offset=0,
+            limit=2,
+        )
+        assert [row["user_id"] for row in first_page] == [candidate.id, third.id]
+        assert [row["user_id"] for row in second_page] == [fourth.id]

--- a/tests/integration/repos/test_partition_membership_repo.py
+++ b/tests/integration/repos/test_partition_membership_repo.py
@@ -92,6 +92,7 @@ class TestPartitionMemberships:
             {
                 "user_id": candidate.id,
                 "display_name": "Candidate Sam",
+                "email": "candidate@example.com",
             }
         ]
 

--- a/tests/integration/repos/test_partition_membership_repo.py
+++ b/tests/integration/repos/test_partition_membership_repo.py
@@ -65,16 +65,16 @@ class TestPartitionMemberships:
         postgres_store: PostgresStore,
     ):
         member = await postgres_store.user_repo.create_user(
-            _user(display_name="Sam Lee", email="member@example.com"),
+            _user(display_name="Candidate Member", email="member@example.com"),
         )
         candidate = await postgres_store.user_repo.create_user(
-            _user(display_name="Sam Lee", email="candidate@example.com"),
+            _user(display_name="Candidate Sam", email="candidate@example.com"),
         )
         third = await postgres_store.user_repo.create_user(
-            _user(display_name="Taylor", email="taylor@example.com"),
+            _user(display_name="Candidate Taylor", email="taylor@example.com"),
         )
         fourth = await postgres_store.user_repo.create_user(
-            _user(display_name="Jordan", email="jordan@example.com"),
+            _user(display_name="Candidate Jordan", email="jordan@example.com"),
         )
         await postgres_store.partition_repo.create_partition("docs")
         await postgres_store.membership_repo.assign_partition(
@@ -83,28 +83,60 @@ class TestPartitionMemberships:
 
         matches = await postgres_store.membership_repo.list_partition_member_candidates(
             "docs",
-            search="SAM",
-            offset=0,
+            search_prefix="candidate s",
+            search_user_id=None,
+            after_id=None,
             limit=10,
         )
         assert matches == [
             {
                 "user_id": candidate.id,
-                "display_name": "Sam Lee",
+                "display_name": "Candidate Sam",
             }
         ]
 
         first_page = await postgres_store.membership_repo.list_partition_member_candidates(
             "docs",
-            search=None,
-            offset=0,
+            search_prefix="candidate",
+            search_user_id=None,
+            after_id=None,
             limit=2,
         )
         second_page = await postgres_store.membership_repo.list_partition_member_candidates(
             "docs",
-            search=str(fourth.id),
-            offset=0,
+            search_prefix="candidate",
+            search_user_id=None,
+            after_id=third.id,
             limit=2,
         )
         assert [row["user_id"] for row in first_page] == [candidate.id, third.id]
         assert [row["user_id"] for row in second_page] == [fourth.id]
+
+        exact_match = await postgres_store.membership_repo.list_partition_member_candidates(
+            "docs",
+            search_prefix=None,
+            search_user_id=fourth.id,
+            after_id=None,
+            limit=2,
+        )
+        assert [row["user_id"] for row in exact_match] == [fourth.id]
+
+    async def test_add_partition_member_conflict_preserves_existing_role(
+        self,
+        postgres_store: PostgresStore,
+    ):
+        user = await postgres_store.user_repo.create_user(_user())
+        await postgres_store.partition_repo.create_partition("docs")
+        await postgres_store.membership_repo.assign_partition(
+            UserPartition(user_id=user.id, partition="docs", role=PartitionRole.VIEWER),
+        )
+
+        created = await postgres_store.membership_repo.add_partition_member(
+            "docs",
+            user.id,
+            "owner",
+        )
+
+        memberships = await postgres_store.membership_repo.list_user_partitions(user.id)
+        assert created is False
+        assert memberships[0].role == PartitionRole.VIEWER

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -115,8 +115,8 @@ class FakeMemberCandidateService:
         )
         return {
             "candidates": [
-                {"user_id": 2, "display_name": "Sam"},
-                {"user_id": 3, "display_name": "Sam"},
+                {"user_id": 2, "display_name": "Sam", "email": "sam.2@example.com"},
+                {"user_id": 3, "display_name": "Sam", "email": "sam.3@example.com"},
             ],
             "limit": limit,
             "has_more": True,
@@ -188,8 +188,8 @@ async def test_list_partition_member_candidates_returns_stable_identities(async_
     assert response.status_code == 200
     assert response.json() == {
         "candidates": [
-            {"user_id": 2, "display_name": "Sam"},
-            {"user_id": 3, "display_name": "Sam"},
+            {"user_id": 2, "display_name": "Sam", "email": "sam.2@example.com"},
+            {"user_id": 3, "display_name": "Sam", "email": "sam.3@example.com"},
         ],
         "limit": 10,
         "has_more": True,

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -10,7 +10,7 @@ from api.dependencies.auth import (
 )
 from api.routers.admin import partitions
 from di.providers import get_partition_service
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
 
 
 def _partition_detail(**overrides: Any) -> dict[str, Any]:
@@ -95,14 +95,34 @@ class FakeMemberCandidateService:
     """Service double for the partition member candidate route."""
 
     def __init__(self) -> None:
-        self.partitions: list[str] = []
+        self.calls: list[dict[str, Any]] = []
 
-    async def list_member_candidates(self, partition: str) -> list[dict[str, Any]]:
-        self.partitions.append(partition)
-        return [
-            {"user_id": 2, "display_name": "Sam"},
-            {"user_id": 3, "display_name": "Sam"},
-        ]
+    async def list_member_candidates(
+        self,
+        partition: str,
+        *,
+        search: str | None,
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "partition": partition,
+                "search": search,
+                "offset": offset,
+                "limit": limit,
+            }
+        )
+        return {
+            "candidates": [
+                {"user_id": 2, "display_name": "Sam"},
+                {"user_id": 3, "display_name": "Sam"},
+            ],
+            "offset": offset,
+            "limit": limit,
+            "has_more": True,
+            "next_offset": offset + limit,
+        }
 
 
 def _build_list_app(*, is_admin: bool) -> FastAPI:
@@ -161,16 +181,50 @@ async def test_list_partition_member_candidates_returns_stable_identities(async_
     app = _build_app(service)
 
     async with async_client_factory(app) as client:
-        response = await client.get("/partition/legal/users/candidates")
+        response = await client.get(
+            "/partition/legal/users/candidates",
+            params={"search": "sam", "offset": 20, "limit": 10},
+        )
 
     assert response.status_code == 200
     assert response.json() == {
         "candidates": [
             {"user_id": 2, "display_name": "Sam"},
             {"user_id": 3, "display_name": "Sam"},
-        ]
+        ],
+        "offset": 20,
+        "limit": 10,
+        "has_more": True,
+        "next_offset": 30,
     }
-    assert service.partitions == ["legal"]
+    assert service.calls == [
+        {
+            "partition": "legal",
+            "search": "sam",
+            "offset": 20,
+            "limit": 10,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_partition_member_candidates_rejects_non_owner(async_client_factory):
+    service = FakeMemberCandidateService()
+    app = _build_app(service)
+
+    async def reject_non_owner():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Partition owner role required",
+        )
+
+    app.dependency_overrides[require_partition_owner] = reject_non_owner
+
+    async with async_client_factory(app) as client:
+        response = await client.get("/partition/legal/users/candidates")
+
+    assert response.status_code == 403
+    assert service.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -91,6 +91,20 @@ class FakeCreatePartitionService:
         self.created.append(kwargs)
 
 
+class FakeMemberCandidateService:
+    """Service double for the partition member candidate route."""
+
+    def __init__(self) -> None:
+        self.partitions: list[str] = []
+
+    async def list_member_candidates(self, partition: str) -> list[dict[str, Any]]:
+        self.partitions.append(partition)
+        return [
+            {"user_id": 2, "display_name": "Sam"},
+            {"user_id": 3, "display_name": "Sam"},
+        ]
+
+
 def _build_list_app(*, is_admin: bool) -> FastAPI:
     """App for the list route, with a regular user whose sole membership is ``all``."""
     app = FastAPI()
@@ -139,6 +153,24 @@ async def test_list_partitions_does_not_expand_all_for_non_admin(async_client_fa
         response = await client.get("/partition/")
     assert response.status_code == 200
     assert [p["partition"] for p in response.json()["partitions"]] == ["all"]
+
+
+@pytest.mark.asyncio
+async def test_list_partition_member_candidates_returns_stable_identities(async_client_factory):
+    service = FakeMemberCandidateService()
+    app = _build_app(service)
+
+    async with async_client_factory(app) as client:
+        response = await client.get("/partition/legal/users/candidates")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "candidates": [
+            {"user_id": 2, "display_name": "Sam"},
+            {"user_id": 3, "display_name": "Sam"},
+        ]
+    }
+    assert service.partitions == ["legal"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/admin/test_phase14_partition_routes.py
+++ b/tests/unit/api/routers/admin/test_phase14_partition_routes.py
@@ -101,15 +101,15 @@ class FakeMemberCandidateService:
         self,
         partition: str,
         *,
-        search: str | None,
-        offset: int,
+        search: str,
+        cursor: int | None,
         limit: int,
     ) -> dict[str, Any]:
         self.calls.append(
             {
                 "partition": partition,
                 "search": search,
-                "offset": offset,
+                "cursor": cursor,
                 "limit": limit,
             }
         )
@@ -118,10 +118,9 @@ class FakeMemberCandidateService:
                 {"user_id": 2, "display_name": "Sam"},
                 {"user_id": 3, "display_name": "Sam"},
             ],
-            "offset": offset,
             "limit": limit,
             "has_more": True,
-            "next_offset": offset + limit,
+            "next_cursor": 30,
         }
 
 
@@ -183,7 +182,7 @@ async def test_list_partition_member_candidates_returns_stable_identities(async_
     async with async_client_factory(app) as client:
         response = await client.get(
             "/partition/legal/users/candidates",
-            params={"search": "sam", "offset": 20, "limit": 10},
+            params={"search": "sam", "cursor": 20, "limit": 10},
         )
 
     assert response.status_code == 200
@@ -192,16 +191,15 @@ async def test_list_partition_member_candidates_returns_stable_identities(async_
             {"user_id": 2, "display_name": "Sam"},
             {"user_id": 3, "display_name": "Sam"},
         ],
-        "offset": 20,
         "limit": 10,
         "has_more": True,
-        "next_offset": 30,
+        "next_cursor": 30,
     }
     assert service.calls == [
         {
             "partition": "legal",
             "search": "sam",
-            "offset": 20,
+            "cursor": 20,
             "limit": 10,
         }
     ]
@@ -221,9 +219,24 @@ async def test_list_partition_member_candidates_rejects_non_owner(async_client_f
     app.dependency_overrides[require_partition_owner] = reject_non_owner
 
     async with async_client_factory(app) as client:
-        response = await client.get("/partition/legal/users/candidates")
+        response = await client.get(
+            "/partition/legal/users/candidates",
+            params={"search": "sam"},
+        )
 
     assert response.status_code == 403
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_partition_member_candidates_requires_search(async_client_factory):
+    service = FakeMemberCandidateService()
+    app = _build_app(service)
+
+    async with async_client_factory(app) as client:
+        response = await client.get("/partition/legal/users/candidates")
+
+    assert response.status_code == 422
     assert service.calls == []
 
 

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
+from core.models.user import User
 from core.utils.exceptions import NotFoundError, PartitionNotFoundError, UserNotFoundError, ValidationError
 from services.orchestrators.partition_service import PartitionService
 
@@ -212,11 +213,15 @@ class FakeVectorStore:
 
 
 class FakeUserRepo:
-    def __init__(self, existing: set[int] | None = None):
+    def __init__(self, existing: set[int] | None = None, users: list[User] | None = None):
         self._existing = existing if existing is not None else set()
+        self._users = users or []
 
     async def user_exists(self, user_id: int) -> bool:
         return user_id in self._existing
+
+    async def list_users(self, offset: int = 0, limit: int = 50) -> list[User]:
+        return self._users[offset : offset + limit]
 
 
 def _svc(
@@ -828,6 +833,37 @@ async def test_get_file_chunks_rejects_negative_limit():
 async def test_list_members_missing_partition_404():
     with pytest.raises(PartitionNotFoundError):
         await _svc(prepo=FakePartitionRepo(set())).list_members("x")
+
+
+@pytest.mark.asyncio
+async def test_list_member_candidates_excludes_existing_members():
+    users = [
+        User(id=1, display_name="Partition owner"),
+        User(id=2, display_name="Sam"),
+        User(id=3, display_name="Sam"),
+    ]
+    svc = _svc(
+        prepo=FakePartitionRepo({"p"}),
+        mrepo=FakeMembershipRepo({(1, "p"), (3, "p")}),
+        urepo=FakeUserRepo({1, 2, 3}, users),
+    )
+
+    assert await svc.list_member_candidates("p") == [
+        {"user_id": 2, "display_name": "Sam"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_member_candidates_reads_every_user_page():
+    users = [User(id=user_id, display_name=f"User {user_id}") for user_id in range(1, 102)]
+    svc = _svc(
+        prepo=FakePartitionRepo({"p"}),
+        urepo=FakeUserRepo(set(range(1, 102)), users),
+    )
+
+    candidates = await svc.list_member_candidates("p")
+
+    assert [candidate["user_id"] for candidate in candidates] == list(range(1, 102))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -130,12 +130,15 @@ class FakeMembershipRepo:
         self,
         members: set[tuple[int, str]] | None = None,
         owned: dict[int, int] | None = None,
+        candidate_rows: list[dict] | None = None,
     ):
         self._members = members or set()
         self._owned = owned or {}  # user_id -> number of partitions owned
+        self._candidate_rows = candidate_rows or []
         self.added: list[tuple[str, int, str]] = []
         self.removed: list[tuple[str, int]] = []
         self.role_updates: list[tuple[str, int, str]] = []
+        self.candidate_calls: list[dict] = []
 
     async def list_user_partitions(self, user_id: int):
         from core.models.user import PartitionRole, UserPartition
@@ -150,6 +153,32 @@ class FakeMembershipRepo:
 
     async def list_partition_members(self, partition: str) -> list[dict]:
         return [{"user_id": u, "role": "viewer"} for (u, p) in self._members if p == partition]
+
+    async def list_partition_member_candidates(
+        self,
+        partition: str,
+        *,
+        search: str | None,
+        offset: int,
+        limit: int,
+    ) -> list[dict]:
+        self.candidate_calls.append(
+            {
+                "partition": partition,
+                "search": search,
+                "offset": offset,
+                "limit": limit,
+            }
+        )
+        rows = [
+            row
+            for row in self._candidate_rows
+            if (row["user_id"], partition) not in self._members
+            and (
+                search is None or search.lower() in (row["display_name"] or "").lower() or search in str(row["user_id"])
+            )
+        ]
+        return rows[offset : offset + limit]
 
     async def add_partition_member(self, partition: str, user_id: int, role: str) -> bool:
         self.added.append((partition, user_id, role))
@@ -837,33 +866,64 @@ async def test_list_members_missing_partition_404():
 
 @pytest.mark.asyncio
 async def test_list_member_candidates_excludes_existing_members():
-    users = [
-        User(id=1, display_name="Partition owner"),
-        User(id=2, display_name="Sam"),
-        User(id=3, display_name="Sam"),
+    candidate_rows = [
+        {"user_id": 1, "display_name": "Partition owner"},
+        {"user_id": 2, "display_name": "Sam"},
+        {"user_id": 3, "display_name": "Sam"},
     ]
+    mrepo = FakeMembershipRepo(
+        {(1, "p"), (3, "p")},
+        candidate_rows=candidate_rows,
+    )
     svc = _svc(
         prepo=FakePartitionRepo({"p"}),
-        mrepo=FakeMembershipRepo({(1, "p"), (3, "p")}),
-        urepo=FakeUserRepo({1, 2, 3}, users),
+        mrepo=mrepo,
     )
 
-    assert await svc.list_member_candidates("p") == [
-        {"user_id": 2, "display_name": "Sam"},
+    assert await svc.list_member_candidates("p", search="  sam  ") == {
+        "candidates": [{"user_id": 2, "display_name": "Sam"}],
+        "offset": 0,
+        "limit": 25,
+        "has_more": False,
+        "next_offset": None,
+    }
+    assert mrepo.candidate_calls == [
+        {
+            "partition": "p",
+            "search": "sam",
+            "offset": 0,
+            "limit": 26,
+        }
     ]
 
 
 @pytest.mark.asyncio
-async def test_list_member_candidates_reads_every_user_page():
-    users = [User(id=user_id, display_name=f"User {user_id}") for user_id in range(1, 102)]
+async def test_list_member_candidates_returns_bounded_page_with_continuation():
+    candidate_rows = [{"user_id": user_id, "display_name": f"User {user_id}"} for user_id in range(1, 102)]
+    mrepo = FakeMembershipRepo(candidate_rows=candidate_rows)
     svc = _svc(
         prepo=FakePartitionRepo({"p"}),
-        urepo=FakeUserRepo(set(range(1, 102)), users),
+        mrepo=mrepo,
     )
 
-    candidates = await svc.list_member_candidates("p")
+    page = await svc.list_member_candidates("p", offset=10, limit=20)
 
-    assert [candidate["user_id"] for candidate in candidates] == list(range(1, 102))
+    assert [candidate["user_id"] for candidate in page["candidates"]] == list(range(11, 31))
+    assert page == {
+        "candidates": candidate_rows[10:30],
+        "offset": 10,
+        "limit": 20,
+        "has_more": True,
+        "next_offset": 30,
+    }
+    assert mrepo.candidate_calls == [
+        {
+            "partition": "p",
+            "search": None,
+            "offset": 10,
+            "limit": 21,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -972,7 +972,7 @@ async def test_list_member_candidates_requires_a_targeted_search(search):
 
 
 @pytest.mark.asyncio
-async def test_list_member_candidates_uses_exact_numeric_id():
+async def test_list_member_candidates_searches_numeric_id_and_name_prefix():
     candidate = {"user_id": 42, "display_name": "Unrelated name"}
     mrepo = FakeMembershipRepo(candidate_rows=[candidate])
     svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo)
@@ -984,7 +984,29 @@ async def test_list_member_candidates_uses_exact_numeric_id():
         "next_cursor": None,
     }
     assert mrepo.candidate_calls[0]["search_user_id"] == 42
+    assert mrepo.candidate_calls[0]["search_prefix"] == "0042"
+
+
+@pytest.mark.asyncio
+async def test_list_member_candidates_keeps_short_numeric_search_id_only():
+    mrepo = FakeMembershipRepo()
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo)
+
+    await svc.list_member_candidates("p", search="42")
+
+    assert mrepo.candidate_calls[0]["search_user_id"] == 42
     assert mrepo.candidate_calls[0]["search_prefix"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_member_candidates_uses_name_prefix_for_numeric_values_outside_id_range():
+    mrepo = FakeMembershipRepo()
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo)
+
+    await svc.list_member_candidates("p", search="2147483648")
+
+    assert mrepo.candidate_calls[0]["search_user_id"] is None
+    assert mrepo.candidate_calls[0]["search_prefix"] == "2147483648"
 
 
 @pytest.mark.asyncio
@@ -1002,7 +1024,6 @@ async def test_list_member_candidates_treats_non_ascii_digits_as_a_name_prefix()
 @pytest.mark.parametrize(
     ("search", "cursor"),
     [
-        ("2147483648", None),
         ("User", 2_147_483_648),
         ("User", -1),
     ],

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -8,7 +8,13 @@ from types import SimpleNamespace
 
 import pytest
 from core.models.user import User
-from core.utils.exceptions import NotFoundError, PartitionNotFoundError, UserNotFoundError, ValidationError
+from core.utils.exceptions import (
+    ConflictError,
+    NotFoundError,
+    PartitionNotFoundError,
+    UserNotFoundError,
+    ValidationError,
+)
 from services.orchestrators.partition_service import PartitionService
 
 
@@ -131,10 +137,12 @@ class FakeMembershipRepo:
         members: set[tuple[int, str]] | None = None,
         owned: dict[int, int] | None = None,
         candidate_rows: list[dict] | None = None,
+        add_result: bool = True,
     ):
         self._members = members or set()
         self._owned = owned or {}  # user_id -> number of partitions owned
         self._candidate_rows = candidate_rows or []
+        self._add_result = add_result
         self.added: list[tuple[str, int, str]] = []
         self.removed: list[tuple[str, int]] = []
         self.role_updates: list[tuple[str, int, str]] = []
@@ -158,15 +166,17 @@ class FakeMembershipRepo:
         self,
         partition: str,
         *,
-        search: str | None,
-        offset: int,
+        search_prefix: str | None,
+        search_user_id: int | None,
+        after_id: int | None,
         limit: int,
     ) -> list[dict]:
         self.candidate_calls.append(
             {
                 "partition": partition,
-                "search": search,
-                "offset": offset,
+                "search_prefix": search_prefix,
+                "search_user_id": search_user_id,
+                "after_id": after_id,
                 "limit": limit,
             }
         )
@@ -175,14 +185,16 @@ class FakeMembershipRepo:
             for row in self._candidate_rows
             if (row["user_id"], partition) not in self._members
             and (
-                search is None or search.lower() in (row["display_name"] or "").lower() or search in str(row["user_id"])
+                row["user_id"] == search_user_id
+                or (search_prefix is not None and (row["display_name"] or "").lower().startswith(search_prefix.lower()))
             )
+            and (after_id is None or row["user_id"] > after_id)
         ]
-        return rows[offset : offset + limit]
+        return rows[:limit]
 
     async def add_partition_member(self, partition: str, user_id: int, role: str) -> bool:
         self.added.append((partition, user_id, role))
-        return True
+        return self._add_result
 
     async def remove_partition_member(self, partition: str, user_id: int) -> bool:
         self.removed.append((partition, user_id))
@@ -882,16 +894,16 @@ async def test_list_member_candidates_excludes_existing_members():
 
     assert await svc.list_member_candidates("p", search="  sam  ") == {
         "candidates": [{"user_id": 2, "display_name": "Sam"}],
-        "offset": 0,
         "limit": 25,
         "has_more": False,
-        "next_offset": None,
+        "next_cursor": None,
     }
     assert mrepo.candidate_calls == [
         {
             "partition": "p",
-            "search": "sam",
-            "offset": 0,
+            "search_prefix": "sam",
+            "search_user_id": None,
+            "after_id": None,
             "limit": 26,
         }
     ]
@@ -906,24 +918,65 @@ async def test_list_member_candidates_returns_bounded_page_with_continuation():
         mrepo=mrepo,
     )
 
-    page = await svc.list_member_candidates("p", offset=10, limit=20)
+    page = await svc.list_member_candidates("p", search="User", cursor=10, limit=20)
 
     assert [candidate["user_id"] for candidate in page["candidates"]] == list(range(11, 31))
     assert page == {
         "candidates": candidate_rows[10:30],
-        "offset": 10,
         "limit": 20,
         "has_more": True,
-        "next_offset": 30,
+        "next_cursor": 30,
     }
     assert mrepo.candidate_calls == [
         {
             "partition": "p",
-            "search": None,
-            "offset": 10,
+            "search_prefix": "User",
+            "search_user_id": None,
+            "after_id": 10,
             "limit": 21,
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search", [None, "", "  ", "sa"])
+async def test_list_member_candidates_requires_a_targeted_search(search):
+    svc = _svc(prepo=FakePartitionRepo({"p"}))
+
+    with pytest.raises(ValidationError):
+        await svc.list_member_candidates("p", search=search)
+
+
+@pytest.mark.asyncio
+async def test_list_member_candidates_uses_exact_numeric_id():
+    candidate = {"user_id": 42, "display_name": "Unrelated name"}
+    mrepo = FakeMembershipRepo(candidate_rows=[candidate])
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo)
+
+    assert await svc.list_member_candidates("p", search="0042") == {
+        "candidates": [candidate],
+        "limit": 25,
+        "has_more": False,
+        "next_cursor": None,
+    }
+    assert mrepo.candidate_calls[0]["search_user_id"] == 42
+    assert mrepo.candidate_calls[0]["search_prefix"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("search", "cursor"),
+    [
+        ("2147483648", None),
+        ("User", 2_147_483_648),
+        ("User", -1),
+    ],
+)
+async def test_list_member_candidates_rejects_ids_outside_postgres_range(search, cursor):
+    svc = _svc(prepo=FakePartitionRepo({"p"}))
+
+    with pytest.raises(ValidationError):
+        await svc.list_member_candidates("p", search=search, cursor=cursor)
 
 
 @pytest.mark.asyncio
@@ -936,6 +989,21 @@ async def test_add_member_checks_partition_and_user():
     )
     await svc.add_member("p", 9, "editor")
     assert mrepo.added == [("p", 9, "editor")]
+
+
+@pytest.mark.asyncio
+async def test_add_member_rejects_existing_membership_without_changing_role():
+    mrepo = FakeMembershipRepo(add_result=False)
+    svc = _svc(
+        prepo=FakePartitionRepo({"p"}),
+        mrepo=mrepo,
+        urepo=FakeUserRepo({9}),
+    )
+
+    with pytest.raises(ConflictError) as error:
+        await svc.add_member("p", 9, "editor")
+
+    assert error.value.code == "PARTITION_MEMBER_EXISTS"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -988,6 +988,17 @@ async def test_list_member_candidates_uses_exact_numeric_id():
 
 
 @pytest.mark.asyncio
+async def test_list_member_candidates_treats_non_ascii_digits_as_a_name_prefix():
+    mrepo = FakeMembershipRepo()
+    svc = _svc(prepo=FakePartitionRepo({"p"}), mrepo=mrepo)
+
+    await svc.list_member_candidates("p", search="١٢٣")
+
+    assert mrepo.candidate_calls[0]["search_user_id"] is None
+    assert mrepo.candidate_calls[0]["search_prefix"] == "١٢٣"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("search", "cursor"),
     [
@@ -1078,6 +1089,7 @@ async def test_add_member_rejects_existing_membership_without_changing_role():
         await svc.add_member("p", 9, "editor")
 
     assert error.value.code == "PARTITION_MEMBER_EXISTS"
+    assert "PATCH /partition/p/users/9" in error.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_add_partition_member.py
+++ b/tests/unit/services/persistence/test_add_partition_member.py
@@ -15,8 +15,9 @@ class _AsyncContext:
 
 
 class _FakeConn:
-    def __init__(self, partition_exists: bool):
+    def __init__(self, partition_exists: bool, membership_insert_result: str = "INSERT 0 1"):
         self.partition_exists = partition_exists
+        self.membership_insert_result = membership_insert_result
         self.executed: list[tuple[str, tuple]] = []
 
     def transaction(self):
@@ -29,12 +30,14 @@ class _FakeConn:
 
     async def execute(self, query: str, *params):
         self.executed.append((query, params))
+        if "INSERT INTO partition_memberships" in query:
+            return self.membership_insert_result
         return "INSERT 0 1"
 
 
 class _FakePool:
-    def __init__(self, partition_exists: bool):
-        self.conn = _FakeConn(partition_exists)
+    def __init__(self, partition_exists: bool, membership_insert_result: str = "INSERT 0 1"):
+        self.conn = _FakeConn(partition_exists, membership_insert_result)
 
     def acquire(self):
         return _AsyncContext(self.conn)
@@ -74,3 +77,16 @@ async def test_add_member_to_existing_partition_allows_any_role():
 
     assert await repo.add_partition_member("existing", 6, "editor") is True
     assert any("INSERT INTO partition_memberships" in query for query, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_add_member_conflict_does_not_overwrite_existing_role():
+    from services.persistence.partition_membership_repo import PgPartitionMembershipRepository
+
+    pool = _FakePool(partition_exists=True, membership_insert_result="INSERT 0 0")
+    repo = PgPartitionMembershipRepository(pool_getter=lambda: pool)
+
+    assert await repo.add_partition_member("existing", 6, "editor") is False
+    membership_query = next(query for query, _ in pool.conn.executed if "INSERT INTO partition_memberships" in query)
+    assert "DO NOTHING" in membership_query
+    assert "DO UPDATE" not in membership_query

--- a/tests/unit/services/persistence/test_add_partition_member.py
+++ b/tests/unit/services/persistence/test_add_partition_member.py
@@ -15,9 +15,9 @@ class _AsyncContext:
 
 
 class _FakeConn:
-    def __init__(self, partition_exists: bool, membership_insert_result: str = "INSERT 0 1"):
+    def __init__(self, partition_exists: bool, membership_created: bool = True):
         self.partition_exists = partition_exists
-        self.membership_insert_result = membership_insert_result
+        self.membership_created = membership_created
         self.executed: list[tuple[str, tuple]] = []
 
     def transaction(self):
@@ -26,18 +26,19 @@ class _FakeConn:
     async def fetchval(self, query: str, *params):
         if "SELECT 1 FROM partitions" in query:
             return 1 if self.partition_exists else None
+        if "INSERT INTO partition_memberships" in query:
+            self.executed.append((query, params))
+            return 1 if self.membership_created else None
         return None
 
     async def execute(self, query: str, *params):
         self.executed.append((query, params))
-        if "INSERT INTO partition_memberships" in query:
-            return self.membership_insert_result
         return "INSERT 0 1"
 
 
 class _FakePool:
-    def __init__(self, partition_exists: bool, membership_insert_result: str = "INSERT 0 1"):
-        self.conn = _FakeConn(partition_exists, membership_insert_result)
+    def __init__(self, partition_exists: bool, membership_created: bool = True):
+        self.conn = _FakeConn(partition_exists, membership_created)
 
     def acquire(self):
         return _AsyncContext(self.conn)
@@ -83,10 +84,11 @@ async def test_add_member_to_existing_partition_allows_any_role():
 async def test_add_member_conflict_does_not_overwrite_existing_role():
     from services.persistence.partition_membership_repo import PgPartitionMembershipRepository
 
-    pool = _FakePool(partition_exists=True, membership_insert_result="INSERT 0 0")
+    pool = _FakePool(partition_exists=True, membership_created=False)
     repo = PgPartitionMembershipRepository(pool_getter=lambda: pool)
 
     assert await repo.add_partition_member("existing", 6, "editor") is False
     membership_query = next(query for query, _ in pool.conn.executed if "INSERT INTO partition_memberships" in query)
     assert "DO NOTHING" in membership_query
     assert "DO UPDATE" not in membership_query
+    assert "RETURNING 1" in membership_query

--- a/tests/unit/services/persistence/test_display_name_index_migration.py
+++ b/tests/unit/services/persistence/test_display_name_index_migration.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def migration(monkeypatch):
+    alembic_dir = (
+        Path(__file__).resolve().parents[4]
+        / "openrag"
+        / "services"
+        / "persistence"
+        / "migrations"
+        / "alembic"
+    )
+    monkeypatch.syspath_prepend(str(alembic_dir))
+    return importlib.import_module(
+        "services.persistence.migrations.alembic.versions.e5f6a7b8c9d0_add_user_display_name_prefix_index",
+    )
+
+
+class _FakeContext:
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+
+    @contextmanager
+    def autocommit_block(self):
+        self.calls.append("autocommit")
+        yield
+
+
+class _FakeOp:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.context = _FakeContext(self.calls)
+
+    def get_context(self):
+        return self.context
+
+    def execute(self, statement) -> None:
+        self.calls.append(str(statement))
+
+
+def test_upgrade_rebuilds_an_invalid_concurrent_index(monkeypatch, migration) -> None:
+    fake_op = _FakeOp()
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration, "table_exists", lambda _table: True)
+    monkeypatch.setattr(migration, "_index_validity", lambda: False)
+
+    migration.upgrade()
+
+    statements = "\n".join(fake_op.calls)
+    assert "DROP INDEX CONCURRENTLY ix_users_lower_display_name_pattern" in statements
+    assert "CREATE INDEX CONCURRENTLY ix_users_lower_display_name_pattern" in statements
+
+
+def test_upgrade_keeps_a_valid_index(monkeypatch, migration) -> None:
+    fake_op = _FakeOp()
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration, "table_exists", lambda _table: True)
+    monkeypatch.setattr(migration, "_index_validity", lambda: True)
+
+    migration.upgrade()
+
+    assert fake_op.calls == []
+
+
+def test_upgrade_creates_a_missing_index(monkeypatch, migration) -> None:
+    fake_op = _FakeOp()
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration, "table_exists", lambda _table: True)
+    monkeypatch.setattr(migration, "_index_validity", lambda: None)
+
+    migration.upgrade()
+
+    statements = "\n".join(fake_op.calls)
+    assert "DROP INDEX" not in statements
+    assert "CREATE INDEX CONCURRENTLY ix_users_lower_display_name_pattern" in statements

--- a/tests/unit/services/persistence/test_display_name_index_migration.py
+++ b/tests/unit/services/persistence/test_display_name_index_migration.py
@@ -10,12 +10,7 @@ import pytest
 @pytest.fixture
 def migration(monkeypatch):
     alembic_dir = (
-        Path(__file__).resolve().parents[4]
-        / "openrag"
-        / "services"
-        / "persistence"
-        / "migrations"
-        / "alembic"
+        Path(__file__).resolve().parents[4] / "openrag" / "services" / "persistence" / "migrations" / "alembic"
     )
     monkeypatch.syspath_prepend(str(alembic_dir))
     return importlib.import_module(

--- a/tests/unit/services/persistence/test_partition_member_candidates.py
+++ b/tests/unit/services/persistence/test_partition_member_candidates.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+
+class _FakePool:
+    def __init__(self):
+        self.query = ""
+        self.params: tuple = ()
+
+    async def fetch(self, query: str, *params):
+        self.query = query
+        self.params = params
+        return []
+
+
+@pytest.mark.asyncio
+async def test_candidate_search_escapes_like_wildcards_and_uses_a_cursor():
+    from services.persistence.partition_membership_repo import PgPartitionMembershipRepository
+
+    pool = _FakePool()
+    repo = PgPartitionMembershipRepository(pool_getter=lambda: pool)
+
+    await repo.list_partition_member_candidates(
+        "legal",
+        search_prefix=r"Sam_%\\",
+        search_user_id=None,
+        after_id=42,
+        limit=26,
+    )
+
+    assert pool.params == ("legal", None, r"Sam\_\%\\\\", 42, 26)
+    assert "u.id > $4" in pool.query
+    assert "OFFSET" not in pool.query

--- a/ui/src/lib/api/partitions.test.ts
+++ b/ui/src/lib/api/partitions.test.ts
@@ -69,10 +69,9 @@ describe("listPartitionMemberCandidates", () => {
       fakeResponse({
         body: JSON.stringify({
           candidates: [{ user_id: 2, display_name: "Sam" }],
-          offset: 20,
           limit: 10,
           has_more: true,
-          next_offset: 30,
+          next_cursor: 30,
         }),
       }),
     );
@@ -80,22 +79,21 @@ describe("listPartitionMemberCandidates", () => {
     await expect(
       listPartitionMemberCandidates("legal docs", {
         search: "Sam Lee",
-        offset: 20,
+        cursor: 20,
         limit: 10,
       }),
     ).resolves.toEqual({
       candidates: [{ user_id: 2, display_name: "Sam" }],
-      offset: 20,
       limit: 10,
       has_more: true,
-      next_offset: 30,
+      next_cursor: 30,
     });
     const requestedUrl = String(fetchMock.mock.calls[0][0]);
     expect(requestedUrl).toContain("/partition/legal%20docs/users/candidates?");
     expect(Array.from(new URLSearchParams(requestedUrl.split("?")[1]).entries())).toEqual(
       expect.arrayContaining([
         ["search", "Sam Lee"],
-        ["offset", "20"],
+        ["cursor", "20"],
         ["limit", "10"],
       ]),
     );

--- a/ui/src/lib/api/partitions.test.ts
+++ b/ui/src/lib/api/partitions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createPartition } from "./partitions";
+import { createPartition, listPartitionMemberCandidates } from "./partitions";
 
 // Minimal Response-like object covering what `request` reads (mirrors client.test.ts).
 function fakeResponse({ status = 200, body = "" }: { status?: number; body?: string } = {}): Response {
@@ -60,5 +60,25 @@ describe("createPartition", () => {
     await createPartition({ name: "p", embedder: "good" });
 
     expect(fetchMock.mock.calls.map(methodOf)).not.toContain("DELETE");
+  });
+});
+
+describe("listPartitionMemberCandidates", () => {
+  it("requests the owner-protected candidate endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        body: JSON.stringify({
+          candidates: [{ user_id: 2, display_name: "Sam" }],
+        }),
+      }),
+    );
+
+    await expect(listPartitionMemberCandidates("legal docs")).resolves.toEqual({
+      candidates: [{ user_id: 2, display_name: "Sam" }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/partition/legal%20docs/users/candidates"),
+      expect.any(Object),
+    );
   });
 });

--- a/ui/src/lib/api/partitions.test.ts
+++ b/ui/src/lib/api/partitions.test.ts
@@ -68,7 +68,7 @@ describe("listPartitionMemberCandidates", () => {
     fetchMock.mockResolvedValue(
       fakeResponse({
         body: JSON.stringify({
-          candidates: [{ user_id: 2, display_name: "Sam" }],
+          candidates: [{ user_id: 2, display_name: "Sam", email: "sam@example.com" }],
           limit: 10,
           has_more: true,
           next_cursor: 30,
@@ -83,7 +83,7 @@ describe("listPartitionMemberCandidates", () => {
         limit: 10,
       }),
     ).resolves.toEqual({
-      candidates: [{ user_id: 2, display_name: "Sam" }],
+      candidates: [{ user_id: 2, display_name: "Sam", email: "sam@example.com" }],
       limit: 10,
       has_more: true,
       next_cursor: 30,

--- a/ui/src/lib/api/partitions.test.ts
+++ b/ui/src/lib/api/partitions.test.ts
@@ -69,16 +69,35 @@ describe("listPartitionMemberCandidates", () => {
       fakeResponse({
         body: JSON.stringify({
           candidates: [{ user_id: 2, display_name: "Sam" }],
+          offset: 20,
+          limit: 10,
+          has_more: true,
+          next_offset: 30,
         }),
       }),
     );
 
-    await expect(listPartitionMemberCandidates("legal docs")).resolves.toEqual({
+    await expect(
+      listPartitionMemberCandidates("legal docs", {
+        search: "Sam Lee",
+        offset: 20,
+        limit: 10,
+      }),
+    ).resolves.toEqual({
       candidates: [{ user_id: 2, display_name: "Sam" }],
+      offset: 20,
+      limit: 10,
+      has_more: true,
+      next_offset: 30,
     });
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/partition/legal%20docs/users/candidates"),
-      expect.any(Object),
+    const requestedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toContain("/partition/legal%20docs/users/candidates?");
+    expect(Array.from(new URLSearchParams(requestedUrl.split("?")[1]).entries())).toEqual(
+      expect.arrayContaining([
+        ["search", "Sam Lee"],
+        ["offset", "20"],
+        ["limit", "10"],
+      ]),
     );
   });
 });

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -203,15 +203,36 @@ export interface PartitionMemberCandidate {
   display_name: string | null;
 }
 
+export interface PartitionMemberCandidatePage {
+  candidates: PartitionMemberCandidate[];
+  offset: number;
+  limit: number;
+  has_more: boolean;
+  next_offset: number | null;
+}
+
+interface ListPartitionMemberCandidatesOptions {
+  search?: string;
+  offset?: number;
+  limit?: number;
+}
+
 export function listPartitionMembers(name: string): Promise<{ members: PartitionMember[] }> {
   return request<{ members: PartitionMember[] }>(`${P}/${enc(name)}/users`);
 }
 
 export function listPartitionMemberCandidates(
   name: string,
-): Promise<{ candidates: PartitionMemberCandidate[] }> {
-  return request<{ candidates: PartitionMemberCandidate[] }>(
-    `${P}/${enc(name)}/users/candidates`,
+  options: ListPartitionMemberCandidatesOptions = {},
+): Promise<PartitionMemberCandidatePage> {
+  const query = new URLSearchParams();
+  const search = options.search?.trim();
+  if (search) query.set("search", search);
+  if (options.offset !== undefined) query.set("offset", String(options.offset));
+  if (options.limit !== undefined) query.set("limit", String(options.limit));
+  const suffix = query.toString();
+  return request<PartitionMemberCandidatePage>(
+    `${P}/${enc(name)}/users/candidates${suffix ? `?${suffix}` : ""}`,
   );
 }
 

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -205,15 +205,14 @@ export interface PartitionMemberCandidate {
 
 export interface PartitionMemberCandidatePage {
   candidates: PartitionMemberCandidate[];
-  offset: number;
   limit: number;
   has_more: boolean;
-  next_offset: number | null;
+  next_cursor: number | null;
 }
 
 interface ListPartitionMemberCandidatesOptions {
-  search?: string;
-  offset?: number;
+  search: string;
+  cursor?: number;
   limit?: number;
 }
 
@@ -223,16 +222,14 @@ export function listPartitionMembers(name: string): Promise<{ members: Partition
 
 export function listPartitionMemberCandidates(
   name: string,
-  options: ListPartitionMemberCandidatesOptions = {},
+  options: ListPartitionMemberCandidatesOptions,
 ): Promise<PartitionMemberCandidatePage> {
   const query = new URLSearchParams();
-  const search = options.search?.trim();
-  if (search) query.set("search", search);
-  if (options.offset !== undefined) query.set("offset", String(options.offset));
+  query.set("search", options.search.trim());
+  if (options.cursor !== undefined) query.set("cursor", String(options.cursor));
   if (options.limit !== undefined) query.set("limit", String(options.limit));
-  const suffix = query.toString();
   return request<PartitionMemberCandidatePage>(
-    `${P}/${enc(name)}/users/candidates${suffix ? `?${suffix}` : ""}`,
+    `${P}/${enc(name)}/users/candidates?${query.toString()}`,
   );
 }
 

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -198,8 +198,21 @@ export interface PartitionMember {
   added_at: string | null;
 }
 
+export interface PartitionMemberCandidate {
+  user_id: number;
+  display_name: string | null;
+}
+
 export function listPartitionMembers(name: string): Promise<{ members: PartitionMember[] }> {
   return request<{ members: PartitionMember[] }>(`${P}/${enc(name)}/users`);
+}
+
+export function listPartitionMemberCandidates(
+  name: string,
+): Promise<{ candidates: PartitionMemberCandidate[] }> {
+  return request<{ candidates: PartitionMemberCandidate[] }>(
+    `${P}/${enc(name)}/users/candidates`,
+  );
 }
 
 export function addPartitionMember(name: string, userId: number, role: PartitionRole): Promise<void> {

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -203,6 +203,7 @@ export interface PartitionMember {
 export interface PartitionMemberCandidate {
   user_id: number;
   display_name: string | null;
+  email: string | null;
 }
 
 export interface PartitionMemberCandidatePage {

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -42,6 +42,7 @@ import {
   updatePartition,
   listPartitions,
   listPartitionMembers,
+  listPartitionMemberCandidates,
   addPartitionMember,
   removePartitionMember,
   updatePartitionMemberRole,
@@ -51,6 +52,7 @@ import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
+import { MemberPicker } from "./member-picker";
 
 // --- General Tab ---
 
@@ -378,7 +380,7 @@ function PipelineConfigTab({ partition }: { partition: PartitionConfig }) {
 
 function UsersTab({ partitionName }: { partitionName: string }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [userId, setUserId] = useState("");
+  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
   const [role, setRole] = useState("viewer");
   const queryClient = useQueryClient();
   const { canManageMembers } = usePermissions();
@@ -395,19 +397,56 @@ function UsersTab({ partitionName }: { partitionName: string }) {
   const callerRole = partitionsQuery.data?.partitions.find((p) => p.partition === partitionName)?.role;
   const canManage = canManageMembers(callerRole);
 
+  const candidatesQuery = useQuery({
+    queryKey: ["partition", partitionName, "member-candidates"],
+    queryFn: () => listPartitionMemberCandidates(partitionName),
+    enabled: dialogOpen && canManage,
+  });
+
   const addMutation = useMutation({
-    mutationFn: () => addPartitionMember(partitionName, Number(userId), role as PartitionRole),
-    onSuccess: () => {
-      toast.success("User added to partition");
+    mutationFn: async ({
+      userIds,
+      selectedRole,
+    }: {
+      userIds: number[];
+      selectedRole: PartitionRole;
+    }) => {
+      const addedUserIds: number[] = [];
+      const failedUserIds: number[] = [];
+      for (const userId of userIds) {
+        try {
+          await addPartitionMember(partitionName, userId, selectedRole);
+          addedUserIds.push(userId);
+        } catch {
+          failedUserIds.push(userId);
+        }
+      }
+      return { addedUserIds, failedUserIds };
+    },
+    onSuccess: ({ addedUserIds, failedUserIds }) => {
       queryClient.invalidateQueries({
         queryKey: ["partition", partitionName, "users"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["partition", partitionName, "member-candidates"],
+      });
+
+      if (failedUserIds.length > 0) {
+        setSelectedUserIds(failedUserIds);
+        toast.error(
+          addedUserIds.length > 0
+            ? `${addedUserIds.length} user${addedUserIds.length === 1 ? "" : "s"} added; ${failedUserIds.length} failed`
+            : "Failed to add the selected users",
+        );
+        return;
+      }
+
+      toast.success(
+        `${addedUserIds.length} user${addedUserIds.length === 1 ? "" : "s"} added to partition`,
+      );
       setDialogOpen(false);
-      setUserId("");
+      setSelectedUserIds([]);
       setRole("viewer");
-    },
-    onError: (error: Error) => {
-      toast.error(`Failed to add user: ${error.message}`);
     },
   });
 
@@ -436,12 +475,24 @@ function UsersTab({ partitionName }: { partitionName: string }) {
     },
   });
 
-  const handleAddUser = () => {
-    if (!userId.trim() || Number.isNaN(Number(userId))) {
-      toast.error("A numeric user ID is required");
+  const handleAddUsers = () => {
+    if (selectedUserIds.length === 0) {
+      toast.error("Select at least one user");
       return;
     }
-    addMutation.mutate();
+    addMutation.mutate({
+      userIds: selectedUserIds,
+      selectedRole: role as PartitionRole,
+    });
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    if (!open && addMutation.isPending) return;
+    setDialogOpen(open);
+    if (!open) {
+      setSelectedUserIds([]);
+      setRole("viewer");
+    }
   };
 
   return (
@@ -532,23 +583,22 @@ function UsersTab({ partitionName }: { partitionName: string }) {
           </p>
         )}
 
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Add User to Partition</DialogTitle>
+              <DialogTitle>Add Users to Partition</DialogTitle>
               <DialogDescription>
-                Assign a user to this partition with a specific role.
+                Select users and assign the same partition role to each of them.
               </DialogDescription>
             </DialogHeader>
             <div className="space-y-4">
-              <div className="space-y-2">
-                <Label>User ID</Label>
-                <Input
-                  placeholder="Enter user ID..."
-                  value={userId}
-                  onChange={(e) => setUserId(e.target.value)}
-                />
-              </div>
+              <MemberPicker
+                candidates={candidatesQuery.data?.candidates ?? []}
+                isLoading={candidatesQuery.isLoading}
+                isError={candidatesQuery.isError}
+                selectedUserIds={selectedUserIds}
+                onSelectionChange={setSelectedUserIds}
+              />
               <div className="space-y-2">
                 <Label>Role</Label>
                 <Select value={role} onValueChange={setRole}>
@@ -568,11 +618,19 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                 type="button"
                 variant="outline"
                 onClick={() => setDialogOpen(false)}
+                disabled={addMutation.isPending}
               >
                 Cancel
               </Button>
-              <Button onClick={handleAddUser} disabled={addMutation.isPending}>
-                {addMutation.isPending ? "Adding..." : "Add User"}
+              <Button
+                onClick={handleAddUsers}
+                disabled={addMutation.isPending || selectedUserIds.length === 0}
+              >
+                {addMutation.isPending
+                  ? "Adding..."
+                  : selectedUserIds.length === 0
+                    ? "Add Users"
+                    : `Add ${selectedUserIds.length} User${selectedUserIds.length === 1 ? "" : "s"}`}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -53,7 +53,7 @@ import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } 
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
 import { MemberPicker } from "./member-picker";
-import { candidateLabel } from "./member-candidate";
+import { candidateLabel, candidateSecondaryLabel } from "./member-candidate";
 import { addPartitionMembers } from "./member-batch";
 import type { MemberAddFailure } from "./member-batch";
 import {
@@ -672,7 +672,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                     <ul className="list-disc space-y-1 pl-4">
                       {addFailures.map((failure) => (
                         <li key={failure.candidate.user_id}>
-                          {candidateLabel(failure.candidate)} (user ID {failure.candidate.user_id}):
+                          {candidateLabel(failure.candidate)} ({candidateSecondaryLabel(failure.candidate)}):
                           {" "}
                           {failure.message}
                         </li>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -53,6 +53,7 @@ import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } 
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
 import { MemberPicker } from "./member-picker";
+import { candidateLabel } from "./member-candidate";
 import { addPartitionMembers } from "./member-batch";
 import type { MemberAddFailure } from "./member-batch";
 import {
@@ -450,6 +451,9 @@ function UsersTab({ partitionName }: { partitionName: string }) {
         candidates: selected,
         role: selectedRole,
       }),
+    onError: (error: Error) => {
+      toast.error(`Failed to add users: ${error.message}`);
+    },
     onSuccess: ({ addedCandidates, failures }) => {
       queryClient.invalidateQueries({
         queryKey: ["partition", partitionName, "users"],
@@ -668,8 +672,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
                     <ul className="list-disc space-y-1 pl-4">
                       {addFailures.map((failure) => (
                         <li key={failure.candidate.user_id}>
-                          {failure.candidate.display_name?.trim() || "Unnamed user"} (user ID{" "}
-                          {failure.candidate.user_id}):
+                          {candidateLabel(failure.candidate)} (user ID {failure.candidate.user_id}):
                           {" "}
                           {failure.message}
                         </li>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Save, UserPlus, Trash2, CheckCircle, XCircle, Loader2, Info 
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -43,16 +44,17 @@ import {
   listPartitions,
   listPartitionMembers,
   listPartitionMemberCandidates,
-  addPartitionMember,
   removePartitionMember,
   updatePartitionMemberRole,
 } from "@/lib/api/partitions";
-import type { PartitionConfig, PartitionRole } from "@/lib/api/partitions";
+import type { PartitionConfig, PartitionMemberCandidate, PartitionRole } from "@/lib/api/partitions";
 import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
 import { MemberPicker } from "./member-picker";
+import { addPartitionMembers } from "./member-batch";
+import type { MemberAddFailure } from "./member-batch";
 
 // --- General Tab ---
 
@@ -380,7 +382,8 @@ function PipelineConfigTab({ partition }: { partition: PartitionConfig }) {
 
 function UsersTab({ partitionName }: { partitionName: string }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
+  const [selectedCandidates, setSelectedCandidates] = useState<PartitionMemberCandidate[]>([]);
+  const [addFailures, setAddFailures] = useState<MemberAddFailure[]>([]);
   const [role, setRole] = useState("viewer");
   const [candidateSearch, setCandidateSearch] = useState("");
   const [debouncedCandidateSearch, setDebouncedCandidateSearch] = useState("");
@@ -406,42 +409,43 @@ function UsersTab({ partitionName }: { partitionName: string }) {
     return () => window.clearTimeout(timeout);
   }, [candidateSearch]);
 
+  const normalizedCandidateSearch = candidateSearch.trim();
+  const candidateSearchReady =
+    /^\d+$/.test(normalizedCandidateSearch) || normalizedCandidateSearch.length >= 3;
+
   const candidatesQuery = useInfiniteQuery({
     queryKey: ["partition", partitionName, "member-candidates", debouncedCandidateSearch],
     queryFn: ({ pageParam }) =>
       listPartitionMemberCandidates(partitionName, {
         search: debouncedCandidateSearch,
-        offset: pageParam,
+        cursor: pageParam ?? undefined,
         limit: 25,
       }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
-    enabled: dialogOpen && canManage,
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    enabled:
+      dialogOpen &&
+      canManage &&
+      (/^\d+$/.test(debouncedCandidateSearch) || debouncedCandidateSearch.length >= 3),
   });
   const candidates = candidatesQuery.data?.pages.flatMap((page) => page.candidates) ?? [];
-  const candidateSearchPending = candidateSearch.trim() !== debouncedCandidateSearch;
+  const candidateSearchPending =
+    candidateSearchReady && normalizedCandidateSearch !== debouncedCandidateSearch;
 
   const addMutation = useMutation({
     mutationFn: async ({
-      userIds,
+      candidates: selected,
       selectedRole,
     }: {
-      userIds: number[];
+      candidates: PartitionMemberCandidate[];
       selectedRole: PartitionRole;
-    }) => {
-      const addedUserIds: number[] = [];
-      const failedUserIds: number[] = [];
-      for (const userId of userIds) {
-        try {
-          await addPartitionMember(partitionName, userId, selectedRole);
-          addedUserIds.push(userId);
-        } catch {
-          failedUserIds.push(userId);
-        }
-      }
-      return { addedUserIds, failedUserIds };
-    },
-    onSuccess: ({ addedUserIds, failedUserIds }) => {
+    }) =>
+      addPartitionMembers({
+        partitionName,
+        candidates: selected,
+        role: selectedRole,
+      }),
+    onSuccess: ({ addedCandidates, failures }) => {
       queryClient.invalidateQueries({
         queryKey: ["partition", partitionName, "users"],
       });
@@ -449,21 +453,22 @@ function UsersTab({ partitionName }: { partitionName: string }) {
         queryKey: ["partition", partitionName, "member-candidates"],
       });
 
-      if (failedUserIds.length > 0) {
-        setSelectedUserIds(failedUserIds);
+      if (failures.length > 0) {
+        setSelectedCandidates(failures.map((failure) => failure.candidate));
+        setAddFailures(failures);
+        const firstFailure = failures[0];
         toast.error(
-          addedUserIds.length > 0
-            ? `${addedUserIds.length} user${addedUserIds.length === 1 ? "" : "s"} added; ${failedUserIds.length} failed`
-            : "Failed to add the selected users",
+          `${addedCandidates.length > 0 ? `${addedCandidates.length} added; ` : ""}${failures.length} failed: ${firstFailure.message}`,
         );
         return;
       }
 
       toast.success(
-        `${addedUserIds.length} user${addedUserIds.length === 1 ? "" : "s"} added to partition`,
+        `${addedCandidates.length} user${addedCandidates.length === 1 ? "" : "s"} added to partition`,
       );
       setDialogOpen(false);
-      setSelectedUserIds([]);
+      setSelectedCandidates([]);
+      setAddFailures([]);
       setRole("viewer");
       setCandidateSearch("");
       setDebouncedCandidateSearch("");
@@ -496,12 +501,13 @@ function UsersTab({ partitionName }: { partitionName: string }) {
   });
 
   const handleAddUsers = () => {
-    if (selectedUserIds.length === 0) {
+    if (selectedCandidates.length === 0) {
       toast.error("Select at least one user");
       return;
     }
+    setAddFailures([]);
     addMutation.mutate({
-      userIds: selectedUserIds,
+      candidates: selectedCandidates,
       selectedRole: role as PartitionRole,
     });
   };
@@ -510,7 +516,8 @@ function UsersTab({ partitionName }: { partitionName: string }) {
     if (!open && addMutation.isPending) return;
     setDialogOpen(open);
     if (!open) {
-      setSelectedUserIds([]);
+      setSelectedCandidates([]);
+      setAddFailures([]);
       setRole("viewer");
       setCandidateSearch("");
       setDebouncedCandidateSearch("");
@@ -617,20 +624,59 @@ function UsersTab({ partitionName }: { partitionName: string }) {
               <MemberPicker
                 candidates={candidates}
                 isLoading={candidatesQuery.isLoading || candidateSearchPending}
-                isError={candidatesQuery.isError && candidatesQuery.data === undefined}
+                isInitialError={candidatesQuery.isError && candidatesQuery.data === undefined}
+                isRefreshError={
+                  candidatesQuery.isRefetchError &&
+                  candidatesQuery.data !== undefined &&
+                  !candidatesQuery.isFetchNextPageError
+                }
+                isLoadMoreError={candidatesQuery.isFetchNextPageError}
                 search={candidateSearch}
-                onSearchChange={setCandidateSearch}
+                searchReady={candidateSearchReady}
+                onSearchChange={(search) => {
+                  setCandidateSearch(search);
+                  setAddFailures([]);
+                }}
+                onRetry={() => {
+                  void candidatesQuery.refetch();
+                }}
                 hasMore={Boolean(candidatesQuery.hasNextPage)}
                 isLoadingMore={candidatesQuery.isFetchingNextPage}
                 onLoadMore={() => {
                   void candidatesQuery.fetchNextPage();
                 }}
-                selectedUserIds={selectedUserIds}
-                onSelectionChange={setSelectedUserIds}
+                selectedCandidates={selectedCandidates}
+                onSelectionChange={(selection) => {
+                  setSelectedCandidates(selection);
+                  setAddFailures([]);
+                }}
               />
+              {addFailures.length > 0 && (
+                <Alert variant="destructive">
+                  <AlertTitle>Some users were not added</AlertTitle>
+                  <AlertDescription>
+                    <ul className="list-disc space-y-1 pl-4">
+                      {addFailures.map((failure) => (
+                        <li key={failure.candidate.user_id}>
+                          {failure.candidate.display_name?.trim() || "Unnamed user"} (user ID{" "}
+                          {failure.candidate.user_id}):
+                          {" "}
+                          {failure.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </AlertDescription>
+                </Alert>
+              )}
               <div className="space-y-2">
                 <Label>Role</Label>
-                <Select value={role} onValueChange={setRole}>
+                <Select
+                  value={role}
+                  onValueChange={(value) => {
+                    setRole(value);
+                    setAddFailures([]);
+                  }}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder="Select a role" />
                   </SelectTrigger>
@@ -653,13 +699,13 @@ function UsersTab({ partitionName }: { partitionName: string }) {
               </Button>
               <Button
                 onClick={handleAddUsers}
-                disabled={addMutation.isPending || selectedUserIds.length === 0}
+                disabled={addMutation.isPending || selectedCandidates.length === 0}
               >
                 {addMutation.isPending
                   ? "Adding..."
-                  : selectedUserIds.length === 0
+                  : selectedCandidates.length === 0
                     ? "Add Users"
-                    : `Add ${selectedUserIds.length} User${selectedUserIds.length === 1 ? "" : "s"}`}
+                    : `Add ${selectedCandidates.length} User${selectedCandidates.length === 1 ? "" : "s"}`}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Save, UserPlus, Trash2, CheckCircle, XCircle, Loader2, Info } from "lucide-react";
 import { toast } from "sonner";
 
@@ -382,6 +382,8 @@ function UsersTab({ partitionName }: { partitionName: string }) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
   const [role, setRole] = useState("viewer");
+  const [candidateSearch, setCandidateSearch] = useState("");
+  const [debouncedCandidateSearch, setDebouncedCandidateSearch] = useState("");
   const queryClient = useQueryClient();
   const { canManageMembers } = usePermissions();
 
@@ -397,11 +399,27 @@ function UsersTab({ partitionName }: { partitionName: string }) {
   const callerRole = partitionsQuery.data?.partitions.find((p) => p.partition === partitionName)?.role;
   const canManage = canManageMembers(callerRole);
 
-  const candidatesQuery = useQuery({
-    queryKey: ["partition", partitionName, "member-candidates"],
-    queryFn: () => listPartitionMemberCandidates(partitionName),
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedCandidateSearch(candidateSearch.trim());
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [candidateSearch]);
+
+  const candidatesQuery = useInfiniteQuery({
+    queryKey: ["partition", partitionName, "member-candidates", debouncedCandidateSearch],
+    queryFn: ({ pageParam }) =>
+      listPartitionMemberCandidates(partitionName, {
+        search: debouncedCandidateSearch,
+        offset: pageParam,
+        limit: 25,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
     enabled: dialogOpen && canManage,
   });
+  const candidates = candidatesQuery.data?.pages.flatMap((page) => page.candidates) ?? [];
+  const candidateSearchPending = candidateSearch.trim() !== debouncedCandidateSearch;
 
   const addMutation = useMutation({
     mutationFn: async ({
@@ -447,6 +465,8 @@ function UsersTab({ partitionName }: { partitionName: string }) {
       setDialogOpen(false);
       setSelectedUserIds([]);
       setRole("viewer");
+      setCandidateSearch("");
+      setDebouncedCandidateSearch("");
     },
   });
 
@@ -492,6 +512,8 @@ function UsersTab({ partitionName }: { partitionName: string }) {
     if (!open) {
       setSelectedUserIds([]);
       setRole("viewer");
+      setCandidateSearch("");
+      setDebouncedCandidateSearch("");
     }
   };
 
@@ -593,9 +615,16 @@ function UsersTab({ partitionName }: { partitionName: string }) {
             </DialogHeader>
             <div className="space-y-4">
               <MemberPicker
-                candidates={candidatesQuery.data?.candidates ?? []}
-                isLoading={candidatesQuery.isLoading}
-                isError={candidatesQuery.isError}
+                candidates={candidates}
+                isLoading={candidatesQuery.isLoading || candidateSearchPending}
+                isError={candidatesQuery.isError && candidatesQuery.data === undefined}
+                search={candidateSearch}
+                onSearchChange={setCandidateSearch}
+                hasMore={Boolean(candidatesQuery.hasNextPage)}
+                isLoadingMore={candidatesQuery.isFetchingNextPage}
+                onLoadMore={() => {
+                  void candidatesQuery.fetchNextPage();
+                }}
                 selectedUserIds={selectedUserIds}
                 onSelectionChange={setSelectedUserIds}
               />
@@ -617,7 +646,7 @@ function UsersTab({ partitionName }: { partitionName: string }) {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => setDialogOpen(false)}
+                onClick={() => handleDialogOpenChange(false)}
                 disabled={addMutation.isPending}
               >
                 Cancel

--- a/ui/src/pages/admin/partitions/member-batch.test.ts
+++ b/ui/src/pages/admin/partitions/member-batch.test.ts
@@ -4,9 +4,9 @@ import { ApiError } from "@/lib/api/client";
 import { addPartitionMembers } from "./member-batch";
 
 const candidates = [
-  { user_id: 2, display_name: "Sam Lee" },
-  { user_id: 3, display_name: "Alex Morgan" },
-  { user_id: 4, display_name: null },
+  { user_id: 2, display_name: "Sam Lee", email: "sam@example.com" },
+  { user_id: 3, display_name: "Alex Morgan", email: "alex@example.com" },
+  { user_id: 4, display_name: null, email: null },
 ];
 
 describe("addPartitionMembers", () => {
@@ -28,12 +28,10 @@ describe("addPartitionMembers", () => {
       {
         candidate: candidates[1],
         message: "User is already a member",
-        attempted: true,
       },
       {
         candidate: candidates[2],
         message: "Account is inactive",
-        attempted: true,
       },
     ]);
   });
@@ -55,11 +53,10 @@ describe("addPartitionMembers", () => {
     expect(result.failures[0]).toMatchObject({
       candidate: candidates[0],
       message: "Partition owner role required",
-      attempted: true,
     });
     expect(result.failures[1]).toMatchObject({
       candidate: candidates[1],
-      attempted: false,
+      message: "Not attempted because permission to manage members was lost.",
     });
   });
 });

--- a/ui/src/pages/admin/partitions/member-batch.test.ts
+++ b/ui/src/pages/admin/partitions/member-batch.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/lib/api/client";
+import { addPartitionMembers } from "./member-batch";
+
+const candidates = [
+  { user_id: 2, display_name: "Sam Lee" },
+  { user_id: 3, display_name: "Alex Morgan" },
+  { user_id: 4, display_name: null },
+];
+
+describe("addPartitionMembers", () => {
+  it("preserves the server reason for each failed user", async () => {
+    const addMember = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("User is already a member"))
+      .mockRejectedValueOnce(new Error("Account is inactive"));
+
+    const result = await addPartitionMembers({
+      partitionName: "legal",
+      candidates,
+      role: "viewer",
+      addMember,
+    });
+
+    expect(result.addedCandidates).toEqual([candidates[0]]);
+    expect(result.failures).toEqual([
+      {
+        candidate: candidates[1],
+        message: "User is already a member",
+        attempted: true,
+      },
+      {
+        candidate: candidates[2],
+        message: "Account is inactive",
+        attempted: true,
+      },
+    ]);
+  });
+
+  it("stops sending requests after authorization is lost", async () => {
+    const addMember = vi.fn().mockRejectedValueOnce(
+      new ApiError(403, { detail: "Partition owner role required" }),
+    );
+
+    const result = await addPartitionMembers({
+      partitionName: "legal",
+      candidates,
+      role: "editor",
+      addMember,
+    });
+
+    expect(addMember).toHaveBeenCalledOnce();
+    expect(result.failures).toHaveLength(3);
+    expect(result.failures[0]).toMatchObject({
+      candidate: candidates[0],
+      message: "Partition owner role required",
+      attempted: true,
+    });
+    expect(result.failures[1]).toMatchObject({
+      candidate: candidates[1],
+      attempted: false,
+    });
+  });
+});

--- a/ui/src/pages/admin/partitions/member-batch.ts
+++ b/ui/src/pages/admin/partitions/member-batch.ts
@@ -1,0 +1,52 @@
+import { addPartitionMember } from "@/lib/api/partitions";
+import type { PartitionMemberCandidate, PartitionRole } from "@/lib/api/partitions";
+import { ApiError } from "@/lib/api/client";
+
+export interface MemberAddFailure {
+  candidate: PartitionMemberCandidate;
+  message: string;
+  attempted: boolean;
+}
+
+interface AddPartitionMembersOptions {
+  partitionName: string;
+  candidates: PartitionMemberCandidate[];
+  role: PartitionRole;
+  addMember?: typeof addPartitionMember;
+}
+
+export async function addPartitionMembers({
+  partitionName,
+  candidates,
+  role,
+  addMember = addPartitionMember,
+}: AddPartitionMembersOptions): Promise<{
+  addedCandidates: PartitionMemberCandidate[];
+  failures: MemberAddFailure[];
+}> {
+  const addedCandidates: PartitionMemberCandidate[] = [];
+  const failures: MemberAddFailure[] = [];
+
+  for (const [index, candidate] of candidates.entries()) {
+    try {
+      await addMember(partitionName, candidate.user_id, role);
+      addedCandidates.push(candidate);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      failures.push({ candidate, message, attempted: true });
+
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        for (const remainingCandidate of candidates.slice(index + 1)) {
+          failures.push({
+            candidate: remainingCandidate,
+            message: "Not attempted because permission to manage members was lost.",
+            attempted: false,
+          });
+        }
+        break;
+      }
+    }
+  }
+
+  return { addedCandidates, failures };
+}

--- a/ui/src/pages/admin/partitions/member-batch.ts
+++ b/ui/src/pages/admin/partitions/member-batch.ts
@@ -5,7 +5,6 @@ import { ApiError } from "@/lib/api/client";
 export interface MemberAddFailure {
   candidate: PartitionMemberCandidate;
   message: string;
-  attempted: boolean;
 }
 
 interface AddPartitionMembersOptions {
@@ -33,14 +32,13 @@ export async function addPartitionMembers({
       addedCandidates.push(candidate);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
-      failures.push({ candidate, message, attempted: true });
+      failures.push({ candidate, message });
 
       if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
         for (const remainingCandidate of candidates.slice(index + 1)) {
           failures.push({
             candidate: remainingCandidate,
             message: "Not attempted because permission to manage members was lost.",
-            attempted: false,
           });
         }
         break;

--- a/ui/src/pages/admin/partitions/member-candidate.ts
+++ b/ui/src/pages/admin/partitions/member-candidate.ts
@@ -3,3 +3,7 @@ import type { PartitionMemberCandidate } from "@/lib/api/partitions";
 export function candidateLabel(candidate: PartitionMemberCandidate): string {
   return candidate.display_name?.trim() || "Unnamed user";
 }
+
+export function candidateSecondaryLabel(candidate: PartitionMemberCandidate): string {
+  return candidate.email?.trim() || `User ID ${candidate.user_id}`;
+}

--- a/ui/src/pages/admin/partitions/member-candidate.ts
+++ b/ui/src/pages/admin/partitions/member-candidate.ts
@@ -1,0 +1,5 @@
+import type { PartitionMemberCandidate } from "@/lib/api/partitions";
+
+export function candidateLabel(candidate: PartitionMemberCandidate): string {
+  return candidate.display_name?.trim() || "Unnamed user";
+}

--- a/ui/src/pages/admin/partitions/member-picker.test.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.test.tsx
@@ -6,9 +6,9 @@ import { MemberPicker } from "./member-picker";
 import type { PartitionMemberCandidate } from "@/lib/api/partitions";
 
 const candidates = [
-  { user_id: 2, display_name: "Sam Lee" },
-  { user_id: 3, display_name: "Sam Lee" },
-  { user_id: 4, display_name: null },
+  { user_id: 2, display_name: "Sam Lee", email: "sam.lee@example.com" },
+  { user_id: 3, display_name: "Sam Lee", email: "sam.lee@linagora.com" },
+  { user_id: 4, display_name: null, email: null },
 ];
 
 function renderPicker(
@@ -35,13 +35,14 @@ function renderPicker(
 }
 
 describe("MemberPicker", () => {
-  it("shows stable IDs so duplicate names remain distinguishable", () => {
+  it("shows email addresses so duplicate names remain distinguishable", () => {
     renderPicker();
 
     expect(screen.getAllByText("Sam Lee")).toHaveLength(2);
-    expect(screen.getByText("User ID 2")).not.toBeNull();
-    expect(screen.getByText("User ID 3")).not.toBeNull();
+    expect(screen.getByText("sam.lee@example.com")).not.toBeNull();
+    expect(screen.getByText("sam.lee@linagora.com")).not.toBeNull();
     expect(screen.getByText("Unnamed user")).not.toBeNull();
+    expect(screen.getByText("User ID 4")).not.toBeNull();
   });
 
   it("forwards search changes to the server-backed query", async () => {
@@ -60,7 +61,7 @@ describe("MemberPicker", () => {
     const user = userEvent.setup();
     renderPicker({ selectedCandidates: [candidates[0]], onSelectionChange });
 
-    await user.click(screen.getByRole("checkbox", { name: /select sam lee, user id 3/i }));
+    await user.click(screen.getByRole("checkbox", { name: /select sam lee, sam.lee@linagora.com/i }));
 
     expect(onSelectionChange).toHaveBeenCalledWith([candidates[0], candidates[1]]);
   });
@@ -79,6 +80,7 @@ describe("MemberPicker", () => {
     const selected: PartitionMemberCandidate = {
       user_id: 9,
       display_name: "Alex Morgan",
+      email: "alex@example.com",
     };
     const onSelectionChange = vi.fn();
     const user = userEvent.setup();
@@ -90,7 +92,7 @@ describe("MemberPicker", () => {
 
     expect(screen.getByRole("region", { name: "Selected users" })).not.toBeNull();
     expect(screen.getByText("Alex Morgan")).not.toBeNull();
-    await user.click(screen.getByRole("button", { name: /remove alex morgan, user id 9/i }));
+    await user.click(screen.getByRole("button", { name: /remove alex morgan, alex@example.com/i }));
 
     expect(onSelectionChange).toHaveBeenCalledWith([]);
   });

--- a/ui/src/pages/admin/partitions/member-picker.test.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { MemberPicker } from "./member-picker";
+import type { PartitionMemberCandidate } from "@/lib/api/partitions";
 
 const candidates = [
   { user_id: 2, display_name: "Sam Lee" },
@@ -10,22 +11,32 @@ const candidates = [
   { user_id: 4, display_name: null },
 ];
 
+function renderPicker(
+  overrides: Partial<React.ComponentProps<typeof MemberPicker>> = {},
+) {
+  const props: React.ComponentProps<typeof MemberPicker> = {
+    candidates,
+    isLoading: false,
+    isInitialError: false,
+    isRefreshError: false,
+    isLoadMoreError: false,
+    search: "Sam",
+    searchReady: true,
+    onSearchChange: vi.fn(),
+    onRetry: vi.fn(),
+    hasMore: false,
+    isLoadingMore: false,
+    onLoadMore: vi.fn(),
+    selectedCandidates: [],
+    onSelectionChange: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<MemberPicker {...props} />), props };
+}
+
 describe("MemberPicker", () => {
   it("shows stable IDs so duplicate names remain distinguishable", () => {
-    render(
-      <MemberPicker
-        candidates={candidates}
-        isLoading={false}
-        isError={false}
-        search=""
-        onSearchChange={vi.fn()}
-        hasMore={false}
-        isLoadingMore={false}
-        onLoadMore={vi.fn()}
-        selectedUserIds={[]}
-        onSelectionChange={vi.fn()}
-      />,
-    );
+    renderPicker();
 
     expect(screen.getAllByText("Sam Lee")).toHaveLength(2);
     expect(screen.getByText("User ID 2")).not.toBeNull();
@@ -36,20 +47,7 @@ describe("MemberPicker", () => {
   it("forwards search changes to the server-backed query", async () => {
     const onSearchChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <MemberPicker
-        candidates={candidates}
-        isLoading={false}
-        isError={false}
-        search=""
-        onSearchChange={onSearchChange}
-        hasMore={false}
-        isLoadingMore={false}
-        onLoadMore={vi.fn()}
-        selectedUserIds={[]}
-        onSelectionChange={vi.fn()}
-      />,
-    );
+    renderPicker({ search: "", searchReady: false, onSearchChange });
 
     const search = screen.getByRole("textbox", { name: "Users" });
     await user.type(search, "3");
@@ -57,48 +55,67 @@ describe("MemberPicker", () => {
     expect(onSearchChange).toHaveBeenCalledWith("3");
   });
 
-  it("returns all selected user IDs when a candidate is checked", async () => {
+  it("returns selected identities when a candidate is checked", async () => {
     const onSelectionChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <MemberPicker
-        candidates={candidates}
-        isLoading={false}
-        isError={false}
-        search=""
-        onSearchChange={vi.fn()}
-        hasMore={false}
-        isLoadingMore={false}
-        onLoadMore={vi.fn()}
-        selectedUserIds={[2]}
-        onSelectionChange={onSelectionChange}
-      />,
-    );
+    renderPicker({ selectedCandidates: [candidates[0]], onSelectionChange });
 
     await user.click(screen.getByRole("checkbox", { name: /select sam lee, user id 3/i }));
 
-    expect(onSelectionChange).toHaveBeenCalledWith([2, 3]);
+    expect(onSelectionChange).toHaveBeenCalledWith([candidates[0], candidates[1]]);
   });
 
   it("loads the next server page on request", async () => {
     const onLoadMore = vi.fn();
     const user = userEvent.setup();
-    render(
-      <MemberPicker
-        candidates={candidates}
-        isLoading={false}
-        isError={false}
-        search=""
-        onSearchChange={vi.fn()}
-        hasMore
-        isLoadingMore={false}
-        onLoadMore={onLoadMore}
-        selectedUserIds={[]}
-        onSelectionChange={vi.fn()}
-      />,
-    );
+    renderPicker({ hasMore: true, onLoadMore });
 
     await user.click(screen.getByRole("button", { name: "Load more users" }));
+
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+
+  it("keeps selected identities visible when they are absent from current results", async () => {
+    const selected: PartitionMemberCandidate = {
+      user_id: 9,
+      display_name: "Alex Morgan",
+    };
+    const onSelectionChange = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({
+      candidates: [candidates[0]],
+      selectedCandidates: [selected],
+      onSelectionChange,
+    });
+
+    expect(screen.getByRole("region", { name: "Selected users" })).not.toBeNull();
+    expect(screen.getByText("Alex Morgan")).not.toBeNull();
+    await user.click(screen.getByRole("button", { name: /remove alex morgan, user id 9/i }));
+
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it("asks for a targeted search before showing candidates", () => {
+    renderPicker({ search: "Sa", searchReady: false });
+
+    expect(screen.getByText("Enter at least 3 characters or an exact user ID.")).not.toBeNull();
+    expect(screen.queryByText("Sam Lee")).toBeNull();
+  });
+
+  it("keeps cached candidates visible after a refresh error", () => {
+    renderPicker({ isRefreshError: true });
+
+    expect(screen.getByText(/previous results remain available/i)).not.toBeNull();
+    expect(screen.getAllByText("Sam Lee")).toHaveLength(2);
+  });
+
+  it("offers a page-specific retry without discarding loaded candidates", async () => {
+    const onLoadMore = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({ isLoadMoreError: true, onLoadMore });
+
+    expect(screen.getByText(/retry without losing this page/i)).not.toBeNull();
+    await user.click(screen.getByRole("button", { name: "Retry loading more" }));
 
     expect(onLoadMore).toHaveBeenCalledOnce();
   });

--- a/ui/src/pages/admin/partitions/member-picker.test.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.test.tsx
@@ -41,7 +41,7 @@ describe("MemberPicker", () => {
     expect(screen.getAllByText("Sam Lee")).toHaveLength(2);
     expect(screen.getByText("User ID 2")).not.toBeNull();
     expect(screen.getByText("User ID 3")).not.toBeNull();
-    expect(screen.getByText("User #4")).not.toBeNull();
+    expect(screen.getByText("Unnamed user")).not.toBeNull();
   });
 
   it("forwards search changes to the server-backed query", async () => {

--- a/ui/src/pages/admin/partitions/member-picker.test.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.test.tsx
@@ -17,6 +17,11 @@ describe("MemberPicker", () => {
         candidates={candidates}
         isLoading={false}
         isError={false}
+        search=""
+        onSearchChange={vi.fn()}
+        hasMore={false}
+        isLoadingMore={false}
+        onLoadMore={vi.fn()}
         selectedUserIds={[]}
         onSelectionChange={vi.fn()}
       />,
@@ -28,13 +33,19 @@ describe("MemberPicker", () => {
     expect(screen.getByText("User #4")).not.toBeNull();
   });
 
-  it("searches by display name and user ID", async () => {
+  it("forwards search changes to the server-backed query", async () => {
+    const onSearchChange = vi.fn();
     const user = userEvent.setup();
     render(
       <MemberPicker
         candidates={candidates}
         isLoading={false}
         isError={false}
+        search=""
+        onSearchChange={onSearchChange}
+        hasMore={false}
+        isLoadingMore={false}
+        onLoadMore={vi.fn()}
         selectedUserIds={[]}
         onSelectionChange={vi.fn()}
       />,
@@ -43,8 +54,7 @@ describe("MemberPicker", () => {
     const search = screen.getByRole("textbox", { name: "Users" });
     await user.type(search, "3");
 
-    expect(screen.getByText("User ID 3")).not.toBeNull();
-    expect(screen.queryByText("User ID 2")).toBeNull();
+    expect(onSearchChange).toHaveBeenCalledWith("3");
   });
 
   it("returns all selected user IDs when a candidate is checked", async () => {
@@ -55,6 +65,11 @@ describe("MemberPicker", () => {
         candidates={candidates}
         isLoading={false}
         isError={false}
+        search=""
+        onSearchChange={vi.fn()}
+        hasMore={false}
+        isLoadingMore={false}
+        onLoadMore={vi.fn()}
         selectedUserIds={[2]}
         onSelectionChange={onSelectionChange}
       />,
@@ -63,5 +78,28 @@ describe("MemberPicker", () => {
     await user.click(screen.getByRole("checkbox", { name: /select sam lee, user id 3/i }));
 
     expect(onSelectionChange).toHaveBeenCalledWith([2, 3]);
+  });
+
+  it("loads the next server page on request", async () => {
+    const onLoadMore = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MemberPicker
+        candidates={candidates}
+        isLoading={false}
+        isError={false}
+        search=""
+        onSearchChange={vi.fn()}
+        hasMore
+        isLoadingMore={false}
+        onLoadMore={onLoadMore}
+        selectedUserIds={[]}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Load more users" }));
+
+    expect(onLoadMore).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/admin/partitions/member-picker.test.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MemberPicker } from "./member-picker";
+
+const candidates = [
+  { user_id: 2, display_name: "Sam Lee" },
+  { user_id: 3, display_name: "Sam Lee" },
+  { user_id: 4, display_name: null },
+];
+
+describe("MemberPicker", () => {
+  it("shows stable IDs so duplicate names remain distinguishable", () => {
+    render(
+      <MemberPicker
+        candidates={candidates}
+        isLoading={false}
+        isError={false}
+        selectedUserIds={[]}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("Sam Lee")).toHaveLength(2);
+    expect(screen.getByText("User ID 2")).not.toBeNull();
+    expect(screen.getByText("User ID 3")).not.toBeNull();
+    expect(screen.getByText("User #4")).not.toBeNull();
+  });
+
+  it("searches by display name and user ID", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemberPicker
+        candidates={candidates}
+        isLoading={false}
+        isError={false}
+        selectedUserIds={[]}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    const search = screen.getByRole("textbox", { name: "Users" });
+    await user.type(search, "3");
+
+    expect(screen.getByText("User ID 3")).not.toBeNull();
+    expect(screen.queryByText("User ID 2")).toBeNull();
+  });
+
+  it("returns all selected user IDs when a candidate is checked", async () => {
+    const onSelectionChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MemberPicker
+        candidates={candidates}
+        isLoading={false}
+        isError={false}
+        selectedUserIds={[2]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: /select sam lee, user id 3/i }));
+
+    expect(onSelectionChange).toHaveBeenCalledWith([2, 3]);
+  });
+});

--- a/ui/src/pages/admin/partitions/member-picker.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -11,14 +12,18 @@ import type { PartitionMemberCandidate } from "@/lib/api/partitions";
 interface MemberPickerProps {
   candidates: PartitionMemberCandidate[];
   isLoading: boolean;
-  isError: boolean;
+  isInitialError: boolean;
+  isRefreshError: boolean;
+  isLoadMoreError: boolean;
   search: string;
+  searchReady: boolean;
   onSearchChange: (search: string) => void;
+  onRetry: () => void;
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
-  selectedUserIds: number[];
-  onSelectionChange: (userIds: number[]) => void;
+  selectedCandidates: PartitionMemberCandidate[];
+  onSelectionChange: (candidates: PartitionMemberCandidate[]) => void;
 }
 
 function candidateLabel(candidate: PartitionMemberCandidate): string {
@@ -28,25 +33,34 @@ function candidateLabel(candidate: PartitionMemberCandidate): string {
 export function MemberPicker({
   candidates,
   isLoading,
-  isError,
+  isInitialError,
+  isRefreshError,
+  isLoadMoreError,
   search,
+  searchReady,
   onSearchChange,
+  onRetry,
   hasMore,
   isLoadingMore,
   onLoadMore,
-  selectedUserIds,
+  selectedCandidates,
   onSelectionChange,
 }: MemberPickerProps) {
-  const selected = useMemo(() => new Set(selectedUserIds), [selectedUserIds]);
+  const selected = useMemo(
+    () => new Set(selectedCandidates.map((candidate) => candidate.user_id)),
+    [selectedCandidates],
+  );
 
-  const toggleCandidate = (userId: number, checked: boolean) => {
-    const next = new Set(selected);
+  const toggleCandidate = (candidate: PartitionMemberCandidate, checked: boolean) => {
     if (checked) {
-      next.add(userId);
+      onSelectionChange(
+        selected.has(candidate.user_id) ? selectedCandidates : [...selectedCandidates, candidate],
+      );
     } else {
-      next.delete(userId);
+      onSelectionChange(
+        selectedCandidates.filter((selectedCandidate) => selectedCandidate.user_id !== candidate.user_id),
+      );
     }
-    onSelectionChange([...next]);
   };
 
   return (
@@ -54,7 +68,7 @@ export function MemberPicker({
       <div className="flex items-center justify-between gap-3">
         <Label htmlFor="partition-member-search">Users</Label>
         <span className="text-xs text-muted-foreground" aria-live="polite">
-          {selectedUserIds.length} selected
+          {selectedCandidates.length} selected
         </span>
       </div>
       <div className="relative">
@@ -71,22 +85,71 @@ export function MemberPicker({
         />
       </div>
 
+      {selectedCandidates.length > 0 && (
+        <div
+          className="space-y-1.5 rounded-md border bg-muted/30 p-2"
+          role="region"
+          aria-label="Selected users"
+        >
+          <p className="text-xs font-medium text-muted-foreground">Selected users</p>
+          {selectedCandidates.map((candidate) => {
+            const label = candidateLabel(candidate);
+            return (
+              <div
+                key={candidate.user_id}
+                className="flex items-center justify-between gap-2 rounded bg-background px-2 py-1.5 text-sm"
+              >
+                <span className="min-w-0 truncate">
+                  {label} <span className="font-mono text-xs text-muted-foreground">#{candidate.user_id}</span>
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 shrink-0"
+                  onClick={() => toggleCandidate(candidate, false)}
+                  aria-label={`Remove ${label}, user ID ${candidate.user_id}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {isRefreshError && (
+        <Alert variant="destructive">
+          <AlertDescription className="flex-row items-center justify-between gap-3">
+            <span>Results could not be refreshed. The previous results remain available.</span>
+            <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
       <div className="max-h-64 overflow-y-auto rounded-md border" role="group" aria-label="Available users">
-        {isLoading ? (
+        {!searchReady ? (
+          <p className="p-4 text-center text-sm text-muted-foreground">
+            Enter at least 3 characters or an exact user ID.
+          </p>
+        ) : isLoading ? (
           <div className="space-y-2 p-3">
             {Array.from({ length: 3 }).map((_, index) => (
               <Skeleton key={index} className="h-11 w-full" />
             ))}
           </div>
-        ) : isError ? (
-          <p className="p-4 text-center text-sm text-destructive">
-            Users could not be loaded. Close the dialog and try again.
-          </p>
+        ) : isInitialError ? (
+          <div className="space-y-2 p-4 text-center text-sm text-destructive">
+            <p>Users could not be loaded.</p>
+            <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          </div>
         ) : candidates.length === 0 ? (
           <p className="p-4 text-center text-sm text-muted-foreground">
-            {search.trim()
-              ? "No users match this search."
-              : "All users are already members of this partition."}
+            No available users match this search.
           </p>
         ) : (
           <>
@@ -103,7 +166,7 @@ export function MemberPicker({
                     <Checkbox
                       id={checkboxId}
                       checked={selected.has(candidate.user_id)}
-                      onCheckedChange={(checked) => toggleCandidate(candidate.user_id, checked === true)}
+                      onCheckedChange={(checked) => toggleCandidate(candidate, checked === true)}
                       aria-label={`Select ${label}, user ID ${candidate.user_id}`}
                     />
                     <span className="min-w-0 flex-1">
@@ -116,8 +179,13 @@ export function MemberPicker({
                 );
               })}
             </div>
-            {hasMore && (
+            {(hasMore || isLoadMoreError) && (
               <div className="border-t p-2">
+                {isLoadMoreError && (
+                  <p className="mb-2 text-center text-xs text-destructive">
+                    More users could not be loaded. You can retry without losing this page.
+                  </p>
+                )}
                 <Button
                   type="button"
                   variant="ghost"
@@ -126,7 +194,7 @@ export function MemberPicker({
                   onClick={onLoadMore}
                   disabled={isLoadingMore}
                 >
-                  {isLoadingMore ? "Loading..." : "Load more users"}
+                  {isLoadingMore ? "Loading..." : isLoadMoreError ? "Retry loading more" : "Load more users"}
                 </Button>
               </div>
             )}

--- a/ui/src/pages/admin/partitions/member-picker.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { PartitionMemberCandidate } from "@/lib/api/partitions";
+import { candidateLabel } from "./member-candidate";
 
 interface MemberPickerProps {
   candidates: PartitionMemberCandidate[];
@@ -24,10 +25,6 @@ interface MemberPickerProps {
   onLoadMore: () => void;
   selectedCandidates: PartitionMemberCandidate[];
   onSelectionChange: (candidates: PartitionMemberCandidate[]) => void;
-}
-
-function candidateLabel(candidate: PartitionMemberCandidate): string {
-  return candidate.display_name?.trim() || `User #${candidate.user_id}`;
 }
 
 export function MemberPicker({

--- a/ui/src/pages/admin/partitions/member-picker.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Search } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -11,6 +12,11 @@ interface MemberPickerProps {
   candidates: PartitionMemberCandidate[];
   isLoading: boolean;
   isError: boolean;
+  search: string;
+  onSearchChange: (search: string) => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
   selectedUserIds: number[];
   onSelectionChange: (userIds: number[]) => void;
 }
@@ -23,18 +29,15 @@ export function MemberPicker({
   candidates,
   isLoading,
   isError,
+  search,
+  onSearchChange,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
   selectedUserIds,
   onSelectionChange,
 }: MemberPickerProps) {
-  const [search, setSearch] = useState("");
   const selected = useMemo(() => new Set(selectedUserIds), [selectedUserIds]);
-  const filteredCandidates = useMemo(() => {
-    const query = search.trim().toLocaleLowerCase();
-    if (!query) return candidates;
-    return candidates.filter((candidate) =>
-      `${candidateLabel(candidate)} ${candidate.user_id}`.toLocaleLowerCase().includes(query),
-    );
-  }, [candidates, search]);
 
   const toggleCandidate = (userId: number, checked: boolean) => {
     const next = new Set(selected);
@@ -62,7 +65,7 @@ export function MemberPicker({
         <Input
           id="partition-member-search"
           value={search}
-          onChange={(event) => setSearch(event.target.value)}
+          onChange={(event) => onSearchChange(event.target.value)}
           placeholder="Search by name or user ID..."
           className="pl-9"
         />
@@ -81,39 +84,53 @@ export function MemberPicker({
           </p>
         ) : candidates.length === 0 ? (
           <p className="p-4 text-center text-sm text-muted-foreground">
-            All users are already members of this partition.
-          </p>
-        ) : filteredCandidates.length === 0 ? (
-          <p className="p-4 text-center text-sm text-muted-foreground">
-            No users match this search.
+            {search.trim()
+              ? "No users match this search."
+              : "All users are already members of this partition."}
           </p>
         ) : (
-          <div className="divide-y">
-            {filteredCandidates.map((candidate) => {
-              const label = candidateLabel(candidate);
-              const checkboxId = `partition-member-${candidate.user_id}`;
-              return (
-                <label
-                  key={candidate.user_id}
-                  htmlFor={checkboxId}
-                  className="flex min-h-11 cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/50"
-                >
-                  <Checkbox
-                    id={checkboxId}
-                    checked={selected.has(candidate.user_id)}
-                    onCheckedChange={(checked) => toggleCandidate(candidate.user_id, checked === true)}
-                    aria-label={`Select ${label}, user ID ${candidate.user_id}`}
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm font-medium">{label}</span>
-                    <span className="block font-mono text-xs text-muted-foreground">
-                      User ID {candidate.user_id}
+          <>
+            <div className="divide-y">
+              {candidates.map((candidate) => {
+                const label = candidateLabel(candidate);
+                const checkboxId = `partition-member-${candidate.user_id}`;
+                return (
+                  <label
+                    key={candidate.user_id}
+                    htmlFor={checkboxId}
+                    className="flex min-h-11 cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      id={checkboxId}
+                      checked={selected.has(candidate.user_id)}
+                      onCheckedChange={(checked) => toggleCandidate(candidate.user_id, checked === true)}
+                      aria-label={`Select ${label}, user ID ${candidate.user_id}`}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">{label}</span>
+                      <span className="block font-mono text-xs text-muted-foreground">
+                        User ID {candidate.user_id}
+                      </span>
                     </span>
-                  </span>
-                </label>
-              );
-            })}
-          </div>
+                  </label>
+                );
+              })}
+            </div>
+            {hasMore && (
+              <div className="border-t p-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="w-full"
+                  onClick={onLoadMore}
+                  disabled={isLoadingMore}
+                >
+                  {isLoadingMore ? "Loading..." : "Load more users"}
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/ui/src/pages/admin/partitions/member-picker.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from "react";
+import { Search } from "lucide-react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { PartitionMemberCandidate } from "@/lib/api/partitions";
+
+interface MemberPickerProps {
+  candidates: PartitionMemberCandidate[];
+  isLoading: boolean;
+  isError: boolean;
+  selectedUserIds: number[];
+  onSelectionChange: (userIds: number[]) => void;
+}
+
+function candidateLabel(candidate: PartitionMemberCandidate): string {
+  return candidate.display_name?.trim() || `User #${candidate.user_id}`;
+}
+
+export function MemberPicker({
+  candidates,
+  isLoading,
+  isError,
+  selectedUserIds,
+  onSelectionChange,
+}: MemberPickerProps) {
+  const [search, setSearch] = useState("");
+  const selected = useMemo(() => new Set(selectedUserIds), [selectedUserIds]);
+  const filteredCandidates = useMemo(() => {
+    const query = search.trim().toLocaleLowerCase();
+    if (!query) return candidates;
+    return candidates.filter((candidate) =>
+      `${candidateLabel(candidate)} ${candidate.user_id}`.toLocaleLowerCase().includes(query),
+    );
+  }, [candidates, search]);
+
+  const toggleCandidate = (userId: number, checked: boolean) => {
+    const next = new Set(selected);
+    if (checked) {
+      next.add(userId);
+    } else {
+      next.delete(userId);
+    }
+    onSelectionChange([...next]);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <Label htmlFor="partition-member-search">Users</Label>
+        <span className="text-xs text-muted-foreground" aria-live="polite">
+          {selectedUserIds.length} selected
+        </span>
+      </div>
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <Input
+          id="partition-member-search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search by name or user ID..."
+          className="pl-9"
+        />
+      </div>
+
+      <div className="max-h-64 overflow-y-auto rounded-md border" role="group" aria-label="Available users">
+        {isLoading ? (
+          <div className="space-y-2 p-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Skeleton key={index} className="h-11 w-full" />
+            ))}
+          </div>
+        ) : isError ? (
+          <p className="p-4 text-center text-sm text-destructive">
+            Users could not be loaded. Close the dialog and try again.
+          </p>
+        ) : candidates.length === 0 ? (
+          <p className="p-4 text-center text-sm text-muted-foreground">
+            All users are already members of this partition.
+          </p>
+        ) : filteredCandidates.length === 0 ? (
+          <p className="p-4 text-center text-sm text-muted-foreground">
+            No users match this search.
+          </p>
+        ) : (
+          <div className="divide-y">
+            {filteredCandidates.map((candidate) => {
+              const label = candidateLabel(candidate);
+              const checkboxId = `partition-member-${candidate.user_id}`;
+              return (
+                <label
+                  key={candidate.user_id}
+                  htmlFor={checkboxId}
+                  className="flex min-h-11 cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/50"
+                >
+                  <Checkbox
+                    id={checkboxId}
+                    checked={selected.has(candidate.user_id)}
+                    onCheckedChange={(checked) => toggleCandidate(candidate.user_id, checked === true)}
+                    aria-label={`Select ${label}, user ID ${candidate.user_id}`}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{label}</span>
+                    <span className="block font-mono text-xs text-muted-foreground">
+                      User ID {candidate.user_id}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/admin/partitions/member-picker.tsx
+++ b/ui/src/pages/admin/partitions/member-picker.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { PartitionMemberCandidate } from "@/lib/api/partitions";
-import { candidateLabel } from "./member-candidate";
+import { candidateLabel, candidateSecondaryLabel } from "./member-candidate";
 
 interface MemberPickerProps {
   candidates: PartitionMemberCandidate[];
@@ -91,13 +91,14 @@ export function MemberPicker({
           <p className="text-xs font-medium text-muted-foreground">Selected users</p>
           {selectedCandidates.map((candidate) => {
             const label = candidateLabel(candidate);
+            const secondaryLabel = candidateSecondaryLabel(candidate);
             return (
               <div
                 key={candidate.user_id}
                 className="flex items-center justify-between gap-2 rounded bg-background px-2 py-1.5 text-sm"
               >
                 <span className="min-w-0 truncate">
-                  {label} <span className="font-mono text-xs text-muted-foreground">#{candidate.user_id}</span>
+                  {label} <span className="text-xs text-muted-foreground">({secondaryLabel})</span>
                 </span>
                 <Button
                   type="button"
@@ -105,7 +106,7 @@ export function MemberPicker({
                   size="icon"
                   className="h-6 w-6 shrink-0"
                   onClick={() => toggleCandidate(candidate, false)}
-                  aria-label={`Remove ${label}, user ID ${candidate.user_id}`}
+                  aria-label={`Remove ${label}, ${secondaryLabel}`}
                 >
                   <X className="h-3.5 w-3.5" />
                 </Button>
@@ -153,6 +154,7 @@ export function MemberPicker({
             <div className="divide-y">
               {candidates.map((candidate) => {
                 const label = candidateLabel(candidate);
+                const secondaryLabel = candidateSecondaryLabel(candidate);
                 const checkboxId = `partition-member-${candidate.user_id}`;
                 return (
                   <label
@@ -164,13 +166,11 @@ export function MemberPicker({
                       id={checkboxId}
                       checked={selected.has(candidate.user_id)}
                       onCheckedChange={(checked) => toggleCandidate(candidate, checked === true)}
-                      aria-label={`Select ${label}, user ID ${candidate.user_id}`}
+                      aria-label={`Select ${label}, ${secondaryLabel}`}
                     />
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm font-medium">{label}</span>
-                      <span className="block font-mono text-xs text-muted-foreground">
-                        User ID {candidate.user_id}
-                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">{secondaryLabel}</span>
                     </span>
                   </label>
                 );


### PR DESCRIPTION
## Why

Partition access is granted to people, but partition owners usually know a name rather than an internal numeric ID. Requiring raw IDs makes the workflow difficult to verify and increases the risk of granting access to the wrong account.

## What changed

The add-member dialog now supports targeted search by display-name prefix and matching ASCII user ID. Results include email when available so duplicate names can be distinguished, selected identities remain visible, and one role can be assigned to multiple people.

Candidate search is paginated and remains stable while memberships change. Concurrent additions cannot overwrite an existing role, and refresh, paging, and per-user failures remain visible and retryable.

## Compatibility

Adding a member is now insert-only. Posting an existing member returns `409` and preserves their current role; callers must use the existing role-update endpoint to change it.

## Trust model

Search gating and pagination prevent the UI from loading the complete user directory at once. They are load and usability controls, not a privacy boundary. Partition owners are trusted to discover the identities needed to manage access.

## Validation

- Admin UI: 179 tests passed
- Backend unit suite: 2234 tests passed
- Production Admin UI build
- Python and Admin UI lint
- Alembic migration graph has one head

Closes #777

Related to #757 and #809.