### PR TITLE
fix(chunking): stop dropping real captions beside an image placeholder

### DIFF
--- a/openrag/core/chunking/recursive.py
+++ b/openrag/core/chunking/recursive.py
@@ -33,6 +33,31 @@ from core.utils.text import sanitize_text
 # they don't pollute the index.
 _IMAGE_PLACEHOLDER_MARKER = "[image placeholder]"
 
+# Strips the block's own wrapper so only the caption text is weighed.
+_IMAGE_BLOCK_TAG_RE = re.compile(r"</?image_description>", re.IGNORECASE)
+_IMAGE_PLACEHOLDER_RE = re.compile(re.escape(_IMAGE_PLACEHOLDER_MARKER), re.IGNORECASE)
+
+
+def is_placeholder_image(content: str) -> bool:
+    """True when an image block carries no caption beyond the placeholder.
+
+    The marker means the captioner found nothing useful in *one* image, but a
+    single block can describe several. Dropping the whole block on any
+    occurrence therefore deleted real caption text along with it: on the corpus
+    that cost a 132-token chart caption ("92 000 COLLABORATEURS…") and 225 words
+    of a tourism description, silently, from the index — and from *both*
+    chunkers, since they share this test.
+
+    So a block is only skipped when nothing but the wrapper and the marker(s)
+    remains. Anything with actual characters left is real caption text and is
+    kept.
+    """
+    if _IMAGE_PLACEHOLDER_MARKER not in content.lower():
+        return False
+    remainder = _IMAGE_PLACEHOLDER_RE.sub(" ", _IMAGE_BLOCK_TAG_RE.sub(" ", content))
+    return not any(char.isalnum() for char in remainder)
+
+
 # Tables/images smaller than this token count are inlined with surrounding
 # text rather than emitted as standalone chunks.
 _INLINE_ELEMENT_TOKEN_THRESHOLD = 100
@@ -228,7 +253,7 @@ class BaseChunker(ChunkingStrategy):
 
         for element in md_elements:
             if element.type in ("table", "image"):
-                if element.type == "image" and _IMAGE_PLACEHOLDER_MARKER in element.content.lower():
+                if element.type == "image" and is_placeholder_image(element.content):
                     continue
                 if self.length_function(element.content) <= _INLINE_ELEMENT_TOKEN_THRESHOLD:
                     texts.append(element)

--- a/openrag/core/chunking/recursive.py
+++ b/openrag/core/chunking/recursive.py
@@ -36,26 +36,47 @@ _IMAGE_PLACEHOLDER_MARKER = "[image placeholder]"
 # Strips the block's own wrapper so only the caption text is weighed.
 _IMAGE_BLOCK_TAG_RE = re.compile(r"</?image_description>", re.IGNORECASE)
 _IMAGE_PLACEHOLDER_RE = re.compile(re.escape(_IMAGE_PLACEHOLDER_MARKER), re.IGNORECASE)
+# Removing a marker leaves the blank lines that surrounded it.
+_COLLAPSE_BLANK_RE = re.compile(r"\n{3,}")
 
 
 def is_placeholder_image(content: str) -> bool:
     """True when an image block carries no caption beyond the placeholder.
 
-    The marker means the captioner found nothing useful in *one* image, but a
-    single block can describe several. Dropping the whole block on any
-    occurrence therefore deleted real caption text along with it: on the corpus
-    that cost a 132-token chart caption ("92 000 COLLABORATEURS…") and 225 words
-    of a tourism description, silently, from the index — and from *both*
-    chunkers, since they share this test.
+    ``wrap_caption`` emits one wrapper per image, so the shape that matters is
+    the marker and real caption text inside the *same* wrapper: a composite
+    figure where the VLM could describe some parts and not others. Dropping the
+    whole block on any occurrence of the marker deleted that caption text along
+    with it — on the corpus, a 132-token chart caption
+    ("92 000 COLLABORATEURS…") and 225 words of a tourism description,
+    silently, from the index, and from *both* chunkers since they share this
+    test. (Two *adjacent* wrappers were never affected: ``IMAGE_RE`` is
+    non-greedy, so they parse as separate elements and only the placeholder-only
+    one was dropped.)
 
     So a block is only skipped when nothing but the wrapper and the marker(s)
     remains. Anything with actual characters left is real caption text and is
-    kept.
+    kept — see ``strip_placeholder_markers`` for removing the marker from it.
     """
     if _IMAGE_PLACEHOLDER_MARKER not in content.lower():
         return False
     remainder = _IMAGE_PLACEHOLDER_RE.sub(" ", _IMAGE_BLOCK_TAG_RE.sub(" ", content))
     return not any(char.isalnum() for char in remainder)
+
+
+def strip_placeholder_markers(content: str) -> str:
+    """Drop the marker(s) from a block that also carries real caption text.
+
+    Keeping the caption must not smuggle the marker into the index with it: the
+    dense vector is computed over the chunk text, and that text is what
+    ``format_context`` puts in front of the LLM, so the marker would read as
+    caption content. (The BM25 stop-word list in ``milvus_store`` already
+    ignores it, so only the dense side and the prompt are affected.)
+
+    Stripping before the size test also makes the inline-vs-standalone decision
+    measure the caption rather than the marker's tokens.
+    """
+    return _COLLAPSE_BLANK_RE.sub("\n\n", _IMAGE_PLACEHOLDER_RE.sub("", content)).strip()
 
 
 # Tables/images smaller than this token count are inlined with surrounding
@@ -253,8 +274,10 @@ class BaseChunker(ChunkingStrategy):
 
         for element in md_elements:
             if element.type in ("table", "image"):
-                if element.type == "image" and is_placeholder_image(element.content):
-                    continue
+                if element.type == "image":
+                    if is_placeholder_image(element.content):
+                        continue
+                    element.content = strip_placeholder_markers(element.content)
                 if self.length_function(element.content) <= _INLINE_ELEMENT_TOKEN_THRESHOLD:
                     texts.append(element)
                 else:

--- a/openrag/core/chunking/recursive.py
+++ b/openrag/core/chunking/recursive.py
@@ -55,13 +55,16 @@ def is_placeholder_image(content: str) -> bool:
     one was dropped.)
 
     So a block is only skipped when nothing but the wrapper and the marker(s)
-    remains. Anything with actual characters left is real caption text and is
-    kept — see ``strip_placeholder_markers`` for removing the marker from it.
+    remains. Anything else is caption text and is kept — see
+    ``strip_placeholder_markers`` for removing the marker from it. The test is
+    whitespace, not alphanumerics: a caption reduced to "©" or an em dash is
+    still content, and a rule about not dropping content should not carve out
+    an exception for symbols.
     """
     if _IMAGE_PLACEHOLDER_MARKER not in content.lower():
         return False
     remainder = _IMAGE_PLACEHOLDER_RE.sub(" ", _IMAGE_BLOCK_TAG_RE.sub(" ", content))
-    return not any(char.isalnum() for char in remainder)
+    return not remainder.strip()
 
 
 def strip_placeholder_markers(content: str) -> str:

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -324,9 +324,12 @@ def test_image_block_keeps_real_caption_beside_a_placeholder():
     tourism description went missing from the index on the test corpus."""
     from core.chunking.recursive import is_placeholder_image
 
+    # One wrapper holding both. wrap_caption() emits one wrapper per image, so
+    # this is the shape the bug actually takes: a composite figure the VLM
+    # partly described. Two *adjacent* wrappers were never affected — IMAGE_RE
+    # is non-greedy, so they parse as separate elements.
     mixed = (
-        "<image_description>\n\n[Image Placeholder]\n\n</image_description>\n"
-        "<image_description>\n\n92 000 COLLABORATEURS\n27 000 AVTOVAZ\n16 PAYS\n\n</image_description>"
+        "<image_description>\n\n[Image Placeholder]\n\n92 000 COLLABORATEURS\n27 000 AVTOVAZ\n\n</image_description>"
     )
     assert not is_placeholder_image(mixed)
 
@@ -339,8 +342,8 @@ def test_mixed_image_block_survives_chunking():
             TextBlock(
                 text=(
                     "Intro paragraph.\n\n"
-                    "<image_description>\n\n[Image Placeholder]\n\n</image_description>\n"
-                    "<image_description>\n\n92 000 COLLABORATEURS 27 000 AVTOVAZ\n\n</image_description>\n\n"
+                    "<image_description>\n\n[Image Placeholder]\n\n"
+                    "92 000 COLLABORATEURS 27 000 AVTOVAZ\n\n</image_description>\n\n"
                     "Closing paragraph."
                 ),
                 page_number=1,
@@ -350,3 +353,4 @@ def test_mixed_image_block_survives_chunking():
     )
     joined = "\n".join(c.text for c in splitter.chunk(doc, partition="p"))
     assert "92 000 COLLABORATEURS" in joined, "real caption text dropped alongside the placeholder"
+    assert "[Image Placeholder]" not in joined, "the marker reached the index as if it were caption text"

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -354,3 +354,13 @@ def test_mixed_image_block_survives_chunking():
     joined = "\n".join(c.text for c in splitter.chunk(doc, partition="p"))
     assert "92 000 COLLABORATEURS" in joined, "real caption text dropped alongside the placeholder"
     assert "[Image Placeholder]" not in joined, "the marker reached the index as if it were caption text"
+
+
+def test_symbol_only_caption_is_not_treated_as_a_placeholder():
+    """A caption reduced to punctuation is still content. Testing for
+    alphanumerics rather than whitespace would carve out an exception to the
+    rule this guard exists to enforce."""
+    from core.chunking.recursive import is_placeholder_image
+
+    assert not is_placeholder_image("<image_description>\n\n[Image Placeholder]\n\n©\n\n</image_description>")
+    assert is_placeholder_image("<image_description>\n\n[Image Placeholder]\n\n   \n\n</image_description>")

--- a/tests/unit/core/chunking/test_recursive.py
+++ b/tests/unit/core/chunking/test_recursive.py
@@ -306,3 +306,47 @@ def test_dewrap_preserves_code_fence_verbatim():
     assert "    return 1" in lines  # indentation preserved
     assert "Intro wrapped across two lines." in lines  # prose still reflowed
     assert "Outro wrapped across two." in lines
+
+
+def test_placeholder_only_image_block_is_skipped():
+    """A caption the VLM could make nothing of is still noise — keep skipping it."""
+    from core.chunking.recursive import is_placeholder_image
+
+    assert is_placeholder_image("<image_description>\n\n[Image Placeholder]\n\n</image_description>")
+    assert is_placeholder_image("[IMAGE PLACEHOLDER]")
+    assert not is_placeholder_image("<image_description>\n\nA bar chart of revenue.\n\n</image_description>")
+
+
+def test_image_block_keeps_real_caption_beside_a_placeholder():
+    """The marker means the captioner found nothing in *one* image, but a block
+    can describe several. Dropping the whole block on any occurrence deleted
+    real caption text with it — a 132-token chart caption and 225 words of a
+    tourism description went missing from the index on the test corpus."""
+    from core.chunking.recursive import is_placeholder_image
+
+    mixed = (
+        "<image_description>\n\n[Image Placeholder]\n\n</image_description>\n"
+        "<image_description>\n\n92 000 COLLABORATEURS\n27 000 AVTOVAZ\n16 PAYS\n\n</image_description>"
+    )
+    assert not is_placeholder_image(mixed)
+
+
+def test_mixed_image_block_survives_chunking():
+    splitter = RecursiveSplitter(chunk_size=200, chunk_overlap_rate=0.0, length_function=_word_tokens)
+    doc = ProcessedDocument(
+        document_id="d1",
+        text_blocks=[
+            TextBlock(
+                text=(
+                    "Intro paragraph.\n\n"
+                    "<image_description>\n\n[Image Placeholder]\n\n</image_description>\n"
+                    "<image_description>\n\n92 000 COLLABORATEURS 27 000 AVTOVAZ\n\n</image_description>\n\n"
+                    "Closing paragraph."
+                ),
+                page_number=1,
+            )
+        ],
+        metadata={"source": "test.md"},
+    )
+    joined = "\n".join(c.text for c in splitter.chunk(doc, partition="p"))
+    assert "92 000 COLLABORATEURS" in joined, "real caption text dropped alongside the placeholder"


### PR DESCRIPTION
Silent content loss in `recursive_splitter`, the current default chunker. Split out of #861, where it was found — it stands alone and needs no part of that PR.

## The bug

`BaseChunker` skipped an image block whenever `[Image Placeholder]` appeared **anywhere** in it:

```python
if element.type == "image" and _IMAGE_PLACEHOLDER_MARKER in element.content.lower():
    continue
```

The marker means the captioner found nothing useful in *one* image — but a single block can describe several. A marker sitting next to real caption text took that text with it, before the chunk was ever built. No error, no log; the content simply never reaches the index and is unretrievable.

## How it was found

By reassembling every chunk and diffing against the parsed source across a 30-document corpus — a check none of the existing cleanliness metrics can make, since a chunker that silently drops text scores well on all of them.

Two examples of what never reached the index:

- a 132-token chart caption — `92 000 COLLABORATEURS / 55% DU GROUP / 27 000 AVTOVAZ / 65 000 RENAULT GROUP / 16 PAYS …`
- 225 words of a tourism description — `tout Étretat est une destination riche en attractions naturelles et culturelles …`

## The fix

`is_placeholder_image()` skips a block only when nothing but the wrapper and the marker(s) remains. Anything with characters left is real caption text and is kept. Placeholder-only blocks are still dropped, so the noise this guard exists to remove is unaffected.

## Effect

Coverage against the source, marker corpus, `recursive_splitter`:

| | before | after |
|---|---|---|
| mean | 99.55% | **99.81%** |
| worst document | 95.16% | **99.10%** |
| documents below 99% | 3 | **0** |

## Notes

- Affects indexing only; no API or config change, nothing to migrate. Documents already indexed keep their current chunks until re-indexed.
- `structured_section` (#861) shares this code path and inherits the fix; that PR currently carries the same change and it will drop out of its diff once this merges.
- Three tests: placeholder-only blocks still skipped, a mixed block keeps its caption, and an end-to-end check that the caption survives chunking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image filtering to skip only image blocks without meaningful caption text.
  * Preserved captions that include placeholder markers alongside descriptive content.
  * Removed placeholder markers while retaining meaningful image captions during content chunking.
  * Recognized punctuation-only captions as meaningful content while continuing to ignore whitespace-only captions.

* **Tests**
  * Added coverage for placeholder-only images and mixed image blocks with real captions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->