### PR TITLE
feat(ui): admin prompt library and prompt selection in the preset/partition editors

### DIFF
--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   Cpu,
   Settings,
+  MessageSquareText,
   Users,
   Activity,
   UserCog,
@@ -40,6 +41,7 @@ const navItems: NavItem[] = [
   { title: "Jobs", href: "/jobs", icon: Clock },
   { title: "Models", href: "/models", icon: Cpu, requires: (p) => p.canManageModels },
   { title: "Presets", href: "/presets", icon: Settings, requires: (p) => p.canManagePresets },
+  { title: "Prompts", href: "/prompts", icon: MessageSquareText, requires: (p) => p.canManagePrompts },
   { title: "Users", href: "/users", icon: Users, requires: (p) => p.canManageUsers },
   { title: "System", href: "/system", icon: Activity, requires: (p) => p.canViewSystem },
 ];

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
   {
     variants: {
       variant: {
@@ -62,7 +62,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-3 py-1 text-xs font-semibold whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -66,6 +66,10 @@ export interface PartitionConfig {
   document_count: number;
   chat_history_depth: number;
   chat_llm: string | null;
+  // Generation prompts selected for this partition, keyed by prompt type
+  // (sys_prompt / spoken_style_answer / query_contextualizer). Absent keys fall
+  // back to the type's global default.
+  generation_prompt_names: Record<string, string>;
 }
 
 export interface UpdatePartitionRequest {
@@ -75,6 +79,7 @@ export interface UpdatePartitionRequest {
   retrieval_preset?: string;
   chat_history_depth?: number;
   chat_llm?: string | null;
+  generation_prompt_names?: Record<string, string>;
   /** Accepted for compat but never sent (server has no such column). */
   collection_name?: string;
 }
@@ -90,6 +95,7 @@ const _PATCH_FIELDS = [
   "retrieval_preset",
   "chat_history_depth",
   "chat_llm",
+  "generation_prompt_names",
 ] as const;
 
 function _toRow(r: Record<string, unknown>): PartitionResponse {

--- a/ui/src/lib/api/partitions.ts
+++ b/ui/src/lib/api/partitions.ts
@@ -66,9 +66,8 @@ export interface PartitionConfig {
   document_count: number;
   chat_history_depth: number;
   chat_llm: string | null;
-  // Generation prompts selected for this partition, keyed by prompt type
-  // (sys_prompt / spoken_style_answer / query_contextualizer). Absent keys fall
-  // back to the type's global default.
+  // The final-answer prompt selected for this partition, keyed by prompt type
+  // (sys_prompt). Absent = the type's global default.
   generation_prompt_names: Record<string, string>;
 }
 

--- a/ui/src/lib/api/prompts.test.ts
+++ b/ui/src/lib/api/prompts.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
+  listAllPrompts,
   listPrompts,
   getPrompt,
   createPrompt,
@@ -99,5 +100,39 @@ describe("CRUD verbs and paths", () => {
     fetchMock.mockResolvedValue(fakeResponse({ body: "{}" }));
     await getPrompt("a b/c");
     expect(lastCall().url).toBe("/prompts/a%20b%2Fc");
+  });
+});
+
+// A single capped request hid prompts past the cap and reported a partial count
+// as the total, leaving them unmanageable in the library and unselectable in
+// every picker.
+describe("listAllPrompts", () => {
+  const page = (n: number, from: number) =>
+    JSON.stringify(Array.from({ length: n }, (_, i) => ({ id: `p${from + i}`, name: `p${from + i}` })));
+
+  it("follows pagination until a short page", async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ body: page(200, 0) }))
+      .mockResolvedValueOnce(fakeResponse({ body: page(200, 200) }))
+      .mockResolvedValueOnce(fakeResponse({ body: page(37, 400) }));
+
+    const all = await listAllPrompts();
+
+    expect(all).toHaveLength(437);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1][0]).toContain("offset=200");
+    expect(fetchMock.mock.calls[2][0]).toContain("offset=400");
+  });
+
+  it("stops after one request when the first page is short", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ body: page(7, 0) }));
+    expect(await listAllPrompts()).toHaveLength(7);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty library without looping", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ body: "[]" }));
+    expect(await listAllPrompts()).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/lib/api/prompts.test.ts
+++ b/ui/src/lib/api/prompts.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  listPrompts,
+  getPrompt,
+  createPrompt,
+  updatePrompt,
+  setPromptDefault,
+  deletePrompt,
+} from "./prompts";
+
+function fakeResponse({
+  status = 200,
+  body = "{}",
+}: { status?: number; body?: string } = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (key: string) => (key.toLowerCase() === "content-type" ? "application/json" : null) },
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function lastCall() {
+  const [url, init] = fetchMock.mock.calls.at(-1)!;
+  return { url: url as string, init: (init ?? {}) as RequestInit };
+}
+
+describe("listPrompts", () => {
+  it("hits /prompts/ and returns the bare array", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: '[{"id":"1","name":"a","used_by":2}]' }));
+    const result = await listPrompts();
+    expect(lastCall().url).toBe("/prompts/");
+    expect(result).toEqual([{ id: "1", name: "a", used_by: 2 }]);
+  });
+
+  it("serializes type/offset/limit into the query string", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: "[]" }));
+    await listPrompts({ prompt_type: "sys_prompt", offset: 10, limit: 50 });
+    expect(lastCall().url).toBe("/prompts/?prompt_type=sys_prompt&offset=10&limit=50");
+  });
+});
+
+describe("CRUD verbs and paths", () => {
+  it("getPrompt → GET /prompts/{id}", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: '{"id":"abc"}' }));
+    await getPrompt("abc");
+    const { url, init } = lastCall();
+    expect(url).toBe("/prompts/abc");
+    expect(init.method ?? "GET").toBe("GET");
+  });
+
+  it("createPrompt → POST /prompts/ with a JSON body", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ status: 201, body: '{"id":"new"}' }));
+    await createPrompt({ prompt_type: "hyde", name: "x", content: "c" });
+    const { url, init } = lastCall();
+    expect(url).toBe("/prompts/");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ prompt_type: "hyde", name: "x", content: "c" });
+  });
+
+  it("updatePrompt → PATCH /prompts/{id}", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: '{"id":"abc"}' }));
+    await updatePrompt("abc", { content: "new" });
+    const { url, init } = lastCall();
+    expect(url).toBe("/prompts/abc");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ content: "new" });
+  });
+
+  it("setPromptDefault → PUT /prompts/{id}/default", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: '{"id":"abc","is_default":true}' }));
+    await setPromptDefault("abc");
+    const { url, init } = lastCall();
+    expect(url).toBe("/prompts/abc/default");
+    expect(init.method).toBe("PUT");
+  });
+
+  it("deletePrompt → DELETE /prompts/{id} (204)", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ status: 204, body: "" }));
+    await deletePrompt("abc");
+    const { url, init } = lastCall();
+    expect(url).toBe("/prompts/abc");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("url-encodes the id", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ body: "{}" }));
+    await getPrompt("a b/c");
+    expect(lastCall().url).toBe("/prompts/a%20b%2Fc");
+  });
+});

--- a/ui/src/lib/api/prompts.ts
+++ b/ui/src/lib/api/prompts.ts
@@ -67,6 +67,26 @@ export function listPrompts(params?: {
   return request<PromptResponse[]>(`${BASE}/${qs ? `?${qs}` : ""}`);
 }
 
+/** Page size used when walking the whole library. The API caps `limit` at 500. */
+const PAGE_SIZE = 200;
+
+/** Fetch every library prompt, following offset pagination to the end.
+ *
+ *  The management page and every prompt picker need the complete library: a
+ *  single capped request would silently hide prompts past the cap and report a
+ *  partial count as if it were the total, leaving those prompts unmanageable
+ *  and unselectable.
+ */
+export async function listAllPrompts(params?: { prompt_type?: PromptType }): Promise<PromptResponse[]> {
+  const all: PromptResponse[] = [];
+  for (let offset = 0; ; offset += PAGE_SIZE) {
+    const page = await listPrompts({ ...params, offset, limit: PAGE_SIZE });
+    all.push(...page);
+    // A short page means the end; a full page means there may be more.
+    if (page.length < PAGE_SIZE) return all;
+  }
+}
+
 export function getPrompt(id: string) {
   return request<PromptResponse>(`${BASE}/${enc(id)}`);
 }

--- a/ui/src/lib/api/prompts.ts
+++ b/ui/src/lib/api/prompts.ts
@@ -1,34 +1,62 @@
 import { request } from "./client";
 
-export interface PromptUsedBy {
-  count: number;
-  partitions: string[];
-}
+// OpenRag prompt library (admin-only). Mounted at `/prompts`.
+// Shapes verified against openrag/api/schemas/admin/prompt_schemas.py + routers/admin/prompts.py:
+//   GET    /prompts/                 list (bare array; optional ?prompt_type=&offset=&limit=)
+//   POST   /prompts/                 create → 201
+//   GET    /prompts/{id}             get one
+//   PATCH  /prompts/{id}             update (name/content/is_default)
+//   PUT    /prompts/{id}/default     promote to default for its type
+//   DELETE /prompts/{id}             delete → 204
+//
+// Prompts are *named*; a preset or partition selects one by naming it. There is
+// no partition-assignment endpoint — selection lives in the preset/partition
+// editors (see presets.tsx / partitions).
+
+// The 8 managed prompt types (mirrors PromptTypeName on the backend).
+export type PromptType =
+  | "sys_prompt"
+  | "query_contextualizer"
+  | "chunk_contextualizer"
+  | "image_captioning"
+  | "hyde"
+  | "multi_query"
+  | "spoken_style_answer"
+  | "topic_tagger";
 
 export interface PromptResponse {
   id: string;
-  prompt_type: string;
+  prompt_type: PromptType;
   name: string;
   content: string;
   is_default: boolean;
   created_at: string;
   updated_at: string;
-  used_by: PromptUsedBy | null;
+  // Number of partitions that reference this prompt by name (directly for
+  // generation prompts, transitively via preset for indexation/retrieval).
+  // Only populated by listPrompts(); single-item responses default it to 0.
+  used_by: number;
 }
 
-export interface PromptListResponse {
-  prompts: PromptResponse[];
-  offset: number;
-  limit: number;
+export interface CreatePromptRequest {
+  prompt_type: PromptType;
+  name: string;
+  content: string;
+  is_default?: boolean;
 }
 
-const BASE = "/api/v1/admin/prompts";
+export interface UpdatePromptRequest {
+  name?: string;
+  content?: string;
+  is_default?: boolean;
+}
 
-// Prompts is a dropped feature; presets only reads the prompt list (to pick a
-// chat prompt). The CRUD/partition-assignment surface was removed — re-add from
-// git history if a prompt-management page is reinstated.
+const BASE = "/prompts";
+const enc = encodeURIComponent;
+
+/** List library prompts (bare array). Optionally filter by type. */
 export function listPrompts(params?: {
-  prompt_type?: string;
+  prompt_type?: PromptType;
   offset?: number;
   limit?: number;
 }) {
@@ -37,5 +65,36 @@ export function listPrompts(params?: {
   if (params?.offset !== undefined) search.set("offset", String(params.offset));
   if (params?.limit !== undefined) search.set("limit", String(params.limit));
   const qs = search.toString();
-  return request<PromptListResponse>(`${BASE}${qs ? `?${qs}` : ""}`);
+  return request<PromptResponse[]>(`${BASE}/${qs ? `?${qs}` : ""}`);
+}
+
+export function getPrompt(id: string) {
+  return request<PromptResponse>(`${BASE}/${enc(id)}`);
+}
+
+export function createPrompt(data: CreatePromptRequest) {
+  return request<PromptResponse>(`${BASE}/`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function updatePrompt(id: string, data: UpdatePromptRequest) {
+  return request<PromptResponse>(`${BASE}/${enc(id)}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+/** Promote a prompt to the default for its type. */
+export function setPromptDefault(id: string) {
+  return request<PromptResponse>(`${BASE}/${enc(id)}/default`, {
+    method: "PUT",
+  });
+}
+
+export function deletePrompt(id: string) {
+  return request<void>(`${BASE}/${enc(id)}`, {
+    method: "DELETE",
+  });
 }

--- a/ui/src/lib/api/prompts.ts
+++ b/ui/src/lib/api/prompts.ts
@@ -21,7 +21,6 @@ export type PromptType =
   | "image_captioning"
   | "hyde"
   | "multi_query"
-  | "spoken_style_answer"
   | "topic_tagger";
 
 export interface PromptResponse {

--- a/ui/src/lib/permissions.ts
+++ b/ui/src/lib/permissions.ts
@@ -35,6 +35,7 @@ export interface Permissions {
   canManageUsers: boolean;
   canManageModels: boolean;
   canManagePresets: boolean;
+  canManagePrompts: boolean;
   canManagePartitions: boolean;
   // Any authenticated user may create (and thereby own) a partition — the backend's
   // POST /partition/{name} has no admin guard. Distinct from canManagePartitions,
@@ -74,6 +75,7 @@ export function usePermissions(): Permissions {
     canManageUsers: isAdmin,
     canManageModels: isAdmin,
     canManagePresets: isAdmin,
+    canManagePrompts: isAdmin,
     canManagePartitions: isAdmin,
     canCreatePartition: true,
     canRead: (role) => superAdmin || !!role,

--- a/ui/src/lib/prompt-meta.test.ts
+++ b/ui/src/lib/prompt-meta.test.ts
@@ -104,9 +104,13 @@ describe("renderPreview", () => {
     expect(flat('emit {{"a": 1}} verbatim')).toBe('emit {"a": 1} verbatim');
   });
 
-  it("substitutes a field carrying a format spec or conversion", () => {
-    expect(flat("Today is {current_date:>12}.")).toContain("2026-07-27");
-    expect(flat("Today is {current_date!r}.")).toContain("2026-07-27");
+  it("substitutes a modified field without emulating the format mini-language", () => {
+    // Python would pad to width 12 and `!r` would add quotes. The preview shows
+    // the illustrative sample where the value lands, and deliberately does not
+    // reimplement the format spec — asserted exactly so the choice is pinned
+    // rather than left ambiguous by a substring match.
+    expect(flat("Today is {current_date:>12}.")).toBe("Today is 2026-07-27.");
+    expect(flat("Today is {current_date!r}.")).toBe("Today is 2026-07-27.");
   });
 
   it("leaves an unknown field visible rather than dropping it", () => {

--- a/ui/src/lib/prompt-meta.test.ts
+++ b/ui/src/lib/prompt-meta.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROMPT_DEFAULT_OPTION,
+  promptOptionToName,
+  promptOptionValue,
+  promptSelectValue,
+  scanTemplate,
+  validatePlaceholders,
+} from "./prompt-meta";
+
+// The editor must reach the same verdict as the API's `string.Formatter`
+// validation, or a template looks fine here and comes back 422 on save.
+describe("scanTemplate", () => {
+  it("collects simple fields", () => {
+    expect(scanTemplate("Answer with {context} on {current_date}").fields).toEqual([
+      "context",
+      "current_date",
+    ]);
+  });
+
+  it("treats doubled braces as literal text, not placeholders", () => {
+    const scan = scanTemplate('emit {{"a": 1}} verbatim');
+    expect(scan.malformed).toBe(false);
+    expect(scan.fields).toEqual([]);
+  });
+
+  it("flags a lone opening brace the way Python does", () => {
+    expect(scanTemplate("what { is this").malformed).toBe(true);
+  });
+
+  it("flags a lone closing brace", () => {
+    expect(scanTemplate("what } is this").malformed).toBe(true);
+  });
+
+  it("reduces conversions, format specs and attribute/index access to the root", () => {
+    expect(scanTemplate("{context!r} {context:>10} {context.attr} {context[0]}").fields).toEqual([
+      "context",
+    ]);
+  });
+
+  it("treats auto-numbering as an unnamed field, which the API rejects", () => {
+    expect(validatePlaceholders("hello {}", "sys_prompt").unknown).toEqual([""]);
+  });
+});
+
+describe("validatePlaceholders", () => {
+  it("accepts a template using only its type's variables", () => {
+    const v = validatePlaceholders("Use {context} on {current_date}", "sys_prompt");
+    expect(v.unknown).toEqual([]);
+    expect(v.malformed).toBe(false);
+  });
+
+  it("reports an unknown variable", () => {
+    expect(validatePlaceholders("About {topic}", "sys_prompt").unknown).toEqual(["topic"]);
+  });
+
+  it("accepts any literal text for verbatim prompt types", () => {
+    // chunk_contextualizer is sent to the model as-is and never `.format`-ed,
+    // so braces in it are just characters.
+    const v = validatePlaceholders('Return {"json": true} exactly', "chunk_contextualizer");
+    expect(v.unknown).toEqual([]);
+    expect(v.malformed).toBe(false);
+  });
+});
+
+describe("prompt picker option values", () => {
+  it("round-trips a name", () => {
+    expect(promptOptionToName(promptOptionValue("legal-assistant"))).toBe("legal-assistant");
+  });
+
+  it("maps an unset name to the default sentinel", () => {
+    expect(promptSelectValue(undefined)).toBe(PROMPT_DEFAULT_OPTION);
+    expect(promptSelectValue("")).toBe(PROMPT_DEFAULT_OPTION);
+    expect(promptOptionToName(PROMPT_DEFAULT_OPTION)).toBe("");
+  });
+
+  it("keeps a prompt whose name looks like the sentinel selectable", () => {
+    // Names are free text, so the sentinel must not be able to collide with one.
+    for (const name of ["__default__", "__use_default__"]) {
+      const value = promptOptionValue(name);
+      expect(value).not.toBe(PROMPT_DEFAULT_OPTION);
+      expect(promptOptionToName(value)).toBe(name);
+    }
+  });
+});

--- a/ui/src/lib/prompt-meta.test.ts
+++ b/ui/src/lib/prompt-meta.test.ts
@@ -104,11 +104,10 @@ describe("renderPreview", () => {
     expect(flat('emit {{"a": 1}} verbatim')).toBe('emit {"a": 1} verbatim');
   });
 
-  it("substitutes a modified field without emulating the format mini-language", () => {
-    // Python would pad to width 12 and `!r` would add quotes. The preview shows
-    // the illustrative sample where the value lands, and deliberately does not
-    // reimplement the format spec — asserted exactly so the choice is pinned
-    // rather than left ambiguous by a substring match.
+  it("still previews a modified field, though such a template cannot be saved", () => {
+    // Modifiers are rejected at validation (see below), so this only governs
+    // what the editor shows while the author is mid-edit: the sample lands
+    // where the value would, with no attempt to emulate padding or `!r`.
     expect(flat("Today is {current_date:>12}.")).toBe("Today is 2026-07-27.");
     expect(flat("Today is {current_date!r}.")).toBe("Today is 2026-07-27.");
   });
@@ -120,5 +119,30 @@ describe("renderPreview", () => {
   it("previews a verbatim prompt type unchanged", () => {
     const raw = 'Return {"json": true} exactly';
     expect(flat(raw, "chunk_contextualizer")).toBe(raw);
+  });
+});
+
+
+// Reducing an expression to its root name made unrenderable templates look
+// valid: `{context!x}` raises ValueError and `{context.missing}` raises
+// AttributeError when the pipeline formats the prompt. As a type's default that
+// breaks every request, so only plain placeholders are accepted — mirroring
+// `_validate_template` on the API.
+describe("validatePlaceholders rejects non-plain placeholders", () => {
+  it.each([
+    "{context!x} on {current_date}",
+    "{context.missing} on {current_date}",
+    "{context[0]} on {current_date}",
+    "{context:>10} on {current_date}",
+  ])("rejects %s", (content) => {
+    const v = validatePlaceholders(content, "sys_prompt");
+    expect(v.malformed).toBe(true);
+    expect(v.error).toMatch(/not supported/);
+  });
+
+  it("still accepts the plain form", () => {
+    const v = validatePlaceholders("Use {context} on {current_date}", "sys_prompt");
+    expect(v.malformed).toBe(false);
+    expect(v.unknown).toEqual([]);
   });
 });

--- a/ui/src/lib/prompt-meta.test.ts
+++ b/ui/src/lib/prompt-meta.test.ts
@@ -4,6 +4,7 @@ import {
   promptOptionToName,
   promptOptionValue,
   promptSelectValue,
+  renderPreview,
   scanTemplate,
   validatePlaceholders,
 } from "./prompt-meta";
@@ -81,5 +82,39 @@ describe("prompt picker option values", () => {
       expect(value).not.toBe(PROMPT_DEFAULT_OPTION);
       expect(promptOptionToName(value)).toBe(name);
     }
+  });
+});
+
+// The preview must agree with what the pipeline actually renders — it shares
+// the tokenizer with validation so the two can't drift apart.
+describe("renderPreview", () => {
+  const flat = (content: string, type = "sys_prompt") =>
+    renderPreview(content, type)
+      .map((s) => s.value)
+      .join("");
+
+  it("substitutes a known variable with its sample", () => {
+    const segments = renderPreview("Today is {current_date}.", "sys_prompt");
+    const substituted = segments.find((s) => s.isVariable);
+    expect(substituted?.varName).toBe("current_date");
+    expect(flat("Today is {current_date}.")).toContain("2026-07-27");
+  });
+
+  it("unescapes doubled braces the way str.format does", () => {
+    expect(flat('emit {{"a": 1}} verbatim')).toBe('emit {"a": 1} verbatim');
+  });
+
+  it("substitutes a field carrying a format spec or conversion", () => {
+    expect(flat("Today is {current_date:>12}.")).toContain("2026-07-27");
+    expect(flat("Today is {current_date!r}.")).toContain("2026-07-27");
+  });
+
+  it("leaves an unknown field visible rather than dropping it", () => {
+    expect(flat("About {topic}")).toBe("About {topic}");
+  });
+
+  it("previews a verbatim prompt type unchanged", () => {
+    const raw = 'Return {"json": true} exactly';
+    expect(flat(raw, "chunk_contextualizer")).toBe(raw);
   });
 });

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -92,49 +92,77 @@ export interface TemplateScan {
   error?: string;
 }
 
-/** Scan a template the way Python's ``string.Formatter().parse`` does.
+type TemplateToken =
+  | { kind: "literal"; text: string }
+  | { kind: "field"; root: string; raw: string };
+
+interface TokenizeResult {
+  tokens: TemplateToken[];
+  malformed: boolean;
+  error?: string;
+}
+
+/** Tokenize a template the way Python's ``string.Formatter().parse`` does.
  *
- *  The backend validates with the real thing, so approximating it with a
- *  `/\{(\w+)\}/` regex let templates through that were rejected only on save:
- *  `{{` / `}}` are literal braces, a lone brace is an error, and a field may
- *  carry a conversion (`!r`), a format spec (`:>10`) or attribute/index access
- *  (`a.b`, `a[0]`) — all of which reduce to the root name.
+ *  Single source of grammar for both validation and the preview, so the two can
+ *  never disagree about what a template means: `{{`/`}}` are literal braces, a
+ *  lone brace is an error, and a field may carry a conversion (`!r`), a format
+ *  spec (`:>10`) or attribute/index access (`a.b`, `a[0]`), all of which reduce
+ *  to the root name the backend validates against.
  */
-export function scanTemplate(content: string): TemplateScan {
-  const fields: string[] = [];
+function tokenizeTemplate(content: string): TokenizeResult {
+  const tokens: TemplateToken[] = [];
+  let literal = "";
   let i = 0;
+  const flush = () => {
+    if (literal) {
+      tokens.push({ kind: "literal", text: literal });
+      literal = "";
+    }
+  };
   while (i < content.length) {
     const ch = content[i];
     if (ch === "{") {
       if (content[i + 1] === "{") {
+        literal += "{";
         i += 2;
         continue;
       }
       const end = content.indexOf("}", i + 1);
       if (end === -1) {
-        return { fields, malformed: true, error: "Single '{' encountered in format string" };
+        flush();
+        return { tokens, malformed: true, error: "Single '{' encountered in format string" };
       }
-      const root = content
-        .slice(i + 1, end)
-        .split("!")[0]
-        .split(":")[0]
-        .split(".")[0]
-        .split("[")[0]
-        .trim();
-      if (!fields.includes(root)) fields.push(root);
+      const raw = content.slice(i + 1, end);
+      const root = raw.split("!")[0].split(":")[0].split(".")[0].split("[")[0].trim();
+      flush();
+      tokens.push({ kind: "field", root, raw });
       i = end + 1;
       continue;
     }
     if (ch === "}") {
       if (content[i + 1] === "}") {
+        literal += "}";
         i += 2;
         continue;
       }
-      return { fields, malformed: true, error: "Single '}' encountered in format string" };
+      flush();
+      return { tokens, malformed: true, error: "Single '}' encountered in format string" };
     }
+    literal += ch;
     i += 1;
   }
-  return { fields, malformed: false };
+  flush();
+  return { tokens, malformed: false };
+}
+
+export function scanTemplate(content: string): TemplateScan {
+  const { tokens, malformed, error } = tokenizeTemplate(content);
+  const fields: string[] = [];
+  for (const token of tokens) {
+    if (token.kind === "field" && !fields.includes(token.root)) fields.push(token.root);
+  }
+  return { fields, malformed, error };
 }
 
 export function extractPlaceholders(content: string): string[] {
@@ -173,34 +201,30 @@ export interface PreviewSegment {
   varName?: string;
 }
 
-/** Substitute each known `{var}` with its sample value, tracking which spans
- *  were substituted so the preview can highlight them. */
+/** Render the template the way the pipeline will: substitute each known
+ *  `{var}` with its sample value, unescape `{{`/`}}`, and track which spans were
+ *  substituted so the preview can highlight them.
+ *
+ *  Shares `tokenizeTemplate` with validation so what an author sees here matches
+ *  what the model receives — a separate regex used to leave escaped braces
+ *  doubled and skip formatted fields entirely.
+ */
 export function renderPreview(content: string, promptType: string): PreviewSegment[] {
+  // Verbatim types are never `.format`-ed at runtime, so they preview as-is.
+  if (!FORMATTED_PROMPT_TYPES.has(promptType)) {
+    return content ? [{ value: content, isVariable: false }] : [];
+  }
   const vars = PROMPT_TYPE_VARIABLES[promptType] ?? [];
   const varMap = Object.fromEntries(vars.map((v) => [v.name, v.sample]));
+  const { tokens } = tokenizeTemplate(content);
 
-  const segments: PreviewSegment[] = [];
-  let lastIndex = 0;
-  let m: RegExpExecArray | null;
-  const regex = /\{(\w+)\}/g;
-
-  while ((m = regex.exec(content)) !== null) {
-    if (m.index > lastIndex) {
-      segments.push({ value: content.slice(lastIndex, m.index), isVariable: false });
-    }
-    const varName = m[1];
-    const sample = varMap[varName];
-    if (sample !== undefined) {
-      segments.push({ value: sample, isVariable: true, varName });
-    } else {
-      segments.push({ value: m[0], isVariable: false });
-    }
-    lastIndex = m.index + m[0].length;
-  }
-  if (lastIndex < content.length) {
-    segments.push({ value: content.slice(lastIndex), isVariable: false });
-  }
-  return segments;
+  return tokens.map((token) => {
+    if (token.kind === "literal") return { value: token.text, isVariable: false };
+    const sample = varMap[token.root];
+    return sample !== undefined
+      ? { value: sample, isVariable: true, varName: token.root }
+      : { value: `{${token.raw}}`, isVariable: false };
+  });
 }
 
 /* ---------- Prompt picker option values ---------- */

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -20,12 +20,9 @@ export interface PromptGroup {
 
 export const PROMPT_GROUPS: PromptGroup[] = [
   {
-    name: "Generation",
-    description: "Chat & answer prompts — selected per partition",
-    types: [
-      { value: "sys_prompt", label: "System prompt" },
-      { value: "spoken_style_answer", label: "Spoken-style answer" },
-    ],
+    name: "Answer",
+    description: "The final-answer prompt — selected per partition",
+    types: [{ value: "sys_prompt", label: "Final answer prompt" }],
   },
   {
     name: "Indexation",
@@ -69,10 +66,6 @@ export interface TemplateVariable {
 export const PROMPT_TYPE_VARIABLES: Record<string, TemplateVariable[]> = {
   sys_prompt: [
     { name: "context", description: "Retrieved document chunks injected by the pipeline", sample: "[Source 1] Employees are entitled to 20 days of paid vacation per year, accrued monthly." },
-    { name: "current_date", description: "Today's date, injected at request time", sample: "2026-07-27" },
-  ],
-  spoken_style_answer: [
-    { name: "context", description: "Retrieved document chunks injected by the pipeline", sample: "[Source 1] The office is open from 9am to 6pm on weekdays." },
     { name: "current_date", description: "Today's date, injected at request time", sample: "2026-07-27" },
   ],
   query_contextualizer: [

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -1,0 +1,148 @@
+import type { PromptType } from "@/lib/api/prompts";
+
+// Shared metadata for the 8 managed prompt types: their human labels, how they
+// group by concern, and the `{variables}` each template understands. Consumed by
+// the Prompt Library page and by the preset/partition editors that select a
+// prompt by name.
+
+export interface PromptTypeEntry {
+  value: PromptType;
+  label: string;
+}
+
+export interface PromptGroup {
+  // Concern this group of prompts belongs to.
+  name: string;
+  // Where a prompt of this concern is *selected* (presets vs partition).
+  description: string;
+  types: PromptTypeEntry[];
+}
+
+export const PROMPT_GROUPS: PromptGroup[] = [
+  {
+    name: "Generation",
+    description: "Chat & answer prompts — selected per partition",
+    types: [
+      { value: "sys_prompt", label: "System prompt" },
+      { value: "spoken_style_answer", label: "Spoken-style answer" },
+      { value: "query_contextualizer", label: "Query contextualizer" },
+    ],
+  },
+  {
+    name: "Indexation",
+    description: "Document-enrichment prompts — selected on the indexation preset",
+    types: [
+      { value: "chunk_contextualizer", label: "Contextualization" },
+      { value: "image_captioning", label: "Image captioning" },
+      { value: "topic_tagger", label: "Topic tagging" },
+    ],
+  },
+  {
+    name: "Retrieval",
+    description: "Query-transformation prompts — selected on the retrieval preset",
+    types: [
+      { value: "hyde", label: "HyDE" },
+      { value: "multi_query", label: "Multi-query" },
+    ],
+  },
+];
+
+export const PROMPT_TYPES: PromptTypeEntry[] = PROMPT_GROUPS.flatMap((g) => g.types);
+
+const PROMPT_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+  PROMPT_TYPES.map((t) => [t.value, t.label]),
+);
+
+export function promptTypeLabel(type: string): string {
+  return PROMPT_TYPE_LABELS[type] ?? type;
+}
+
+export interface TemplateVariable {
+  name: string;
+  description: string;
+  sample: string;
+}
+
+// Placeholders each template understands, keyed by prompt type. Empty arrays are
+// intentional: those prompts are system messages sent with the chunk/image
+// attached as a separate message — they take no inline placeholders.
+export const PROMPT_TYPE_VARIABLES: Record<string, TemplateVariable[]> = {
+  sys_prompt: [
+    { name: "context", description: "Retrieved document chunks injected by the pipeline", sample: "[Source 1] Employees are entitled to 20 days of paid vacation per year, accrued monthly." },
+    { name: "current_date", description: "Today's date, injected at request time", sample: "2026-07-27" },
+  ],
+  spoken_style_answer: [
+    { name: "context", description: "Retrieved document chunks injected by the pipeline", sample: "[Source 1] The office is open from 9am to 6pm on weekdays." },
+    { name: "current_date", description: "Today's date, injected at request time", sample: "2026-07-27" },
+  ],
+  query_contextualizer: [
+    { name: "current_date", description: "Today's date, injected at request time", sample: "2026-07-27" },
+    { name: "query_language", description: "Detected language of the user's query", sample: "English" },
+  ],
+  chunk_contextualizer: [],
+  image_captioning: [],
+  topic_tagger: [],
+  hyde: [
+    { name: "question", description: "The user's search query", sample: "How do I configure SSL certificates?" },
+  ],
+  multi_query: [
+    { name: "k_queries", description: "Number of alternative queries to generate", sample: "3" },
+    { name: "query", description: "The user's original search query", sample: "What are the termination clauses in the contract?" },
+  ],
+};
+
+const PLACEHOLDER_REGEX = /\{(\w+)\}/g;
+
+export function extractPlaceholders(content: string): string[] {
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  PLACEHOLDER_REGEX.lastIndex = 0;
+  while ((m = PLACEHOLDER_REGEX.exec(content)) !== null) {
+    if (!matches.includes(m[1])) matches.push(m[1]);
+  }
+  return matches;
+}
+
+export function validatePlaceholders(content: string, promptType: string) {
+  const used = extractPlaceholders(content);
+  const known = new Set((PROMPT_TYPE_VARIABLES[promptType] ?? []).map((v) => v.name));
+  const unknown = used.filter((v) => !known.has(v));
+  const missing = [...known].filter((v) => !used.includes(v));
+  return { used, unknown, missing };
+}
+
+export interface PreviewSegment {
+  value: string;
+  isVariable: boolean;
+  varName?: string;
+}
+
+/** Substitute each known `{var}` with its sample value, tracking which spans
+ *  were substituted so the preview can highlight them. */
+export function renderPreview(content: string, promptType: string): PreviewSegment[] {
+  const vars = PROMPT_TYPE_VARIABLES[promptType] ?? [];
+  const varMap = Object.fromEntries(vars.map((v) => [v.name, v.sample]));
+
+  const segments: PreviewSegment[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  const regex = /\{(\w+)\}/g;
+
+  while ((m = regex.exec(content)) !== null) {
+    if (m.index > lastIndex) {
+      segments.push({ value: content.slice(lastIndex, m.index), isVariable: false });
+    }
+    const varName = m[1];
+    const sample = varMap[varName];
+    if (sample !== undefined) {
+      segments.push({ value: sample, isVariable: true, varName });
+    } else {
+      segments.push({ value: m[0], isVariable: false });
+    }
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ value: content.slice(lastIndex), isVariable: false });
+  }
+  return segments;
+}

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -20,7 +20,7 @@ export interface PromptGroup {
 
 export const PROMPT_GROUPS: PromptGroup[] = [
   {
-    name: "Answer",
+    name: "Final Answer",
     description: "The final-answer prompt — selected per partition",
     types: [{ value: "sys_prompt", label: "Final answer prompt" }],
   },

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -25,7 +25,6 @@ export const PROMPT_GROUPS: PromptGroup[] = [
     types: [
       { value: "sys_prompt", label: "System prompt" },
       { value: "spoken_style_answer", label: "Spoken-style answer" },
-      { value: "query_contextualizer", label: "Query contextualizer" },
     ],
   },
   {
@@ -41,6 +40,7 @@ export const PROMPT_GROUPS: PromptGroup[] = [
     name: "Retrieval",
     description: "Query-transformation prompts — selected on the retrieval preset",
     types: [
+      { value: "query_contextualizer", label: "Query contextualizer" },
       { value: "hyde", label: "HyDE" },
       { value: "multi_query", label: "Multi-query" },
     ],

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -87,6 +87,9 @@ export const PROMPT_TYPE_VARIABLES: Record<string, TemplateVariable[]> = {
 export interface TemplateScan {
   /** Root field names, reduced the way the backend reduces them. */
   fields: string[];
+  /** Raw expressions carrying a conversion/format spec/attribute access, which
+   *  the API rejects as not-plain placeholders. */
+  modified: string[];
   /** True when Python's parser would raise — i.e. the API would return 422. */
   malformed: boolean;
   error?: string;
@@ -94,7 +97,7 @@ export interface TemplateScan {
 
 type TemplateToken =
   | { kind: "literal"; text: string }
-  | { kind: "field"; root: string; raw: string };
+  | { kind: "field"; root: string; raw: string; hasModifier: boolean };
 
 interface TokenizeResult {
   tokens: TemplateToken[];
@@ -135,8 +138,13 @@ function tokenizeTemplate(content: string): TokenizeResult {
       }
       const raw = content.slice(i + 1, end);
       const root = raw.split("!")[0].split(":")[0].split(".")[0].split("[")[0].trim();
+      // A conversion, format spec or attribute/index access is not a plain
+      // placeholder. The API rejects those because reducing them to a root name
+      // hides templates `.format()` cannot render (`{context!x}` raises
+      // ValueError, `{context.missing}` raises AttributeError).
+      const hasModifier = raw !== root;
       flush();
-      tokens.push({ kind: "field", root, raw });
+      tokens.push({ kind: "field", root, raw, hasModifier });
       i = end + 1;
       continue;
     }
@@ -159,10 +167,13 @@ function tokenizeTemplate(content: string): TokenizeResult {
 export function scanTemplate(content: string): TemplateScan {
   const { tokens, malformed, error } = tokenizeTemplate(content);
   const fields: string[] = [];
+  const modified: string[] = [];
   for (const token of tokens) {
-    if (token.kind === "field" && !fields.includes(token.root)) fields.push(token.root);
+    if (token.kind !== "field") continue;
+    if (!fields.includes(token.root)) fields.push(token.root);
+    if (token.hasModifier && !modified.includes(token.raw)) modified.push(token.raw);
   }
-  return { fields, malformed, error };
+  return { fields, modified, malformed, error };
 }
 
 export function extractPlaceholders(content: string): string[] {
@@ -192,6 +203,17 @@ export function validatePlaceholders(content: string, promptType: string) {
   const used = scan.fields;
   const unknown = used.filter((v) => !known.has(v));
   const missing = [...known].filter((v) => !used.includes(v));
+  if (!scan.malformed && scan.modified.length > 0) {
+    return {
+      used,
+      unknown,
+      missing,
+      malformed: true,
+      error:
+        `Placeholder {${scan.modified[0]}} uses a conversion, format spec or attribute access, ` +
+        `which is not supported. Use a plain placeholder.`,
+    };
+  }
   return { used, unknown, missing, malformed: scan.malformed, error: scan.error };
 }
 

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -208,6 +208,12 @@ export interface PreviewSegment {
  *  Shares `tokenizeTemplate` with validation so what an author sees here matches
  *  what the model receives — a separate regex used to leave escaped braces
  *  doubled and skip formatted fields entirely.
+ *
+ *  A field's conversion (`!r`) and format spec (`:>12`) are recognised but
+ *  deliberately NOT emulated: the substituted value is the illustrative sample,
+ *  not the runtime one, so reimplementing Python's format mini-language in
+ *  TypeScript would add a second thing to keep in sync for no gain. The preview
+ *  shows where a value lands, not its exact padding or quoting.
  */
 export function renderPreview(content: string, promptType: string): PreviewSegment[] {
   // Verbatim types are never `.format`-ed at runtime, so they preview as-is.

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -84,24 +84,87 @@ export const PROMPT_TYPE_VARIABLES: Record<string, TemplateVariable[]> = {
   ],
 };
 
-const PLACEHOLDER_REGEX = /\{(\w+)\}/g;
-
-export function extractPlaceholders(content: string): string[] {
-  const matches: string[] = [];
-  let m: RegExpExecArray | null;
-  PLACEHOLDER_REGEX.lastIndex = 0;
-  while ((m = PLACEHOLDER_REGEX.exec(content)) !== null) {
-    if (!matches.includes(m[1])) matches.push(m[1]);
-  }
-  return matches;
+export interface TemplateScan {
+  /** Root field names, reduced the way the backend reduces them. */
+  fields: string[];
+  /** True when Python's parser would raise — i.e. the API would return 422. */
+  malformed: boolean;
+  error?: string;
 }
 
+/** Scan a template the way Python's ``string.Formatter().parse`` does.
+ *
+ *  The backend validates with the real thing, so approximating it with a
+ *  `/\{(\w+)\}/` regex let templates through that were rejected only on save:
+ *  `{{` / `}}` are literal braces, a lone brace is an error, and a field may
+ *  carry a conversion (`!r`), a format spec (`:>10`) or attribute/index access
+ *  (`a.b`, `a[0]`) — all of which reduce to the root name.
+ */
+export function scanTemplate(content: string): TemplateScan {
+  const fields: string[] = [];
+  let i = 0;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "{") {
+      if (content[i + 1] === "{") {
+        i += 2;
+        continue;
+      }
+      const end = content.indexOf("}", i + 1);
+      if (end === -1) {
+        return { fields, malformed: true, error: "Single '{' encountered in format string" };
+      }
+      const root = content
+        .slice(i + 1, end)
+        .split("!")[0]
+        .split(":")[0]
+        .split(".")[0]
+        .split("[")[0]
+        .trim();
+      if (!fields.includes(root)) fields.push(root);
+      i = end + 1;
+      continue;
+    }
+    if (ch === "}") {
+      if (content[i + 1] === "}") {
+        i += 2;
+        continue;
+      }
+      return { fields, malformed: true, error: "Single '}' encountered in format string" };
+    }
+    i += 1;
+  }
+  return { fields, malformed: false };
+}
+
+export function extractPlaceholders(content: string): string[] {
+  return scanTemplate(content).fields;
+}
+
+/** Types the backend renders with `str.format` and therefore validates.
+ *
+ *  Mirrors `_PROMPT_FORMAT_FIELDS` in `prompt_service.py`. It cannot be derived
+ *  from `PROMPT_TYPE_VARIABLES`, because a type there may legitimately have an
+ *  empty variable list; the others are sent to the model verbatim, so braces in
+ *  them are ordinary characters and must not be validated at all.
+ */
+const FORMATTED_PROMPT_TYPES = new Set([
+  "sys_prompt",
+  "query_contextualizer",
+  "hyde",
+  "multi_query",
+]);
+
 export function validatePlaceholders(content: string, promptType: string) {
-  const used = extractPlaceholders(content);
   const known = new Set((PROMPT_TYPE_VARIABLES[promptType] ?? []).map((v) => v.name));
+  if (!FORMATTED_PROMPT_TYPES.has(promptType)) {
+    return { used: [], unknown: [], missing: [], malformed: false, error: undefined };
+  }
+  const scan = scanTemplate(content);
+  const used = scan.fields;
   const unknown = used.filter((v) => !known.has(v));
   const missing = [...known].filter((v) => !used.includes(v));
-  return { used, unknown, missing };
+  return { used, unknown, missing, malformed: scan.malformed, error: scan.error };
 }
 
 export interface PreviewSegment {
@@ -138,4 +201,30 @@ export function renderPreview(content: string, promptType: string): PreviewSegme
     segments.push({ value: content.slice(lastIndex), isVariable: false });
   }
   return segments;
+}
+
+/* ---------- Prompt picker option values ---------- */
+
+/** Sentinel for the "use the type's global default" choice.
+ *
+ *  Prompt names are free text, so any bare sentinel is a name a prompt could
+ *  legitimately have — a prompt actually called `__default__` would then be
+ *  impossible to select. Real options are therefore namespaced with a prefix
+ *  and the sentinel is the only unprefixed value, which makes a collision
+ *  structurally impossible rather than merely unlikely.
+ */
+export const PROMPT_DEFAULT_OPTION = "__use_default__";
+const PROMPT_OPTION_PREFIX = "name:";
+
+export function promptOptionValue(name: string): string {
+  return `${PROMPT_OPTION_PREFIX}${name}`;
+}
+
+export function promptOptionToName(value: string): string {
+  return value.startsWith(PROMPT_OPTION_PREFIX) ? value.slice(PROMPT_OPTION_PREFIX.length) : "";
+}
+
+/** The Select value for a stored prompt name ("" / unset → the default). */
+export function promptSelectValue(name: string | undefined | null): string {
+  return name ? promptOptionValue(name) : PROMPT_DEFAULT_OPTION;
 }

--- a/ui/src/lib/prompt-meta.ts
+++ b/ui/src/lib/prompt-meta.ts
@@ -1,6 +1,6 @@
 import type { PromptType } from "@/lib/api/prompts";
 
-// Shared metadata for the 8 managed prompt types: their human labels, how they
+// Shared metadata for the managed prompt types: their human labels, how they
 // group by concern, and the `{variables}` each template understands. Consumed by
 // the Prompt Library page and by the preset/partition editors that select a
 // prompt by name.

--- a/ui/src/pages/admin/jobs/list.test.tsx
+++ b/ui/src/pages/admin/jobs/list.test.tsx
@@ -128,7 +128,7 @@ describe("JobListPage filters", () => {
     await userEvent.type(search, "completed");
     expect(search.value).toBe("completed");
 
-    await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Failed" }));
 
     await waitFor(() => expect(search.value).toBe(""));
     expect(await screen.findByText("failed.pdf")).not.toBeNull();
@@ -245,7 +245,7 @@ describe("JobListPage filters", () => {
       [expect.objectContaining({ task_id: "all-named-task" })],
     );
 
-    await userEvent.click(screen.getByRole("tab", { name: "FAILED" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Failed" }));
     await waitFor(() => expect(screen.getByText("docs.pdf")).not.toBeNull());
   });
 

--- a/ui/src/pages/admin/jobs/list.tsx
+++ b/ui/src/pages/admin/jobs/list.tsx
@@ -351,7 +351,7 @@ export default function JobListPage() {
         <TabsList>
           {STATUS_TABS.map((tab) => (
             <TabsTrigger key={tab} value={tab}>
-              {tab}
+              {tab.charAt(0) + tab.slice(1).toLowerCase()}
             </TabsTrigger>
           ))}
         </TabsList>

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -210,7 +210,7 @@ export default function ModelsPage() {
                             </CardTitle>
                             <div className="flex items-center gap-1.5 shrink-0">
                               {isDefault && (
-                                <Badge variant="secondary" className="text-xs">Default</Badge>
+                                <Badge className="shrink-0 bg-green-600 text-xs hover:bg-green-700">Default</Badge>
                               )}
                             </div>
                           </div>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -235,7 +235,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               disabled={!canEdit}
             />
           </div>
-          <div className="grid grid-cols-3 gap-6">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
             <div className="space-y-2">
               <Label className="text-muted-foreground">Dimension</Label>
               <p className="text-sm font-medium pt-1">{partition.dimension}</p>
@@ -353,6 +353,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               type="number"
               min={1}
               required
+              className="max-w-[8rem]"
               value={chatHistoryDepth}
               onChange={(e) => setChatHistoryDepth(e.target.value)}
               disabled={!canEdit}

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -61,8 +61,8 @@ import {
 import { describePartitionMember } from "./partition-member";
 
 // The answer prompt is selected on the partition (keyed by prompt type). Mirrors
-// the "Answer" concern in the prompt library.
-const GENERATION_PROMPT_TYPES = PROMPT_GROUPS.find((g) => g.name === "Answer")!.types;
+// the "Final Answer" concern in the prompt library.
+const GENERATION_PROMPT_TYPES = PROMPT_GROUPS.find((g) => g.name === "Final Answer")!.types;
 
 // --- General Tab ---
 
@@ -251,7 +251,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               <p className="text-sm font-medium pt-1">{partition.document_count}</p>
             </div>
           </div>
-          <div className="pt-2 grid grid-cols-3 gap-6">
+          <div className="pt-2 grid grid-cols-4 gap-6">
             <div className="space-y-2">
               <Label>Indexation Preset</Label>
               <Select value={indexationPreset} onValueChange={setIndexationPreset} disabled={!canEdit || !isAdmin}>
@@ -307,6 +307,31 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
                 </SelectContent>
               </Select>
             </div>
+            {GENERATION_PROMPT_TYPES.map((t) => {
+              const options = promptsByType(t.value);
+              return (
+                <div key={t.value} className="space-y-2">
+                  <Label>{t.label}</Label>
+                  <Select
+                    value={generationPrompts[t.value] ?? "__default__"}
+                    onValueChange={(v) => setGenerationPrompt(t.value, v === "__default__" ? "" : v)}
+                    disabled={!canEdit || !isAdmin}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__default__">Use default</SelectItem>
+                      {options.map((p) => (
+                        <SelectItem key={p.id} value={p.name}>
+                          {p.name}{p.is_default ? " (default)" : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              );
+            })}
           </div>
           <div className="space-y-2">
             <Label className="flex items-center gap-1.5">
@@ -333,46 +358,6 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               disabled={!canEdit}
             />
           </div>
-          {isAdmin && (
-            <div className="space-y-3">
-              <div>
-                <Label>Answer Prompt</Label>
-                <p className="text-xs text-muted-foreground">
-                  Override the prompt used to write answers in this partition. Leave as{" "}
-                  <span className="font-medium">Use default</span> to inherit the library default. Manage the
-                  prompt options in{" "}
-                  <Link to="/prompts" className="underline underline-offset-2">Prompts</Link>.
-                </p>
-              </div>
-              <div className="grid grid-cols-3 gap-6">
-                {GENERATION_PROMPT_TYPES.map((t) => {
-                  const options = promptsByType(t.value);
-                  return (
-                    <div key={t.value} className="space-y-2">
-                      <Label className="text-muted-foreground">{t.label}</Label>
-                      <Select
-                        value={generationPrompts[t.value] ?? "__default__"}
-                        onValueChange={(v) => setGenerationPrompt(t.value, v === "__default__" ? "" : v)}
-                        disabled={!canEdit}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="__default__">Use default</SelectItem>
-                          {options.map((p) => (
-                            <SelectItem key={p.id} value={p.name}>
-                              {p.name}{p.is_default ? " (default)" : ""}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
           {canEdit && (
             <Button
               type="submit"

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -49,6 +49,9 @@ import {
 import type { PartitionConfig, PartitionRole } from "@/lib/api/partitions";
 import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
+import { listPrompts } from "@/lib/api/prompts";
+import type { PromptResponse } from "@/lib/api/prompts";
+import { PROMPT_GROUPS } from "@/lib/prompt-meta";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
 import {
@@ -56,6 +59,10 @@ import {
   PartitionMemberIdentity,
 } from "./partition-member-identity";
 import { describePartitionMember } from "./partition-member";
+
+// Generation prompts are selected on the partition (keyed by prompt type). This
+// mirrors the "Generation" concern in the prompt library.
+const GENERATION_PROMPT_TYPES = PROMPT_GROUPS.find((g) => g.name === "Generation")!.types;
 
 // --- General Tab ---
 
@@ -76,6 +83,9 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
   const [indexationPreset, setIndexationPreset] = useState(partition.indexation_preset);
   const [retrievalPreset, setRetrievalPreset] = useState(partition.retrieval_preset);
   const [chatLlm, setChatLlm] = useState(partition.chat_llm ?? "__default__");
+  const [generationPrompts, setGenerationPrompts] = useState<Record<string, string>>(
+    partition.generation_prompt_names ?? {},
+  );
   const [llmValidated, setLlmValidated] = useState<boolean | null>(
     partition.chat_llm ? null : true,
   );
@@ -100,6 +110,23 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
     queryFn: () => listModelEndpoints("embedder"),
     enabled: isAdmin,
   });
+
+  const { data: promptsData } = useQuery({
+    queryKey: ["prompts-library"],
+    queryFn: () => listPrompts({ limit: 500 }),
+    enabled: isAdmin,
+  });
+  const promptsByType = (type: string): PromptResponse[] =>
+    (promptsData ?? []).filter((p) => p.prompt_type === type);
+
+  const setGenerationPrompt = (type: string, name: string) => {
+    setGenerationPrompts((prev) => {
+      const next = { ...prev };
+      if (name) next[type] = name;
+      else delete next[type];
+      return next;
+    });
+  };
 
   const validateLlm = useCallback(
     async (name: string) => {
@@ -150,6 +177,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
         indexation_preset: indexationPreset,
         retrieval_preset: retrievalPreset,
         chat_llm: chatLlm === "__default__" ? null : chatLlm,
+        generation_prompt_names: generationPrompts,
       }),
     onSuccess: () => {
       toast.success("Partition updated");
@@ -300,6 +328,46 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               disabled={!canEdit}
             />
           </div>
+          {isAdmin && (
+            <div className="space-y-3">
+              <div>
+                <Label>Generation Prompts</Label>
+                <p className="text-xs text-muted-foreground">
+                  Override the prompts used when answering in this partition. Leave as{" "}
+                  <span className="font-medium">Use default</span> to inherit the library default. Manage the
+                  prompt options in{" "}
+                  <Link to="/prompts" className="underline underline-offset-2">Prompts</Link>.
+                </p>
+              </div>
+              <div className="grid grid-cols-3 gap-6">
+                {GENERATION_PROMPT_TYPES.map((t) => {
+                  const options = promptsByType(t.value);
+                  return (
+                    <div key={t.value} className="space-y-2">
+                      <Label className="text-muted-foreground">{t.label}</Label>
+                      <Select
+                        value={generationPrompts[t.value] ?? "__default__"}
+                        onValueChange={(v) => setGenerationPrompt(t.value, v === "__default__" ? "" : v)}
+                        disabled={!canEdit}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__default__">Use default</SelectItem>
+                          {options.map((p) => (
+                            <SelectItem key={p.id} value={p.name}>
+                              {p.name}{p.is_default ? " (default)" : ""}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           {canEdit && (
             <Button
               type="submit"

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Save, UserPlus, Trash2, CheckCircle, XCircle, Loader2, Info } from "lucide-react";
@@ -52,7 +52,13 @@ import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
 import { listPrompts } from "@/lib/api/prompts";
 import type { PromptResponse } from "@/lib/api/prompts";
-import { PROMPT_GROUPS } from "@/lib/prompt-meta";
+import {
+  PROMPT_DEFAULT_OPTION,
+  PROMPT_GROUPS,
+  promptOptionToName,
+  promptOptionValue,
+  promptSelectValue,
+} from "@/lib/prompt-meta";
 import { usePermissions } from "@/lib/permissions";
 import { formatDate, intOr } from "@/lib/utils";
 import { MemberPicker } from "./member-picker";
@@ -90,12 +96,14 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
   const [chatLlm, setChatLlm] = useState(partition.chat_llm ?? "__default__");
   // Only carry the generation types this editor manages — a stale key (e.g. a
   // pre-move query_contextualizer) would be rejected by the partition PATCH.
-  const [generationPrompts, setGenerationPrompts] = useState<Record<string, string>>(() => {
+  const initialGenerationPrompts = useMemo(() => {
     const allowed = new Set<string>(GENERATION_PROMPT_TYPES.map((t) => t.value));
     return Object.fromEntries(
       Object.entries(partition.generation_prompt_names ?? {}).filter(([k]) => allowed.has(k)),
     );
-  });
+  }, [partition.generation_prompt_names]);
+  const [generationPrompts, setGenerationPrompts] =
+    useState<Record<string, string>>(initialGenerationPrompts);
   const [llmValidated, setLlmValidated] = useState<boolean | null>(
     partition.chat_llm ? null : true,
   );
@@ -128,6 +136,11 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
   });
   const promptsByType = (type: string): PromptResponse[] =>
     (promptsData ?? []).filter((p) => p.prompt_type === type);
+
+  // Compared against what the partition was loaded with, so an untouched
+  // mapping is omitted from the PATCH entirely.
+  const generationPromptsChanged =
+    JSON.stringify(generationPrompts) !== JSON.stringify(initialGenerationPrompts);
 
   const setGenerationPrompt = (type: string, name: string) => {
     setGenerationPrompts((prev) => {
@@ -187,7 +200,12 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
         indexation_preset: indexationPreset,
         retrieval_preset: retrievalPreset,
         chat_llm: chatLlm === "__default__" ? null : chatLlm,
-        generation_prompt_names: generationPrompts,
+        // Only sent when this editor actually changed it. The backend validates
+        // every name in the mapping, so resubmitting an untouched-but-stale
+        // reference (its prompt since renamed or deleted) would 422 the whole
+        // PATCH and block unrelated edits like the description — and a non-admin
+        // owner, for whom this picker is disabled, could never clear it.
+        ...(generationPromptsChanged ? { generation_prompt_names: generationPrompts } : {}),
       }),
     onSuccess: () => {
       toast.success("Partition updated");
@@ -318,17 +336,17 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
                 <div key={t.value} className="space-y-2">
                   <Label>{t.label}</Label>
                   <Select
-                    value={generationPrompts[t.value] ?? "__default__"}
-                    onValueChange={(v) => setGenerationPrompt(t.value, v === "__default__" ? "" : v)}
+                    value={promptSelectValue(generationPrompts[t.value])}
+                    onValueChange={(v) => setGenerationPrompt(t.value, promptOptionToName(v))}
                     disabled={!canEdit || !isAdmin}
                   >
                     <SelectTrigger className="w-full">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__default__">Use default</SelectItem>
+                      <SelectItem value={PROMPT_DEFAULT_OPTION}>Use default</SelectItem>
                       {options.map((p) => (
-                        <SelectItem key={p.id} value={p.name}>
+                        <SelectItem key={p.id} value={promptOptionValue(p.name)}>
                           {p.name}{p.is_default ? " (default)" : ""}
                         </SelectItem>
                       ))}

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -60,9 +60,9 @@ import {
 } from "./partition-member-identity";
 import { describePartitionMember } from "./partition-member";
 
-// Generation prompts are selected on the partition (keyed by prompt type). This
-// mirrors the "Generation" concern in the prompt library.
-const GENERATION_PROMPT_TYPES = PROMPT_GROUPS.find((g) => g.name === "Generation")!.types;
+// The answer prompt is selected on the partition (keyed by prompt type). Mirrors
+// the "Answer" concern in the prompt library.
+const GENERATION_PROMPT_TYPES = PROMPT_GROUPS.find((g) => g.name === "Answer")!.types;
 
 // --- General Tab ---
 
@@ -336,9 +336,9 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
           {isAdmin && (
             <div className="space-y-3">
               <div>
-                <Label>Generation Prompts</Label>
+                <Label>Answer Prompt</Label>
                 <p className="text-xs text-muted-foreground">
-                  Override the prompts used when answering in this partition. Leave as{" "}
+                  Override the prompt used to write answers in this partition. Leave as{" "}
                   <span className="font-medium">Use default</span> to inherit the library default. Manage the
                   prompt options in{" "}
                   <Link to="/prompts" className="underline underline-offset-2">Prompts</Link>.

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -214,7 +214,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
         <CardTitle className="text-base">General Settings</CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-6 max-w-3xl">
+        <form onSubmit={handleSubmit} className="space-y-6 max-w-5xl">
           {!canEdit && (
             <p className="rounded-md border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
               You have read-only access to this partition's settings. Only an owner can change them.
@@ -251,11 +251,11 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
               <p className="text-sm font-medium pt-1">{partition.document_count}</p>
             </div>
           </div>
-          <div className="pt-2 grid grid-cols-4 gap-6">
+          <div className="pt-2 grid grid-cols-2 lg:grid-cols-4 gap-6">
             <div className="space-y-2">
               <Label>Indexation Preset</Label>
               <Select value={indexationPreset} onValueChange={setIndexationPreset} disabled={!canEdit || !isAdmin}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select preset" />
                 </SelectTrigger>
                 <SelectContent>
@@ -270,7 +270,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
             <div className="space-y-2">
               <Label>Retrieval Preset</Label>
               <Select value={retrievalPreset} onValueChange={setRetrievalPreset} disabled={!canEdit || !isAdmin}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select preset" />
                 </SelectTrigger>
                 <SelectContent>
@@ -294,7 +294,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
                 )}
               </Label>
               <Select value={chatLlm} onValueChange={handleChatLlmChange} disabled={!canEdit || !isAdmin}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select LLM" />
                 </SelectTrigger>
                 <SelectContent>
@@ -317,7 +317,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
                     onValueChange={(v) => setGenerationPrompt(t.value, v === "__default__" ? "" : v)}
                     disabled={!canEdit || !isAdmin}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger className="w-full">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -83,9 +83,14 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
   const [indexationPreset, setIndexationPreset] = useState(partition.indexation_preset);
   const [retrievalPreset, setRetrievalPreset] = useState(partition.retrieval_preset);
   const [chatLlm, setChatLlm] = useState(partition.chat_llm ?? "__default__");
-  const [generationPrompts, setGenerationPrompts] = useState<Record<string, string>>(
-    partition.generation_prompt_names ?? {},
-  );
+  // Only carry the generation types this editor manages — a stale key (e.g. a
+  // pre-move query_contextualizer) would be rejected by the partition PATCH.
+  const [generationPrompts, setGenerationPrompts] = useState<Record<string, string>>(() => {
+    const allowed = new Set<string>(GENERATION_PROMPT_TYPES.map((t) => t.value));
+    return Object.fromEntries(
+      Object.entries(partition.generation_prompt_names ?? {}).filter(([k]) => allowed.has(k)),
+    );
+  });
   const [llmValidated, setLlmValidated] = useState<boolean | null>(
     partition.chat_llm ? null : true,
   );

--- a/ui/src/pages/admin/partitions/detail.tsx
+++ b/ui/src/pages/admin/partitions/detail.tsx
@@ -50,7 +50,7 @@ import {
 import type { PartitionConfig, PartitionMemberCandidate, PartitionRole } from "@/lib/api/partitions";
 import { listPresets } from "@/lib/api/presets";
 import { listModelEndpoints, validateStoredModelEndpoint, resolveEmbedderName } from "@/lib/api/models";
-import { listPrompts } from "@/lib/api/prompts";
+import { listAllPrompts } from "@/lib/api/prompts";
 import type { PromptResponse } from "@/lib/api/prompts";
 import {
   PROMPT_DEFAULT_OPTION,
@@ -131,7 +131,7 @@ function GeneralTab({ partition }: { partition: PartitionConfig }) {
 
   const { data: promptsData } = useQuery({
     queryKey: ["prompts-library"],
-    queryFn: () => listPrompts({ limit: 500 }),
+    queryFn: () => listAllPrompts(),
     enabled: isAdmin,
   });
   const promptsByType = (type: string): PromptResponse[] =>

--- a/ui/src/pages/admin/presets.test.tsx
+++ b/ui/src/pages/admin/presets.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/lib/api/presets", async () => {
 });
 
 vi.mock("@/lib/api/prompts", () => ({
-  listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+  listPrompts: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/lib/api/models", () => ({

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -40,6 +40,12 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, intOr, numOr } from "@/lib/utils";
 import {
+  PROMPT_DEFAULT_OPTION,
+  promptOptionToName,
+  promptOptionValue,
+  promptSelectValue,
+} from "@/lib/prompt-meta";
+import {
   type Config,
   configGet,
   configSet,
@@ -579,16 +585,16 @@ function FeatureToggle({
                 <PromptViewButton prompts={prompts} selectedName={promptValue || ""} />
               </div>
               <Select
-                value={promptValue || "__default__"}
-                onValueChange={(v) => onPromptChange(v === "__default__" ? "" : v)}
+                value={promptSelectValue(promptValue)}
+                onValueChange={(v) => onPromptChange(promptOptionToName(v))}
               >
                 <SelectTrigger size="sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__default__">Use default</SelectItem>
+                  <SelectItem value={PROMPT_DEFAULT_OPTION}>Use default</SelectItem>
                   {prompts.map((p) => (
-                    <SelectItem key={p.id} value={p.name}>
+                    <SelectItem key={p.id} value={promptOptionValue(p.name)}>
                       {p.name}{p.is_default ? " (default)" : ""}
                     </SelectItem>
                   ))}
@@ -622,16 +628,16 @@ function PromptSelect({
         {prompts.length > 0 && <PromptViewButton prompts={prompts} selectedName={value} />}
       </div>
       <Select
-        value={value || "__default__"}
-        onValueChange={(v) => onChange(v === "__default__" ? "" : v)}
+        value={promptSelectValue(value)}
+        onValueChange={(v) => onChange(promptOptionToName(v))}
       >
         <SelectTrigger size="sm">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="__default__">Use default</SelectItem>
+          <SelectItem value={PROMPT_DEFAULT_OPTION}>Use default</SelectItem>
           {prompts.map((p) => (
-            <SelectItem key={p.id} value={p.name}>
+            <SelectItem key={p.id} value={promptOptionValue(p.name)}>
               {p.name}{p.is_default ? " (default)" : ""}
             </SelectItem>
           ))}

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -10,7 +10,7 @@ import {
   getPresetOptions,
 } from "@/lib/api/presets";
 import type { PresetResponse, PresetType } from "@/lib/api/presets";
-import { listPrompts } from "@/lib/api/prompts";
+import { listAllPrompts } from "@/lib/api/prompts";
 import type { PromptResponse } from "@/lib/api/prompts";
 import { listModelEndpoints, pickDefaultEndpoint } from "@/lib/api/models";
 import { PageHeader } from "@/components/shared/page-header";
@@ -522,23 +522,20 @@ function FeatureToggle({
 }) {
   const handleToggle = (on: boolean) => {
     onToggle(on);
-    if (on) {
-      // Auto-select when only one option available
-      if (models.length === 1 && !modelValue) onModelChange(models[0]);
-      if (prompts?.length === 1 && onPromptChange && !promptValue) onPromptChange(prompts[0].name);
-    }
+    // Auto-select the sole model, but never the sole prompt: an empty prompt
+    // value is a real choice ("use the type's global default"), and after
+    // seeding a type usually has exactly one prompt — the default itself.
+    // Auto-selecting it would pin that *name* into the preset just by opening
+    // and saving, so promoting a different global default later would silently
+    // stop affecting this preset. Models have no such fallback, so they keep it.
+    if (on && models.length === 1 && !modelValue) onModelChange(models[0]);
   };
 
-  // Auto-select if toggled on and model/prompt list resolves to single item later
+  // Same for a list that resolves to a single item after the query settles.
   useEffect(() => {
     if (!enabled) return;
     if (models.length === 1 && !modelValue) onModelChange(models[0]);
   }, [enabled, models, modelValue, onModelChange]);
-
-  useEffect(() => {
-    if (!enabled || !prompts || !onPromptChange) return;
-    if (prompts.length === 1 && !promptValue) onPromptChange(prompts[0].name);
-  }, [enabled, prompts, promptValue, onPromptChange]);
 
   return (
     <div className="space-y-2">
@@ -928,7 +925,7 @@ function PresetDialog({
 
   const { data: promptData } = useQuery({
     queryKey: ["prompts-for-presets"],
-    queryFn: () => listPrompts({ limit: 500 }),
+    queryFn: () => listAllPrompts(),
     enabled: open,
   });
   const allPrompts = promptData ?? [];

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -387,9 +387,9 @@ function IndexationPresetForm({
           onModelChange={(v) => set("vlm", v)}
           models={vlms}
           promptLabel="Caption prompt"
-          promptValue={configGet(config, "vlm_caption_prompt_name", "")}
-          onPromptChange={(v) => set("vlm_caption_prompt_name", v || null)}
-          prompts={promptsByType("vlm_caption")}
+          promptValue={configGet(config, "image_captioning_prompt_name", "")}
+          onPromptChange={(v) => set("image_captioning_prompt_name", v || null)}
+          prompts={promptsByType("image_captioning")}
         />
         <FeatureToggle
           label="Contextualization"
@@ -402,7 +402,7 @@ function IndexationPresetForm({
           promptLabel="Prompt"
           promptValue={configGet(config, "contextualization_prompt_name", "")}
           onPromptChange={(v) => set("contextualization_prompt_name", v || null)}
-          prompts={promptsByType("contextualization")}
+          prompts={promptsByType("chunk_contextualizer")}
         />
         <FeatureToggle
           label="Topic tagging"
@@ -416,6 +416,10 @@ function IndexationPresetForm({
           modelValue={configGet(config, "topic_tagging_llm", "")}
           onModelChange={(v) => set("topic_tagging_llm", v)}
           models={llms}
+          promptLabel="Prompt"
+          promptValue={configGet(config, "topic_tagging_prompt_name", "")}
+          onPromptChange={(v) => set("topic_tagging_prompt_name", v || null)}
+          prompts={promptsByType("topic_tagger")}
           numberLabel="Max tags"
           numberValue={configGet(config, "max_topic_tags", 7)}
           onNumberChange={(v) => set("max_topic_tags", v)}
@@ -575,17 +579,17 @@ function FeatureToggle({
                 <PromptViewButton prompts={prompts} selectedName={promptValue || ""} />
               </div>
               <Select
-                value={promptValue || "__active__"}
-                onValueChange={(v) => onPromptChange(v === "__active__" ? "" : v)}
+                value={promptValue || "__default__"}
+                onValueChange={(v) => onPromptChange(v === "__default__" ? "" : v)}
               >
                 <SelectTrigger size="sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__active__">Active prompt</SelectItem>
+                  <SelectItem value="__default__">Use default</SelectItem>
                   {prompts.map((p) => (
                     <SelectItem key={p.id} value={p.name}>
-                      {p.name}{p.is_default ? " (active)" : ""}
+                      {p.name}{p.is_default ? " (default)" : ""}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -598,6 +602,45 @@ function FeatureToggle({
   );
 }
 
+/* ---------- Standalone prompt picker (retrieval hyde / multi_query) ---------- */
+
+function PromptSelect({
+  label,
+  prompts,
+  value,
+  onChange,
+}: {
+  label: string;
+  prompts: PromptResponse[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1">
+        <Label className="text-xs">{label}</Label>
+        {prompts.length > 0 && <PromptViewButton prompts={prompts} selectedName={value} />}
+      </div>
+      <Select
+        value={value || "__default__"}
+        onValueChange={(v) => onChange(v === "__default__" ? "" : v)}
+      >
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__default__">Use default</SelectItem>
+          {prompts.map((p) => (
+            <SelectItem key={p.id} value={p.name}>
+              {p.name}{p.is_default ? " (default)" : ""}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 /* ---------- Retrieval form ---------- */
 
 function RetrievalPresetForm({
@@ -606,16 +649,19 @@ function RetrievalPresetForm({
   retrievalPipelines,
   rerankers,
   llms,
+  prompts,
 }: {
   config: Config;
   onChange: (c: Config) => void;
   retrievalPipelines: string[];
   rerankers: string[];
   llms: string[];
+  prompts: PromptResponse[];
 }) {
   const set = (key: string, value: unknown) => onChange(configSet(config, key, value));
   const pipelineType: string = configGet(config, "type", "single");
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const promptsByType = (type: string) => prompts.filter((p) => p.prompt_type === type);
 
   return (
     <div className="space-y-5">
@@ -653,6 +699,22 @@ function RetrievalPresetForm({
               </SelectContent>
             </Select>
           </div>
+        )}
+        {pipelineType === "hyde" && (
+          <PromptSelect
+            label="HyDE prompt"
+            prompts={promptsByType("hyde")}
+            value={configGet(config, "hyde_prompt_name", "")}
+            onChange={(v) => set("hyde_prompt_name", v || null)}
+          />
+        )}
+        {pipelineType === "multiQuery" && (
+          <PromptSelect
+            label="Multi-query prompt"
+            prompts={promptsByType("multi_query")}
+            value={configGet(config, "multi_query_prompt_name", "")}
+            onChange={(v) => set("multi_query_prompt_name", v || null)}
+          />
         )}
         <div className="space-y-1.5">
           <Label className="text-xs">top_k (vector retrieval count)</Label>
@@ -854,10 +916,10 @@ function PresetDialog({
 
   const { data: promptData } = useQuery({
     queryKey: ["prompts-for-presets"],
-    queryFn: () => listPrompts({ limit: 200 }),
-    enabled: open && presetType === "indexation",
+    queryFn: () => listPrompts({ limit: 500 }),
+    enabled: open,
   });
-  const allPrompts = promptData?.prompts ?? [];
+  const allPrompts = promptData ?? [];
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -901,6 +963,7 @@ function PresetDialog({
               retrievalPipelines={options?.retrieval_types ?? []}
               rerankers={rerankers}
               llms={llms}
+              prompts={allPrompts}
             />
           )}
 

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -679,6 +679,12 @@ function RetrievalPresetForm({
             </SelectContent>
           </Select>
         </div>
+        <PromptSelect
+          label="Query contextualizer prompt"
+          prompts={promptsByType("query_contextualizer")}
+          value={configGet(config, "query_contextualizer_prompt_name", "")}
+          onChange={(v) => set("query_contextualizer_prompt_name", v || null)}
+        />
         {pipelineType !== "single" && (
           <div className="space-y-1.5">
             <Label className="text-xs">Expansion LLM</Label>

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -239,7 +239,17 @@ function PromptCard({
             </Button>
           )}
           <div className="flex-1" />
-          {!prompt.is_default && (
+          {prompt.is_default ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-muted-foreground"
+              disabled
+              title="The default prompt can't be deleted. Promote another prompt to default first."
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          ) : (
             <ConfirmDialog
               title="Delete prompt?"
               description={
@@ -249,7 +259,7 @@ function PromptCard({
               }
               onConfirm={onDelete}
             >
-              <Button size="sm" variant="ghost" className="text-destructive">
+              <Button size="sm" variant="ghost" className="text-destructive" title="Delete prompt">
                 <Trash2 className="h-3 w-3" />
               </Button>
             </ConfirmDialog>

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -13,7 +13,7 @@ import {
   Users,
 } from "lucide-react";
 import {
-  listPrompts,
+  listAllPrompts,
   createPrompt,
   updatePrompt,
   deletePrompt,
@@ -65,7 +65,7 @@ export default function PromptsPage() {
 
   const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ["prompts-library"],
-    queryFn: () => listPrompts({ limit: 500 }),
+    queryFn: () => listAllPrompts(),
   });
   const prompts = data ?? [];
   // An API or database failure must never render as "there are no prompts":

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -56,6 +56,8 @@ import { formatDate } from "@/lib/utils";
 
 // Filter chips: "all" plus one per concern group.
 const CONCERN_FILTERS = ["all", ...PROMPT_GROUPS.map((g) => g.name)] as const;
+/** Types this page manages — everything grouped under a concern. */
+const MANAGED_PROMPT_TYPES = new Set(PROMPT_TYPES.map((t) => t.value as string));
 
 export default function PromptsPage() {
   const queryClient = useQueryClient();
@@ -107,7 +109,12 @@ export default function PromptsPage() {
   };
 
   const visibleGroups = PROMPT_GROUPS.filter((g) => concern === "all" || g.name === concern);
-  const customCount = prompts.filter((p) => !p.is_default).length;
+  // The API can return types this page deliberately doesn't surface yet (today:
+  // spoken_style_answer, driven by a chat metadata flag rather than by anything
+  // configurable here). Only the grouped types render, so count those too —
+  // otherwise the header advertises more prompts than there are cards.
+  const managed = prompts.filter((p) => MANAGED_PROMPT_TYPES.has(p.prompt_type));
+  const customCount = managed.filter((p) => !p.is_default).length;
 
   return (
     <div>
@@ -140,7 +147,7 @@ export default function PromptsPage() {
         </div>
         {!isLoading && !loadFailed && (
           <span className="text-xs text-muted-foreground">
-            {prompts.length} prompt{prompts.length === 1 ? "" : "s"} · {customCount} custom
+            {managed.length} prompt{managed.length === 1 ? "" : "s"} · {customCount} custom
           </span>
         )}
       </div>

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -63,16 +63,25 @@ export default function PromptsPage() {
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<PromptResponse | null>(null);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
     queryKey: ["prompts-library"],
     queryFn: () => listPrompts({ limit: 500 }),
   });
   const prompts = data ?? [];
+  // An API or database failure must never render as "there are no prompts":
+  // that reads as a successful empty library and invites an admin to recreate
+  // prompts that already exist. Cached data stays visible across a failed
+  // refetch, with the banner explaining that what's shown may be stale.
+  const loadFailed = isError && data === undefined;
 
   const setDefaultMut = useMutation({
     mutationFn: (id: string) => setPromptDefault(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      // The preset editors read their picker options from their own query, so
+      // a promotion here must refresh them too or they keep showing the old
+      // default badge.
+      queryClient.invalidateQueries({ queryKey: ["prompts-for-presets"] });
       toast.success("Default prompt updated");
     },
     onError: (e) => toast.error(e.message),
@@ -82,6 +91,7 @@ export default function PromptsPage() {
     mutationFn: (id: string) => deletePrompt(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      queryClient.invalidateQueries({ queryKey: ["prompts-for-presets"] });
       toast.success("Prompt deleted");
     },
     onError: (e) => toast.error(e.message),
@@ -128,12 +138,24 @@ export default function PromptsPage() {
             </button>
           ))}
         </div>
-        {!isLoading && (
+        {!isLoading && !loadFailed && (
           <span className="text-xs text-muted-foreground">
             {prompts.length} prompt{prompts.length === 1 ? "" : "s"} · {customCount} custom
           </span>
         )}
       </div>
+
+      {isError && (
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm">
+          <span>
+            {loadFailed ? "Could not load the prompt library." : "Could not refresh the prompt library; showing the last known data."}{" "}
+            <span className="text-muted-foreground">{(error as Error)?.message}</span>
+          </span>
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+            {isFetching ? "Retrying…" : "Retry"}
+          </Button>
+        </div>
+      )}
 
       {isLoading ? (
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
@@ -141,7 +163,7 @@ export default function PromptsPage() {
             <Skeleton key={i} className="h-40" />
           ))}
         </div>
-      ) : (
+      ) : loadFailed ? null : (
         <div className="space-y-8">
           {visibleGroups.map((group) => {
             const groupTypes = new Set(group.types.map((t) => t.value));
@@ -325,6 +347,16 @@ function PromptEditorSheet({
     onError: (e) => toast.error(e.message),
   });
 
+  const loading = createMut.isPending || updateMut.isPending;
+  const effectiveType = editing?.prompt_type ?? promptType;
+  const templateCheck = validatePlaceholders(content, effectiveType);
+  // Presets and partitions reference a prompt by *name*, so a rename silently
+  // orphans every selection pointing at the old one — they fall back to the
+  // global default. Warn before that happens instead of letting the drawer's
+  // "changes apply everywhere" promise quietly become false.
+  const isRename = !!editing && name.trim() !== editing.name;
+  const renameBreaksRefs = isRename && (editing?.used_by ?? 0) > 0;
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) {
@@ -335,15 +367,32 @@ function PromptEditorSheet({
       toast.error("Content is required");
       return;
     }
+    // Mirror the API's template rules here so a malformed template is caught
+    // before the request instead of coming back as a 422.
+    if (templateCheck.malformed) {
+      toast.error(templateCheck.error ?? "The template has unbalanced braces.");
+      return;
+    }
+    if (templateCheck.unknown.length > 0) {
+      toast.error(`Unknown variable(s): ${templateCheck.unknown.map((v) => `{${v}}`).join(", ")}`);
+      return;
+    }
+    if (
+      renameBreaksRefs &&
+      !window.confirm(
+        `"${editing?.name}" is selected by ${editing?.used_by} partition(s). ` +
+          `Renaming it to "${name.trim()}" drops those selections — they fall back to the ` +
+          `default ${promptTypeLabel(effectiveType).toLowerCase()}. Rename anyway?`,
+      )
+    ) {
+      return;
+    }
     if (editing) {
       updateMut.mutate({ id: editing.id, name, content });
     } else {
       createMut.mutate({ prompt_type: promptType, name, content });
     }
   };
-
-  const loading = createMut.isPending || updateMut.isPending;
-  const effectiveType = editing?.prompt_type ?? promptType;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -364,6 +413,11 @@ function PromptEditorSheet({
                 onChange={(e) => setName(e.target.value)}
                 required
               />
+              {renameBreaksRefs && (
+                <p className="text-xs text-amber-600 dark:text-amber-500">
+                  Selected by {editing?.used_by} partition(s) — renaming drops those selections.
+                </p>
+              )}
             </div>
             <div className="space-y-1.5">
               <Label>Type</Label>

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -207,7 +207,7 @@ function PromptCard({
           variant="outline"
           className={
             used > 0
-              ? "text-xs bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/30 dark:text-sky-200 dark:border-sky-900/60"
+              ? "text-xs bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/30 dark:text-amber-100 dark:border-amber-900/60"
               : "text-xs bg-muted text-muted-foreground border-transparent"
           }
         >

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -1,0 +1,566 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Plus,
+  Trash2,
+  Pencil,
+  Star,
+  Code2,
+  Eye,
+  AlertTriangle,
+  Circle,
+  Users,
+} from "lucide-react";
+import {
+  listPrompts,
+  createPrompt,
+  updatePrompt,
+  deletePrompt,
+  setPromptDefault,
+} from "@/lib/api/prompts";
+import type { PromptResponse, PromptType } from "@/lib/api/prompts";
+import {
+  PROMPT_GROUPS,
+  PROMPT_TYPES,
+  promptTypeLabel,
+  PROMPT_TYPE_VARIABLES,
+  validatePlaceholders,
+  renderPreview,
+} from "@/lib/prompt-meta";
+import { PageHeader } from "@/components/shared/page-header";
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatDate } from "@/lib/utils";
+
+// Filter chips: "all" plus one per concern group.
+const CONCERN_FILTERS = ["all", ...PROMPT_GROUPS.map((g) => g.name)] as const;
+
+export default function PromptsPage() {
+  const queryClient = useQueryClient();
+  const [concern, setConcern] = useState<(typeof CONCERN_FILTERS)[number]>("all");
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<PromptResponse | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["prompts-library"],
+    queryFn: () => listPrompts({ limit: 500 }),
+  });
+  const prompts = data ?? [];
+
+  const setDefaultMut = useMutation({
+    mutationFn: (id: string) => setPromptDefault(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      toast.success("Default prompt updated");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deletePrompt(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      toast.success("Prompt deleted");
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const openCreate = () => {
+    setEditing(null);
+    setEditorOpen(true);
+  };
+  const openEdit = (p: PromptResponse) => {
+    setEditing(p);
+    setEditorOpen(true);
+  };
+
+  const visibleGroups = PROMPT_GROUPS.filter((g) => concern === "all" || g.name === concern);
+  const customCount = prompts.filter((p) => !p.is_default).length;
+
+  return (
+    <div>
+      <PageHeader
+        title="Prompt Library"
+        description="Author the prompts your presets and partitions select. Edits take effect on the next request — no redeploy."
+        actions={
+          <Button onClick={openCreate}>
+            <Plus className="mr-2 h-4 w-4" /> New Prompt
+          </Button>
+        }
+      />
+
+      <div className="mb-6 flex items-center gap-4">
+        <div className="flex gap-1 rounded-lg border bg-muted p-1">
+          {CONCERN_FILTERS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setConcern(c)}
+              className={`rounded-md px-3 py-1 text-xs font-semibold capitalize transition-colors ${
+                concern === c
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {c === "all" ? "All types" : c}
+            </button>
+          ))}
+        </div>
+        {!isLoading && (
+          <span className="text-xs text-muted-foreground">
+            {prompts.length} prompt{prompts.length === 1 ? "" : "s"} · {customCount} custom
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <Skeleton key={i} className="h-40" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {visibleGroups.map((group) => {
+            const groupTypes = new Set(group.types.map((t) => t.value));
+            const groupPrompts = prompts.filter((p) => groupTypes.has(p.prompt_type));
+            return (
+              <section key={group.name}>
+                <div className="mb-3">
+                  <h2 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                    {group.name}
+                  </h2>
+                  <p className="text-xs text-muted-foreground/70">{group.description}</p>
+                </div>
+                {groupPrompts.length === 0 ? (
+                  <p className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+                    No {group.name.toLowerCase()} prompts yet.
+                  </p>
+                ) : (
+                  <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+                    {groupPrompts.map((prompt) => (
+                      <PromptCard
+                        key={prompt.id}
+                        prompt={prompt}
+                        onEdit={() => openEdit(prompt)}
+                        onSetDefault={() => setDefaultMut.mutate(prompt.id)}
+                        onDelete={() => deleteMut.mutate(prompt.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      <PromptEditorSheet
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        editing={editing}
+      />
+    </div>
+  );
+}
+
+/* ---------- Prompt card ---------- */
+
+function PromptCard({
+  prompt,
+  onEdit,
+  onSetDefault,
+  onDelete,
+}: {
+  prompt: PromptResponse;
+  onEdit: () => void;
+  onSetDefault: () => void;
+  onDelete: () => void;
+}) {
+  const used = prompt.used_by;
+  return (
+    <Card className="relative flex flex-col">
+      <div className="absolute right-3 top-3">
+        <Badge
+          variant="outline"
+          className={
+            used > 0
+              ? "text-xs bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/30 dark:text-sky-200 dark:border-sky-900/60"
+              : "text-xs bg-muted text-muted-foreground border-transparent"
+          }
+        >
+          <Users className="mr-1 h-3 w-3" />
+          {used > 0 ? `${used} partition${used === 1 ? "" : "s"}` : "Unused"}
+        </Badge>
+      </div>
+      <CardHeader className="pb-2">
+        <p className="font-mono text-[0.7rem] text-muted-foreground">{prompt.prompt_type}</p>
+        <div className="flex items-center gap-2 pr-24">
+          <span className="truncate font-semibold">{prompt.name || "Untitled"}</span>
+          {prompt.is_default && (
+            <Badge className="shrink-0 bg-green-600 text-xs hover:bg-green-700">Default</Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col text-sm">
+        <p className="mb-3 line-clamp-2 flex-1 border-l-2 border-muted pl-2.5 text-xs text-muted-foreground">
+          {prompt.content.slice(0, 160) || "(empty)"}
+        </p>
+        <div className="text-[0.7rem] text-muted-foreground">Updated {formatDate(prompt.updated_at)}</div>
+        <div className="mt-3 flex items-center gap-1.5 border-t pt-3">
+          <Button size="sm" variant="outline" onClick={onEdit}>
+            <Pencil className="mr-1 h-3 w-3" /> Edit
+          </Button>
+          {!prompt.is_default && (
+            <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={onSetDefault}>
+              <Star className="mr-1 h-3 w-3" /> Set default
+            </Button>
+          )}
+          <div className="flex-1" />
+          {!prompt.is_default && (
+            <ConfirmDialog
+              title="Delete prompt?"
+              description={
+                used > 0
+                  ? `"${prompt.name}" is selected by ${used} partition${used === 1 ? "" : "s"}. They will fall back to the default. Delete anyway?`
+                  : `This will permanently delete "${prompt.name}".`
+              }
+              onConfirm={onDelete}
+            >
+              <Button size="sm" variant="ghost" className="text-destructive">
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </ConfirmDialog>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ---------- Editor drawer ---------- */
+
+function PromptEditorSheet({
+  open,
+  onOpenChange,
+  editing,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  editing: PromptResponse | null;
+}) {
+  const queryClient = useQueryClient();
+  const [promptType, setPromptType] = useState<PromptType>("sys_prompt");
+  const [name, setName] = useState("");
+  const [content, setContent] = useState("");
+
+  // Sync the form to the editing target each time the drawer opens (reset for
+  // "create"). Controlled-drawer reset pattern.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      setPromptType(editing.prompt_type);
+      setName(editing.name);
+      setContent(editing.content);
+    } else {
+      setPromptType("sys_prompt");
+      setName("");
+      setContent("");
+    }
+  }, [open, editing]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const createMut = useMutation({
+    mutationFn: createPrompt,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      queryClient.invalidateQueries({ queryKey: ["prompts-for-presets"] });
+      toast.success("Prompt created");
+      onOpenChange(false);
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, ...data }: { id: string; name: string; content: string }) =>
+      updatePrompt(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompts-library"] });
+      queryClient.invalidateQueries({ queryKey: ["prompts-for-presets"] });
+      toast.success("Prompt updated");
+      onOpenChange(false);
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    if (!content.trim()) {
+      toast.error("Content is required");
+      return;
+    }
+    if (editing) {
+      updateMut.mutate({ id: editing.id, name, content });
+    } else {
+      createMut.mutate({ prompt_type: promptType, name, content });
+    }
+  };
+
+  const loading = createMut.isPending || updateMut.isPending;
+  const effectiveType = editing?.prompt_type ?? promptType;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>{editing ? "Edit prompt" : "New prompt"}</SheetTitle>
+          <SheetDescription>
+            Changes apply to every preset and partition that selects this prompt.
+          </SheetDescription>
+        </SheetHeader>
+        <form onSubmit={handleSubmit} className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>Name</Label>
+              <Input
+                placeholder="e.g. legal-assistant"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Type</Label>
+              {editing ? (
+                <Input value={promptTypeLabel(editing.prompt_type)} disabled />
+              ) : (
+                <Select value={promptType} onValueChange={(v) => setPromptType(v as PromptType)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PROMPT_TYPES.map((t) => (
+                      <SelectItem key={t.value} value={t.value}>
+                        {t.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+          </div>
+
+          <PromptTemplateEditor promptType={effectiveType} value={content} onChange={setContent} />
+
+          {editing && (
+            <p className="flex items-center gap-1.5 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              <Users className="h-3.5 w-3.5" />
+              {editing.used_by > 0
+                ? `Selected by ${editing.used_by} partition${editing.used_by === 1 ? "" : "s"}.`
+                : "Not selected by any partition yet."}
+            </p>
+          )}
+
+          <SheetFooter className="mt-auto flex-row justify-end gap-2 px-0">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Saving..." : editing ? "Save prompt" : "Create prompt"}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/* ---------- Template editor (edit / preview + {var} helpers) ---------- */
+
+function PromptTemplateEditor({
+  promptType,
+  value,
+  onChange,
+}: {
+  promptType: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [tab, setTab] = useState<"edit" | "preview">("edit");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const variables = PROMPT_TYPE_VARIABLES[promptType] ?? [];
+  const hasVariables = variables.length > 0;
+
+  const validation = useMemo(() => validatePlaceholders(value, promptType), [value, promptType]);
+  const preview = useMemo(() => renderPreview(value, promptType), [value, promptType]);
+
+  const insertVariable = (varName: string) => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const start = ta.selectionStart;
+    const end = ta.selectionEnd;
+    const placeholder = `{${varName}}`;
+    onChange(value.slice(0, start) + placeholder + value.slice(end));
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(start + placeholder.length, start + placeholder.length);
+    });
+  };
+
+  return (
+    <div className="flex flex-1 flex-col space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>Content</Label>
+        <div className="flex rounded-md border bg-muted p-0.5">
+          <button
+            type="button"
+            onClick={() => setTab("edit")}
+            className={`flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+              tab === "edit" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Code2 className="h-3 w-3" /> Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("preview")}
+            className={`flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+              tab === "preview" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Eye className="h-3 w-3" /> Preview
+          </button>
+        </div>
+      </div>
+
+      {hasVariables && tab === "edit" && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="mr-1 text-xs text-muted-foreground">Variables:</span>
+          {variables.map((v) => (
+            <button
+              key={v.name}
+              type="button"
+              onClick={() => insertVariable(v.name)}
+              title={`${v.description} — click to insert`}
+              className="inline-flex items-center gap-1 rounded-md border bg-muted/50 px-2 py-0.5 font-mono text-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              <span className="text-sky-600 dark:text-sky-400">{`{${v.name}}`}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {tab === "edit" ? (
+        <>
+          <Textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            rows={14}
+            className="min-h-[260px] resize-y font-mono text-sm"
+            placeholder={
+              hasVariables
+                ? `Write your prompt template here.\nUse ${variables.map((v) => `{${v.name}}`).join(", ")} as placeholders.`
+                : "Write your prompt here..."
+            }
+            required
+          />
+          {(validation.unknown.length > 0 || validation.missing.length > 0) && (
+            <div className="space-y-1.5">
+              {validation.unknown.map((v) => (
+                <div key={v} className="flex items-start gap-2 text-xs text-amber-600 dark:text-amber-400">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                  <span>
+                    Unknown variable <code className="rounded bg-muted px-1 font-mono">{`{${v}}`}</code> — the
+                    pipeline won't replace this.
+                    {variables.length > 0 && (
+                      <>
+                        {" "}Known:{" "}
+                        {variables.map((kv) => (
+                          <code key={kv.name} className="rounded bg-muted px-1 font-mono">{`{${kv.name}}`}</code>
+                        ))}
+                      </>
+                    )}
+                  </span>
+                </div>
+              ))}
+              {validation.missing.map((v) => (
+                <div key={v} className="flex items-start gap-2 text-xs text-muted-foreground">
+                  <Circle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                  <span>
+                    <code className="rounded bg-muted px-1 font-mono">{`{${v}}`}</code> is available but not used —
+                    fine if intentional.
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          {!hasVariables && (
+            <p className="text-xs text-muted-foreground">
+              This prompt is sent as a system message; the document, chunk, or image content is attached
+              separately at runtime. No placeholders needed.
+            </p>
+          )}
+        </>
+      ) : (
+        <div className="min-h-[240px] rounded-md border bg-muted/30 p-4">
+          {!value.trim() ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Nothing to preview — write some content first.
+            </p>
+          ) : hasVariables ? (
+            <div className="space-y-3">
+              <p className="text-xs text-muted-foreground">
+                Preview with sample values. Highlighted spans are injected by the pipeline at runtime.
+              </p>
+              <div className="whitespace-pre-wrap font-mono text-sm leading-relaxed">
+                {preview.map((seg, i) =>
+                  seg.isVariable ? (
+                    <span
+                      key={i}
+                      className="rounded border border-sky-300/50 bg-sky-100 px-0.5 text-sky-700 dark:border-sky-700/50 dark:bg-sky-900/40 dark:text-sky-300"
+                      title={`{${seg.varName}} — sample value`}
+                    >
+                      {seg.value}
+                    </span>
+                  ) : (
+                    <span key={i}>{seg.value}</span>
+                  ),
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="whitespace-pre-wrap font-mono text-sm leading-relaxed">{value}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/admin/prompts.tsx
+++ b/ui/src/pages/admin/prompts.tsx
@@ -229,25 +229,24 @@ function PromptCard({
           {prompt.content.slice(0, 160) || "(empty)"}
         </p>
         <div className="text-[0.7rem] text-muted-foreground">Updated {formatDate(prompt.updated_at)}</div>
-        <div className="mt-3 flex items-center gap-1.5 border-t pt-3">
+        <div className="flex flex-wrap gap-2 pt-3">
+          {!prompt.is_default && (
+            <Button size="sm" variant="outline" onClick={onSetDefault}>
+              <Star className="mr-1 h-3 w-3" /> Set Default
+            </Button>
+          )}
           <Button size="sm" variant="outline" onClick={onEdit}>
             <Pencil className="mr-1 h-3 w-3" /> Edit
           </Button>
-          {!prompt.is_default && (
-            <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={onSetDefault}>
-              <Star className="mr-1 h-3 w-3" /> Set default
-            </Button>
-          )}
-          <div className="flex-1" />
           {prompt.is_default ? (
             <Button
               size="sm"
-              variant="ghost"
-              className="text-muted-foreground"
+              variant="outline"
+              className="text-destructive"
               disabled
               title="The default prompt can't be deleted. Promote another prompt to default first."
             >
-              <Trash2 className="h-3 w-3" />
+              <Trash2 className="mr-1 h-3 w-3" /> Delete
             </Button>
           ) : (
             <ConfirmDialog
@@ -259,8 +258,8 @@ function PromptCard({
               }
               onConfirm={onDelete}
             >
-              <Button size="sm" variant="ghost" className="text-destructive" title="Delete prompt">
-                <Trash2 className="h-3 w-3" />
+              <Button size="sm" variant="outline" className="text-destructive">
+                <Trash2 className="mr-1 h-3 w-3" /> Delete
               </Button>
             </ConfirmDialog>
           )}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -15,6 +15,7 @@ import { ProtectedRoute } from "@/components/layout/protected-route";
 // Admin-only pages — lazy loaded so they are never downloaded by regular users
 const ModelsPage = lazy(() => import("@/pages/admin/models"));
 const PresetsPage = lazy(() => import("@/pages/admin/presets"));
+const PromptsPage = lazy(() => import("@/pages/admin/prompts"));
 const UserListPage = lazy(() => import("@/pages/admin/users/list"));
 const UserDetailPage = lazy(() => import("@/pages/admin/users/detail"));
 const SystemPage = lazy(() => import("@/pages/admin/system"));
@@ -69,6 +70,16 @@ export const router = createBrowserRouter(
             <AdminRoute>
               <Suspense fallback={<div className="p-6">Loading...</div>}>
                 <PresetsPage />
+              </Suspense>
+            </AdminRoute>
+          ),
+        },
+        {
+          path: "prompts",
+          element: (
+            <AdminRoute>
+              <Suspense fallback={<div className="p-6">Loading...</div>}>
+                <PromptsPage />
               </Suspense>
             </AdminRoute>
           ),


### PR DESCRIPTION
Admin UI for the prompt library added in #835. **Stacked on that PR — review
and merge it first**; this branch targets `feat/pm-backend`, so the diff here
is UI-only.

Part of #772.

## What it adds

**Prompt Library page** (`/admin/prompts`, new sidebar entry) — prompts grouped
by concern (Answer / Indexation / Retrieval) as cards, with a drawer editor
offering an edit tab and a preview tab that renders the template against sample
values. Insert-variable buttons only offer the placeholders the type actually
accepts, so the editor can't produce a template the API would reject.

Each card carries a used-by badge and a default badge, and exposes the same
card-action affordances as Presets and Models rather than a new pattern.

**Selection lives in the editors that own the setting**, not in a separate
assignment screen:

- Preset editor — indexation presets pick contextualization / image-captioning /
  topic-tagging prompts; retrieval presets pick query-contextualizer, plus HyDE
  or multi-query, shown only when the retriever type actually uses them.
- Partition editor — an Answer section picks the final answer prompt.

Every picker offers "Use default", which clears the name and falls back to the
type's global default.

## Also in here

A few consistency fixes this page surfaced: the Jobs, Presets and Models tabs
now match the Library's tab sizing, the Jobs status tabs are title-cased, the
Default badge renders identically in Prompts and Models, and the partition
config rows no longer overflow their grid cells.

## Verification

`tsc -b` clean, 176 vitest tests green, production build clean. eslint reports
one pre-existing warning in `models.tsx`, untouched here.

Driven end-to-end against a live deployment: creating a prompt, selecting it in
a preset and in a partition, and confirming the selection reached the model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only Prompt Library (create/edit, preview with placeholder validation, set default, delete) and a new `/prompts` admin route.
  * Added “Prompts” to the sidebar, visible only with prompt-management permission.

* **Improvements**
  * Expanded prompt API and updated prompt/partition/preset wiring to support prompt-type–driven selection with “use default”.
  * Enhanced General Settings to edit `generation_prompt_names`; refined several admin UI details (tabs, badges, layout/spacing).

* **Tests**
  * Added pagination coverage for prompt listing and updated prompt/template utility and related admin UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->