### PR TITLE
fix(retrieval): return no matches instead of erroring when the vector collection doesn't exist yet

### DIFF
--- a/openrag/services/storage/vector_store_searcher.py
+++ b/openrag/services/storage/vector_store_searcher.py
@@ -69,6 +69,9 @@ class VectorStoreSearcher(RetrievalSearcher):
         similarity_threshold: float = 0.0,
         with_surrounding_chunks: bool = True,
     ) -> list[Chunk]:
+        # Collection is created lazily on first insert (#508); absent means no chunks.
+        if not await self._store.collection_exists(self._collection):
+            return []
         (embedding,) = await self._embedder.embed([query])
         filters: dict[str, Any] = {"partition": partition}
         if filter:
@@ -100,6 +103,8 @@ class VectorStoreSearcher(RetrievalSearcher):
         similarity_threshold: float = 0.0,
         with_surrounding_chunks: bool = True,
     ) -> list[Chunk]:
+        if not await self._store.collection_exists(self._collection):  # see search()
+            return []
         embeddings = await self._embedder.embed(queries)
         filters: dict[str, Any] = {"partition": partition}
         if filter:

--- a/tests/unit/services/storage/test_vector_store_searcher.py
+++ b/tests/unit/services/storage/test_vector_store_searcher.py
@@ -30,6 +30,7 @@ def _make_searcher(
     ancestor_ids=None,
 ) -> tuple[VectorStoreSearcher, MagicMock, MagicMock, MagicMock]:
     store = MagicMock()
+    store.collection_exists = AsyncMock(return_value=True)
     store.search = AsyncMock(return_value=search_results or [])
     store.query_chunks_by_filter = AsyncMock(return_value=filter_results or [])
 
@@ -85,6 +86,22 @@ def test_dict_to_chunk_metadata_excludes_reserved_keys():
 # ---------------------------------------------------------------------------
 # search()
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_when_collection_does_not_exist():
+    """Regression for #505-class bugs: on a fresh stack nothing has ever been
+    indexed, so the shared collection doesn't exist yet. search() must return
+    no matches instead of embedding the query and raising on the missing
+    collection."""
+    searcher, store, embedder, _ = _make_searcher()
+    store.collection_exists = AsyncMock(return_value=False)
+
+    result = await searcher.search(query="hello", partition=["p1"], top_k=5)
+
+    assert result == []
+    embedder.embed.assert_not_awaited()
+    store.search.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -170,6 +187,7 @@ async def test_multi_query_search_merges_filter_params():
     embedder = MagicMock()
     embedder.embed = AsyncMock(return_value=[_EMBED_VEC, _EMBED_VEC])
     store = MagicMock()
+    store.collection_exists = AsyncMock(return_value=True)
     store.search = AsyncMock(return_value=[])
     store.query_chunks_by_filter = AsyncMock(return_value=[])
     searcher = VectorStoreSearcher(vector_store=store, embedder=embedder, document_repo=MagicMock(), collection="col")
@@ -240,11 +258,24 @@ async def test_search_skips_surrounding_when_no_results():
 
 
 @pytest.mark.asyncio
+async def test_multi_query_search_returns_empty_when_collection_does_not_exist():
+    searcher, store, embedder, _ = _make_searcher()
+    store.collection_exists = AsyncMock(return_value=False)
+
+    result = await searcher.multi_query_search(queries=["q1", "q2"], partition=["p1"], top_k_per_query=5)
+
+    assert result == []
+    embedder.embed.assert_not_awaited()
+    store.search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_multi_query_search_embeds_all_queries():
     embedder = MagicMock()
     embedder.embed = AsyncMock(return_value=[_EMBED_VEC, _EMBED_VEC])
 
     store = MagicMock()
+    store.collection_exists = AsyncMock(return_value=True)
     store.search = AsyncMock(return_value=[])
     store.query_chunks_by_filter = AsyncMock(return_value=[])
 
@@ -267,6 +298,7 @@ async def test_multi_query_search_deduplicates_across_queries():
 
     # Both queries return the same chunk "1" plus a unique one each
     store = MagicMock()
+    store.collection_exists = AsyncMock(return_value=True)
     store.search = AsyncMock(
         side_effect=[
             [_make_row("1"), _make_row("2")],


### PR DESCRIPTION
## What

`search()`/`multi_query_search()` on `VectorStoreSearcher` raise instead of
returning an empty result when the shared Milvus collection doesn't exist yet.

## Root cause

The shared collection (`config.vectordb.collection_name`) is created lazily
on the first indexed file *system-wide* (`services/workers/stages/store.py`).
On a fresh deployment — or any retrieval-needing chat/search query before
that first file is indexed, regardless of partition — Milvus raises
`CollectionNotExists`, wrapped as `VDBSearchError`, and propagates as a real
error instead of "no matches."

This is the same class of bug #508 already fixed for `delete_partition`
(`PartitionService`), using the existing `VectorStore.collection_exists()`
port method as the guard. That fix only covered delete; search was still
exposed.

## Fix

Mirror #508's pattern in `VectorStoreSearcher.search()` and
`multi_query_search()`: check `collection_exists()` before embedding/
searching, and return `[]` immediately if the collection is absent — no
collection means no chunks to find, and skipping straight to an empty result
also avoids an unnecessary embedding-API call.

## Test

Adds `test_search_returns_empty_when_collection_does_not_exist` and
`test_multi_query_search_returns_empty_when_collection_does_not_exist`,
asserting the embedder and store are never called when the collection is
absent. Full unit suite: 2433 passed (1 pre-existing unrelated failure on
`develop`, unaffected by this change), ruff clean, layer-import guard clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Searches now safely return no results when the configured vector collection is unavailable.
  * Prevents unnecessary processing and search attempts for missing collections.

* **Tests**
  * Added coverage for standard and multi-query searches when collections do not exist.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->