### PR TITLE
feat(evaluation) 8/15: define the EvaluationRunner port

### DIFF
--- a/openrag/core/evaluation/runner.py
+++ b/openrag/core/evaluation/runner.py
@@ -1,0 +1,67 @@
+"""Port for handing an evaluation run to the worker layer.
+
+``EvaluationService`` owns the orchestration around a run — provisioning the
+throwaway partition and the service-user token, enforcing one-run-at-a-time,
+recording the queued row. The run *itself* (upload the corpus over HTTP, shell
+out to promptfoo, fold the outputs into metrics) executes inside the
+``EvalRunner`` Ray actor.
+
+Defining the three operations the orchestrator needs on a dedicated port keeps
+it Ray-free — the Phase 9 rule that all Ray code lives under
+``services/workers/`` (``docs/refactoring/REFACTORING_STRATEGY_v1.md``). The
+adapter in ``services/workers/eval_dispatcher.py`` binds this to the actor;
+tests bind it to a fake.
+
+No Ray types cross this boundary — only plain strings, mappings and bools.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+class EvaluationRunner(ABC):
+    """Operations the evaluation orchestrator needs from the worker layer."""
+
+    @abstractmethod
+    async def is_busy(self) -> bool:
+        """Whether a run currently occupies the runner.
+
+        Doubles as the orchestrator's liveness probe, so an implementation
+        must raise rather than hang when the worker cannot be reached.
+        """
+        ...
+
+    @abstractmethod
+    async def dispatch(
+        self,
+        *,
+        run_id: str,
+        partition: str,
+        token: str,
+        api_base_url: str,
+        corpus_dir: str,
+        cases: Sequence[Mapping[str, Any]],
+    ) -> None:
+        """Hand a queued run to the worker.
+
+        Fire-and-forget: the worker owns the run from here and records its own
+        terminal status, so this returns as soon as the work is accepted.
+        """
+        ...
+
+    @abstractmethod
+    async def cancel(self, run_id: str) -> bool:
+        """Ask the worker to abandon a run.
+
+        Returns ``False`` when no worker owns ``run_id`` — the orchestrator
+        reaps the orphaned row itself in that case.
+        """
+        ...
+
+
+__all__ = ["EvaluationRunner"]


### PR DESCRIPTION
Part **8 of 15** of the split of #811. Targets `eval/07-dataset-service` (#818). One file, no behaviour — but it is the boundary the next three parts are shaped by, so it is worth reading on its own.

## What

`core/evaluation/runner.py`: the contract between the evaluation orchestrator and the worker layer — `is_busy`, `dispatch`, `cancel`.

## Notable

- **Why a port at all.** `EvaluationService` (parts 7 and 9) owns the orchestration around a run: provisioning the throwaway partition and the service-user token, enforcing one-run-at-a-time, recording the queued row. The run *itself* executes inside a Ray actor (part 10). Declaring the three operations the orchestrator needs on a dedicated port keeps it Ray-free, per the Phase 9 rule that all Ray code lives under `services/workers/` (`docs/refactoring/REFACTORING_STRATEGY_v1.md`). Same port/adapter shape as `IndexingDispatcher`.
- **No Ray types cross it** — only strings, mappings and bools. That is what lets part 9's tests bind an in-memory fake and run with no actor, no worker process and no Ray import.
- **Two docstring contracts are load-bearing**, not decoration:
  - `is_busy` doubles as the liveness probe, so an implementation **must raise rather than hang** when the worker is unreachable. Part 9 depends on this to fail a start fast instead of stranding a run in `QUEUED`.
  - `dispatch` is fire-and-forget — the worker owns the run once accepted and writes its own terminal status. Consequently `cancel` returning `False` means *no worker owns this run*, which is the orchestrator's signal to reap the row itself rather than wait for a status that will never arrive.

## Testing

`ruff` and the layer-import guard pass. Behaviour is exercised in part 9 (against a fake) and part 10 (the Ray adapter).
