### PR TITLE
fix(llm): drop falsy logprobs from payloads for strict providers

### DIFF
--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -116,6 +116,22 @@ def _log_safe_error_detail(exc: BaseException) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _strip_falsy_logprobs(payload: dict) -> dict:
+    """Drop a falsy ``logprobs`` (and its dependent ``top_logprobs``) from *payload*.
+
+    ``logprobs: false`` is already the OpenAI default, so sending it adds
+    nothing — but strict providers whose schema lacks the field reject it by
+    name whatever the value, e.g. Gemini. Without
+    this, the config default (``LLMParamsConfig.logprobs = False``) lands in
+    ``self._defaults`` and is sent on every request. A truthy value is a
+    deliberate opt-in and is forwarded as-is.
+    """
+    if not payload.get("logprobs"):
+        payload.pop("logprobs", None)
+        payload.pop("top_logprobs", None)
+    return payload
+
+
 @llm_registry.register("vllm")
 class VLLMClient(LLM):
     """OpenAI-compatible LLM client backed by vLLM.
@@ -193,6 +209,7 @@ class VLLMClient(LLM):
             chat_template_kwargs = dict(payload_kwargs.get("chat_template_kwargs") or {})
             chat_template_kwargs.setdefault("enable_thinking", enable_thinking)
             payload_kwargs["chat_template_kwargs"] = chat_template_kwargs
+        payload_kwargs = _strip_falsy_logprobs(payload_kwargs)
         return payload_kwargs
 
     @with_circuit_breaker("llm")
@@ -201,6 +218,7 @@ class VLLMClient(LLM):
         base_url, model, headers = self._resolve_overrides(kwargs)
         kwargs.pop("metadata", None)
         payload = {**self._defaults, **kwargs, "model": model, "prompt": prompt}
+        payload = _strip_falsy_logprobs(payload)
         log_llm_call(caller="VLLMClient.generate", model=model, endpoint=base_url, prompt=prompt)
         try:
             resp = await self._client.post(f"{base_url}/completions", json=payload, headers=headers)

--- a/openrag/services/inference/vllm_client.py
+++ b/openrag/services/inference/vllm_client.py
@@ -117,7 +117,7 @@ def _log_safe_error_detail(exc: BaseException) -> dict:
 
 
 def _strip_falsy_logprobs(payload: dict) -> dict:
-    """Drop a falsy ``logprobs`` (and its dependent ``top_logprobs``) from *payload*.
+    """Drop an unset/off ``logprobs`` (and its dependent ``top_logprobs``) from *payload*.
 
     ``logprobs: false`` is already the OpenAI default, so sending it adds
     nothing — but strict providers whose schema lacks the field reject it by
@@ -125,8 +125,16 @@ def _strip_falsy_logprobs(payload: dict) -> dict:
     this, the config default (``LLMParamsConfig.logprobs = False``) lands in
     ``self._defaults`` and is sent on every request. A truthy value is a
     deliberate opt-in and is forwarded as-is.
+
+    Checked with ``is`` against ``None``/``False`` rather than plain
+    truthiness (or ``in (None, False)``, which suffers the same problem since
+    ``0 == False``): the legacy ``/completions`` endpoint's ``logprobs`` is an
+    *integer* (how many alternates to return), where ``0`` is a deliberate,
+    meaningful request — "give me the sampled token's own logprob, no
+    alternates" — not an off state, and must not be conflated with it.
     """
-    if not payload.get("logprobs"):
+    logprobs = payload.get("logprobs")
+    if logprobs is None or logprobs is False:
         payload.pop("logprobs", None)
         payload.pop("top_logprobs", None)
     return payload

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -307,6 +307,21 @@ class TestVLLMClient:
         assert captured["logprobs"] == 5
 
     @pytest.mark.asyncio
+    async def test_zero_logprobs_forwarded_on_generate(self):
+        """`/completions`' integer `logprobs` treats 0 as a deliberate request
+        (the sampled token's own logprob, no alternates) — distinct from
+        unset/False. A truthiness check would wrongly conflate 0 with off."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _completions_response()
+
+        await self._make_client(capture).generate("hi", logprobs=0)
+
+        assert captured["logprobs"] == 0
+
+    @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
         c = VLLMClient(endpoint="http://vllm:8000/v1/", model_name="m")
         assert c._endpoint == "http://vllm:8000/v1"

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -277,7 +277,7 @@ class TestVLLMClient:
         assert "top_logprobs" not in captured
 
     @pytest.mark.asyncio
-    async def test_truthy_logprobs_forwarded(self):
+    async def test_truthy_logprobs_forwarded_on_chat(self):
         """An explicit opt-in must keep flowing through unchanged."""
         captured: dict = {}
 
@@ -289,6 +289,22 @@ class TestVLLMClient:
 
         assert captured["logprobs"] is True
         assert captured["top_logprobs"] == 5
+
+    @pytest.mark.asyncio
+    async def test_truthy_logprobs_forwarded_on_generate(self):
+        """Same opt-in guarantee on the completions path. `/completions` takes
+        an integer `logprobs` (not the chat API's bool + `top_logprobs`), so a
+        truthy int must survive untouched — the strip is falsy-only, not a
+        blanket removal of the field."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _completions_response()
+
+        await self._make_client(capture).generate("hi", logprobs=5)
+
+        assert captured["logprobs"] == 5
 
     @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):

--- a/tests/unit/services/inference/test_vllm_client.py
+++ b/tests/unit/services/inference/test_vllm_client.py
@@ -234,6 +234,63 @@ class TestVLLMClient:
         assert "max_retries" not in captured
 
     @pytest.mark.asyncio
+    async def test_falsy_config_logprobs_not_forwarded_on_chat(self):
+        """The DI container forwards LLMParamsConfig.logprobs (default False)
+        into self._defaults. `logprobs: false` is the OpenAI default, so it adds
+        nothing — but strict providers whose schema lacks the field reject it by
+        name whatever the value, e.g. Gemini"""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        await self._make_client(capture, logprobs=False).chat([{"role": "user", "content": "hi"}])
+
+        assert "logprobs" not in captured
+
+    @pytest.mark.asyncio
+    async def test_falsy_config_logprobs_not_forwarded_on_generate(self):
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _completions_response()
+
+        await self._make_client(capture, logprobs=False).generate("hi")
+
+        assert "logprobs" not in captured
+
+    @pytest.mark.asyncio
+    async def test_falsy_request_logprobs_dropped_with_top_logprobs(self):
+        """A client sending `logprobs: false` alongside `top_logprobs` must not
+        leak either: top_logprobs is only meaningful when logprobs is on."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        await self._make_client(capture).chat([{"role": "user", "content": "hi"}], logprobs=False, top_logprobs=3)
+
+        assert "logprobs" not in captured
+        assert "top_logprobs" not in captured
+
+    @pytest.mark.asyncio
+    async def test_truthy_logprobs_forwarded(self):
+        """An explicit opt-in must keep flowing through unchanged."""
+        captured: dict = {}
+
+        def capture(req: httpx.Request) -> httpx.Response:
+            captured.update(json.loads(req.content))
+            return _chat_response()
+
+        await self._make_client(capture).chat([{"role": "user", "content": "hi"}], logprobs=True, top_logprobs=5)
+
+        assert captured["logprobs"] is True
+        assert captured["top_logprobs"] == 5
+
+    @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):
         c = VLLMClient(endpoint="http://vllm:8000/v1/", model_name="m")
         assert c._endpoint == "http://vllm:8000/v1"


### PR DESCRIPTION
Falsy logprobs were making 400 when using /chat/completions with external LLM providers such as Gemini 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented disabled log-probability settings from being sent in inference requests.
  * Ensured related top-log-probability settings are omitted when log probabilities are disabled.
  * Preserved both settings when log probabilities are explicitly enabled.
  * Preserved an explicitly configured `logprobs=0` value for completion requests.

* **Tests**
  * Added coverage for log-probability serialization across chat and text completion requests, including disabled, enabled, and zero-value configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->