### PR TITLE
feat(evaluation) 12/15: UI API client for the evaluation endpoints

### DIFF
--- a/ui/src/components/shared/status-badge.tsx
+++ b/ui/src/components/shared/status-badge.tsx
@@ -5,6 +5,7 @@ const statusStyles: Record<string, string> = {
   PROCESSING: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
   RUNNING: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
   INDEXING: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  EVALUATING: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
   // OpenRag indexing-task states (TaskStateManager)
   SERIALIZING: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
   CANCELLED: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200",

--- a/ui/src/lib/api/evaluation.ts
+++ b/ui/src/lib/api/evaluation.ts
@@ -1,0 +1,146 @@
+import { request } from "./client";
+
+// Admin evaluation endpoints:
+//   GET    /evaluation/datasets          → EvalDataset[]
+//   POST   /evaluation/datasets          → EvalDataset (multipart)
+//   DELETE /evaluation/datasets/{id}     → 204
+//   GET    /evaluation/runs              → EvalRunSummary[]
+//   POST   /evaluation/runs              → EvalRun (202, 409 when one is in flight)
+//   GET    /evaluation/runs/{id}         → EvalRun
+//   POST   /evaluation/runs/{id}/cancel  → EvalRun
+
+export interface EvalDataset {
+  id: string;
+  name: string;
+  corpus_file_count: number;
+  testset_row_count: number;
+  created_at: string | null;
+  created_by: number | null;
+}
+
+export type EvalRunStatus =
+  | "QUEUED"
+  | "INDEXING"
+  | "EVALUATING"
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED";
+
+export const ACTIVE_RUN_STATUSES: EvalRunStatus[] = ["QUEUED", "INDEXING", "EVALUATING"];
+
+export function isActiveStatus(status: EvalRunStatus): boolean {
+  return ACTIVE_RUN_STATUSES.includes(status);
+}
+
+/** Refetch cadence while a run can still change, shared by both eval views. */
+export const EVAL_POLL_MS = 3000;
+
+export interface FileIndexingSample {
+  filename: string;
+  size_bytes: number;
+  duration_seconds: number;
+  failed: boolean;
+}
+
+export interface IndexingMetrics {
+  files_total: number;
+  files_failed: number;
+  bytes_total: number;
+  wall_seconds: number;
+  files_per_minute: number;
+  megabytes_per_second: number;
+  p50_seconds: number;
+  p95_seconds: number;
+  by_extension: Record<string, Record<string, number>>;
+  samples: FileIndexingSample[];
+}
+
+export interface RetrievalMetrics {
+  scored_cases: number;
+  skipped_cases: number;
+  hit_rate: number;
+  mrr: number;
+  recall: number;
+  context_relevance: number | null;
+}
+
+export interface AnswerMetrics {
+  scored_cases: number;
+  pass_rate: number;
+  factuality: number | null;
+  rubric_score: number | null;
+}
+
+export interface EvalCase {
+  query: string;
+  retrieved_file_ids: string[];
+  expected_file_ids: string[];
+  hit: boolean | null;
+  reciprocal_rank: number | null;
+  answer: string | null;
+  answer_passed: boolean | null;
+  grader_reason: string | null;
+}
+
+export interface EvalRun {
+  id: string;
+  dataset_id: string;
+  status: EvalRunStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  indexing: IndexingMetrics | null;
+  retrieval: RetrievalMetrics | null;
+  answer: AnswerMetrics | null;
+  cases: EvalCase[];
+  error: string | null;
+  created_by: number | null;
+}
+
+export interface EvalRunSummary {
+  id: string;
+  dataset_id: string;
+  status: EvalRunStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  hit_rate: number | null;
+  mrr: number | null;
+  answer_pass_rate: number | null;
+  files_per_minute: number | null;
+  error: string | null;
+}
+
+export function listEvalDatasets() {
+  return request<EvalDataset[]>("/evaluation/datasets");
+}
+
+export function createEvalDataset(name: string, testset: File, corpus: File[]) {
+  const body = new FormData();
+  body.append("name", name);
+  body.append("testset", testset);
+  // FastAPI reads repeated parts as `list[UploadFile]`.
+  corpus.forEach((file) => body.append("corpus", file));
+  return request<EvalDataset>("/evaluation/datasets", { method: "POST", body });
+}
+
+export function deleteEvalDataset(id: string) {
+  return request<void>(`/evaluation/datasets/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+export function listEvalRuns(limit = 50) {
+  return request<EvalRunSummary[]>(`/evaluation/runs?limit=${limit}`);
+}
+
+export function startEvalRun(datasetId: string) {
+  return request<EvalRun>("/evaluation/runs", {
+    method: "POST",
+    body: JSON.stringify({ dataset_id: datasetId }),
+  });
+}
+
+export function getEvalRun(id: string) {
+  return request<EvalRun>(`/evaluation/runs/${encodeURIComponent(id)}`);
+}
+
+export function cancelEvalRun(id: string) {
+  return request<EvalRun>(`/evaluation/runs/${encodeURIComponent(id)}/cancel`, { method: "POST" });
+}


### PR DESCRIPTION
Part **12 of 15** of the split of #811. Targets `eval/11-api-routes` (#822). First of three UI parts: data layer → components → page.

## What

`ui/src/lib/api/evaluation.ts` — typed wrappers over the seven `/evaluation` routes, with interfaces mirroring part 11's response schemas one-for-one.

## Notable

- **Two shared definitions live here rather than in the views.** `isActiveStatus` / `ACTIVE_RUN_STATUSES` gives "can this run still change?" one definition instead of a status list repeated in each view, and `EVAL_POLL_MS` gives the poll cadence one home — both the run list and the run detail poll while a run is in flight, and they should not be able to drift apart.
- **`createEvalDataset` appends `corpus` repeatedly**, which is how FastAPI reads `list[UploadFile]`.
- **`status-badge` learns `EVALUATING`** so a run in its promptfoo phase renders like every other in-flight status rather than falling through to the default styling.

## Testing

`tsc -b` clean; `eslint` reports only the one warning that is already on `develop` (`react-hooks/exhaustive-deps` in an unrelated file). No behaviour yet — nothing imports this until part 13.
