### PR TITLE
fix(docker): make venv writes group-writable to survive APP_UID drift

### DIFF
--- a/infra/charts/openrag-stack/templates/raycluster.yaml
+++ b/infra/charts/openrag-stack/templates/raycluster.yaml
@@ -34,6 +34,10 @@ spec:
               - sh
               - -c
               - |
+                # Keep venv writes group-writable (GID 0) so a later sync under a
+                # different APP_UID can still remove/replace owner-only entries
+                # left by a previous sync. See infra/scripts/entrypoint.sh.
+                umask 002
                 if [ -f /app/.venv/.ready ]; then
                   echo "Existing env detected, skipping install."
                 else

--- a/infra/scripts/entrypoint.sh
+++ b/infra/scripts/entrypoint.sh
@@ -30,6 +30,15 @@ if [ "$(id -u)" = "0" ]; then
   exec setpriv --reuid "$APP_UID" --regid 0 --clear-groups /app/entrypoint.sh "$@"
 fi
 
+# The persisted openrag_venv volume can be re-synced by different APP_UIDs
+# across the container's lifetime (e.g. a locally-built image bakes in the
+# host UID while a pulled/CI-built image bakes in the Dockerfile default) —
+# both share GID 0. Default umask (022) makes `uv sync` create new venv
+# entries owner-writable only, so a later sync under a different UID can't
+# remove/replace them ("Permission denied" on __editable__*.pth). Force
+# group-writable new files/dirs so any GID-0 UID can always resync.
+umask 002
+
 ENV_ARGS=()
 if [[ -n "${SHARED_ENV}" ]]; then
   ENV_ARGS+=("--env-file=${SHARED_ENV}")


### PR DESCRIPTION
## Summary

- The `openrag_venv` named volume persists across container recreations, but its non-root `APP_UID` can differ between a locally built image (defaults to the host UID via compose's build arg) and a pulled/CI-built image (defaults to the Dockerfile's own `10001`) — even when both share the same image tag.
- Default umask (022) makes `uv sync` create new venv entries writable only by the exact UID that wrote them, so a later sync under a different `APP_UID` can't remove/replace existing files (e.g. `__editable__.openrag-X.Y.Z.pth`, which changes on every version bump), failing with `Permission denied`.
- Sets `umask 002` before invoking `uv run` in the entrypoint so all future venv writes stay group (GID 0) writable, letting any `APP_UID` sharing that group resync without wiping the volume.

Note: this only prevents the issue going forward. Anyone hitting this today still needs a one-time `docker volume rm` of their `openrag_venv` volume to clear already-poisoned owner-only files.

## Test plan

- [ ] Populate `openrag_venv` under one `APP_UID` (e.g. local build with host UID), then re-sync under a different `APP_UID` (e.g. a pulled image or different `APP_UID` build arg) and confirm no `Permission denied` on `uv sync`.
- [ ] Confirm normal container startup (`docker compose up`) still works unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured files and directories created during application startup and environment synchronization are writable by the appropriate group, improving compatibility in shared environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->