### PR TITLE
feat(evaluation) 6/15: eval_datasets and eval_runs persistence

### DIFF
--- a/openrag/core/ports/catalog_store.py
+++ b/openrag/core/ports/catalog_store.py
@@ -13,6 +13,7 @@ from .chunk_repo import ChunkRepository
 from .conversation_repo import ConversationRepository
 from .document_repo import DocumentRepository
 from .entity_repo import EntityRepository
+from .evaluation_repo import EvaluationRepository
 from .idempotency_repo import IdempotencyRepository
 from .job_repo import JobRepository
 from .model_endpoint_repo import ModelEndpointRepository
@@ -69,6 +70,10 @@ class CatalogStore(ABC):
     @property
     @abstractmethod
     def preset_repo(self) -> PresetRepository: ...
+
+    @property
+    @abstractmethod
+    def evaluation_repo(self) -> EvaluationRepository: ...
 
     @property
     @abstractmethod

--- a/openrag/core/ports/evaluation_repo.py
+++ b/openrag/core/ports/evaluation_repo.py
@@ -1,0 +1,63 @@
+"""Port for evaluation dataset and run persistence."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from core.models.evaluation import EvalDataset, EvalRun, EvalRunStatus
+
+
+class EvaluationRepository(ABC):
+    """Storage contract for evaluation datasets and runs."""
+
+    @abstractmethod
+    async def create_dataset(self, dataset: EvalDataset) -> EvalDataset:
+        """Persist a new dataset row."""
+
+    @abstractmethod
+    async def list_datasets(self) -> list[EvalDataset]:
+        """All datasets, newest first."""
+
+    @abstractmethod
+    async def get_dataset(self, dataset_id: str) -> EvalDataset | None:
+        """One dataset, or ``None`` when it does not exist."""
+
+    @abstractmethod
+    async def delete_dataset(self, dataset_id: str) -> bool:
+        """Delete a dataset. Returns ``False`` when nothing was deleted."""
+
+    @abstractmethod
+    async def create_run(self, run: EvalRun) -> EvalRun:
+        """Persist a queued run.
+
+        Raises:
+            ConflictError: A run is already active. At most one may be, and the
+                store is what enforces it.
+        """
+
+    @abstractmethod
+    async def list_runs(self, limit: int = 50) -> list[EvalRun]:
+        """Recent runs, newest first."""
+
+    @abstractmethod
+    async def get_run(self, run_id: str) -> EvalRun | None:
+        """One run with its metrics, or ``None``."""
+
+    @abstractmethod
+    async def active_run(self) -> EvalRun | None:
+        """The run currently occupying the runner, if any.
+
+        Advisory only — mutual exclusion between starts is enforced by the
+        store's single-active-run index, not by reading this.
+        """
+
+    @abstractmethod
+    async def update_run_status(self, run_id: str, status: EvalRunStatus, *, error: str | None = None) -> None:
+        """Move a run to a new status, stamping ``finished_at`` when terminal."""
+
+    @abstractmethod
+    async def save_run_results(self, run: EvalRun) -> None:
+        """Write the metric payloads and terminal status of a finished run."""
+
+
+__all__ = ["EvaluationRepository"]

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from core.ports.conversation_repo import ConversationRepository
     from core.ports.document_repo import DocumentRepository
     from core.ports.entity_repo import EntityRepository
+    from core.ports.evaluation_repo import EvaluationRepository
     from core.ports.idempotency_repo import IdempotencyRepository
     from core.ports.job_repo import JobRepository
     from core.ports.model_endpoint_repo import ModelEndpointRepository
@@ -359,6 +360,10 @@ class ServiceContainer:
     @property
     def preset_repo(self) -> PresetRepository:
         return self.catalog_store.preset_repo
+
+    @property
+    def evaluation_repo(self) -> EvaluationRepository:
+        return self.catalog_store.evaluation_repo
 
     # ------------------------------------------------------------------
     # Orchestrators (Phase 8)

--- a/openrag/services/persistence/evaluation_repo.py
+++ b/openrag/services/persistence/evaluation_repo.py
@@ -1,0 +1,210 @@
+"""asyncpg-backed :class:`EvaluationRepository`.
+
+Backs the ``eval_datasets`` and ``eval_runs`` tables. Metric payloads round-trip
+as JSONB; the dataclasses in ``core.models.evaluation`` define their shape.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+from core.models.evaluation import (
+    AnswerMetrics,
+    EvalCaseResult,
+    EvalDataset,
+    EvalRun,
+    EvalRunStatus,
+    FileIndexingSample,
+    IndexingMetrics,
+    RetrievalMetrics,
+)
+from core.ports.evaluation_repo import EvaluationRepository
+from core.utils.exceptions import ConflictError
+
+if TYPE_CHECKING:
+    import asyncpg
+
+_ACTIVE_STATUSES = ("QUEUED", "INDEXING", "EVALUATING")
+
+
+def _dump(payload: Any) -> str | None:
+    """Serialise a metrics dataclass — or a list of them — for a JSONB column."""
+    if payload is None:
+        return None
+    if isinstance(payload, list):
+        return json.dumps([asdict(item) for item in payload])
+    return json.dumps(asdict(payload) if hasattr(payload, "__dataclass_fields__") else payload)
+
+
+def _load(raw: Any) -> Any:
+    """asyncpg returns JSONB as ``str`` unless a codec is registered."""
+    if raw is None:
+        return None
+    return json.loads(raw) if isinstance(raw, str | bytes) else raw
+
+
+class PgEvaluationRepository(EvaluationRepository):
+    """asyncpg-backed implementation of :class:`EvaluationRepository`."""
+
+    def __init__(self, pool_getter: Callable[[], asyncpg.Pool]) -> None:
+        self._pool_getter = pool_getter
+
+    @property
+    def pool(self) -> asyncpg.Pool:
+        return self._pool_getter()
+
+    # ── datasets ─────────────────────────────────────────────────────
+
+    async def create_dataset(self, dataset: EvalDataset) -> EvalDataset:
+        row = await self.pool.fetchrow(
+            """
+            INSERT INTO eval_datasets (id, name, corpus_file_count,
+                                       testset_row_count, created_by)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            """,
+            dataset.id,
+            dataset.name,
+            dataset.corpus_file_count,
+            dataset.testset_row_count,
+            dataset.created_by,
+        )
+        return self._row_to_dataset(row)
+
+    async def list_datasets(self) -> list[EvalDataset]:
+        rows = await self.pool.fetch("SELECT * FROM eval_datasets ORDER BY created_at DESC")
+        return [self._row_to_dataset(row) for row in rows]
+
+    async def get_dataset(self, dataset_id: str) -> EvalDataset | None:
+        row = await self.pool.fetchrow("SELECT * FROM eval_datasets WHERE id = $1", dataset_id)
+        return self._row_to_dataset(row) if row else None
+
+    async def delete_dataset(self, dataset_id: str) -> bool:
+        result = await self.pool.execute("DELETE FROM eval_datasets WHERE id = $1", dataset_id)
+        return result.endswith(" 1")
+
+    # ── runs ─────────────────────────────────────────────────────────
+
+    async def create_run(self, run: EvalRun) -> EvalRun:
+        import asyncpg
+
+        try:
+            row = await self.pool.fetchrow(
+                """
+                INSERT INTO eval_runs (id, dataset_id, status, created_by)
+                VALUES ($1, $2, $3, $4)
+                RETURNING *
+                """,
+                run.id,
+                run.dataset_id,
+                run.status.value,
+                run.created_by,
+            )
+        except asyncpg.UniqueViolationError as exc:
+            # ux_eval_runs_single_active: a run is already in flight.
+            raise ConflictError("An evaluation run is already in progress.") from exc
+        return self._row_to_run(row)
+
+    async def list_runs(self, limit: int = 50) -> list[EvalRun]:
+        rows = await self.pool.fetch("SELECT * FROM eval_runs ORDER BY started_at DESC LIMIT $1", limit)
+        return [self._row_to_run(row) for row in rows]
+
+    async def get_run(self, run_id: str) -> EvalRun | None:
+        row = await self.pool.fetchrow("SELECT * FROM eval_runs WHERE id = $1", run_id)
+        return self._row_to_run(row) if row else None
+
+    async def active_run(self) -> EvalRun | None:
+        row = await self.pool.fetchrow(
+            """
+            SELECT * FROM eval_runs
+            WHERE status = ANY($1::text[])
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            list(_ACTIVE_STATUSES),
+        )
+        return self._row_to_run(row) if row else None
+
+    async def update_run_status(self, run_id: str, status: EvalRunStatus, *, error: str | None = None) -> None:
+        await self.pool.execute(
+            """
+            UPDATE eval_runs
+               SET status = $2,
+                   error = COALESCE($3, error),
+                   finished_at = CASE WHEN $4 THEN now() ELSE finished_at END
+             WHERE id = $1
+            """,
+            run_id,
+            status.value,
+            error,
+            status.is_terminal,
+        )
+
+    async def save_run_results(self, run: EvalRun) -> None:
+        await self.pool.execute(
+            """
+            UPDATE eval_runs
+               SET status = $2,
+                   indexing = $3::jsonb,
+                   retrieval = $4::jsonb,
+                   answer = $5::jsonb,
+                   cases = $6::jsonb,
+                   error = $7,
+                   finished_at = now()
+             WHERE id = $1
+            """,
+            run.id,
+            run.status.value,
+            _dump(run.indexing),
+            _dump(run.retrieval),
+            _dump(run.answer),
+            _dump(run.cases),
+            run.error,
+        )
+
+    # ── row mapping ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _row_to_dataset(row: Any) -> EvalDataset:
+        return EvalDataset(
+            id=row["id"],
+            name=row["name"],
+            corpus_file_count=row["corpus_file_count"],
+            testset_row_count=row["testset_row_count"],
+            created_at=row["created_at"],
+            created_by=row["created_by"],
+        )
+
+    @staticmethod
+    def _row_to_run(row: Any) -> EvalRun:
+        indexing = _load(row["indexing"])
+        retrieval = _load(row["retrieval"])
+        answer = _load(row["answer"])
+        cases = _load(row["cases"]) or []
+        samples = indexing.pop("samples", []) if indexing else []
+        return EvalRun(
+            id=row["id"],
+            dataset_id=row["dataset_id"],
+            status=EvalRunStatus(row["status"]),
+            started_at=row["started_at"],
+            finished_at=row["finished_at"],
+            indexing=(
+                IndexingMetrics(
+                    **indexing,
+                    samples=[FileIndexingSample(**sample) for sample in samples],
+                )
+                if indexing
+                else None
+            ),
+            retrieval=RetrievalMetrics(**retrieval) if retrieval else None,
+            answer=AnswerMetrics(**answer) if answer else None,
+            cases=[EvalCaseResult(**case) for case in cases],
+            error=row["error"],
+            created_by=row["created_by"],
+        )
+
+
+__all__ = ["PgEvaluationRepository"]

--- a/openrag/services/persistence/migrations/alembic/versions/a7c9e1f2b3d4_add_evaluation_tables.py
+++ b/openrag/services/persistence/migrations/alembic/versions/a7c9e1f2b3d4_add_evaluation_tables.py
@@ -1,0 +1,104 @@
+"""add evaluation datasets and runs
+
+Revision ID: a7c9e1f2b3d4
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-27 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from schema_helpers import index_exists, table_exists
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c9e1f2b3d4"
+down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Idempotent: ``Base.metadata.create_all()`` runs at startup, so a freshly
+    bootstrapped database already has these tables before alembic sees them.
+    """
+    if not table_exists("eval_datasets"):
+        op.create_table(
+            "eval_datasets",
+            sa.Column("id", sa.String, primary_key=True),
+            sa.Column("name", sa.String, nullable=False),
+            sa.Column("corpus_file_count", sa.Integer, server_default="0", nullable=False),
+            sa.Column("testset_row_count", sa.Integer, server_default="0", nullable=False),
+            sa.Column(
+                "created_by",
+                sa.Integer,
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+    if not table_exists("eval_runs"):
+        op.create_table(
+            "eval_runs",
+            sa.Column("id", sa.String, primary_key=True),
+            sa.Column(
+                "dataset_id",
+                sa.String,
+                sa.ForeignKey("eval_datasets.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("status", sa.String, server_default="QUEUED", nullable=False),
+            sa.Column("indexing", postgresql.JSONB, nullable=True),
+            sa.Column("retrieval", postgresql.JSONB, nullable=True),
+            sa.Column("answer", postgresql.JSONB, nullable=True),
+            sa.Column("cases", postgresql.JSONB, nullable=True),
+            sa.Column("error", sa.String, nullable=True),
+            sa.Column(
+                "created_by",
+                sa.Integer,
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "started_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('QUEUED','INDEXING','EVALUATING','COMPLETED','FAILED','CANCELLED')",
+                name="ck_eval_run_status",
+            ),
+        )
+    # At most one active run. Created separately from the table so a database
+    # already bootstrapped by create_all() picks it up too.
+    if not index_exists("eval_runs", "ux_eval_runs_single_active"):
+        op.create_index(
+            "ux_eval_runs_single_active",
+            "eval_runs",
+            [sa.text("(status IS NOT NULL)")],
+            unique=True,
+            postgresql_where=sa.text("status IN ('QUEUED','INDEXING','EVALUATING')"),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    if index_exists("eval_runs", "ux_eval_runs_single_active"):
+        op.drop_index("ux_eval_runs_single_active", table_name="eval_runs")
+    if table_exists("eval_runs"):
+        op.drop_table("eval_runs")
+    if table_exists("eval_datasets"):
+        op.drop_table("eval_datasets")

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -331,6 +331,77 @@ workspace_files = Table(
 )
 
 
+eval_datasets = Table(
+    "eval_datasets",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column("name", String, nullable=False),
+    Column("corpus_file_count", Integer, server_default="0", nullable=False),
+    Column("testset_row_count", Integer, server_default="0", nullable=False),
+    Column(
+        "created_by",
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        server_default=text("now()"),
+        nullable=False,
+    ),
+)
+
+
+eval_runs = Table(
+    "eval_runs",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column(
+        "dataset_id",
+        String,
+        ForeignKey("eval_datasets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("status", String, server_default=text("'QUEUED'"), nullable=False),
+    # Metric payloads, shaped by core.models.evaluation. Stored as JSONB rather
+    # than columns because the metric set is expected to grow.
+    Column("indexing", JSONB, nullable=True),
+    Column("retrieval", JSONB, nullable=True),
+    Column("answer", JSONB, nullable=True),
+    Column("cases", JSONB, nullable=True),
+    Column("error", String, nullable=True),
+    Column(
+        "created_by",
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
+    Column(
+        "started_at",
+        DateTime(timezone=True),
+        server_default=text("now()"),
+        nullable=False,
+        index=True,
+    ),
+    Column("finished_at", DateTime(timezone=True), nullable=True),
+    CheckConstraint(
+        "status IN ('QUEUED','INDEXING','EVALUATING','COMPLETED','FAILED','CANCELLED')",
+        name="ck_eval_run_status",
+    ),
+    # At most one active run: starting one regenerates the shared eval user's
+    # token, so concurrent runs would revoke each other's credentials. Indexing
+    # an always-true expression lets the partial index admit a single row.
+    Index(
+        "ux_eval_runs_single_active",
+        text("(status IS NOT NULL)"),
+        unique=True,
+        postgresql_where=text("status IN ('QUEUED','INDEXING','EVALUATING')"),
+    ),
+)
+
+
 __all__ = [
     "metadata",
     "model_endpoints",
@@ -343,4 +414,6 @@ __all__ = [
     "partition_memberships",
     "workspaces",
     "workspace_files",
+    "eval_datasets",
+    "eval_runs",
 ]

--- a/openrag/services/storage/postgres_store.py
+++ b/openrag/services/storage/postgres_store.py
@@ -31,6 +31,7 @@ from services.persistence.connection import ConnectionManager
 from services.persistence.conversation_repo import PgConversationRepository
 from services.persistence.document_repo import PgDocumentRepository
 from services.persistence.entity_repo import PgEntityRepository
+from services.persistence.evaluation_repo import PgEvaluationRepository
 from services.persistence.idempotency_repo import PgIdempotencyRepository
 from services.persistence.job_repo import PgJobRepository
 from services.persistence.model_endpoint_repo import PgModelEndpointRepository
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
     from core.ports.conversation_repo import ConversationRepository
     from core.ports.document_repo import DocumentRepository
     from core.ports.entity_repo import EntityRepository
+    from core.ports.evaluation_repo import EvaluationRepository
     from core.ports.idempotency_repo import IdempotencyRepository
     from core.ports.job_repo import JobRepository
     from core.ports.model_endpoint_repo import ModelEndpointRepository
@@ -96,6 +98,7 @@ class PostgresStore(CatalogStore):
         self._topic_tag_repo = PgTopicTagRepository(pool_getter)
         self._model_endpoint_repo = PgModelEndpointRepository(pool_getter)
         self._preset_repo = PgPresetRepository(pool_getter)
+        self._evaluation_repo = PgEvaluationRepository(pool_getter)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -213,6 +216,10 @@ class PostgresStore(CatalogStore):
     @property
     def preset_repo(self) -> PresetRepository:
         return self._preset_repo
+
+    @property
+    def evaluation_repo(self) -> EvaluationRepository:
+        return self._evaluation_repo
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
Part **6 of 15** of the split of #811. Targets `eval/05-promptfoo-config` (#816).

## What

| | |
|---|---|
| `core/ports/evaluation_repo.py` | the `EvaluationRepository` contract |
| `services/persistence/evaluation_repo.py` | asyncpg implementation |
| `services/persistence/schema.py` | `eval_datasets`, `eval_runs` |
| `migrations/.../a7c9e1f2b3d4_add_evaluation_tables.py` | the migration |
| `postgres_store.py`, `catalog_store.py`, `di/container.py` | expose it on the store and the container |

## Notable

- **The store enforces one run at a time, not the orchestrator.** `ux_eval_runs_single_active` is a partial unique index over an always-true expression, so it admits exactly one row in `QUEUED`/`INDEXING`/`EVALUATING`; `create_run` maps the resulting `UniqueViolationError` to `ConflictError`. A read-then-insert in the service would be a race, and not a harmless one — starting a run regenerates a shared service user's token (part 8), so two racing starts that both passed a read check would revoke each other's credentials mid-indexing.
- **Metrics are JSONB, not columns.** The metric set is expected to grow, and the dataclasses in `core/models/evaluation.py` already define the shape. `_row_to_run` reconstructs them, including lifting `samples` back out of the indexing payload.
- **`_load` exists because asyncpg returns JSONB as `str`** unless a codec is registered on the pool; the repo does not own the pool, so it decodes defensively instead.
- **`created_by` is `ON DELETE SET NULL`**, matching how `files.created_by` behaves — deleting an admin should not cascade away the run history they produced. `eval_runs.dataset_id` *is* `ON DELETE CASCADE`: a run without its dataset is not meaningful.
- **The migration is idempotent** per this repo's alembic rules (`CLAUDE.md`): `Base.metadata.create_all()` runs at startup, so a freshly bootstrapped database already has these tables before alembic sees them. Every op is guarded by `table_exists` / `index_exists`, in both directions.

## Testing

`ruff`, format check, the layer-import guard, and the full unit suite (2258 passed) — including the container and catalog-store wiring tests, which the new abstract property could have broken. The one failure, `test_content_deduplication_can_be_disabled_by_env`, reproduces on `develop`.
