### PR TITLE
fix(vdb): stamp the schema version when the collection is created

### DIFF
--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -244,11 +244,22 @@ class MilvusVectorStore(VectorStore):
                         properties={SCHEMA_VERSION_PROPERTY_KEY: str(self._config.schema_version)},
                     )
                 except MilvusException as e:
-                    raise VDBCreateOrLoadCollectionError(
-                        f"Failed to create collection `{self._collection_name}`: {e!s}",
-                        collection_name=self._collection_name,
-                        operation="create_collection",
-                    ) from e
+                    # A duplicate-create error means another worker may have
+                    # won the race after the initial existence check. Other
+                    # Milvus errors must keep their original failure state.
+                    if "already exist" not in str(e).lower():
+                        raise VDBCreateOrLoadCollectionError(
+                            f"Failed to create collection `{self._collection_name}`: {e!s}",
+                            collection_name=self._collection_name,
+                            operation="create_collection",
+                        ) from e
+                    if not self._client.has_collection(self._collection_name):
+                        raise VDBCreateOrLoadCollectionError(
+                            f"Failed to create collection `{self._collection_name}`: {e!s}",
+                            collection_name=self._collection_name,
+                            operation="create_collection",
+                        ) from e
+                    self._check_schema_version()
 
             self._wait_for_vector_indexes()
             try:

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -1055,6 +1055,20 @@ class TestEnsureLoadedConcurrentCreation:
         assert properties == {SCHEMA_VERSION_PROPERTY_KEY: "1"}
         store._client.alter_collection_properties.assert_not_called()  # type: ignore[attr-defined]
 
+    def test_losing_the_create_race_validates_the_winners_collection(self, store: MilvusVectorStore) -> None:
+        """A worker that loses collection creation should continue indexing."""
+        store._embedding_dimension = 8
+        store._client.has_collection.side_effect = [False, True]
+        store._client.create_collection.side_effect = MilvusException(message="collection already exists")
+        store._client.describe_collection.return_value = {
+            "properties": {SCHEMA_VERSION_PROPERTY_KEY: "1"},
+            "fields": [{"name": "vector"}, {"name": "sparse"}],
+        }
+
+        store._ensure_loaded()
+
+        store._client.load_collection.assert_called_once_with(store._collection_name)
+
     def test_duplicate_collection_with_different_parameters_preserves_error(self, store: MilvusVectorStore) -> None:
         store._embedding_dimension = 8
         store._client.has_collection.return_value = False
@@ -1069,34 +1083,34 @@ class TestEnsureLoadedConcurrentCreation:
 
     def test_real_creation_failure_still_raises(self, store: MilvusVectorStore) -> None:
         store._embedding_dimension = 8
-        store._client.has_collection.side_effect = [False, False]  # first call says "no", second call says "no" too
-        store._client.create_collection.side_effect = MilvusException(
-            message="some other failure, disk full or whatever"
-        )
-
-        with pytest.raises(VDBCreateOrLoadCollectionError):
-            store._ensure_loaded()
-
-    def test_partial_creation_failure_preserves_original_error(
-        self,
-        store: MilvusVectorStore,
-    ) -> None:
-        store._embedding_dimension = 8
-        store._timeout = 0
-
-        creation_error = MilvusException(message="index creation failed")
-        store._client.has_collection.side_effect = [False, True]
+        # A duplicate-create error whose collection is still absent: the
+        # recheck must not swallow the failure.
+        store._client.has_collection.side_effect = [False, False]
+        creation_error = MilvusException(message="collection already exists")
         store._client.create_collection.side_effect = creation_error
-        store._client.describe_collection.return_value = {
-            "properties": {SCHEMA_VERSION_PROPERTY_KEY: "1"},
-            "fields": [{"name": "vector"}, {"name": "sparse"}],
-        }
 
         with pytest.raises(VDBCreateOrLoadCollectionError) as error:
             store._ensure_loaded()
 
-        assert "index creation failed" in str(error.value)
         assert error.value.__cause__ is creation_error
+        store._client.load_collection.assert_not_called()
+
+    def test_partial_creation_rechecks_existing_collection_schema(
+        self,
+        store: MilvusVectorStore,
+    ) -> None:
+        store._embedding_dimension = 8
+
+        creation_error = MilvusException(message="collection already exists: index creation failed")
+        store._client.has_collection.side_effect = [False, True]
+        store._client.create_collection.side_effect = creation_error
+        store._client.describe_collection.return_value = {
+            "properties": {},
+            "fields": [{"name": "vector"}, {"name": "sparse"}],
+        }
+
+        with pytest.raises(VDBSchemaMigrationRequiredError):
+            store._ensure_loaded()
 
     def test_existing_old_collection_still_requires_migration(
         self,


### PR DESCRIPTION
Fixes #862.

## The bug

Indexing several files into a collection that does not exist yet loses one of them. The upload is accepted, the task ends `FAILED`, and the document is simply absent from the index. On a stack booted fresh per run it reproduced on **11 of 12 consecutive boots** (2 files, 2 upload workers).

The failing task's traceback:

```
File "services/workers/stages/store.py", line 35, in store_stage
  await vector_store.ensure_collection("default", len(embedding))
File "services/storage/milvus_store.py", line 1079, in ensure_collection
  await self.initialize(dimension)
File "services/storage/milvus_store.py", line 213, in _ensure_loaded
  self._check_schema_version()
VDBSchemaMigrationRequiredError: Collection `vdb_test` is at schema version 0
but the application requires version 1. Please perform the migration script.
```

The collection had been created seconds earlier, by the neighbouring worker.

## Why

`_ensure_loaded` created the collection and stamped its version in a *second* call:

```python
create_collection(...)      # collection exists; version property absent
_store_schema_version()     # ...stamped only here
```

Indexer workers are separate Ray processes (`IndexerWorkerActor` pids 840 and 848 in the log below), so `_load_lock` — an asyncio lock, per instance — does not serialise them against one another. A worker reaching `has_collection()` inside that window finds the collection, reads no version property, defaults to `0`, and raises "migration required".

The one boot in twelve that indexed both files is the one where both workers arrived after the stamp.

## The fix

Stamp the version in the request that creates the collection, so it never exists without one. `properties` reaches the CreateCollection RPC via `Prepare.create_collection_request`; verified against Milvus v3.0.0 that `describe_collection` returns it immediately after creation:

```
properties -> {'openrag.schema_version': '1', 'timezone': 'UTC'}
```

The same race has a second window: both workers can see `has_collection()` as false and both attempt the create. The loser's `MilvusException` was fatal to its file — it now re-checks, and if the collection is there validates it like any other existing collection. A create that fails *without* leaving a collection still raises `VDBCreateOrLoadCollectionError` unchanged.

`_store_schema_version` had no other caller and is removed; the Milvus migration scripts write the property themselves.

## Tests

`TestEnsureLoadedConcurrentCreation`, four cases: the version is in the create request and no `alter_collection_properties` follows; losing the create race validates the winner's collection instead of failing; a create failure that leaves no collection still raises; and a genuinely stale collection is still refused a migration bypass.

The two race tests fail without the source change and pass with it:

```
FAILED  test_a_new_collection_is_stamped_in_the_create_request
FAILED  test_losing_the_create_race_validates_the_winners_collection
2 failed, 2 passed
```

`tests/unit` is green (2543 passed), `ruff check` and `ruff format` clean.

## Note

The failure is invisible from the API's task list — the state is `FAILED` and the reason only appears via `/indexer/task/{id}/error`. Diagnosing this took reading the Milvus container's own logs, where the visible symptom is a `collection not loaded` delete that is actually the post-failure cleanup in `_cleanup_indexed_vectors`, not the cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes create the same vector collection simultaneously.
  * Concurrent creation races now correctly recognize an existing collection and continue loading it after validating its schema version.
  * Non-duplicate collection creation failures are surfaced immediately with their original error context.
  * Duplicate-creation errors now remain failures when the collection is still unavailable.
  * Existing collections with incompatible schema versions continue to require migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->