### PR TITLE
feat(evaluation) 13/15: dataset card and run detail components

### DIFF
--- a/ui/src/pages/admin/evaluation/dataset-card.tsx
+++ b/ui/src/pages/admin/evaluation/dataset-card.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Play, Trash2, Upload } from "lucide-react";
+import {
+  createEvalDataset,
+  deleteEvalDataset,
+  listEvalDatasets,
+  startEvalRun,
+} from "@/lib/api/evaluation";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const CSV_HINT = "question,expected_answer,expected_file_ids";
+
+export function DatasetCard({ runActive }: { runActive: boolean }) {
+  const queryClient = useQueryClient();
+  const [uploadOpen, setUploadOpen] = useState(false);
+
+  const { data, isLoading } = useQuery({ queryKey: ["eval-datasets"], queryFn: listEvalDatasets });
+
+  const startMut = useMutation({
+    mutationFn: (datasetId: string) => startEvalRun(datasetId),
+    onSuccess: () => {
+      toast.success("Evaluation run queued");
+      queryClient.invalidateQueries({ queryKey: ["eval-runs"] });
+    },
+    onError: (e) => toast.error((e as Error).message),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteEvalDataset(id),
+    onSuccess: () => {
+      toast.success("Dataset deleted");
+      queryClient.invalidateQueries({ queryKey: ["eval-datasets"] });
+    },
+    onError: (e) => toast.error((e as Error).message),
+  });
+
+  const datasets = data ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between">
+        <div>
+          <CardTitle>Datasets</CardTitle>
+          <CardDescription>
+            A corpus to index plus a CSV test set (<code>{CSV_HINT}</code>).
+          </CardDescription>
+        </div>
+        <Button size="sm" onClick={() => setUploadOpen(true)}>
+          <Upload className="mr-2 h-4 w-4" />
+          New dataset
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-24" />
+        ) : datasets.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No datasets yet. Upload a corpus and a test set to run an evaluation.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead className="text-right">Files</TableHead>
+                <TableHead className="text-right">Questions</TableHead>
+                <TableHead className="w-32" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {datasets.map((dataset) => (
+                <TableRow key={dataset.id}>
+                  <TableCell className="font-medium">{dataset.name}</TableCell>
+                  <TableCell className="text-right tabular-nums">{dataset.corpus_file_count}</TableCell>
+                  <TableCell className="text-right tabular-nums">{dataset.testset_row_count}</TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={runActive || startMut.isPending}
+                      title={runActive ? "Another run is already in progress" : undefined}
+                      onClick={() => startMut.mutate(dataset.id)}
+                    >
+                      <Play className="mr-1 h-3 w-3" />
+                      Run
+                    </Button>
+                    <ConfirmDialog
+                      title="Delete dataset?"
+                      description={`"${dataset.name}" and its stored files will be removed. Past runs keep their results.`}
+                      onConfirm={() => deleteMut.mutate(dataset.id)}
+                    >
+                      <Button size="sm" variant="ghost" aria-label={`Delete ${dataset.name}`}>
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </ConfirmDialog>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <UploadDialog open={uploadOpen} onOpenChange={setUploadOpen} />
+    </Card>
+  );
+}
+
+function UploadDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [testset, setTestset] = useState<File | null>(null);
+  const [corpus, setCorpus] = useState<File[]>([]);
+
+  const reset = () => {
+    setName("");
+    setTestset(null);
+    setCorpus([]);
+  };
+
+  const createMut = useMutation({
+    mutationFn: () => createEvalDataset(name, testset as File, corpus),
+    onSuccess: (dataset) => {
+      toast.success(`Dataset "${dataset.name}" created (${dataset.testset_row_count} questions)`);
+      queryClient.invalidateQueries({ queryKey: ["eval-datasets"] });
+      reset();
+      onOpenChange(false);
+    },
+    // The API validates the CSV row by row; surface its message verbatim.
+    onError: (e) => toast.error((e as Error).message),
+  });
+
+  const canSubmit = name.trim() !== "" && testset !== null && corpus.length > 0;
+
+  // Every dismissal path — backdrop, Escape, Cancel — clears the form, so a
+  // reopened dialog never silently resubmits the previous selection.
+  const close = () => {
+    reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New evaluation dataset</DialogTitle>
+          <DialogDescription>
+            The corpus is re-indexed on every run, which is what the indexing-speed numbers measure.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="eval-dataset-name">Name</Label>
+            <Input
+              id="eval-dataset-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Support docs — July"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="eval-testset">Test set (CSV)</Label>
+            <Input
+              id="eval-testset"
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(e) => setTestset(e.target.files?.[0] ?? null)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Header: <code>{CSV_HINT}</code>. <code>expected_file_ids</code> is optional and
+              semicolon-separated; rows without it are excluded from hit rate, MRR and recall.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="eval-corpus">Corpus files</Label>
+            <Input
+              id="eval-corpus"
+              type="file"
+              multiple
+              onChange={(e) => setCorpus(Array.from(e.target.files ?? []))}
+            />
+            {corpus.length > 0 && (
+              <p className="text-xs text-muted-foreground">{corpus.length} file(s) selected</p>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={close}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || createMut.isPending} onClick={() => createMut.mutate()}>
+            {createMut.isPending ? "Uploading…" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/pages/admin/evaluation/run-detail.tsx
+++ b/ui/src/pages/admin/evaluation/run-detail.tsx
@@ -1,0 +1,240 @@
+import { useQuery } from "@tanstack/react-query";
+import { EVAL_POLL_MS, getEvalRun, isActiveStatus, type EvalRun } from "@/lib/api/evaluation";
+import { StatusBadge } from "@/components/shared/status-badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+function percent(value: number | null | undefined): string {
+  return value === null || value === undefined ? "—" : `${(value * 100).toFixed(1)}%`;
+}
+
+function score(value: number | null | undefined): string {
+  return value === null || value === undefined ? "—" : value.toFixed(3);
+}
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="space-y-1">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-mono text-lg font-medium tabular-nums">{value}</dd>
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+export function RunDetail({ runId }: { runId: string }) {
+  const { data: run, isLoading } = useQuery({
+    queryKey: ["eval-run", runId],
+    queryFn: () => getEvalRun(runId),
+    // Poll only while the run can still change.
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && isActiveStatus(status) ? EVAL_POLL_MS : false;
+    },
+  });
+
+  if (isLoading) return <Skeleton className="h-64" />;
+  if (!run) return null;
+
+  return (
+    <div className="space-y-4">
+      <RunHeader run={run} />
+      {run.error && (
+        <Alert variant="destructive">
+          <AlertDescription className="[overflow-wrap:anywhere]">{run.error}</AlertDescription>
+        </Alert>
+      )}
+      <IndexingPanel run={run} />
+      <QualityPanel run={run} />
+      <CasesTable run={run} />
+    </div>
+  );
+}
+
+function RunHeader({ run }: { run: EvalRun }) {
+  const elapsed =
+    run.started_at && run.finished_at
+      ? `${Math.round(
+          (new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()) / 1000,
+        )}s`
+      : "—";
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle className="font-mono text-base">{run.id.slice(0, 12)}</CardTitle>
+          <CardDescription>
+            Started {run.started_at ? new Date(run.started_at).toLocaleString() : "—"} · took {elapsed}
+          </CardDescription>
+        </div>
+        <StatusBadge status={run.status} />
+      </CardHeader>
+    </Card>
+  );
+}
+
+function IndexingPanel({ run }: { run: EvalRun }) {
+  const metrics = run.indexing;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Indexing speed</CardTitle>
+        <CardDescription>End-to-end ingestion of the corpus into a throwaway partition.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!metrics ? (
+          <p className="text-sm text-muted-foreground">Not measured yet.</p>
+        ) : (
+          <>
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm sm:grid-cols-4">
+              <Stat label="Files / min" value={metrics.files_per_minute.toFixed(1)} />
+              <Stat label="MB / s" value={metrics.megabytes_per_second.toFixed(2)} />
+              <Stat label="p50 per file" value={`${metrics.p50_seconds.toFixed(1)}s`} />
+              <Stat label="p95 per file" value={`${metrics.p95_seconds.toFixed(1)}s`} />
+              <Stat label="Wall time" value={`${metrics.wall_seconds.toFixed(1)}s`} />
+              <Stat
+                label="Files"
+                value={`${metrics.files_total}`}
+                hint={metrics.files_failed > 0 ? `${metrics.files_failed} failed` : undefined}
+              />
+              <Stat
+                label="Corpus size"
+                value={`${(metrics.bytes_total / (1024 * 1024)).toFixed(1)} MB`}
+              />
+            </dl>
+            {Object.keys(metrics.by_extension).length > 1 && (
+              <div className="mt-4 flex flex-wrap gap-4 border-t pt-4 text-xs text-muted-foreground">
+                {Object.entries(metrics.by_extension).map(([extension, bucket]) => (
+                  <span key={extension}>
+                    <span className="font-mono">{extension}</span> · {bucket.files} file(s) ·{" "}
+                    {bucket.mean_seconds}s avg
+                  </span>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function QualityPanel({ run }: { run: EvalRun }) {
+  const retrieval = run.retrieval;
+  const answer = run.answer;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Retrieval quality</CardTitle>
+          <CardDescription>
+            {retrieval
+              ? `${retrieval.scored_cases} question(s) scored${
+                  retrieval.skipped_cases > 0
+                    ? `, ${retrieval.skipped_cases} skipped (no expected_file_ids)`
+                    : ""
+                }`
+              : "Not measured yet."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {retrieval && (
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
+              <Stat label="Hit rate" value={percent(retrieval.hit_rate)} />
+              <Stat label="MRR" value={score(retrieval.mrr)} />
+              <Stat label="Recall" value={percent(retrieval.recall)} />
+              <Stat label="Context relevance" value={score(retrieval.context_relevance)} />
+            </dl>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Answer quality</CardTitle>
+          <CardDescription>
+            {answer ? `${answer.scored_cases} answer(s) graded by the LLM` : "Not measured yet."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {answer && (
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
+              <Stat label="Pass rate" value={percent(answer.pass_rate)} />
+              <Stat label="Factuality" value={score(answer.factuality)} />
+              <Stat label="Rubric" value={score(answer.rubric_score)} />
+            </dl>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function CasesTable({ run }: { run: EvalRun }) {
+  if (run.cases.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Questions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Question</TableHead>
+                <TableHead className="w-20">Hit</TableHead>
+                <TableHead className="w-20">RR</TableHead>
+                <TableHead className="w-24">Answer</TableHead>
+                <TableHead>Grader</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {run.cases.map((testCase, index) => (
+                <TableRow key={`${testCase.query}-${index}`}>
+                  <TableCell className="max-w-md">
+                    <p className="truncate font-medium" title={testCase.query}>
+                      {testCase.query}
+                    </p>
+                    {testCase.retrieved_file_ids.length > 0 && (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {testCase.retrieved_file_ids.join(", ")}
+                      </p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {testCase.hit === null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      <StatusBadge status={testCase.hit ? "SUCCESS" : "FAILED"} />
+                    )}
+                  </TableCell>
+                  <TableCell className="tabular-nums">
+                    {testCase.reciprocal_rank === null ? "—" : testCase.reciprocal_rank.toFixed(2)}
+                  </TableCell>
+                  <TableCell>
+                    {testCase.answer_passed === null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      <StatusBadge status={testCase.answer_passed ? "SUCCESS" : "FAILED"} />
+                    )}
+                  </TableCell>
+                  <TableCell className="max-w-sm">
+                    <p className="truncate text-xs text-muted-foreground" title={testCase.grader_reason ?? ""}>
+                      {testCase.grader_reason ?? "—"}
+                    </p>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Part **13 of 15** of the split of #811. Targets `eval/12-ui-api-client` (#823). Two self-contained components; the page composing them is part 14.

## What

- **`DatasetCard`** — lists stored datasets, owns the upload dialog, the start button and the delete confirmation.
- **`RunDetail`** — one run: header, error, indexing panel, quality panel, per-question table.

## Notable

- **Starting is gated on `runActive`**, passed down from the run list. Runs are serialised server-side, so the button should be disabled rather than reliably return `409` — the API still enforces it, this just stops the UI from inviting a click it knows will fail.
- **`RunDetail` polls only while the run can still change** (`isActiveStatus`, part 12). A finished run stops refetching rather than polling a row that will never change again.
- **Errors are rendered with `[overflow-wrap:anywhere]`** — a run error can be a 2000-char promptfoo stderr tail with no spaces in it, which would otherwise blow out the layout.
- **The metric panels degrade rather than disappear.** A run that failed during indexing has `retrieval`/`answer` as `null`; each panel renders "Not measured yet" so the reader can tell *how far* the run got.

## Testing

`tsc -b` clean; `eslint` reports only the warning already present on `develop`. Rendering tests land with the page in part 14, where the components are reachable.
