### PR TITLE
fix: allow re-upload after cancelled indexing tasks

### DIFF
--- a/openrag/api/routers/admin/indexing.py
+++ b/openrag/api/routers/admin/indexing.py
@@ -32,7 +32,7 @@ from api.dependencies.files import (
 )
 from api.routers.admin.task_logs import collect_task_logs
 from core.models.catalog import TERMINAL_TASK_STATES
-from core.utils.exceptions import OpenRAGError
+from core.utils.exceptions import OpenRAGError, indexing_worker_may_be_running
 from core.utils.filename import sanitize_filename
 from core.utils.log_tail import app_log_file
 from core.utils.logging import get_logger
@@ -196,8 +196,12 @@ async def add_file(
             workspace_ids=parsed_workspace_ids,
             content_sha256=content_sha256,
         )
-    except BaseException:
-        file_path.unlink(missing_ok=True)
+    except BaseException as exc:
+        # A submission whose outcome is unknown may have left a worker running
+        # that has not read the file yet; deleting it would fail an indexing
+        # run that could still succeed. The worker cleans up its own input.
+        if not indexing_worker_may_be_running(exc):
+            file_path.unlink(missing_ok=True)
         raise
 
     return JSONResponse(
@@ -331,8 +335,12 @@ async def put_file(
             replace=True,
             content_sha256=content_sha256,
         )
-    except BaseException:
-        file_path.unlink(missing_ok=True)
+    except BaseException as exc:
+        # A submission whose outcome is unknown may have left a worker running
+        # that has not read the file yet; deleting it would fail an indexing
+        # run that could still succeed. The worker cleans up its own input.
+        if not indexing_worker_may_be_running(exc):
+            file_path.unlink(missing_ok=True)
         raise
 
     return JSONResponse(

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -33,6 +33,7 @@ TERMINAL_TASK_STATES = frozenset({DocumentStatus.COMPLETED, DocumentStatus.FAILE
 TASK_CREATED_AT_METADATA_KEY = "_openrag_job_created_at"
 TASK_FINISHED_AT_METADATA_KEY = "_openrag_job_finished_at"
 CONTENT_CLAIM_TOKEN_METADATA_KEY = "_openrag_content_claim_token"
+COPY_CONTENT_CLAIM_TOKEN_PREFIX = "copy:"
 
 
 class JobStatus(str, Enum):

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -33,6 +33,7 @@ TERMINAL_TASK_STATES = frozenset({DocumentStatus.COMPLETED, DocumentStatus.FAILE
 TASK_CREATED_AT_METADATA_KEY = "_openrag_job_created_at"
 TASK_FINISHED_AT_METADATA_KEY = "_openrag_job_finished_at"
 CONTENT_CLAIM_TOKEN_METADATA_KEY = "_openrag_content_claim_token"
+INDEXING_CONTENT_CLAIM_TOKEN_PREFIX = "task:"
 COPY_CONTENT_CLAIM_TOKEN_PREFIX = "copy:"
 
 

--- a/openrag/core/ports/document_repo.py
+++ b/openrag/core/ports/document_repo.py
@@ -53,8 +53,9 @@ class DocumentRepository(ABC):
         content_sha256: str,
         claim_token: str,
         replace: bool = False,
+        active_claim_tokens: set[str] | None = None,
     ) -> str | None:
-        """Reserve content for one indexing attempt, returning a conflicting file id."""
+        """Reserve content, recovering inactive claims when task state is available."""
         ...
 
     @abstractmethod

--- a/openrag/core/ports/document_repo.py
+++ b/openrag/core/ports/document_repo.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from openrag.core.models.catalog import DocumentRecord
+
+
+@dataclass(frozen=True, slots=True)
+class ContentClaimLease:
+    """Versioned content reservation eligible for orphan recovery."""
+
+    file_id: str
+    partition: str
+    content_sha256: str
+    claim_token: str
+    expires_at: datetime
 
 
 class DocumentRepository(ABC):
@@ -53,9 +66,23 @@ class DocumentRepository(ABC):
         content_sha256: str,
         claim_token: str,
         replace: bool = False,
-        active_claim_tokens: set[str] | None = None,
     ) -> str | None:
-        """Reserve content, recovering inactive claims when task state is available."""
+        """Reserve content and return the conflicting file ID when occupied."""
+        ...
+
+    @abstractmethod
+    async def get_recoverable_content_sha256_claim(
+        self,
+        *,
+        partition: str,
+        content_sha256: str,
+    ) -> ContentClaimLease | None:
+        """Return an aged indexing lease that may be orphaned."""
+        ...
+
+    @abstractmethod
+    async def release_recoverable_content_sha256_claim(self, lease: ContentClaimLease) -> bool:
+        """Release the lease only if its owner and version are unchanged."""
         ...
 
     @abstractmethod

--- a/openrag/core/utils/exceptions.py
+++ b/openrag/core/utils/exceptions.py
@@ -432,3 +432,28 @@ class VDBSchemaMigrationRequiredError(VDBError):
 class UnexpectedVDBError(VDBError):
     def __init__(self, message: str, **kwargs):
         super().__init__(message, code="VDB_UNEXPECTED_ERROR", status_code=500, **kwargs)
+
+
+# ``IndexerPool.submit`` launches the worker task before it returns, so a lost
+# or timed-out submit response can leave a worker running against the uploaded
+# file. The dispatcher preserves the task and its content claim in that case
+# (``submission_outcome_unknown``) and marks the propagating exception, so
+# upload handlers keep the file instead of unlinking input the live worker has
+# not read yet. The worker deletes its own input once it settles — see
+# ``services.workers.indexer_actor.delete_uploaded_file``.
+_INDEXING_WORKER_MAY_BE_RUNNING_ATTR = "_openrag_indexing_worker_may_be_running"
+
+
+def mark_indexing_worker_may_be_running(exc: BaseException) -> None:
+    """Flag ``exc`` as propagating while an indexing worker may still be live."""
+    try:
+        setattr(exc, _INDEXING_WORKER_MAY_BE_RUNNING_ATTR, True)
+    except AttributeError:
+        # A few built-in exceptions forbid attribute assignment; losing the
+        # marker only restores the previous (delete-the-upload) behaviour.
+        pass
+
+
+def indexing_worker_may_be_running(exc: BaseException) -> bool:
+    """Whether ``exc`` was raised while an indexing worker may still be live."""
+    return getattr(exc, _INDEXING_WORKER_MAY_BE_RUNNING_ATTR, False) is True

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from core.models.catalog import INDEXING_CONTENT_CLAIM_TOKEN_PREFIX, DocumentRecord, DocumentStatus
-from core.ports.document_repo import DocumentRepository
+from core.ports.document_repo import ContentClaimLease, DocumentRepository
 from core.utils.logging import get_logger
 from services.persistence.file_count import decrement_file_counts
 
@@ -277,7 +277,6 @@ class PgDocumentRepository(DocumentRepository):
         content_sha256: str,
         claim_token: str,
         replace: bool = False,
-        active_claim_tokens: set[str] | None = None,
     ) -> str | None:
         """Atomically reserve content while it is being indexed."""
         async with self.pool.acquire() as conn:
@@ -298,29 +297,6 @@ class PgDocumentRepository(DocumentRepository):
                 )
                 if existing_file_id is not None and not (replace and existing_file_id == file_id):
                     return existing_file_id
-
-                if active_claim_tokens is not None:
-                    # A claim starts with a 24-hour lease and is renewed to the
-                    # same horizon while its task is alive.  Once the owning
-                    # task has disappeared, allow a brief registration grace
-                    # before recovering the abandoned claim.  This closes the
-                    # crash/restart gap without allowing a concurrent upload to
-                    # steal a claim between its INSERT and QUEUED transition.
-                    # Bare legacy tokens are never recovered early because an
-                    # older replica may still own one for a synchronous copy.
-                    await conn.execute(
-                        """
-                        DELETE FROM file_content_claims
-                        WHERE partition_name = $1 AND content_sha256 = $2
-                          AND NOT (claim_token = ANY($3::text[]))
-                          AND claim_token LIKE $4
-                          AND expires_at <= NOW() + interval '23 hours 59 minutes'
-                        """,
-                        partition,
-                        content_sha256,
-                        sorted(active_claim_tokens),
-                        f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}%",
-                    )
 
                 await conn.execute(
                     """
@@ -352,6 +328,60 @@ class PgDocumentRepository(DocumentRepository):
                     partition,
                     content_sha256,
                 )
+
+    async def get_recoverable_content_sha256_claim(
+        self,
+        *,
+        partition: str,
+        content_sha256: str,
+    ) -> ContentClaimLease | None:
+        row = await self.pool.fetchrow(
+            """
+            SELECT file_id, partition_name, content_sha256, claim_token, expires_at
+            FROM file_content_claims
+            WHERE partition_name = $1 AND content_sha256 = $2
+              AND claim_token LIKE $3
+              AND expires_at <= NOW() + interval '23 hours 59 minutes'
+            """,
+            partition,
+            content_sha256,
+            f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}%",
+        )
+        if row is None:
+            return None
+        return ContentClaimLease(
+            file_id=row["file_id"],
+            partition=row["partition_name"],
+            content_sha256=row["content_sha256"],
+            claim_token=row["claim_token"],
+            expires_at=row["expires_at"],
+        )
+
+    async def release_recoverable_content_sha256_claim(self, lease: ContentClaimLease) -> bool:
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))",
+                    lease.partition,
+                    lease.content_sha256,
+                )
+                result = await conn.execute(
+                    """
+                    DELETE FROM file_content_claims
+                    WHERE partition_name = $1 AND content_sha256 = $2
+                      AND file_id = $3 AND claim_token = $4
+                      AND expires_at = $5
+                      AND claim_token LIKE $6
+                      AND expires_at <= NOW() + interval '23 hours 59 minutes'
+                    """,
+                    lease.partition,
+                    lease.content_sha256,
+                    lease.file_id,
+                    lease.claim_token,
+                    lease.expires_at,
+                    f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}%",
+                )
+                return result.endswith(" 1")
 
     async def renew_content_sha256_claim(
         self,

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from core.models.catalog import DocumentRecord, DocumentStatus
+from core.models.catalog import COPY_CONTENT_CLAIM_TOKEN_PREFIX, DocumentRecord, DocumentStatus
 from core.ports.document_repo import DocumentRepository
 from core.utils.logging import get_logger
 from services.persistence.file_count import decrement_file_counts
@@ -277,6 +277,7 @@ class PgDocumentRepository(DocumentRepository):
         content_sha256: str,
         claim_token: str,
         replace: bool = False,
+        active_claim_tokens: set[str] | None = None,
     ) -> str | None:
         """Atomically reserve content while it is being indexed."""
         async with self.pool.acquire() as conn:
@@ -297,6 +298,27 @@ class PgDocumentRepository(DocumentRepository):
                 )
                 if existing_file_id is not None and not (replace and existing_file_id == file_id):
                     return existing_file_id
+
+                if active_claim_tokens is not None:
+                    # A claim starts with a 24-hour lease and is renewed to the
+                    # same horizon while its task is alive.  Once the owning
+                    # task has disappeared, allow a brief registration grace
+                    # before recovering the abandoned claim.  This closes the
+                    # crash/restart gap without allowing a concurrent upload to
+                    # steal a claim between its INSERT and QUEUED transition.
+                    await conn.execute(
+                        """
+                        DELETE FROM file_content_claims
+                        WHERE partition_name = $1 AND content_sha256 = $2
+                          AND NOT (claim_token = ANY($3::text[]))
+                          AND claim_token NOT LIKE $4
+                          AND expires_at <= NOW() + interval '23 hours 59 minutes'
+                        """,
+                        partition,
+                        content_sha256,
+                        sorted(active_claim_tokens),
+                        f"{COPY_CONTENT_CLAIM_TOKEN_PREFIX}%",
+                    )
 
                 await conn.execute(
                     """

--- a/openrag/services/persistence/document_repo.py
+++ b/openrag/services/persistence/document_repo.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from core.models.catalog import COPY_CONTENT_CLAIM_TOKEN_PREFIX, DocumentRecord, DocumentStatus
+from core.models.catalog import INDEXING_CONTENT_CLAIM_TOKEN_PREFIX, DocumentRecord, DocumentStatus
 from core.ports.document_repo import DocumentRepository
 from core.utils.logging import get_logger
 from services.persistence.file_count import decrement_file_counts
@@ -306,18 +306,20 @@ class PgDocumentRepository(DocumentRepository):
                     # before recovering the abandoned claim.  This closes the
                     # crash/restart gap without allowing a concurrent upload to
                     # steal a claim between its INSERT and QUEUED transition.
+                    # Bare legacy tokens are never recovered early because an
+                    # older replica may still own one for a synchronous copy.
                     await conn.execute(
                         """
                         DELETE FROM file_content_claims
                         WHERE partition_name = $1 AND content_sha256 = $2
                           AND NOT (claim_token = ANY($3::text[]))
-                          AND claim_token NOT LIKE $4
+                          AND claim_token LIKE $4
                           AND expires_at <= NOW() + interval '23 hours 59 minutes'
                         """,
                         partition,
                         content_sha256,
                         sorted(active_claim_tokens),
-                        f"{COPY_CONTENT_CLAIM_TOKEN_PREFIX}%",
+                        f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}%",
                     )
 
                 await conn.execute(

--- a/openrag/services/workers/bootstrap.py
+++ b/openrag/services/workers/bootstrap.py
@@ -36,6 +36,7 @@ logger = get_logger()
 
 actor_creation_map: dict[str, callable] = {}
 _settings: "Settings | None" = None
+_TRACKER_PROTOCOL_TIMEOUT_SECONDS = 5
 
 
 def _require_settings() -> "Settings":
@@ -113,18 +114,56 @@ def _supports_task_state_recovery(actor) -> bool:
 
 
 def get_task_completion_tracker(namespace: str = "openrag"):
+    from time import monotonic, sleep
+
+    import ray
     from services.workers.task_completion import TaskCompletionTrackerActor
 
-    tracker = get_or_create_actor(
-        "TaskCompletionTracker",
-        TaskCompletionTrackerActor,
-        namespace=namespace,
-        remote_args=(namespace,),
-        lifetime="detached",
-    )
+    def create_or_get():
+        return get_or_create_actor(
+            "TaskCompletionTracker",
+            TaskCompletionTrackerActor,
+            namespace=namespace,
+            remote_args=(namespace,),
+            lifetime="detached",
+        )
+
+    tracker = create_or_get()
+    if not _supports_task_completion_recovery(tracker):
+        logger.warning("Replacing legacy TaskCompletionTracker without cancellation recovery")
+        ray.kill(tracker, no_restart=True)
+        deadline = monotonic() + 30
+        while monotonic() < deadline:
+            try:
+                current = ray.get_actor("TaskCompletionTracker", namespace=namespace)
+            except ValueError:
+                tracker = create_or_get()
+                break
+            if _supports_task_completion_recovery(current):
+                tracker = current
+                break
+            sleep(0.05)
+        else:
+            raise RuntimeError("Timed out replacing legacy TaskCompletionTracker")
     tracker.recover.remote()
     actor_creation_map["TaskCompletionTracker"] = lambda: get_task_completion_tracker(namespace=namespace)
     return tracker
+
+
+def _supports_task_completion_recovery(actor) -> bool:
+    method_names = getattr(actor, "_ray_actor_method_names", None)
+    if isinstance(method_names, (frozenset, list, set, tuple)) and "supports_cancellation_recovery" not in method_names:
+        return False
+    method = getattr(actor, "supports_cancellation_recovery", None)
+    remote = getattr(method, "remote", None)
+    if remote is None:
+        return False
+    try:
+        import ray
+
+        return ray.get(remote(), timeout=_TRACKER_PROTOCOL_TIMEOUT_SECONDS) is True
+    except Exception:
+        return False
 
 
 def register_parser_pool_restart_factories() -> None:

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -288,6 +288,18 @@ class WorkerDispatcher(IndexingDispatcher):
             }
             if require_existing_partition:
                 submit_kwargs[_REQUIRE_EXISTING_PARTITION_KWARG] = True
+            if claimed_content:
+                still_owned = await self._document_repo.renew_content_sha256_claim(
+                    file_id=file_id,
+                    partition=partition,
+                    content_sha256=content_sha256,
+                    claim_token=content_claim_token,
+                )
+                if not still_owned:
+                    raise ConflictError(
+                        "The content reservation expired before indexing started. Please retry the upload.",
+                        code="DOCUMENT_CONTENT_CLAIM_LOST",
+                    )
             task = await self._submit_indexing_task(
                 task_id,
                 submit_kwargs,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -324,7 +324,7 @@ class WorkerDispatcher(IndexingDispatcher):
             )
             self._track_completion(task_id, task)
         except BaseException:
-            submission_outcome_unknown = claimed_content and submission_started and task is None
+            submission_outcome_unknown = submission_started and task is None
             mark_submit_failed = not submission_outcome_unknown
             try:
                 if task is not None:

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -15,7 +15,7 @@ from core.models.catalog import (
     TASK_FINISHED_AT_METADATA_KEY,
 )
 from core.utils.conts import is_internal_metadata_key, strip_internal_metadata
-from core.utils.exceptions import ConflictError
+from core.utils.exceptions import ConflictError, mark_indexing_worker_may_be_running
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_with_timeout, retry_idempotent_ray_actor_method
@@ -345,7 +345,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 allow_legacy_retry=allow_legacy_require_existing_partition_retry,
             )
             self._track_completion(task_id, task)
-        except BaseException:
+        except BaseException as exc:
             submission_outcome_unknown = submission_started and task is None
             mark_submit_failed = not submission_outcome_unknown
             try:
@@ -365,6 +365,10 @@ class WorkerDispatcher(IndexingDispatcher):
                         content_sha256=content_sha256,
                         claim_token=content_claim_token,
                     )
+            if submission_outcome_unknown:
+                # The pool may have launched a worker that has not read the
+                # uploaded file yet; tell the caller to keep it on disk.
+                mark_indexing_worker_may_be_running(exc)
             raise
         return task_id
 

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -147,6 +147,19 @@ class WorkerDispatcher(IndexingDispatcher):
             raise RuntimeError("TaskStateManager returned invalid claim owners for content claim recovery")
         return {f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}{task_id}" for task_id in task_ids}
 
+    async def _mark_worker_submitted(self, task_id: str) -> bool:
+        remote = _remote_actor_method(self._tsm, "mark_worker_submitted")
+        if remote is None:
+            # Older task-state actors do not recover claims early, so their
+            # existing conservative behavior is safe during a rolling deploy.
+            return True
+        submitted = await retry_idempotent_ray_actor_method(
+            lambda: remote(task_id),
+            recovery_timeout=self._timeout,
+            task_description=f"mark_worker_submitted({task_id})",
+        )
+        return submitted is True
+
     async def _begin_file_delete_fence(self, *, file_id: str, partition: str, fence_id: str) -> None:
         remote = _remote_actor_method(self._tsm, "begin_file_delete")
         if remote is None:
@@ -300,6 +313,8 @@ class WorkerDispatcher(IndexingDispatcher):
                         "The content reservation expired before indexing started. Please retry the upload.",
                         code="DOCUMENT_CONTENT_CLAIM_LOST",
                     )
+            if not await self._mark_worker_submitted(task_id):
+                raise RuntimeError(f"Task {task_id} was rejected before worker submission")
             task = await self._submit_indexing_task(
                 task_id,
                 submit_kwargs,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -147,18 +147,18 @@ class WorkerDispatcher(IndexingDispatcher):
             raise RuntimeError("TaskStateManager returned invalid claim owners for content claim recovery")
         return {f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}{task_id}" for task_id in task_ids}
 
-    async def _mark_worker_submitted(self, task_id: str) -> bool:
-        remote = _remote_actor_method(self._tsm, "mark_worker_submitted")
+    async def _begin_worker_submission(self, task_id: str) -> bool:
+        remote = _remote_actor_method(self._tsm, "begin_worker_submission")
         if remote is None:
             # Older task-state actors do not recover claims early, so their
             # existing conservative behavior is safe during a rolling deploy.
             return True
-        submitted = await retry_idempotent_ray_actor_method(
+        accepted = await retry_idempotent_ray_actor_method(
             lambda: remote(task_id),
             recovery_timeout=self._timeout,
-            task_description=f"mark_worker_submitted({task_id})",
+            task_description=f"begin_worker_submission({task_id})",
         )
-        return submitted is True
+        return accepted is True
 
     async def _begin_file_delete_fence(self, *, file_id: str, partition: str, fence_id: str) -> None:
         remote = _remote_actor_method(self._tsm, "begin_file_delete")
@@ -313,7 +313,7 @@ class WorkerDispatcher(IndexingDispatcher):
                         "The content reservation expired before indexing started. Please retry the upload.",
                         code="DOCUMENT_CONTENT_CLAIM_LOST",
                     )
-            if not await self._mark_worker_submitted(task_id):
+            if not await self._begin_worker_submission(task_id):
                 raise RuntimeError(f"Task {task_id} was rejected before worker submission")
             task = await self._submit_indexing_task(
                 task_id,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -10,6 +10,7 @@ from core.indexing.dispatcher import IndexingDispatcher
 from core.models.catalog import (
     CONTENT_CLAIM_TOKEN_METADATA_KEY,
     COPY_CONTENT_CLAIM_TOKEN_PREFIX,
+    INDEXING_CONTENT_CLAIM_TOKEN_PREFIX,
     TASK_CREATED_AT_METADATA_KEY,
     TASK_FINISHED_AT_METADATA_KEY,
 )
@@ -135,16 +136,16 @@ class WorkerDispatcher(IndexingDispatcher):
         cannot provide the active-task lookup.  That fallback keeps rolling
         deployments conservative.
         """
-        remote = _remote_actor_method(self._tsm, "get_matching_active_task_refs_v2")
+        remote = _remote_actor_method(self._tsm, "get_content_claim_task_ids")
         if remote is None:
             return None
-        matches = await self._call_method(
+        task_ids = await self._call_method(
             lambda: remote(partition=partition),
             task_description=f"get_active_content_claim_tokens({partition})",
         )
-        if not isinstance(matches, dict):
-            raise RuntimeError("TaskStateManager returned invalid active tasks for content claim recovery")
-        return {str(task_id) for task_id in matches}
+        if not isinstance(task_ids, (list, set, tuple)):
+            raise RuntimeError("TaskStateManager returned invalid claim owners for content claim recovery")
+        return {f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}{task_id}" for task_id in task_ids}
 
     async def _begin_file_delete_fence(self, *, file_id: str, partition: str, fence_id: str) -> None:
         remote = _remote_actor_method(self._tsm, "begin_file_delete")
@@ -213,6 +214,7 @@ class WorkerDispatcher(IndexingDispatcher):
         task_id = uuid.uuid4().hex
         file_id = str(metadata.get("file_id") or "")
         content_sha256 = metadata.get("content_sha256")
+        content_claim_token = f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}{task_id}"
         claimed_content = False
 
         if content_sha256:
@@ -221,7 +223,7 @@ class WorkerDispatcher(IndexingDispatcher):
                 file_id=file_id,
                 partition=partition,
                 content_sha256=content_sha256,
-                claim_token=task_id,
+                claim_token=content_claim_token,
                 replace=replace,
                 active_claim_tokens=active_claim_tokens,
             )
@@ -253,7 +255,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=file_id,
                     partition=partition,
                     content_sha256=content_sha256,
-                    claim_token=task_id,
+                    claim_token=content_claim_token,
                 )
             raise
         if not accepted:
@@ -262,7 +264,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=file_id,
                     partition=partition,
                     content_sha256=content_sha256,
-                    claim_token=task_id,
+                    claim_token=content_claim_token,
                 )
             raise RuntimeError(
                 f"Task {task_id} was rejected because file {file_id!r} in partition {partition!r} is being deleted"
@@ -272,7 +274,7 @@ class WorkerDispatcher(IndexingDispatcher):
         try:
             worker_metadata = dict(metadata)
             if claimed_content:
-                worker_metadata[CONTENT_CLAIM_TOKEN_METADATA_KEY] = task_id
+                worker_metadata[CONTENT_CLAIM_TOKEN_METADATA_KEY] = content_claim_token
             submit_kwargs: dict[str, Any] = {
                 "task_id": task_id,
                 "path": path,
@@ -315,7 +317,7 @@ class WorkerDispatcher(IndexingDispatcher):
                         file_id=file_id,
                         partition=partition,
                         content_sha256=content_sha256,
-                        claim_token=task_id,
+                        claim_token=content_claim_token,
                     )
             raise
         return task_id
@@ -642,13 +644,6 @@ class WorkerDispatcher(IndexingDispatcher):
                 return False
 
         ray.cancel(obj_ref["ref"], recursive=True)
-        finish_cancellation = _remote_actor_method(self._tsm, "finish_cancellation")
-        if finish_cancellation is not None:
-            await retry_idempotent_ray_actor_method(
-                submit=lambda: finish_cancellation(task_id),
-                recovery_timeout=self._timeout,
-                task_description=f"finish_cancellation({task_id})",
-            )
         return True
 
 

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -284,6 +284,7 @@ class WorkerDispatcher(IndexingDispatcher):
             )
 
         task: Any | None = None
+        submission_started = False
         try:
             worker_metadata = dict(metadata)
             if claimed_content:
@@ -315,6 +316,7 @@ class WorkerDispatcher(IndexingDispatcher):
                     )
             if not await self._begin_worker_submission(task_id):
                 raise RuntimeError(f"Task {task_id} was rejected before worker submission")
+            submission_started = True
             task = await self._submit_indexing_task(
                 task_id,
                 submit_kwargs,
@@ -329,17 +331,19 @@ class WorkerDispatcher(IndexingDispatcher):
                 raise RuntimeError(f"Task {task_id} was cancelled before worker ref registration")
             self._track_completion(task_id, task)
         except BaseException:
-            mark_submit_failed = True
+            submission_outcome_unknown = claimed_content and submission_started and task is None
+            mark_submit_failed = not submission_outcome_unknown
             try:
                 if task is not None:
                     mark_submit_failed = await self._cancel_submitted_task(task_id, task)
                     if mark_submit_failed:
                         await self._cleanup_submitted_vectors(task_id, metadata=metadata, partition=partition)
-                await self._record_finished_at(task_id, task_details)
-                if mark_submit_failed:
-                    await self._mark_submit_failed(task_id, traceback.format_exc())
+                if not submission_outcome_unknown:
+                    await self._record_finished_at(task_id, task_details)
+                    if mark_submit_failed:
+                        await self._mark_submit_failed(task_id, traceback.format_exc())
             finally:
-                if claimed_content and (task is None or mark_submit_failed):
+                if claimed_content and not submission_outcome_unknown and (task is None or mark_submit_failed):
                     await self._document_repo.release_content_sha256_claim(
                         file_id=file_id,
                         partition=partition,

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -322,13 +322,6 @@ class WorkerDispatcher(IndexingDispatcher):
                 submit_kwargs,
                 allow_legacy_retry=allow_legacy_require_existing_partition_retry,
             )
-
-            registered = await self._call_method(
-                lambda: self._tsm.set_object_ref.remote(task_id, {"ref": task}),
-                task_description=f"set_object_ref({task_id})",
-            )
-            if registered is False:
-                raise RuntimeError(f"Task {task_id} was cancelled before worker ref registration")
             self._track_completion(task_id, task)
         except BaseException:
             submission_outcome_unknown = claimed_content and submission_started and task is None

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -147,6 +147,24 @@ class WorkerDispatcher(IndexingDispatcher):
             raise RuntimeError("TaskStateManager returned invalid claim owners for content claim recovery")
         return {f"{INDEXING_CONTENT_CLAIM_TOKEN_PREFIX}{task_id}" for task_id in task_ids}
 
+    async def _recover_inactive_content_claim(self, *, partition: str, content_sha256: str) -> bool:
+        get_lease = getattr(self._document_repo, "get_recoverable_content_sha256_claim", None)
+        release_lease = getattr(self._document_repo, "release_recoverable_content_sha256_claim", None)
+        if not callable(get_lease) or not callable(release_lease):
+            return False
+
+        lease = await get_lease(partition=partition, content_sha256=content_sha256)
+        if lease is None:
+            return False
+        active_claim_tokens = await self._active_content_claim_tokens(partition)
+        if active_claim_tokens is None or lease.claim_token in active_claim_tokens:
+            return False
+
+        # The lease contains the expiry value observed before the fresh owner
+        # lookup. A concurrent renewal changes that value, so the repository's
+        # conditional delete fails instead of reclaiming a live reservation.
+        return bool(await release_lease(lease))
+
     async def _begin_worker_submission(self, task_id: str) -> bool:
         remote = _remote_actor_method(self._tsm, "begin_worker_submission")
         if remote is None:
@@ -231,15 +249,19 @@ class WorkerDispatcher(IndexingDispatcher):
         claimed_content = False
 
         if content_sha256:
-            active_claim_tokens = await self._active_content_claim_tokens(partition)
-            conflicting_file_id = await self._document_repo.claim_content_sha256(
-                file_id=file_id,
+            claim_kwargs = {
+                "file_id": file_id,
+                "partition": partition,
+                "content_sha256": content_sha256,
+                "claim_token": content_claim_token,
+                "replace": replace,
+            }
+            conflicting_file_id = await self._document_repo.claim_content_sha256(**claim_kwargs)
+            if conflicting_file_id is not None and await self._recover_inactive_content_claim(
                 partition=partition,
                 content_sha256=content_sha256,
-                claim_token=content_claim_token,
-                replace=replace,
-                active_claim_tokens=active_claim_tokens,
-            )
+            ):
+                conflicting_file_id = await self._document_repo.claim_content_sha256(**claim_kwargs)
             if conflicting_file_id is not None:
                 raise ConflictError(
                     f"This document already exists in partition '{partition}'.",

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -9,6 +9,7 @@ from typing import Any
 from core.indexing.dispatcher import IndexingDispatcher
 from core.models.catalog import (
     CONTENT_CLAIM_TOKEN_METADATA_KEY,
+    COPY_CONTENT_CLAIM_TOKEN_PREFIX,
     TASK_CREATED_AT_METADATA_KEY,
     TASK_FINISHED_AT_METADATA_KEY,
 )
@@ -127,6 +128,24 @@ class WorkerDispatcher(IndexingDispatcher):
         )
         return True
 
+    async def _active_content_claim_tokens(self, partition: str) -> set[str] | None:
+        """Return task tokens whose content reservations must be preserved.
+
+        ``None`` disables orphan recovery for an older TaskStateManager that
+        cannot provide the active-task lookup.  That fallback keeps rolling
+        deployments conservative.
+        """
+        remote = _remote_actor_method(self._tsm, "get_matching_active_task_refs_v2")
+        if remote is None:
+            return None
+        matches = await self._call_method(
+            lambda: remote(partition=partition),
+            task_description=f"get_active_content_claim_tokens({partition})",
+        )
+        if not isinstance(matches, dict):
+            raise RuntimeError("TaskStateManager returned invalid active tasks for content claim recovery")
+        return {str(task_id) for task_id in matches}
+
     async def _begin_file_delete_fence(self, *, file_id: str, partition: str, fence_id: str) -> None:
         remote = _remote_actor_method(self._tsm, "begin_file_delete")
         if remote is None:
@@ -197,12 +216,14 @@ class WorkerDispatcher(IndexingDispatcher):
         claimed_content = False
 
         if content_sha256:
+            active_claim_tokens = await self._active_content_claim_tokens(partition)
             conflicting_file_id = await self._document_repo.claim_content_sha256(
                 file_id=file_id,
                 partition=partition,
                 content_sha256=content_sha256,
                 claim_token=task_id,
                 replace=replace,
+                active_claim_tokens=active_claim_tokens,
             )
             if conflicting_file_id is not None:
                 raise ConflictError(
@@ -510,7 +531,7 @@ class WorkerDispatcher(IndexingDispatcher):
         target_partition = metadata.get("partition", partition)
         content_sha256 = metadata.get("content_sha256")
         claimed_content = False
-        claim_token = uuid.uuid4().hex
+        claim_token = f"{COPY_CONTENT_CLAIM_TOKEN_PREFIX}{uuid.uuid4().hex}"
         if content_sha256:
             conflicting_file_id = await self._document_repo.claim_content_sha256(
                 file_id=target_file_id,

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -75,10 +75,12 @@ class IndexerWorker:
         on success.  On failure, state is set to FAILED and the exception
         is re-raised so the Ray task is marked as errored.
         """
-        await retry_idempotent_ray_actor_method(
+        accepted = await retry_idempotent_ray_actor_method(
             lambda: self._tsm.set_state.remote(task_id, "SERIALIZING"),
             task_description=f"set_state({task_id}, SERIALIZING)",
         )
+        if accepted is False:
+            raise RuntimeError(f"Task {task_id} was cancelled before indexing started")
         row: dict[str, Any] | None = None
         catalog_written = False
         try:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -479,6 +479,7 @@ class IndexerPool:
         """
         if not self._accepting_tasks:
             raise RuntimeError("IndexerPool is draining and cannot accept new tasks")
+        task_id = str(kwargs.get("task_id") or "")
         idx = min(range(len(self._workers)), key=self._inflight.__getitem__)
         self._inflight[idx] += 1
         try:
@@ -487,6 +488,7 @@ class IndexerPool:
             # Submission failed before a ref exists (e.g. unserializable args or
             # a dead actor); roll back so load balancing stays accurate.
             self._inflight[idx] -= 1
+            await self._finish_rejected_submission(task_id)
             raise
         metadata = kwargs.get("metadata") or {}
         content_sha256 = metadata.get("content_sha256")
@@ -504,7 +506,6 @@ class IndexerPool:
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
-        task_id = str(kwargs.get("task_id") or "")
         try:
             registered = await self._register_worker_ref(task_id, ref)
         except BaseException:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -19,6 +19,7 @@ from openrag.core.config.root import Settings
 # of indexing throughput.
 _MODEL_REGISTRY_TTL_SECONDS = 60.0
 _CONTENT_CLAIM_RENEW_INTERVAL_SECONDS = 60 * 60
+_REJECTED_SUBMISSION_ERROR = "Indexer worker submission was rejected before the worker started."
 # Named detached actors survive API rolling deployments. Keep the dispatcher
 # and workers on the same protocol generation whenever their remote contract or
 # cross-process indexing semantics change, so new replicas cannot attach to a
@@ -552,16 +553,30 @@ class IndexerPool:
     async def _finish_rejected_submission(self, task_id: str) -> None:
         task_state_manager = self._task_state_actor()
         method_names = getattr(task_state_manager, "_ray_actor_method_names", None)
-        if isinstance(method_names, (frozenset, list, set, tuple)) and "finish_rejected_submission" not in method_names:
+        known_methods = set(method_names) if isinstance(method_names, (frozenset, list, set, tuple)) else None
+        if known_methods is None or "finish_rejected_submission" in known_methods:
+            method = getattr(task_state_manager, "finish_rejected_submission", None)
+            remote = getattr(method, "remote", None)
+            if remote is not None:
+                await retry_idempotent_ray_actor_method(
+                    lambda: remote(task_id),
+                    task_description=f"finish_rejected_submission({task_id}) from indexer pool",
+                )
+                return
+
+        # A TaskStateManager retained during a rolling deployment may predate
+        # the submission finalizer. It still exposes the atomic failure guard,
+        # which prevents rejected work from remaining QUEUED and consuming the
+        # uploader's pending-task quota indefinitely.
+        if known_methods is not None and "set_failed_if_not_cancelled" not in known_methods:
             return
-        method = getattr(task_state_manager, "finish_rejected_submission", None)
-        remote = getattr(method, "remote", None)
-        if remote is None:
-            return
-        await retry_idempotent_ray_actor_method(
-            lambda: remote(task_id),
-            task_description=f"finish_rejected_submission({task_id}) from indexer pool",
-        )
+        set_failed = getattr(task_state_manager, "set_failed_if_not_cancelled", None)
+        remote = getattr(set_failed, "remote", None)
+        if remote is not None:
+            await retry_idempotent_ray_actor_method(
+                lambda: remote(task_id, _REJECTED_SUBMISSION_ERROR),
+                task_description=f"set_failed_if_not_cancelled({task_id}) from indexer pool",
+            )
 
     async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
         task_state_manager = self._task_state_actor()

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -510,14 +510,6 @@ class IndexerPool:
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
         try:
-            accepted = await self._accept_worker_submission(task_id)
-        except BaseException:
-            await self._guard_rejected_worker(task_id, ref)
-            raise
-        if not accepted:
-            await self._guard_rejected_worker(task_id, ref)
-            raise RuntimeError(f"Task {task_id} was cancelled before the pool accepted it")
-        try:
             registered = await self._register_worker_ref(task_id, ref)
         except BaseException:
             await self._guard_rejected_worker(task_id, ref)
@@ -577,21 +569,6 @@ class IndexerPool:
             task_description=f"set_object_ref({task_id}) from indexer pool",
         )
         return registered is not False
-
-    async def _accept_worker_submission(self, task_id: str) -> bool:
-        task_state_manager = self._task_state_actor()
-        method_names = getattr(task_state_manager, "_ray_actor_method_names", None)
-        if isinstance(method_names, (frozenset, list, set, tuple)) and "accept_worker_submission" not in method_names:
-            return True
-        method = getattr(task_state_manager, "accept_worker_submission", None)
-        remote = getattr(method, "remote", None)
-        if remote is None:
-            return True
-        accepted = await retry_idempotent_ray_actor_method(
-            lambda: remote(task_id),
-            task_description=f"accept_worker_submission({task_id}) from indexer pool",
-        )
-        return accepted is True
 
     def _task_state_actor(self) -> Any:
         if self._task_state_manager is None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -547,10 +547,11 @@ class IndexerPool:
         await self._finish_rejected_submission(task_id)
 
     async def _finish_rejected_submission(self, task_id: str) -> None:
-        method_names = getattr(self._task_state_manager, "_ray_actor_method_names", None)
+        task_state_manager = self._task_state_actor()
+        method_names = getattr(task_state_manager, "_ray_actor_method_names", None)
         if isinstance(method_names, (frozenset, list, set, tuple)) and "finish_rejected_submission" not in method_names:
             return
-        method = getattr(self._task_state_manager, "finish_rejected_submission", None)
+        method = getattr(task_state_manager, "finish_rejected_submission", None)
         remote = getattr(method, "remote", None)
         if remote is None:
             return
@@ -562,13 +563,17 @@ class IndexerPool:
     async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
         if not task_id:
             raise ValueError("IndexerPool submission requires a task_id")
-        if self._task_state_manager is None:
-            self._task_state_manager = ray.get_actor("TaskStateManager", namespace=self._namespace)
+        task_state_manager = self._task_state_actor()
         registered = await retry_idempotent_ray_actor_method(
-            lambda: self._task_state_manager.set_object_ref.remote(task_id, {"ref": ref}),
+            lambda: task_state_manager.set_object_ref.remote(task_id, {"ref": ref}),
             task_description=f"set_object_ref({task_id}) from indexer pool",
         )
         return registered is not False
+
+    def _task_state_actor(self) -> Any:
+        if self._task_state_manager is None:
+            self._task_state_manager = ray.get_actor("TaskStateManager", namespace=self._namespace)
+        return self._task_state_manager
 
     async def _release(self, idx: int, ref: Any, *, claim: dict[str, str] | None = None) -> None:
         renewal_task = None

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -477,19 +477,7 @@ class IndexerPool:
         one-element list — see the class docstring); in-flight bookkeeping is
         released when the task settles (success, failure, or cancellation).
         """
-        if not self._accepting_tasks:
-            raise RuntimeError("IndexerPool is draining and cannot accept new tasks")
         task_id = str(kwargs.get("task_id") or "")
-        idx = min(range(len(self._workers)), key=self._inflight.__getitem__)
-        self._inflight[idx] += 1
-        try:
-            ref = self._workers[idx].process_file.remote(**kwargs)
-        except Exception:
-            # Submission failed before a ref exists (e.g. unserializable args or
-            # a dead actor); roll back so load balancing stays accurate.
-            self._inflight[idx] -= 1
-            await self._finish_rejected_submission(task_id)
-            raise
         metadata = kwargs.get("metadata") or {}
         content_sha256 = metadata.get("content_sha256")
         file_id = metadata.get("file_id")
@@ -502,6 +490,19 @@ class IndexerPool:
                 "content_sha256": str(content_sha256),
                 "claim_token": str(claim_token),
             }
+        if not self._accepting_tasks:
+            await self._guard_prelaunch_rejection(task_id, claim)
+            raise RuntimeError("IndexerPool is draining and cannot accept new tasks")
+        idx = min(range(len(self._workers)), key=self._inflight.__getitem__)
+        self._inflight[idx] += 1
+        try:
+            ref = self._workers[idx].process_file.remote(**kwargs)
+        except Exception:
+            # Submission failed before a ref exists (e.g. unserializable args or
+            # a dead actor); roll back so load balancing stays accurate.
+            self._inflight[idx] -= 1
+            await self._guard_prelaunch_rejection(task_id, claim)
+            raise
         task = asyncio.get_running_loop().create_task(self._release(idx, ref, claim=claim))
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
@@ -521,6 +522,18 @@ class IndexerPool:
         self._release_tasks.add(settlement)
         settlement.add_done_callback(self._release_tasks.discard)
         await asyncio.shield(settlement)
+
+    async def _guard_prelaunch_rejection(self, task_id: str, claim: dict[str, str] | None) -> None:
+        cleanup = asyncio.create_task(self._finish_prelaunch_rejection(task_id, claim))
+        self._release_tasks.add(cleanup)
+        cleanup.add_done_callback(self._release_tasks.discard)
+        await asyncio.shield(cleanup)
+
+    async def _finish_prelaunch_rejection(self, task_id: str, claim: dict[str, str] | None) -> None:
+        try:
+            await self._finish_rejected_submission(task_id)
+        finally:
+            await self._release_content_claim(claim)
 
     async def _cancel_worker_and_wait(self, task_id: str, ref: Any) -> None:
         """Keep the submission fenced until a rejected worker has settled."""
@@ -569,17 +582,22 @@ class IndexerPool:
                 renewal_task.cancel()
                 await asyncio.gather(renewal_task, return_exceptions=True)
             if claim is not None:
-                try:
-                    repo = await self._claim_document_repo()
-                    await repo.release_content_sha256_claim(**claim)
-                except Exception as exc:  # noqa: BLE001 - stale claims expire automatically
-                    from core.utils.logging import get_logger
-
-                    get_logger().bind(file_id=claim["file_id"], partition=claim["partition"]).warning(
-                        "Failed to release settled content deduplication claim.",
-                        error=str(exc),
-                    )
+                await self._release_content_claim(claim)
             self._inflight[idx] -= 1
+
+    async def _release_content_claim(self, claim: dict[str, str] | None) -> None:
+        if claim is None:
+            return
+        try:
+            repo = await self._claim_document_repo()
+            await repo.release_content_sha256_claim(**claim)
+        except Exception as exc:  # noqa: BLE001 - stale claims expire automatically
+            from core.utils.logging import get_logger
+
+            get_logger().bind(file_id=claim["file_id"], partition=claim["partition"]).warning(
+                "Failed to release settled content deduplication claim.",
+                error=str(exc),
+            )
 
     async def _claim_document_repo(self) -> Any:
         if self._claim_store is None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -10,6 +10,7 @@ import ray
 from core.config.model_endpoints import CONTROL_EXTRA_KEYS
 from core.models.catalog import CONTENT_CLAIM_TOKEN_METADATA_KEY
 from services.workers.indexer_actor import IndexerWorker, delete_uploaded_file
+from services.workers.ray_utils import retry_idempotent_ray_actor_method
 
 from openrag.core.config.root import Settings
 
@@ -434,6 +435,8 @@ class IndexerPool:
         self._release_tasks: set[asyncio.Task[Any]] = set()
         self._claim_store: Any = None
         self._claim_store_lock = asyncio.Lock()
+        self._namespace = namespace
+        self._task_state_manager: Any = None
 
     async def size(self) -> int:
         return len(self._workers)
@@ -501,7 +504,26 @@ class IndexerPool:
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
+        try:
+            registered = await self._register_worker_ref(str(kwargs.get("task_id") or ""), ref)
+        except BaseException:
+            ray.cancel(ref, recursive=True)
+            raise
+        if not registered:
+            ray.cancel(ref, recursive=True)
+            raise RuntimeError(f"Task {kwargs.get('task_id')} was cancelled before worker ref registration")
         return [ref]
+
+    async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
+        if not task_id:
+            raise ValueError("IndexerPool submission requires a task_id")
+        if self._task_state_manager is None:
+            self._task_state_manager = ray.get_actor("TaskStateManager", namespace=self._namespace)
+        registered = await retry_idempotent_ray_actor_method(
+            lambda: self._task_state_manager.set_object_ref.remote(task_id, {"ref": ref}),
+            task_description=f"set_object_ref({task_id}) from indexer pool",
+        )
+        return registered is not False
 
     async def _release(self, idx: int, ref: Any, *, claim: dict[str, str] | None = None) -> None:
         renewal_task = None

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -504,23 +504,24 @@ class IndexerPool:
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
+        task_id = str(kwargs.get("task_id") or "")
         try:
-            registered = await self._register_worker_ref(str(kwargs.get("task_id") or ""), ref)
+            registered = await self._register_worker_ref(task_id, ref)
         except BaseException:
-            await self._guard_rejected_worker(ref)
+            await self._guard_rejected_worker(task_id, ref)
             raise
         if not registered:
-            await self._guard_rejected_worker(ref)
+            await self._guard_rejected_worker(task_id, ref)
             raise RuntimeError(f"Task {kwargs.get('task_id')} was cancelled before worker ref registration")
         return [ref]
 
-    async def _guard_rejected_worker(self, ref: Any) -> None:
-        settlement = asyncio.create_task(self._cancel_worker_and_wait(ref))
+    async def _guard_rejected_worker(self, task_id: str, ref: Any) -> None:
+        settlement = asyncio.create_task(self._cancel_worker_and_wait(task_id, ref))
         self._release_tasks.add(settlement)
         settlement.add_done_callback(self._release_tasks.discard)
         await asyncio.shield(settlement)
 
-    async def _cancel_worker_and_wait(self, ref: Any) -> None:
+    async def _cancel_worker_and_wait(self, task_id: str, ref: Any) -> None:
         """Keep the submission fenced until a rejected worker has settled."""
         try:
             ray.cancel(ref, recursive=True)
@@ -529,6 +530,20 @@ class IndexerPool:
             # the caller can safely release the content claim.
             pass
         await asyncio.gather(ref, return_exceptions=True)
+        await self._finish_rejected_submission(task_id)
+
+    async def _finish_rejected_submission(self, task_id: str) -> None:
+        method_names = getattr(self._task_state_manager, "_ray_actor_method_names", None)
+        if isinstance(method_names, (frozenset, list, set, tuple)) and "finish_rejected_submission" not in method_names:
+            return
+        method = getattr(self._task_state_manager, "finish_rejected_submission", None)
+        remote = getattr(method, "remote", None)
+        if remote is None:
+            return
+        await retry_idempotent_ray_actor_method(
+            lambda: remote(task_id),
+            task_description=f"finish_rejected_submission({task_id}) from indexer pool",
+        )
 
     async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
         if not task_id:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -19,7 +19,10 @@ from openrag.core.config.root import Settings
 # of indexing throughput.
 _MODEL_REGISTRY_TTL_SECONDS = 60.0
 _CONTENT_CLAIM_RENEW_INTERVAL_SECONDS = 60 * 60
+_WORKER_REF_REGISTRATION_TIMEOUT_SECONDS = 60.0
+_WORKER_REF_REGISTRATION_POLL_SECONDS = 0.05
 _REJECTED_SUBMISSION_ERROR = "Indexer worker submission was rejected before the worker started."
+_MISSING_WORKER_REF_ERROR = "Indexer worker did not receive a registered task reference before starting."
 # Named detached actors survive API rolling deployments. Keep the dispatcher
 # and workers on the same protocol generation whenever their remote contract or
 # cross-process indexing semantics change, so new replicas cannot attach to a
@@ -100,6 +103,7 @@ class IndexerWorkerActor:
         )
         self._vector_store = MilvusVectorStore(cfg.vectordb)
         task_state_manager = ray.get_actor("TaskStateManager", namespace=self._namespace)
+        self._task_state_manager = task_state_manager
         pipeline = build_indexing_pipeline(
             parser=parser,
             chunker=chunker,
@@ -336,6 +340,7 @@ class IndexerWorkerActor:
         content_claim_token = metadata.get(CONTENT_CLAIM_TOKEN_METADATA_KEY)
         worker_metadata = {key: value for key, value in metadata.items() if key != CONTENT_CLAIM_TOKEN_METADATA_KEY}
         try:
+            await self._await_worker_ref_registration(task_id)
             await self._ensure_catalog()
             await self._ensure_registry_fresh(_required_model_endpoint_names(indexation_config, embedder_name))
             # Resolve the enrichment-stage prompts once for this file (partition
@@ -388,6 +393,28 @@ class IndexerWorkerActor:
             # SERIALIZING state update) that never enter the worker's try block.
             if not self._save_uploaded_files:
                 await delete_uploaded_file(path, self._logger)
+
+    async def _await_worker_ref_registration(self, task_id: str) -> None:
+        """Do not start indexing until cancellation can target this worker."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _WORKER_REF_REGISTRATION_TIMEOUT_SECONDS
+        while loop.time() < deadline:
+            remaining = max(0.01, deadline - loop.time())
+            object_ref = await retry_idempotent_ray_actor_method(
+                lambda: self._task_state_manager.get_object_ref.remote(task_id),
+                recovery_timeout=remaining,
+                task_description=f"get_object_ref({task_id}) before indexing",
+            )
+            ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+            if ref is not None:
+                return
+            await asyncio.sleep(min(_WORKER_REF_REGISTRATION_POLL_SECONDS, remaining))
+
+        await retry_idempotent_ray_actor_method(
+            lambda: self._task_state_manager.set_failed_if_not_cancelled.remote(task_id, _MISSING_WORKER_REF_ERROR),
+            task_description=f"set_failed_if_not_cancelled({task_id}) after missing worker ref",
+        )
+        raise RuntimeError(_MISSING_WORKER_REF_ERROR)
 
 
 @ray.remote

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -478,6 +478,8 @@ class IndexerPool:
         released when the task settles (success, failure, or cancellation).
         """
         task_id = str(kwargs.get("task_id") or "")
+        if not task_id:
+            raise ValueError("IndexerPool submission requires a task_id")
         metadata = kwargs.get("metadata") or {}
         content_sha256 = metadata.get("content_sha256")
         file_id = metadata.get("file_id")
@@ -507,6 +509,14 @@ class IndexerPool:
         # Keep a strong ref so the tracker isn't GC'd mid-flight (asyncio docs).
         self._release_tasks.add(task)
         task.add_done_callback(self._release_tasks.discard)
+        try:
+            accepted = await self._accept_worker_submission(task_id)
+        except BaseException:
+            await self._guard_rejected_worker(task_id, ref)
+            raise
+        if not accepted:
+            await self._guard_rejected_worker(task_id, ref)
+            raise RuntimeError(f"Task {task_id} was cancelled before the pool accepted it")
         try:
             registered = await self._register_worker_ref(task_id, ref)
         except BaseException:
@@ -561,14 +571,27 @@ class IndexerPool:
         )
 
     async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
-        if not task_id:
-            raise ValueError("IndexerPool submission requires a task_id")
         task_state_manager = self._task_state_actor()
         registered = await retry_idempotent_ray_actor_method(
             lambda: task_state_manager.set_object_ref.remote(task_id, {"ref": ref}),
             task_description=f"set_object_ref({task_id}) from indexer pool",
         )
         return registered is not False
+
+    async def _accept_worker_submission(self, task_id: str) -> bool:
+        task_state_manager = self._task_state_actor()
+        method_names = getattr(task_state_manager, "_ray_actor_method_names", None)
+        if isinstance(method_names, (frozenset, list, set, tuple)) and "accept_worker_submission" not in method_names:
+            return True
+        method = getattr(task_state_manager, "accept_worker_submission", None)
+        remote = getattr(method, "remote", None)
+        if remote is None:
+            return True
+        accepted = await retry_idempotent_ray_actor_method(
+            lambda: remote(task_id),
+            task_description=f"accept_worker_submission({task_id}) from indexer pool",
+        )
+        return accepted is True
 
     def _task_state_actor(self) -> Any:
         if self._task_state_manager is None:

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -48,7 +48,7 @@ class IndexerWorkerActor:
     of these and load-balances across them.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, namespace: str = "openrag") -> None:
         import services.inference.ollama_client  # noqa: F401
         import services.inference.vllm_client  # noqa: F401
         from core.config import load_config
@@ -63,6 +63,7 @@ class IndexerWorkerActor:
         )
         from services.workers.pipeline_builder import build_indexing_pipeline
 
+        self._namespace = namespace
         cfg = load_config()
         parser = build_parser_dispatcher(
             cfg,
@@ -97,7 +98,7 @@ class IndexerWorkerActor:
             embed_concurrency=embed_cfg.embed_concurrency,
         )
         self._vector_store = MilvusVectorStore(cfg.vectordb)
-        task_state_manager = ray.get_actor("TaskStateManager", namespace="openrag")
+        task_state_manager = ray.get_actor("TaskStateManager", namespace=self._namespace)
         pipeline = build_indexing_pipeline(
             parser=parser,
             chunker=chunker,
@@ -426,7 +427,7 @@ class IndexerPool:
                 get_if_exists=True,
                 lifetime="detached",
                 max_concurrency=max_tasks_per_worker,
-            ).remote()
+            ).remote(namespace)
             for i in range(pool_size)
         ]
         self._worker_names = [_indexer_worker_actor_name(i) for i in range(pool_size)]

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -507,12 +507,18 @@ class IndexerPool:
         try:
             registered = await self._register_worker_ref(str(kwargs.get("task_id") or ""), ref)
         except BaseException:
-            await self._cancel_worker_and_wait(ref)
+            await self._guard_rejected_worker(ref)
             raise
         if not registered:
-            await self._cancel_worker_and_wait(ref)
+            await self._guard_rejected_worker(ref)
             raise RuntimeError(f"Task {kwargs.get('task_id')} was cancelled before worker ref registration")
         return [ref]
+
+    async def _guard_rejected_worker(self, ref: Any) -> None:
+        settlement = asyncio.create_task(self._cancel_worker_and_wait(ref))
+        self._release_tasks.add(settlement)
+        settlement.add_done_callback(self._release_tasks.discard)
+        await asyncio.shield(settlement)
 
     async def _cancel_worker_and_wait(self, ref: Any) -> None:
         """Keep the submission fenced until a rejected worker has settled."""

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -507,12 +507,22 @@ class IndexerPool:
         try:
             registered = await self._register_worker_ref(str(kwargs.get("task_id") or ""), ref)
         except BaseException:
-            ray.cancel(ref, recursive=True)
+            await self._cancel_worker_and_wait(ref)
             raise
         if not registered:
-            ray.cancel(ref, recursive=True)
+            await self._cancel_worker_and_wait(ref)
             raise RuntimeError(f"Task {kwargs.get('task_id')} was cancelled before worker ref registration")
         return [ref]
+
+    async def _cancel_worker_and_wait(self, ref: Any) -> None:
+        """Keep the submission fenced until a rejected worker has settled."""
+        try:
+            ray.cancel(ref, recursive=True)
+        except Exception:
+            # Cancellation is best-effort, but settlement is mandatory before
+            # the caller can safely release the content claim.
+            pass
+        await asyncio.gather(ref, return_exceptions=True)
 
     async def _register_worker_ref(self, task_id: str, ref: Any) -> bool:
         if not task_id:

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -149,8 +149,9 @@ async def _get_matching_active_task_refs_legacy(
         if not isinstance(info, dict):
             continue
         state = info.get("state")
+        submission_started = isinstance(info.get("submission_started_at"), (int, float))
         cancelled_unsettled = state == "CANCELLED" and (
-            info.get("worker_submitted") is True or get_object_ref_remote is not None
+            info.get("worker_submitted") is True or submission_started or get_object_ref_remote is not None
         )
         if state not in CANCELLABLE_INDEXING_STATES and not cancelled_unsettled:
             continue
@@ -171,9 +172,14 @@ async def _get_matching_active_task_refs_legacy(
                 timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
                 task_description=f"get_object_ref({task_id}) for delete cleanup",
             )
-        if state == "CANCELLED" and object_ref is None and info.get("worker_submitted") is not True:
+        if (
+            state == "CANCELLED"
+            and object_ref is None
+            and info.get("worker_submitted") is not True
+            and not submission_started
+        ):
             continue
-        if object_ref is None and info.get("worker_submitted") is True:
+        if object_ref is None and (info.get("worker_submitted") is True or submission_started):
             matches[task_id] = SUBMITTED_TASK_WITHOUT_REF
         else:
             matches[task_id] = object_ref

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -8,13 +8,10 @@ import ray
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_method_with_timeout, call_ray_actor_with_timeout
-from services.workers.task_state import CANCELLABLE_INDEXING_STATES, PENDING_TASK_DETAILS
+from services.workers.task_state import CANCELLABLE_INDEXING_STATES, PENDING_TASK_DETAILS, STALE_REFLESS_TASK_ERROR
 
 logger = get_logger()
 _REF_WAIT_INTERVAL = 0.05
-_STALE_REFLESS_TASK_ERROR = (
-    "Indexing task never exposed a cancellable worker ref before delete cleanup; marking it failed as stale."
-)
 
 
 async def cancel_active_indexing_tasks(
@@ -205,6 +202,13 @@ async def _cancel_refs(
             timeout=remaining,
             task_description=f"set_state({task_id}, CANCELLED)",
         )
+        finish_cancellation_remote = _remote_actor_method(task_state_manager, "finish_cancellation")
+        if finish_cancellation_remote is not None:
+            await call_ray_actor_method_with_timeout(
+                submit=lambda task_id=task_id: finish_cancellation_remote(task_id),
+                timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
+                task_description=f"finish_cancellation({task_id})",
+            )
         cancelled += 1
     return cancelled, pending_without_ref, pending_details
 
@@ -269,7 +273,7 @@ async def _mark_ref_less_tasks_failed(
     if set_failed is not None:
         for task_id in task_ids:
             await call_ray_actor_method_with_timeout(
-                submit=lambda task_id=task_id: set_failed.remote(task_id, _STALE_REFLESS_TASK_ERROR),
+                submit=lambda task_id=task_id: set_failed.remote(task_id, STALE_REFLESS_TASK_ERROR),
                 timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
                 task_description=f"set_failed_if_not_cancelled({task_id})",
             )

--- a/openrag/services/workers/task_cancellation.py
+++ b/openrag/services/workers/task_cancellation.py
@@ -8,7 +8,12 @@ import ray
 from core.utils.logging import get_logger
 from ray.exceptions import TaskCancelledError
 from services.workers.ray_utils import call_ray_actor_method_with_timeout, call_ray_actor_with_timeout
-from services.workers.task_state import CANCELLABLE_INDEXING_STATES, PENDING_TASK_DETAILS, STALE_REFLESS_TASK_ERROR
+from services.workers.task_state import (
+    CANCELLABLE_INDEXING_STATES,
+    PENDING_TASK_DETAILS,
+    STALE_REFLESS_TASK_ERROR,
+    SUBMITTED_TASK_WITHOUT_REF,
+)
 
 logger = get_logger()
 _REF_WAIT_INTERVAL = 0.05
@@ -31,7 +36,7 @@ async def cancel_active_indexing_tasks(
             partition=partition,
             file_id=file_id,
         )
-        cancelled_now, pending_without_ref, pending_details = await _cancel_refs(
+        cancelled_now, pending_without_ref, pending_details, submitted_without_ref = await _cancel_refs(
             task_state_manager,
             matches,
             deadline=deadline,
@@ -39,7 +44,7 @@ async def cancel_active_indexing_tasks(
             file_id=file_id,
         )
         cancelled += cancelled_now
-        if not pending_without_ref and not pending_details:
+        if not pending_without_ref and not pending_details and not submitted_without_ref:
             return cancelled
         logger.info(
             "Waiting for active indexing tasks to finish registration before delete cleanup",
@@ -47,6 +52,7 @@ async def cancel_active_indexing_tasks(
             file_id=file_id,
             pending_without_ref=pending_without_ref,
             pending_details=pending_details,
+            submitted_without_ref=submitted_without_ref,
         )
         remaining = deadline - monotonic()
         if remaining <= _REF_WAIT_INTERVAL:
@@ -57,7 +63,7 @@ async def cancel_active_indexing_tasks(
                 file_id=file_id,
                 final=True,
             )
-            cancelled_now, pending_without_ref, pending_details = await _cancel_refs(
+            cancelled_now, pending_without_ref, pending_details, submitted_without_ref = await _cancel_refs(
                 task_state_manager,
                 final_matches,
                 deadline=deadline,
@@ -67,6 +73,12 @@ async def cancel_active_indexing_tasks(
             cancelled += cancelled_now
             if pending_details:
                 _raise_pending_details_timeout(pending_details, partition=partition, file_id=file_id)
+            if submitted_without_ref:
+                _raise_submitted_without_ref_timeout(
+                    submitted_without_ref,
+                    partition=partition,
+                    file_id=file_id,
+                )
             if not pending_without_ref:
                 return cancelled
             await _mark_ref_less_tasks_failed(
@@ -136,7 +148,11 @@ async def _get_matching_active_task_refs_legacy(
     for task_id, info in all_info.items():
         if not isinstance(info, dict):
             continue
-        if info.get("state") not in CANCELLABLE_INDEXING_STATES:
+        state = info.get("state")
+        cancelled_unsettled = state == "CANCELLED" and (
+            info.get("worker_submitted") is True or get_object_ref_remote is not None
+        )
+        if state not in CANCELLABLE_INDEXING_STATES and not cancelled_unsettled:
             continue
         details = info.get("details") or {}
         if not isinstance(details, dict):
@@ -155,7 +171,12 @@ async def _get_matching_active_task_refs_legacy(
                 timeout=_remaining_timeout(deadline, partition=partition, file_id=file_id),
                 task_description=f"get_object_ref({task_id}) for delete cleanup",
             )
-        matches[task_id] = object_ref
+        if state == "CANCELLED" and object_ref is None and info.get("worker_submitted") is not True:
+            continue
+        if object_ref is None and info.get("worker_submitted") is True:
+            matches[task_id] = SUBMITTED_TASK_WITHOUT_REF
+        else:
+            matches[task_id] = object_ref
     return matches
 
 
@@ -166,13 +187,17 @@ async def _cancel_refs(
     deadline: float,
     partition: str,
     file_id: str | None,
-) -> tuple[int, list[str], list[str]]:
+) -> tuple[int, list[str], list[str], list[str]]:
     cancelled = 0
     pending_without_ref: list[str] = []
     pending_details: list[str] = []
+    submitted_without_ref: list[str] = []
     for task_id, object_ref in matches.items():
         if _task_details_pending(object_ref):
             pending_details.append(task_id)
+            continue
+        if _task_submitted_without_ref(object_ref):
+            submitted_without_ref.append(task_id)
             continue
         ref = _task_ref(object_ref)
         if ref is None:
@@ -210,11 +235,15 @@ async def _cancel_refs(
                 task_description=f"finish_cancellation({task_id})",
             )
         cancelled += 1
-    return cancelled, pending_without_ref, pending_details
+    return cancelled, pending_without_ref, pending_details, submitted_without_ref
 
 
 def _task_details_pending(object_ref: Any) -> bool:
     return object_ref == PENDING_TASK_DETAILS
+
+
+def _task_submitted_without_ref(object_ref: Any) -> bool:
+    return object_ref == SUBMITTED_TASK_WITHOUT_REF
 
 
 def _task_ref(object_ref: Any) -> Any | None:
@@ -311,5 +340,12 @@ def _remaining_timeout(deadline: float, *, partition: str, file_id: str | None) 
 def _raise_pending_details_timeout(task_ids: list[str], *, partition: str, file_id: str | None) -> None:
     raise TimeoutError(
         "Timed out waiting for active indexing tasks to record routing details "
+        f"before deleting partition={partition!r}, file_id={file_id!r}, task_ids={task_ids!r}"
+    )
+
+
+def _raise_submitted_without_ref_timeout(task_ids: list[str], *, partition: str, file_id: str | None) -> None:
+    raise TimeoutError(
+        "Timed out waiting for submitted indexing tasks to expose worker references or settle "
         f"before deleting partition={partition!r}, file_id={file_id!r}, task_ids={task_ids!r}"
     )

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -132,7 +132,15 @@ class TaskCompletionTracker:
                     await self._finish_cancellation(task_id)
                     return
 
-                if state in _TERMINAL_STATES and not (preserve_cancelled_submission and state == "CANCELLED"):
+                if state == "CANCELLED" and preserve_cancelled_submission:
+                    if await self._has_unsettled_cancelled_worker(task_state_manager, task_id):
+                        await asyncio.sleep(poll_interval)
+                        continue
+                    await self._record_finished_at(task_id)
+                    await self._finish_cancellation(task_id)
+                    return
+
+                if state in _TERMINAL_STATES:
                     await self._record_finished_at(task_id)
                     return
 
@@ -182,6 +190,20 @@ class TaskCompletionTracker:
                 task_id=task_id,
                 error=str(exc),
             )
+
+    async def _has_unsettled_cancelled_worker(self, task_state_manager: Any, task_id: str) -> bool:
+        method = getattr(task_state_manager, "has_unsettled_cancelled_worker", None)
+        remote = getattr(method, "remote", None)
+        if remote is None:
+            # A mixed-version actor cannot prove settlement. Keep the claim
+            # fenced until a compatible TaskStateManager is available.
+            return True
+        return bool(
+            await self._call_task_state(
+                lambda: remote(task_id),
+                f"has_unsettled_cancelled_worker({task_id})",
+            )
+        )
 
     def _task_state_manager(self) -> Any:
         return ray.get_actor("TaskStateManager", namespace=self._namespace)

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -50,14 +50,22 @@ class TaskCompletionTracker:
             try:
                 task_state_manager = self._task_state_manager()
                 tracker = ray.get_actor("TaskCompletionTracker", namespace=self._namespace)
-                all_info = await task_state_manager.get_all_info.remote()
+                all_info = await self._call_task_state(
+                    task_state_manager.get_all_info.remote,
+                    "get_all_info_for_completion_recovery",
+                )
                 for task_id, info in all_info.items():
                     state = info.get("state")
                     if state == "CANCELLED":
-                        object_ref = await task_state_manager.get_object_ref.remote(task_id)
+                        object_ref = await self._call_task_state(
+                            lambda task_id=task_id: task_state_manager.get_object_ref.remote(task_id),
+                            f"get_object_ref({task_id}) for cancellation recovery",
+                        )
                         normalized_ref = _normalize_object_ref(object_ref)
                         if normalized_ref is not None:
                             tracker.track.remote(task_id, normalized_ref)
+                        elif info.get("worker_submitted") is True:
+                            tracker.recover_refless.remote(task_id, preserve_cancelled_submission=True)
                         elif not _has_finished_at(info.get("details")):
                             await self._record_finished_at(task_id)
                         continue
@@ -66,7 +74,10 @@ class TaskCompletionTracker:
                     if state in _TERMINAL_STATES:
                         await self._record_finished_at(task_id)
                         continue
-                    object_ref = await task_state_manager.get_object_ref.remote(task_id)
+                    object_ref = await self._call_task_state(
+                        lambda task_id=task_id: task_state_manager.get_object_ref.remote(task_id),
+                        f"get_object_ref({task_id}) for completion recovery",
+                    )
                     normalized_ref = _normalize_object_ref(object_ref)
                     if normalized_ref is not None:
                         tracker.track.remote(task_id, normalized_ref)
@@ -75,7 +86,13 @@ class TaskCompletionTracker:
             except Exception as exc:
                 self._logger.warning("Failed to recover indexing completion tracking", error=str(exc))
 
-    async def recover_refless(self, task_id: str, poll_interval: float = _REFLESS_RECOVERY_POLL_SECONDS) -> None:
+    async def recover_refless(
+        self,
+        task_id: str,
+        poll_interval: float = _REFLESS_RECOVERY_POLL_SECONDS,
+        *,
+        preserve_cancelled_submission: bool = False,
+    ) -> None:
         """Watch a recovered active task whose ObjectRef has not been stored yet."""
         if task_id in self._tracked_task_ids:
             return
@@ -83,22 +100,30 @@ class TaskCompletionTracker:
         try:
             while True:
                 task_state_manager = self._task_state_manager()
-                details = await task_state_manager.get_details.remote(task_id)
+                details = await self._call_task_state(
+                    lambda: task_state_manager.get_details.remote(task_id),
+                    f"get_details({task_id}) for ref-less recovery",
+                )
                 if _has_finished_at(details):
                     return
 
                 expire_refless = getattr(task_state_manager, "expire_refless_task_if_stale", None)
                 expire_remote = getattr(expire_refless, "remote", None)
-                if expire_remote is not None and await call_ray_actor_method_with_timeout(
+                if expire_remote is not None and await self._call_task_state(
                     lambda: expire_remote(task_id),
-                    timeout=_TASK_STATE_CALL_TIMEOUT_SECONDS,
-                    task_description=f"expire_refless_task_if_stale({task_id})",
+                    f"expire_refless_task_if_stale({task_id})",
                 ):
                     await self._record_finished_at(task_id)
                     return
 
-                state = await task_state_manager.get_state.remote(task_id)
-                object_ref = await task_state_manager.get_object_ref.remote(task_id)
+                state = await self._call_task_state(
+                    lambda: task_state_manager.get_state.remote(task_id),
+                    f"get_state({task_id}) for ref-less recovery",
+                )
+                object_ref = await self._call_task_state(
+                    lambda: task_state_manager.get_object_ref.remote(task_id),
+                    f"get_object_ref({task_id}) for ref-less recovery",
+                )
                 normalized_ref = _normalize_object_ref(object_ref)
                 if normalized_ref is not None:
                     ref = normalized_ref["ref"]
@@ -107,7 +132,7 @@ class TaskCompletionTracker:
                     await self._finish_cancellation(task_id)
                     return
 
-                if state in _TERMINAL_STATES:
+                if state in _TERMINAL_STATES and not (preserve_cancelled_submission and state == "CANCELLED"):
                     await self._record_finished_at(task_id)
                     return
 
@@ -123,19 +148,25 @@ class TaskCompletionTracker:
 
     async def _record_finished_at(self, task_id: str) -> None:
         task_state_manager = self._task_state_manager()
-        details = await task_state_manager.get_details.remote(task_id)
+        details = await self._call_task_state(
+            lambda: task_state_manager.get_details.remote(task_id),
+            f"get_details({task_id}) for completion timestamp",
+        )
         if not isinstance(details, dict) or _has_finished_at(details):
             return
 
         metadata = details.get("metadata")
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
         metadata[TASK_FINISHED_AT_METADATA_KEY] = _utc_now_iso()
-        await task_state_manager.set_details.remote(
-            task_id,
-            file_id=details.get("file_id"),
-            partition=details.get("partition"),
-            metadata=metadata,
-            user_id=details.get("user_id"),
+        await self._call_task_state(
+            lambda: task_state_manager.set_details.remote(
+                task_id,
+                file_id=details.get("file_id"),
+                partition=details.get("partition"),
+                metadata=metadata,
+                user_id=details.get("user_id"),
+            ),
+            f"set_finished_at({task_id})",
         )
 
     async def _finish_cancellation(self, task_id: str) -> None:
@@ -144,11 +175,7 @@ class TaskCompletionTracker:
             finish_cancellation = getattr(task_state_manager, "finish_cancellation", None)
             remote = getattr(finish_cancellation, "remote", None)
             if remote is not None:
-                await call_ray_actor_method_with_timeout(
-                    lambda: remote(task_id),
-                    timeout=_TASK_STATE_CALL_TIMEOUT_SECONDS,
-                    task_description=f"finish_cancellation({task_id})",
-                )
+                await self._call_task_state(lambda: remote(task_id), f"finish_cancellation({task_id})")
         except Exception as exc:
             self._logger.warning(
                 "Failed to finalize indexing task cancellation",
@@ -158,6 +185,13 @@ class TaskCompletionTracker:
 
     def _task_state_manager(self) -> Any:
         return ray.get_actor("TaskStateManager", namespace=self._namespace)
+
+    async def _call_task_state(self, submit: Any, task_description: str) -> Any:
+        return await call_ray_actor_method_with_timeout(
+            submit,
+            timeout=_TASK_STATE_CALL_TIMEOUT_SECONDS,
+            task_description=task_description,
+        )
 
 
 TaskCompletionTrackerActor = ray.remote(max_restarts=-1, max_task_retries=-1, max_concurrency=1000)(

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -68,6 +68,7 @@ class TaskCompletionTracker:
                             tracker.recover_refless.remote(task_id, preserve_cancelled_submission=True)
                         elif not _has_finished_at(info.get("details")):
                             await self._record_finished_at(task_id)
+                            await self._finish_cancellation(task_id)
                         continue
                     if _has_finished_at(info.get("details")):
                         continue

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -53,8 +53,9 @@ class TaskCompletionTracker:
                     state = info.get("state")
                     if state == "CANCELLED":
                         object_ref = await task_state_manager.get_object_ref.remote(task_id)
-                        if isinstance(object_ref, dict) and object_ref.get("ref") is not None:
-                            tracker.track.remote(task_id, object_ref)
+                        normalized_ref = _normalize_object_ref(object_ref)
+                        if normalized_ref is not None:
+                            tracker.track.remote(task_id, normalized_ref)
                         elif not _has_finished_at(info.get("details")):
                             await self._record_finished_at(task_id)
                         continue
@@ -64,8 +65,9 @@ class TaskCompletionTracker:
                         await self._record_finished_at(task_id)
                         continue
                     object_ref = await task_state_manager.get_object_ref.remote(task_id)
-                    if isinstance(object_ref, dict) and object_ref.get("ref") is not None:
-                        tracker.track.remote(task_id, object_ref)
+                    normalized_ref = _normalize_object_ref(object_ref)
+                    if normalized_ref is not None:
+                        tracker.track.remote(task_id, normalized_ref)
                     else:
                         tracker.recover_refless.remote(task_id)
             except Exception as exc:
@@ -83,10 +85,17 @@ class TaskCompletionTracker:
                 if _has_finished_at(details):
                     return
 
+                expire_refless = getattr(task_state_manager, "expire_refless_task_if_stale", None)
+                expire_remote = getattr(expire_refless, "remote", None)
+                if expire_remote is not None and await expire_remote(task_id):
+                    await self._record_finished_at(task_id)
+                    return
+
                 state = await task_state_manager.get_state.remote(task_id)
                 object_ref = await task_state_manager.get_object_ref.remote(task_id)
-                ref = object_ref.get("ref") if isinstance(object_ref, dict) else None
-                if ref is not None:
+                normalized_ref = _normalize_object_ref(object_ref)
+                if normalized_ref is not None:
+                    ref = normalized_ref["ref"]
                     await asyncio.gather(ref, return_exceptions=True)
                     await self._record_finished_at(task_id)
                     await self._finish_cancellation(task_id)
@@ -151,6 +160,11 @@ def _has_finished_at(details: Any) -> bool:
         return False
     metadata = details.get("metadata")
     return isinstance(metadata, dict) and TASK_FINISHED_AT_METADATA_KEY in metadata
+
+
+def _normalize_object_ref(object_ref: Any) -> dict[str, Any] | None:
+    ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+    return {"ref": ref} if ref is not None else None
 
 
 def _utc_now_iso() -> str:

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -39,6 +39,7 @@ class TaskCompletionTracker:
                 error=str(exc),
             )
         finally:
+            await self._finish_cancellation(task_id)
             self._tracked_task_ids.discard(task_id)
 
     async def recover(self) -> None:
@@ -49,9 +50,17 @@ class TaskCompletionTracker:
                 tracker = ray.get_actor("TaskCompletionTracker", namespace=self._namespace)
                 all_info = await task_state_manager.get_all_info.remote()
                 for task_id, info in all_info.items():
+                    state = info.get("state")
+                    if state == "CANCELLED":
+                        object_ref = await task_state_manager.get_object_ref.remote(task_id)
+                        if isinstance(object_ref, dict) and object_ref.get("ref") is not None:
+                            tracker.track.remote(task_id, object_ref)
+                        elif not _has_finished_at(info.get("details")):
+                            await self._record_finished_at(task_id)
+                        continue
                     if _has_finished_at(info.get("details")):
                         continue
-                    if info.get("state") in _TERMINAL_STATES:
+                    if state in _TERMINAL_STATES:
                         await self._record_finished_at(task_id)
                         continue
                     object_ref = await task_state_manager.get_object_ref.remote(task_id)
@@ -75,14 +84,15 @@ class TaskCompletionTracker:
                     return
 
                 state = await task_state_manager.get_state.remote(task_id)
-                if state in _TERMINAL_STATES:
-                    await self._record_finished_at(task_id)
-                    return
-
                 object_ref = await task_state_manager.get_object_ref.remote(task_id)
                 ref = object_ref.get("ref") if isinstance(object_ref, dict) else None
                 if ref is not None:
                     await asyncio.gather(ref, return_exceptions=True)
+                    await self._record_finished_at(task_id)
+                    await self._finish_cancellation(task_id)
+                    return
+
+                if state in _TERMINAL_STATES:
                     await self._record_finished_at(task_id)
                     return
 
@@ -112,6 +122,20 @@ class TaskCompletionTracker:
             metadata=metadata,
             user_id=details.get("user_id"),
         )
+
+    async def _finish_cancellation(self, task_id: str) -> None:
+        try:
+            task_state_manager = self._task_state_manager()
+            finish_cancellation = getattr(task_state_manager, "finish_cancellation", None)
+            remote = getattr(finish_cancellation, "remote", None)
+            if remote is not None:
+                await remote(task_id)
+        except Exception as exc:
+            self._logger.warning(
+                "Failed to finalize indexing task cancellation",
+                task_id=task_id,
+                error=str(exc),
+            )
 
     def _task_state_manager(self) -> Any:
         return ray.get_actor("TaskStateManager", namespace=self._namespace)

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -6,9 +6,11 @@ from typing import Any
 
 import ray
 from core.models.catalog import TASK_FINISHED_AT_METADATA_KEY, TERMINAL_TASK_STATES
+from services.workers.ray_utils import call_ray_actor_method_with_timeout
 
 _TERMINAL_STATES = frozenset(state.value for state in TERMINAL_TASK_STATES)
 _REFLESS_RECOVERY_POLL_SECONDS = 5.0
+_TASK_STATE_CALL_TIMEOUT_SECONDS = 30.0
 
 
 class TaskCompletionTracker:
@@ -87,7 +89,11 @@ class TaskCompletionTracker:
 
                 expire_refless = getattr(task_state_manager, "expire_refless_task_if_stale", None)
                 expire_remote = getattr(expire_refless, "remote", None)
-                if expire_remote is not None and await expire_remote(task_id):
+                if expire_remote is not None and await call_ray_actor_method_with_timeout(
+                    lambda: expire_remote(task_id),
+                    timeout=_TASK_STATE_CALL_TIMEOUT_SECONDS,
+                    task_description=f"expire_refless_task_if_stale({task_id})",
+                ):
                     await self._record_finished_at(task_id)
                     return
 
@@ -138,7 +144,11 @@ class TaskCompletionTracker:
             finish_cancellation = getattr(task_state_manager, "finish_cancellation", None)
             remote = getattr(finish_cancellation, "remote", None)
             if remote is not None:
-                await remote(task_id)
+                await call_ray_actor_method_with_timeout(
+                    lambda: remote(task_id),
+                    timeout=_TASK_STATE_CALL_TIMEOUT_SECONDS,
+                    task_description=f"finish_cancellation({task_id})",
+                )
         except Exception as exc:
             self._logger.warning(
                 "Failed to finalize indexing task cancellation",

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -24,6 +24,10 @@ class TaskCompletionTracker:
         self._tracked_task_ids: set[str] = set()
         self._recovery_lock = asyncio.Lock()
 
+    def supports_cancellation_recovery(self) -> bool:
+        """Identify trackers that preserve unsettled cancellation fences."""
+        return True
+
     async def track(self, task_id: str, object_ref: dict[str, Any]) -> None:
         ref = object_ref.get("ref")
         if ref is None:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -34,6 +34,7 @@ _TASK_STATE_KV_NAMESPACE = "openrag-task-state-manager"
 _LEGACY_FENCE_ID = "__legacy__"
 _RECOVERABLE_TASK_KV_PREFIX = b"recoverable-task-v1:"
 _CANCELLATION_TOMBSTONE_TTL_SECONDS = 24 * 60 * 60
+_CANCELLATION_SETTLEMENT_TTL_SECONDS = 24 * 60 * 60
 _FILE_DELETE_FENCE_TTL_SECONDS = 2 * 60
 _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS = 60
 STALE_REFLESS_TASK_ERROR = (
@@ -130,14 +131,24 @@ def _load_recoverable_tasks() -> dict[str, TaskInfo]:
         return {}
     tasks: dict[str, TaskInfo] = {}
     namespace = _task_state_kv_namespace()
+    now = time.time()
     for key in _internal_kv_list(_RECOVERABLE_TASK_KV_PREFIX, namespace=namespace):
         payload = _internal_kv_get(key, namespace=namespace)
         if payload is None:
             continue
         task_id, info, expires_at = _decode_recoverable_task(payload)
-        if expires_at is not None and expires_at <= time.time() and not _cancelled_task_unsettled(info):
+        if expires_at is not None and expires_at <= now:
             _internal_kv_del(key, namespace=namespace)
             continue
+        if _cancelled_task_has_worker_fence(info) and not _valid_timestamp(
+            getattr(info, "cancellation_settlement_expires_at", None)
+        ):
+            # Persist the migration immediately. Otherwise each actor restart
+            # would grant the legacy fence another full settlement period.
+            info.cancellation_settlement_expires_at = (
+                expires_at if _valid_timestamp(expires_at) else now + _CANCELLATION_SETTLEMENT_TTL_SECONDS
+            )
+            _save_recoverable_task(task_id, info)
         tasks[task_id] = info
     return tasks
 
@@ -157,19 +168,46 @@ def _recovery_snapshot(info: TaskInfo, *, now: float | None = None) -> tuple[Tas
         object_ref=info.object_ref,
         worker_submitted=getattr(info, "worker_submitted", False),
         submission_started_at=getattr(info, "submission_started_at", None),
+        cancellation_settlement_expires_at=getattr(info, "cancellation_settlement_expires_at", None),
     )
-    if _cancelled_task_unsettled(snapshot):
-        return snapshot, None
     timestamp = time.time() if now is None else now
+    if _cancelled_task_has_worker_fence(snapshot):
+        deadline = _ensure_cancellation_settlement_deadline(snapshot, now=timestamp)
+        return snapshot, deadline
+    snapshot.cancellation_settlement_expires_at = None
     return snapshot, timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS
 
 
-def _cancelled_task_unsettled(info: TaskInfo) -> bool:
+def _valid_timestamp(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _cancelled_task_has_worker_fence(info: TaskInfo) -> bool:
     if info.state != "CANCELLED":
         return False
     object_ref = info.object_ref
     ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
     return ref is not None or getattr(info, "worker_submitted", False)
+
+
+def _ensure_cancellation_settlement_deadline(info: TaskInfo, *, now: float | None = None) -> float:
+    deadline = getattr(info, "cancellation_settlement_expires_at", None)
+    if _valid_timestamp(deadline):
+        return float(deadline)
+    timestamp = time.time() if now is None else now
+    deadline = timestamp + _CANCELLATION_SETTLEMENT_TTL_SECONDS
+    info.cancellation_settlement_expires_at = deadline
+    return deadline
+
+
+def _cancelled_task_unsettled(info: TaskInfo, *, now: float | None = None) -> bool:
+    if not _cancelled_task_has_worker_fence(info):
+        return False
+    deadline = getattr(info, "cancellation_settlement_expires_at", None)
+    if not _valid_timestamp(deadline):
+        return True
+    timestamp = time.time() if now is None else now
+    return float(deadline) > timestamp
 
 
 def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
@@ -215,6 +253,7 @@ class TaskInfo:
     object_ref: ray.ObjectRef | None = None
     worker_submitted: bool = False
     submission_started_at: float | None = None
+    cancellation_settlement_expires_at: float | None = None
 
 
 def _object_ref_is_ready(object_ref: Any) -> bool:
@@ -290,6 +329,27 @@ class TaskStateManager:
             return False
         self._prune_expired_file_delete_fences()
         return bool(self.file_delete_fences.get((partition, file_id)))
+
+    def _set_cancelled_locked(self, task_id: str, info: TaskInfo) -> None:
+        info.state = "CANCELLED"
+        _ensure_cancellation_settlement_deadline(info)
+        _save_recoverable_task(task_id, info)
+
+    def _expire_cancellation_fence_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
+        if not _cancelled_task_has_worker_fence(info):
+            return False
+        deadline_was_missing = not _valid_timestamp(getattr(info, "cancellation_settlement_expires_at", None))
+        deadline = _ensure_cancellation_settlement_deadline(info)
+        if deadline > time.time():
+            if deadline_was_missing:
+                _save_recoverable_task(task_id, info)
+            return False
+        info.object_ref = None
+        info.worker_submitted = False
+        info.submission_started_at = None
+        info.cancellation_settlement_expires_at = None
+        _save_recoverable_task(task_id, info)
+        return True
 
     def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
@@ -369,6 +429,9 @@ class TaskStateManager:
             )
             if state_is_fenced and state != info.state:
                 return False
+            if state == "CANCELLED":
+                self._set_cancelled_locked(task_id, info)
+                return True
             if state == "SERIALIZING":
                 object_ref = info.object_ref
                 ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
@@ -406,8 +469,7 @@ class TaskStateManager:
             info = self.tasks.get(task_id)
             if info is None or info.state in TERMINAL_TASK_STATES:
                 return False
-            info.state = "CANCELLED"
-            _save_recoverable_task(task_id, info)
+            self._set_cancelled_locked(task_id, info)
             return True
 
     @ray.method(concurrency_group="set")
@@ -416,6 +478,8 @@ class TaskStateManager:
             info = self.tasks.get(task_id)
             if info is None or info.state != "CANCELLED":
                 return False
+            if self._expire_cancellation_fence_if_stale_locked(task_id, info):
+                return True
             object_ref = info.object_ref
             ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
             if ref is not None and not _object_ref_is_ready(object_ref):
@@ -423,6 +487,7 @@ class TaskStateManager:
             info.object_ref = None
             info.worker_submitted = False
             info.submission_started_at = None
+            info.cancellation_settlement_expires_at = None
             _save_recoverable_task(task_id, info)
             return True
 
@@ -436,6 +501,8 @@ class TaskStateManager:
             info.object_ref = None
             info.worker_submitted = False
             info.submission_started_at = None
+            if info.state == "CANCELLED":
+                info.cancellation_settlement_expires_at = None
             if info.state in CANCELLABLE_INDEXING_STATES:
                 info.state = "FAILED"
                 info.error = "Indexer worker submission was rejected after the worker settled."
@@ -493,8 +560,7 @@ class TaskStateManager:
                 user_id=user_id,
             )
             if self._file_delete_fenced(partition=partition, file_id=file_id):
-                info.state = "CANCELLED"
-                _save_recoverable_task(task_id, info)
+                self._set_cancelled_locked(task_id, info)
                 return False
             info.state = "QUEUED"
             _save_recoverable_task(task_id, info)
@@ -515,22 +581,25 @@ class TaskStateManager:
     @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         with self.lock:
-            info = self._ensure_task(task_id)
+            info = self.tasks.get(task_id)
+            if info is None:
+                return False
             if info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR:
                 return False
             if self._expire_refless_task_if_stale_locked(task_id, info):
+                return False
+            accepted = info.state in CANCELLABLE_INDEXING_STATES or info.state in TERMINAL_INDEXING_STATES
+            if not accepted:
                 return False
             info.object_ref = object_ref
             info.worker_submitted = True
             info.submission_started_at = None
             details = info.details or {}
             if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
-                info.state = "CANCELLED"
-                _save_recoverable_task(task_id, info)
+                self._set_cancelled_locked(task_id, info)
                 return False
-            accepted = info.state in ACTIVE_INDEXING_STATES or info.state in TERMINAL_INDEXING_STATES
             _save_recoverable_task(task_id, info)
-            return accepted
+            return True
 
     @ray.method(concurrency_group="get")
     async def get_state(self, task_id: str) -> str | None:
@@ -554,6 +623,8 @@ class TaskStateManager:
     async def get_object_ref(self, task_id: str) -> ray.ObjectRef | None:
         with self.lock:
             info = self.tasks.get(task_id)
+            if info is not None:
+                self._expire_cancellation_fence_if_stale_locked(task_id, info)
             return info.object_ref if info else None
 
     @ray.method(concurrency_group="get")
@@ -584,6 +655,7 @@ class TaskStateManager:
             for task_id, info in self.tasks.items():
                 if self._expire_refless_task_if_stale_locked(task_id, info):
                     continue
+                self._expire_cancellation_fence_if_stale_locked(task_id, info)
                 owns_claim = info.state in CANCELLABLE_INDEXING_STATES or _cancelled_task_unsettled(info)
                 if not owns_claim:
                     continue
@@ -602,6 +674,8 @@ class TaskStateManager:
         """Return whether cancellation still owns a worker submission fence."""
         with self.lock:
             info = self.tasks.get(task_id)
+            if info is not None:
+                self._expire_cancellation_fence_if_stale_locked(task_id, info)
             return info is not None and _cancelled_task_unsettled(info)
 
     def _matching_active_task_refs_locked(
@@ -614,6 +688,7 @@ class TaskStateManager:
         for task_id, info in self.tasks.items():
             if self._expire_refless_task_if_stale_locked(task_id, info):
                 continue
+            self._expire_cancellation_fence_if_stale_locked(task_id, info)
             if info.state not in CANCELLABLE_INDEXING_STATES and not _cancelled_task_unsettled(info):
                 continue
             details = info.details or {}

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -4,6 +4,7 @@ import base64
 import json
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -370,6 +371,12 @@ class TaskStateManager:
         _save_recoverable_task(task_id, info)
         return True
 
+    def _expire_refless_tasks_if_stale_locked(self, task_ids: Iterable[str] | None = None) -> None:
+        for task_id in self.tasks if task_ids is None else task_ids:
+            info = self.tasks.get(task_id)
+            if info is not None:
+                self._expire_refless_task_if_stale_locked(task_id, info)
+
     @ray.method(concurrency_group="set")
     async def begin_file_delete(self, *, partition: str, file_id: str, fence_id: str | None = None) -> None:
         with self.lock:
@@ -604,6 +611,8 @@ class TaskStateManager:
     async def get_state(self, task_id: str) -> str | None:
         with self.lock:
             info = self.tasks.get(task_id)
+            if info is not None:
+                self._expire_refless_task_if_stale_locked(task_id, info)
             return info.state if info else None
 
     @ray.method(concurrency_group="get")
@@ -710,11 +719,13 @@ class TaskStateManager:
     @ray.method(concurrency_group="queue_info")
     async def get_all_states(self) -> dict[str, str | None]:
         with self.lock:
+            self._expire_refless_tasks_if_stale_locked()
             return {tid: info.state for tid, info in self.tasks.items()}
 
     @ray.method(concurrency_group="queue_info")
     async def get_all_info(self) -> dict[str, dict]:
         with self.lock:
+            self._expire_refless_tasks_if_stale_locked()
             return {
                 task_id: {
                     "state": info.state,
@@ -730,6 +741,7 @@ class TaskStateManager:
     async def get_all_user_info(self, user_id: int) -> dict[str, dict]:
         with self.lock:
             task_ids = self.user_index.get(user_id, set())
+            self._expire_refless_tasks_if_stale_locked(task_ids)
             return {
                 tid: {
                     "state": self.tasks[tid].state,
@@ -757,6 +769,7 @@ class TaskStateManager:
     async def get_user_pending_task_count(self, user_id: int) -> int:
         with self.lock:
             task_ids = self.user_index.get(user_id, set())
+            self._expire_refless_tasks_if_stale_locked(task_ids)
             return sum(1 for tid in task_ids if (info := self.tasks.get(tid)) and info.state in ACTIVE_INDEXING_STATES)
 
 

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -169,7 +169,10 @@ def _cancelled_task_unsettled(info: TaskInfo) -> bool:
         return False
     object_ref = info.object_ref
     ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
-    return ref is not None or getattr(info, "worker_submitted", False)
+    submission_started_at = getattr(info, "submission_started_at", None)
+    return (
+        ref is not None or getattr(info, "worker_submitted", False) or isinstance(submission_started_at, (int, float))
+    )
 
 
 def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
@@ -294,14 +297,12 @@ class TaskStateManager:
     def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
         submission_started_at = getattr(info, "submission_started_at", None)
-        submission_pending = isinstance(submission_started_at, (int, float)) and (
-            time.time() < submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
-        )
+        submission_in_progress = isinstance(submission_started_at, (int, float))
         if (
             info.state not in CANCELLABLE_INDEXING_STATES
             or ref is not None
             or getattr(info, "worker_submitted", False)
-            or submission_pending
+            or submission_in_progress
             or not _content_claim_registration_expired(info.details or {})
         ):
             return False
@@ -579,11 +580,10 @@ class TaskStateManager:
             for task_id, info in self.tasks.items():
                 worker_submitted = getattr(info, "worker_submitted", False)
                 submission_started_at = getattr(info, "submission_started_at", None)
-                submission_pending = isinstance(submission_started_at, (int, float)) and (
-                    time.time() < submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
-                )
+                submission_in_progress = isinstance(submission_started_at, (int, float))
                 owns_claim = info.state in CANCELLABLE_INDEXING_STATES or (
-                    info.state == "CANCELLED" and (info.object_ref is not None or worker_submitted)
+                    info.state == "CANCELLED"
+                    and (info.object_ref is not None or worker_submitted or submission_in_progress)
                 )
                 if not owns_claim:
                     continue
@@ -596,7 +596,7 @@ class TaskStateManager:
                 if (
                     ref is None
                     and not worker_submitted
-                    and not submission_pending
+                    and not submission_in_progress
                     and _content_claim_registration_expired(details)
                 ):
                     continue
@@ -623,7 +623,10 @@ class TaskStateManager:
                 continue
             if file_id is not None and details.get("file_id") != file_id:
                 continue
-            if info.object_ref is None and getattr(info, "worker_submitted", False):
+            submission_started_at = getattr(info, "submission_started_at", None)
+            if info.object_ref is None and (
+                getattr(info, "worker_submitted", False) or isinstance(submission_started_at, (int, float))
+            ):
                 matches[task_id] = SUBMITTED_TASK_WITHOUT_REF
             else:
                 matches[task_id] = info.object_ref
@@ -643,6 +646,7 @@ class TaskStateManager:
                     "error": info.error,
                     "details": info.details,
                     "worker_submitted": getattr(info, "worker_submitted", False),
+                    "submission_started_at": getattr(info, "submission_started_at", None),
                 }
                 for task_id, info in self.tasks.items()
             }

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -510,24 +510,6 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
-    async def accept_worker_submission(self, task_id: str) -> bool:
-        """Replace the bounded handoff fence once the pool can launch work."""
-        with self.lock:
-            info = self.tasks.get(task_id)
-            if info is None:
-                return False
-            if info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR:
-                return False
-            if self._expire_refless_task_if_stale_locked(task_id, info):
-                return False
-            if info.state not in CANCELLABLE_INDEXING_STATES | TERMINAL_INDEXING_STATES:
-                return False
-            info.worker_submitted = True
-            info.submission_started_at = None
-            _save_recoverable_task(task_id, info)
-            return True
-
-    @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         with self.lock:
             info = self._ensure_task(task_id)

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -295,9 +295,7 @@ class TaskStateManager:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
         submission_started_at = getattr(info, "submission_started_at", None)
         if isinstance(submission_started_at, (int, float)):
-            registration_expired = time.time() >= (
-                submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
-            )
+            registration_expired = time.time() >= (submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS)
         else:
             registration_expired = _content_claim_registration_expired(info.details or {})
         if (

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -5,10 +5,16 @@ import json
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import ray
-from core.models.catalog import TASK_FINISHED_AT_METADATA_KEY, TERMINAL_TASK_STATES, DocumentStatus
+from core.models.catalog import (
+    TASK_CREATED_AT_METADATA_KEY,
+    TASK_FINISHED_AT_METADATA_KEY,
+    TERMINAL_TASK_STATES,
+    DocumentStatus,
+)
 
 ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING"})
 # Legacy indexing states removed from the public state machine in #721. Current
@@ -28,6 +34,10 @@ _LEGACY_FENCE_ID = "__legacy__"
 _RECOVERABLE_TASK_KV_PREFIX = b"recoverable-task-v1:"
 _CANCELLATION_TOMBSTONE_TTL_SECONDS = 24 * 60 * 60
 _FILE_DELETE_FENCE_TTL_SECONDS = 2 * 60
+_CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS = 60
+STALE_REFLESS_TASK_ERROR = (
+    "Indexing task never exposed a worker reference within the registration grace period; marking it failed as stale."
+)
 
 
 def _task_state_storage_available() -> bool:
@@ -132,6 +142,9 @@ def _load_recoverable_tasks() -> dict[str, TaskInfo]:
 
 
 def _recovery_snapshot(info: TaskInfo, *, now: float | None = None) -> tuple[TaskInfo, float | None]:
+    if info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR:
+        timestamp = time.time() if now is None else now
+        return info, timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS
     if info.state != "CANCELLED":
         return info, None
     timestamp = time.time() if now is None else now
@@ -151,7 +164,7 @@ def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
     if not _task_state_storage_available():
         return
     key = _recoverable_task_key(task_id)
-    if info.state in RECOVERABLE_TASK_STATES:
+    if info.state in RECOVERABLE_TASK_STATES or (info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR):
         snapshot, expires_at = _recovery_snapshot(info)
         _internal_kv_put(
             key,
@@ -200,6 +213,20 @@ def _object_ref_is_ready(object_ref: Any) -> bool:
     return bool(ready)
 
 
+def _content_claim_registration_expired(details: dict[str, Any]) -> bool:
+    metadata = details.get("metadata")
+    created_at = metadata.get(TASK_CREATED_AT_METADATA_KEY) if isinstance(metadata, dict) else None
+    if not isinstance(created_at, str):
+        return False
+    try:
+        created = datetime.fromisoformat(created_at)
+    except ValueError:
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    return datetime.now(UTC) >= created + timedelta(seconds=_CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS)
+
+
 @ray.remote(concurrency_groups={"set": 1000, "get": 1000, "queue_info": 1000})
 class TaskStateManager:
     def __init__(self) -> None:
@@ -246,6 +273,19 @@ class TaskStateManager:
             return False
         self._prune_expired_file_delete_fences()
         return bool(self.file_delete_fences.get((partition, file_id)))
+
+    def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
+        ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
+        if (
+            info.state not in CANCELLABLE_INDEXING_STATES
+            or ref is not None
+            or not _content_claim_registration_expired(info.details or {})
+        ):
+            return False
+        info.state = "FAILED"
+        info.error = STALE_REFLESS_TASK_ERROR
+        _save_recoverable_task(task_id, info)
+        return True
 
     @ray.method(concurrency_group="set")
     async def begin_file_delete(self, *, partition: str, file_id: str, fence_id: str | None = None) -> None:
@@ -301,7 +341,10 @@ class TaskStateManager:
     async def set_state(self, task_id: str, state: str) -> None:
         with self.lock:
             info = self._ensure_task(task_id)
-            if info.state == DocumentStatus.CANCELLED and state != DocumentStatus.CANCELLED:
+            state_is_fenced = info.state == DocumentStatus.CANCELLED or (
+                info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR
+            )
+            if state_is_fenced and state != info.state:
                 return
             info.state = state
             _save_recoverable_task(task_id, info)
@@ -348,6 +391,12 @@ class TaskStateManager:
             info.object_ref = None
             _save_recoverable_task(task_id, info)
             return True
+
+    @ray.method(concurrency_group="set")
+    async def expire_refless_task_if_stale(self, task_id: str) -> bool:
+        with self.lock:
+            info = self.tasks.get(task_id)
+            return info is not None and self._expire_refless_task_if_stale_locked(task_id, info)
 
     @ray.method(concurrency_group="set")
     async def set_details(
@@ -405,6 +454,10 @@ class TaskStateManager:
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         with self.lock:
             info = self._ensure_task(task_id)
+            if info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR:
+                return False
+            if self._expire_refless_task_if_stale_locked(task_id, info):
+                return False
             info.object_ref = object_ref
             details = info.details or {}
             if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
@@ -475,6 +528,9 @@ class TaskStateManager:
                 if has_finished or _object_ref_is_ready(info.object_ref):
                     continue
                 details = info.details or {}
+                ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
+                if ref is None and _content_claim_registration_expired(details):
+                    continue
                 if details and details.get("partition") != partition:
                     continue
                 matches.add(task_id)
@@ -557,6 +613,7 @@ __all__ = [
     "CANCELLABLE_INDEXING_STATES",
     "LEGACY_ACTIVE_INDEXING_STATES",
     "PENDING_TASK_DETAILS",
+    "STALE_REFLESS_TASK_ERROR",
     "TERMINAL_INDEXING_STATES",
     "TaskInfo",
     "TaskStateManager",

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -152,7 +152,13 @@ def _recovery_snapshot(info: TaskInfo, *, now: float | None = None) -> tuple[Tas
     # restarts between the durable claim and ray.cancel(), a retry still needs
     # this reference to stop the live worker.
     return (
-        TaskInfo(state="CANCELLED", object_ref=info.object_ref),
+        TaskInfo(
+            state="CANCELLED",
+            details=info.details,
+            object_ref=info.object_ref,
+            worker_submitted=getattr(info, "worker_submitted", False),
+            submission_started_at=getattr(info, "submission_started_at", None),
+        ),
         timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS,
     )
 
@@ -199,6 +205,7 @@ class TaskInfo:
     details: dict[str, Any] = field(default_factory=dict)
     object_ref: ray.ObjectRef | None = None
     worker_submitted: bool = False
+    submission_started_at: float | None = None
 
 
 def _object_ref_is_ready(object_ref: Any) -> bool:
@@ -277,10 +284,15 @@ class TaskStateManager:
 
     def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
+        submission_started_at = getattr(info, "submission_started_at", None)
+        submission_pending = isinstance(submission_started_at, (int, float)) and (
+            time.time() < submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
+        )
         if (
             info.state not in CANCELLABLE_INDEXING_STATES
             or ref is not None
             or getattr(info, "worker_submitted", False)
+            or submission_pending
             or not _content_claim_registration_expired(info.details or {})
         ):
             return False
@@ -340,16 +352,20 @@ class TaskStateManager:
             self.file_delete_fences = updated
 
     @ray.method(concurrency_group="set")
-    async def set_state(self, task_id: str, state: str) -> None:
+    async def set_state(self, task_id: str, state: str) -> bool:
         with self.lock:
             info = self._ensure_task(task_id)
             state_is_fenced = info.state == DocumentStatus.CANCELLED or (
                 info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR
             )
             if state_is_fenced and state != info.state:
-                return
+                return False
             info.state = state
+            if state == "SERIALIZING":
+                info.worker_submitted = True
+                info.submission_started_at = None
             _save_recoverable_task(task_id, info)
+            return True
 
     @ray.method(concurrency_group="set")
     async def set_error(self, task_id: str, tb_str: str) -> None:
@@ -391,6 +407,8 @@ class TaskStateManager:
             if ref is not None and not _object_ref_is_ready(object_ref):
                 return False
             info.object_ref = None
+            info.worker_submitted = False
+            info.submission_started_at = None
             _save_recoverable_task(task_id, info)
             return True
 
@@ -453,14 +471,14 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
-    async def mark_worker_submitted(self, task_id: str) -> bool:
+    async def begin_worker_submission(self, task_id: str) -> bool:
         with self.lock:
             info = self.tasks.get(task_id)
             if info is None or info.state not in CANCELLABLE_INDEXING_STATES:
                 return False
             if self._expire_refless_task_if_stale_locked(task_id, info):
                 return False
-            info.worker_submitted = True
+            info.submission_started_at = time.time()
             _save_recoverable_task(task_id, info)
             return True
 
@@ -473,6 +491,8 @@ class TaskStateManager:
             if self._expire_refless_task_if_stale_locked(task_id, info):
                 return False
             info.object_ref = object_ref
+            info.worker_submitted = True
+            info.submission_started_at = None
             details = info.details or {}
             if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
                 info.state = "CANCELLED"
@@ -533,6 +553,10 @@ class TaskStateManager:
             matches = set()
             for task_id, info in self.tasks.items():
                 worker_submitted = getattr(info, "worker_submitted", False)
+                submission_started_at = getattr(info, "submission_started_at", None)
+                submission_pending = isinstance(submission_started_at, (int, float)) and (
+                    time.time() < submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
+                )
                 owns_claim = info.state in CANCELLABLE_INDEXING_STATES or (
                     info.state == "CANCELLED" and (info.object_ref is not None or worker_submitted)
                 )
@@ -544,7 +568,12 @@ class TaskStateManager:
                     continue
                 details = info.details or {}
                 ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
-                if ref is None and not worker_submitted and _content_claim_registration_expired(details):
+                if (
+                    ref is None
+                    and not worker_submitted
+                    and not submission_pending
+                    and _content_claim_registration_expired(details)
+                ):
                     continue
                 if details and details.get("partition") != partition:
                     continue
@@ -585,6 +614,7 @@ class TaskStateManager:
                     "state": info.state,
                     "error": info.error,
                     "details": info.details,
+                    "worker_submitted": getattr(info, "worker_submitted", False),
                 }
                 for task_id, info in self.tasks.items()
             }

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import ray
-from core.models.catalog import TERMINAL_TASK_STATES, DocumentStatus
+from core.models.catalog import TASK_FINISHED_AT_METADATA_KEY, TERMINAL_TASK_STATES, DocumentStatus
 
 ACTIVE_INDEXING_STATES = frozenset({"QUEUED", "SERIALIZING"})
 # Legacy indexing states removed from the public state machine in #721. Current
@@ -187,6 +187,19 @@ class TaskInfo:
     object_ref: ray.ObjectRef | None = None
 
 
+def _object_ref_is_ready(object_ref: Any) -> bool:
+    ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+    if ref is None:
+        return False
+    try:
+        ready, _ = ray.wait([ref], num_returns=1, timeout=0)
+    except Exception:
+        # Readiness uncertainty must preserve the claim; reclaiming it could
+        # let a second upload run alongside a worker that is still active.
+        return False
+    return bool(ready)
+
+
 @ray.remote(concurrency_groups={"set": 1000, "get": 1000, "queue_info": 1000})
 class TaskStateManager:
     def __init__(self) -> None:
@@ -330,13 +343,8 @@ class TaskStateManager:
                 return False
             object_ref = info.object_ref
             ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
-            if ref is not None:
-                try:
-                    ready, _ = ray.wait([ref], num_returns=1, timeout=0)
-                except Exception:
-                    return False
-                if not ready:
-                    return False
+            if ref is not None and not _object_ref_is_ready(object_ref):
+                return False
             info.object_ref = None
             _save_recoverable_task(task_id, info)
             return True
@@ -461,6 +469,10 @@ class TaskStateManager:
                     info.state == "CANCELLED" and info.object_ref is not None
                 )
                 if not owns_claim:
+                    continue
+                metadata = (info.details or {}).get("metadata")
+                has_finished = isinstance(metadata, dict) and TASK_FINISHED_AT_METADATA_KEY in metadata
+                if has_finished or _object_ref_is_ready(info.object_ref):
                     continue
                 details = info.details or {}
                 if details and details.get("partition") != partition:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -591,13 +591,12 @@ class TaskStateManager:
             accepted = info.state in CANCELLABLE_INDEXING_STATES or info.state in TERMINAL_INDEXING_STATES
             if not accepted:
                 return False
+            details = info.details or {}
+            if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
+                return False
             info.object_ref = object_ref
             info.worker_submitted = True
             info.submission_started_at = None
-            details = info.details or {}
-            if self._file_delete_fenced(partition=details.get("partition"), file_id=details.get("file_id")):
-                self._set_cancelled_locked(task_id, info)
-                return False
             _save_recoverable_task(task_id, info)
             return True
 

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -28,6 +28,7 @@ CANCELLABLE_INDEXING_STATES = ACTIVE_INDEXING_STATES | LEGACY_ACTIVE_INDEXING_ST
 RECOVERABLE_TASK_STATES = CANCELLABLE_INDEXING_STATES | {"CANCELLED"}
 TERMINAL_INDEXING_STATES = frozenset({"COMPLETED", "FAILED"})
 PENDING_TASK_DETAILS = "__openrag_pending_task_details__"
+SUBMITTED_TASK_WITHOUT_REF = "__openrag_submitted_task_without_ref__"
 _FENCE_KV_KEY = b"file-delete-fences-v1"
 _TASK_STATE_KV_NAMESPACE = "openrag-task-state-manager"
 _LEGACY_FENCE_ID = "__legacy__"
@@ -134,7 +135,7 @@ def _load_recoverable_tasks() -> dict[str, TaskInfo]:
         if payload is None:
             continue
         task_id, info, expires_at = _decode_recoverable_task(payload)
-        if expires_at is not None and expires_at <= time.time():
+        if expires_at is not None and expires_at <= time.time() and not _cancelled_task_unsettled(info):
             _internal_kv_del(key, namespace=namespace)
             continue
         tasks[task_id] = info
@@ -147,20 +148,28 @@ def _recovery_snapshot(info: TaskInfo, *, now: float | None = None) -> tuple[Tas
         return info, timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS
     if info.state != "CANCELLED":
         return info, None
-    timestamp = time.time() if now is None else now
     # Keep the worker reference until cancellation is confirmed. If the actor
     # restarts between the durable claim and ray.cancel(), a retry still needs
     # this reference to stop the live worker.
-    return (
-        TaskInfo(
-            state="CANCELLED",
-            details=info.details,
-            object_ref=info.object_ref,
-            worker_submitted=getattr(info, "worker_submitted", False),
-            submission_started_at=getattr(info, "submission_started_at", None),
-        ),
-        timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS,
+    snapshot = TaskInfo(
+        state="CANCELLED",
+        details=info.details,
+        object_ref=info.object_ref,
+        worker_submitted=getattr(info, "worker_submitted", False),
+        submission_started_at=getattr(info, "submission_started_at", None),
     )
+    if _cancelled_task_unsettled(snapshot):
+        return snapshot, None
+    timestamp = time.time() if now is None else now
+    return snapshot, timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS
+
+
+def _cancelled_task_unsettled(info: TaskInfo) -> bool:
+    if info.state != "CANCELLED":
+        return False
+    object_ref = info.object_ref
+    ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+    return ref is not None or getattr(info, "worker_submitted", False)
 
 
 def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
@@ -413,6 +422,22 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
+    async def finish_rejected_submission(self, task_id: str) -> bool:
+        """Clear a submitted-task fence after the pool proves its worker settled."""
+        with self.lock:
+            info = self.tasks.get(task_id)
+            if info is None:
+                return False
+            info.object_ref = None
+            info.worker_submitted = False
+            info.submission_started_at = None
+            if info.state in CANCELLABLE_INDEXING_STATES:
+                info.state = "FAILED"
+                info.error = "Indexer worker submission was rejected after the worker settled."
+            _save_recoverable_task(task_id, info)
+            return True
+
+    @ray.method(concurrency_group="set")
     async def expire_refless_task_if_stale(self, task_id: str) -> bool:
         with self.lock:
             info = self.tasks.get(task_id)
@@ -588,7 +613,7 @@ class TaskStateManager:
     ) -> dict[str, ray.ObjectRef | None | str]:
         matches = {}
         for task_id, info in self.tasks.items():
-            if info.state not in CANCELLABLE_INDEXING_STATES:
+            if info.state not in CANCELLABLE_INDEXING_STATES and not _cancelled_task_unsettled(info):
                 continue
             details = info.details or {}
             if not details:
@@ -598,7 +623,10 @@ class TaskStateManager:
                 continue
             if file_id is not None and details.get("file_id") != file_id:
                 continue
-            matches[task_id] = info.object_ref
+            if info.object_ref is None and getattr(info, "worker_submitted", False):
+                matches[task_id] = SUBMITTED_TASK_WITHOUT_REF
+            else:
+                matches[task_id] = info.object_ref
         return matches
 
     @ray.method(concurrency_group="queue_info")
@@ -658,6 +686,7 @@ __all__ = [
     "CANCELLABLE_INDEXING_STATES",
     "LEGACY_ACTIVE_INDEXING_STATES",
     "PENDING_TASK_DETAILS",
+    "SUBMITTED_TASK_WITHOUT_REF",
     "STALE_REFLESS_TASK_ERROR",
     "TERMINAL_INDEXING_STATES",
     "TaskInfo",

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -35,7 +35,6 @@ _TASK_STATE_KV_NAMESPACE = "openrag-task-state-manager"
 _LEGACY_FENCE_ID = "__legacy__"
 _RECOVERABLE_TASK_KV_PREFIX = b"recoverable-task-v1:"
 _CANCELLATION_TOMBSTONE_TTL_SECONDS = 24 * 60 * 60
-_CANCELLATION_SETTLEMENT_TTL_SECONDS = 24 * 60 * 60
 _FILE_DELETE_FENCE_TTL_SECONDS = 2 * 60
 _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS = 60
 STALE_REFLESS_TASK_ERROR = (
@@ -138,18 +137,9 @@ def _load_recoverable_tasks() -> dict[str, TaskInfo]:
         if payload is None:
             continue
         task_id, info, expires_at = _decode_recoverable_task(payload)
-        if expires_at is not None and expires_at <= now:
+        if expires_at is not None and expires_at <= now and not _cancelled_task_has_worker_fence(info):
             _internal_kv_del(key, namespace=namespace)
             continue
-        if _cancelled_task_has_worker_fence(info) and not _valid_timestamp(
-            getattr(info, "cancellation_settlement_expires_at", None)
-        ):
-            # Persist the migration immediately. Otherwise each actor restart
-            # would grant the legacy fence another full settlement period.
-            info.cancellation_settlement_expires_at = (
-                expires_at if _valid_timestamp(expires_at) else now + _CANCELLATION_SETTLEMENT_TTL_SECONDS
-            )
-            _save_recoverable_task(task_id, info)
         tasks[task_id] = info
     return tasks
 
@@ -169,18 +159,14 @@ def _recovery_snapshot(info: TaskInfo, *, now: float | None = None) -> tuple[Tas
         object_ref=info.object_ref,
         worker_submitted=getattr(info, "worker_submitted", False),
         submission_started_at=getattr(info, "submission_started_at", None),
-        cancellation_settlement_expires_at=getattr(info, "cancellation_settlement_expires_at", None),
     )
     timestamp = time.time() if now is None else now
     if _cancelled_task_has_worker_fence(snapshot):
-        deadline = _ensure_cancellation_settlement_deadline(snapshot, now=timestamp)
-        return snapshot, deadline
-    snapshot.cancellation_settlement_expires_at = None
+        # Ray actor-task cancellation is best effort. An elapsed deadline cannot
+        # prove that an unreachable worker stopped, so unresolved workers remain
+        # durable until their reference settles or the pool confirms settlement.
+        return snapshot, None
     return snapshot, timestamp + _CANCELLATION_TOMBSTONE_TTL_SECONDS
-
-
-def _valid_timestamp(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def _cancelled_task_has_worker_fence(info: TaskInfo) -> bool:
@@ -189,26 +175,6 @@ def _cancelled_task_has_worker_fence(info: TaskInfo) -> bool:
     object_ref = info.object_ref
     ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
     return ref is not None or getattr(info, "worker_submitted", False)
-
-
-def _ensure_cancellation_settlement_deadline(info: TaskInfo, *, now: float | None = None) -> float:
-    deadline = getattr(info, "cancellation_settlement_expires_at", None)
-    if _valid_timestamp(deadline):
-        return float(deadline)
-    timestamp = time.time() if now is None else now
-    deadline = timestamp + _CANCELLATION_SETTLEMENT_TTL_SECONDS
-    info.cancellation_settlement_expires_at = deadline
-    return deadline
-
-
-def _cancelled_task_unsettled(info: TaskInfo, *, now: float | None = None) -> bool:
-    if not _cancelled_task_has_worker_fence(info):
-        return False
-    deadline = getattr(info, "cancellation_settlement_expires_at", None)
-    if not _valid_timestamp(deadline):
-        return True
-    timestamp = time.time() if now is None else now
-    return float(deadline) > timestamp
 
 
 def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
@@ -254,7 +220,6 @@ class TaskInfo:
     object_ref: ray.ObjectRef | None = None
     worker_submitted: bool = False
     submission_started_at: float | None = None
-    cancellation_settlement_expires_at: float | None = None
 
 
 def _object_ref_is_ready(object_ref: Any) -> bool:
@@ -333,24 +298,7 @@ class TaskStateManager:
 
     def _set_cancelled_locked(self, task_id: str, info: TaskInfo) -> None:
         info.state = "CANCELLED"
-        _ensure_cancellation_settlement_deadline(info)
         _save_recoverable_task(task_id, info)
-
-    def _expire_cancellation_fence_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
-        if not _cancelled_task_has_worker_fence(info):
-            return False
-        deadline_was_missing = not _valid_timestamp(getattr(info, "cancellation_settlement_expires_at", None))
-        deadline = _ensure_cancellation_settlement_deadline(info)
-        if deadline > time.time():
-            if deadline_was_missing:
-                _save_recoverable_task(task_id, info)
-            return False
-        info.object_ref = None
-        info.worker_submitted = False
-        info.submission_started_at = None
-        info.cancellation_settlement_expires_at = None
-        _save_recoverable_task(task_id, info)
-        return True
 
     def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
@@ -485,16 +433,13 @@ class TaskStateManager:
             info = self.tasks.get(task_id)
             if info is None or info.state != "CANCELLED":
                 return False
-            if self._expire_cancellation_fence_if_stale_locked(task_id, info):
-                return True
             object_ref = info.object_ref
             ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
-            if ref is not None and not _object_ref_is_ready(object_ref):
+            if _cancelled_task_has_worker_fence(info) and (ref is None or not _object_ref_is_ready(object_ref)):
                 return False
             info.object_ref = None
             info.worker_submitted = False
             info.submission_started_at = None
-            info.cancellation_settlement_expires_at = None
             _save_recoverable_task(task_id, info)
             return True
 
@@ -508,8 +453,6 @@ class TaskStateManager:
             info.object_ref = None
             info.worker_submitted = False
             info.submission_started_at = None
-            if info.state == "CANCELLED":
-                info.cancellation_settlement_expires_at = None
             if info.state in CANCELLABLE_INDEXING_STATES:
                 info.state = "FAILED"
                 info.error = "Indexer worker submission was rejected after the worker settled."
@@ -631,8 +574,6 @@ class TaskStateManager:
     async def get_object_ref(self, task_id: str) -> ray.ObjectRef | None:
         with self.lock:
             info = self.tasks.get(task_id)
-            if info is not None:
-                self._expire_cancellation_fence_if_stale_locked(task_id, info)
             return info.object_ref if info else None
 
     @ray.method(concurrency_group="get")
@@ -663,8 +604,7 @@ class TaskStateManager:
             for task_id, info in self.tasks.items():
                 if self._expire_refless_task_if_stale_locked(task_id, info):
                     continue
-                self._expire_cancellation_fence_if_stale_locked(task_id, info)
-                owns_claim = info.state in CANCELLABLE_INDEXING_STATES or _cancelled_task_unsettled(info)
+                owns_claim = info.state in CANCELLABLE_INDEXING_STATES or _cancelled_task_has_worker_fence(info)
                 if not owns_claim:
                     continue
                 metadata = (info.details or {}).get("metadata")
@@ -682,9 +622,7 @@ class TaskStateManager:
         """Return whether cancellation still owns a worker submission fence."""
         with self.lock:
             info = self.tasks.get(task_id)
-            if info is not None:
-                self._expire_cancellation_fence_if_stale_locked(task_id, info)
-            return info is not None and _cancelled_task_unsettled(info)
+            return info is not None and _cancelled_task_has_worker_fence(info)
 
     def _matching_active_task_refs_locked(
         self,
@@ -696,8 +634,7 @@ class TaskStateManager:
         for task_id, info in self.tasks.items():
             if self._expire_refless_task_if_stale_locked(task_id, info):
                 continue
-            self._expire_cancellation_fence_if_stale_locked(task_id, info)
-            if info.state not in CANCELLABLE_INDEXING_STATES and not _cancelled_task_unsettled(info):
+            if info.state not in CANCELLABLE_INDEXING_STATES and not _cancelled_task_has_worker_fence(info):
                 continue
             details = info.details or {}
             if not details:

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -369,6 +369,11 @@ class TaskStateManager:
             )
             if state_is_fenced and state != info.state:
                 return False
+            if state == "SERIALIZING":
+                object_ref = info.object_ref
+                ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+                if ref is None:
+                    return False
             info.state = state
             if state == "SERIALIZING":
                 info.worker_submitted = True

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -323,13 +323,23 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
-    async def finish_cancellation(self, task_id: str) -> None:
+    async def finish_cancellation(self, task_id: str) -> bool:
         with self.lock:
             info = self.tasks.get(task_id)
             if info is None or info.state != "CANCELLED":
-                return
+                return False
+            object_ref = info.object_ref
+            ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
+            if ref is not None:
+                try:
+                    ready, _ = ray.wait([ref], num_returns=1, timeout=0)
+                except Exception:
+                    return False
+                if not ready:
+                    return False
             info.object_ref = None
             _save_recoverable_task(task_id, info)
+            return True
 
     @ray.method(concurrency_group="set")
     async def set_details(
@@ -440,6 +450,23 @@ class TaskStateManager:
     ) -> dict[str, ray.ObjectRef | None | str]:
         with self.lock:
             return self._matching_active_task_refs_locked(partition=partition, file_id=file_id)
+
+    @ray.method(concurrency_group="get")
+    async def get_content_claim_task_ids(self, *, partition: str) -> set[str]:
+        """Return active tasks and cancellations whose workers have not settled."""
+        with self.lock:
+            matches = set()
+            for task_id, info in self.tasks.items():
+                owns_claim = info.state in CANCELLABLE_INDEXING_STATES or (
+                    info.state == "CANCELLED" and info.object_ref is not None
+                )
+                if not owns_claim:
+                    continue
+                details = info.details or {}
+                if details and details.get("partition") != partition:
+                    continue
+                matches.add(task_id)
+            return matches
 
     def _matching_active_task_refs_locked(
         self,

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -169,10 +169,7 @@ def _cancelled_task_unsettled(info: TaskInfo) -> bool:
         return False
     object_ref = info.object_ref
     ref = object_ref.get("ref") if isinstance(object_ref, dict) else object_ref
-    submission_started_at = getattr(info, "submission_started_at", None)
-    return (
-        ref is not None or getattr(info, "worker_submitted", False) or isinstance(submission_started_at, (int, float))
-    )
+    return ref is not None or getattr(info, "worker_submitted", False)
 
 
 def _save_recoverable_task(task_id: str, info: TaskInfo) -> None:
@@ -297,13 +294,17 @@ class TaskStateManager:
     def _expire_refless_task_if_stale_locked(self, task_id: str, info: TaskInfo) -> bool:
         ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
         submission_started_at = getattr(info, "submission_started_at", None)
-        submission_in_progress = isinstance(submission_started_at, (int, float))
+        if isinstance(submission_started_at, (int, float)):
+            registration_expired = time.time() >= (
+                submission_started_at + _CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS
+            )
+        else:
+            registration_expired = _content_claim_registration_expired(info.details or {})
         if (
             info.state not in CANCELLABLE_INDEXING_STATES
             or ref is not None
             or getattr(info, "worker_submitted", False)
-            or submission_in_progress
-            or not _content_claim_registration_expired(info.details or {})
+            or not registration_expired
         ):
             return False
         info.state = "FAILED"
@@ -509,6 +510,24 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
+    async def accept_worker_submission(self, task_id: str) -> bool:
+        """Replace the bounded handoff fence once the pool can launch work."""
+        with self.lock:
+            info = self.tasks.get(task_id)
+            if info is None:
+                return False
+            if info.state == "FAILED" and info.error == STALE_REFLESS_TASK_ERROR:
+                return False
+            if self._expire_refless_task_if_stale_locked(task_id, info):
+                return False
+            if info.state not in CANCELLABLE_INDEXING_STATES | TERMINAL_INDEXING_STATES:
+                return False
+            info.worker_submitted = True
+            info.submission_started_at = None
+            _save_recoverable_task(task_id, info)
+            return True
+
+    @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         with self.lock:
             info = self._ensure_task(task_id)
@@ -578,6 +597,8 @@ class TaskStateManager:
         with self.lock:
             matches = set()
             for task_id, info in self.tasks.items():
+                if self._expire_refless_task_if_stale_locked(task_id, info):
+                    continue
                 worker_submitted = getattr(info, "worker_submitted", False)
                 submission_started_at = getattr(info, "submission_started_at", None)
                 submission_in_progress = isinstance(submission_started_at, (int, float))
@@ -596,7 +617,6 @@ class TaskStateManager:
                 if (
                     ref is None
                     and not worker_submitted
-                    and not submission_in_progress
                     and _content_claim_registration_expired(details)
                 ):
                     continue
@@ -604,6 +624,13 @@ class TaskStateManager:
                     continue
                 matches.add(task_id)
             return matches
+
+    @ray.method(concurrency_group="get")
+    async def has_unsettled_cancelled_worker(self, task_id: str) -> bool:
+        """Return whether cancellation still owns a worker submission fence."""
+        with self.lock:
+            info = self.tasks.get(task_id)
+            return info is not None and _cancelled_task_unsettled(info)
 
     def _matching_active_task_refs_locked(
         self,
@@ -613,6 +640,8 @@ class TaskStateManager:
     ) -> dict[str, ray.ObjectRef | None | str]:
         matches = {}
         for task_id, info in self.tasks.items():
+            if self._expire_refless_task_if_stale_locked(task_id, info):
+                continue
             if info.state not in CANCELLABLE_INDEXING_STATES and not _cancelled_task_unsettled(info):
                 continue
             details = info.details or {}

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -599,13 +599,7 @@ class TaskStateManager:
             for task_id, info in self.tasks.items():
                 if self._expire_refless_task_if_stale_locked(task_id, info):
                     continue
-                worker_submitted = getattr(info, "worker_submitted", False)
-                submission_started_at = getattr(info, "submission_started_at", None)
-                submission_in_progress = isinstance(submission_started_at, (int, float))
-                owns_claim = info.state in CANCELLABLE_INDEXING_STATES or (
-                    info.state == "CANCELLED"
-                    and (info.object_ref is not None or worker_submitted or submission_in_progress)
-                )
+                owns_claim = info.state in CANCELLABLE_INDEXING_STATES or _cancelled_task_unsettled(info)
                 if not owns_claim:
                     continue
                 metadata = (info.details or {}).get("metadata")
@@ -613,13 +607,6 @@ class TaskStateManager:
                 if has_finished or _object_ref_is_ready(info.object_ref):
                     continue
                 details = info.details or {}
-                ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
-                if (
-                    ref is None
-                    and not worker_submitted
-                    and _content_claim_registration_expired(details)
-                ):
-                    continue
                 if details and details.get("partition") != partition:
                     continue
                 matches.add(task_id)

--- a/openrag/services/workers/task_state.py
+++ b/openrag/services/workers/task_state.py
@@ -198,6 +198,7 @@ class TaskInfo:
     error: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
     object_ref: ray.ObjectRef | None = None
+    worker_submitted: bool = False
 
 
 def _object_ref_is_ready(object_ref: Any) -> bool:
@@ -279,6 +280,7 @@ class TaskStateManager:
         if (
             info.state not in CANCELLABLE_INDEXING_STATES
             or ref is not None
+            or getattr(info, "worker_submitted", False)
             or not _content_claim_registration_expired(info.details or {})
         ):
             return False
@@ -451,6 +453,18 @@ class TaskStateManager:
             return True
 
     @ray.method(concurrency_group="set")
+    async def mark_worker_submitted(self, task_id: str) -> bool:
+        with self.lock:
+            info = self.tasks.get(task_id)
+            if info is None or info.state not in CANCELLABLE_INDEXING_STATES:
+                return False
+            if self._expire_refless_task_if_stale_locked(task_id, info):
+                return False
+            info.worker_submitted = True
+            _save_recoverable_task(task_id, info)
+            return True
+
+    @ray.method(concurrency_group="set")
     async def set_object_ref(self, task_id: str, object_ref: ray.ObjectRef) -> bool:
         with self.lock:
             info = self._ensure_task(task_id)
@@ -518,8 +532,9 @@ class TaskStateManager:
         with self.lock:
             matches = set()
             for task_id, info in self.tasks.items():
+                worker_submitted = getattr(info, "worker_submitted", False)
                 owns_claim = info.state in CANCELLABLE_INDEXING_STATES or (
-                    info.state == "CANCELLED" and info.object_ref is not None
+                    info.state == "CANCELLED" and (info.object_ref is not None or worker_submitted)
                 )
                 if not owns_claim:
                     continue
@@ -529,7 +544,7 @@ class TaskStateManager:
                     continue
                 details = info.details or {}
                 ref = info.object_ref.get("ref") if isinstance(info.object_ref, dict) else info.object_ref
-                if ref is None and _content_claim_registration_expired(details):
+                if ref is None and not worker_submitted and _content_claim_registration_expired(details):
                     continue
                 if details and details.get("partition") != partition:
                     continue

--- a/tests/integration/repos/test_document_repo.py
+++ b/tests/integration/repos/test_document_repo.py
@@ -149,7 +149,6 @@ class TestContentClaims:
                 partition=partition,
                 content_sha256="a" * 64,
                 claim_token="task:early-retry-task",
-                active_claim_tokens=set(),
             )
             == "abandoned-file"
         )
@@ -169,7 +168,21 @@ class TestContentClaims:
                 partition=partition,
                 content_sha256="a" * 64,
                 claim_token="task:retry-task",
-                active_claim_tokens=set(),
+            )
+            == "abandoned-file"
+        )
+        lease = await repo.get_recoverable_content_sha256_claim(
+            partition=partition,
+            content_sha256="a" * 64,
+        )
+        assert lease is not None
+        assert await repo.release_recoverable_content_sha256_claim(lease) is True
+        assert (
+            await repo.claim_content_sha256(
+                file_id="retry-file",
+                partition=partition,
+                content_sha256="a" * 64,
+                claim_token="task:retry-task",
             )
             is None
         )
@@ -200,13 +213,27 @@ class TestContentClaims:
             "b" * 64,
         )
 
+        lease = await repo.get_recoverable_content_sha256_claim(
+            partition=partition,
+            content_sha256="b" * 64,
+        )
+        assert lease is not None
+        assert (
+            await repo.renew_content_sha256_claim(
+                file_id="active-file",
+                partition=partition,
+                content_sha256="b" * 64,
+                claim_token="task:active-task",
+            )
+            is True
+        )
+        assert await repo.release_recoverable_content_sha256_claim(lease) is False
         assert (
             await repo.claim_content_sha256(
                 file_id="duplicate-file",
                 partition=partition,
                 content_sha256="b" * 64,
                 claim_token="task:duplicate-task",
-                active_claim_tokens={"task:active-task"},
             )
             == "active-file"
         )
@@ -238,12 +265,18 @@ class TestContentClaims:
         )
 
         assert (
+            await repo.get_recoverable_content_sha256_claim(
+                partition=partition,
+                content_sha256="c" * 64,
+            )
+            is None
+        )
+        assert (
             await repo.claim_content_sha256(
                 file_id="duplicate-file",
                 partition=partition,
                 content_sha256="c" * 64,
                 claim_token="task:duplicate-task",
-                active_claim_tokens=set(),
             )
             == "copy-file"
         )

--- a/tests/integration/repos/test_document_repo.py
+++ b/tests/integration/repos/test_document_repo.py
@@ -139,7 +139,7 @@ class TestContentClaims:
                 file_id="abandoned-file",
                 partition=partition,
                 content_sha256="a" * 64,
-                claim_token="abandoned-task",
+                claim_token="task:abandoned-task",
             )
             is None
         )
@@ -148,7 +148,7 @@ class TestContentClaims:
                 file_id="early-retry",
                 partition=partition,
                 content_sha256="a" * 64,
-                claim_token="early-retry-task",
+                claim_token="task:early-retry-task",
                 active_claim_tokens=set(),
             )
             == "abandoned-file"
@@ -168,7 +168,7 @@ class TestContentClaims:
                 file_id="retry-file",
                 partition=partition,
                 content_sha256="a" * 64,
-                claim_token="retry-task",
+                claim_token="task:retry-task",
                 active_claim_tokens=set(),
             )
             is None
@@ -186,7 +186,7 @@ class TestContentClaims:
                 file_id="active-file",
                 partition=partition,
                 content_sha256="b" * 64,
-                claim_token="active-task",
+                claim_token="task:active-task",
             )
             is None
         )
@@ -205,13 +205,13 @@ class TestContentClaims:
                 file_id="duplicate-file",
                 partition=partition,
                 content_sha256="b" * 64,
-                claim_token="duplicate-task",
-                active_claim_tokens={"active-task"},
+                claim_token="task:duplicate-task",
+                active_claim_tokens={"task:active-task"},
             )
             == "active-file"
         )
 
-    async def test_preserves_non_task_claim(
+    async def test_preserves_legacy_non_task_claim(
         self,
         postgres_store: PostgresStore,
     ):
@@ -223,7 +223,7 @@ class TestContentClaims:
                 file_id="copy-file",
                 partition=partition,
                 content_sha256="c" * 64,
-                claim_token="copy:active-copy",
+                claim_token="legacy-copy-uuid",
             )
             is None
         )
@@ -242,7 +242,7 @@ class TestContentClaims:
                 file_id="duplicate-file",
                 partition=partition,
                 content_sha256="c" * 64,
-                claim_token="duplicate-task",
+                claim_token="task:duplicate-task",
                 active_claim_tokens=set(),
             )
             == "copy-file"

--- a/tests/integration/repos/test_document_repo.py
+++ b/tests/integration/repos/test_document_repo.py
@@ -124,3 +124,126 @@ class TestDeleteByPartition:
         deleted = await repo.delete_documents_by_partition(partition)
         assert deleted == 2
         assert await repo.count_documents(partition=partition) == 0
+
+
+class TestContentClaims:
+    async def test_recovers_orphaned_claim_after_registration_grace(
+        self,
+        postgres_store: PostgresStore,
+    ):
+        partition = await _seed_partition(postgres_store)
+        repo = postgres_store.document_repo
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="abandoned-file",
+                partition=partition,
+                content_sha256="a" * 64,
+                claim_token="abandoned-task",
+            )
+            is None
+        )
+        assert (
+            await repo.claim_content_sha256(
+                file_id="early-retry",
+                partition=partition,
+                content_sha256="a" * 64,
+                claim_token="early-retry-task",
+                active_claim_tokens=set(),
+            )
+            == "abandoned-file"
+        )
+        await postgres_store.pool.execute(
+            """
+            UPDATE file_content_claims
+            SET expires_at = NOW() + interval '23 hours 58 minutes'
+            WHERE partition_name = $1 AND content_sha256 = $2
+            """,
+            partition,
+            "a" * 64,
+        )
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="retry-file",
+                partition=partition,
+                content_sha256="a" * 64,
+                claim_token="retry-task",
+                active_claim_tokens=set(),
+            )
+            is None
+        )
+
+    async def test_preserves_claim_owned_by_active_task(
+        self,
+        postgres_store: PostgresStore,
+    ):
+        partition = await _seed_partition(postgres_store)
+        repo = postgres_store.document_repo
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="active-file",
+                partition=partition,
+                content_sha256="b" * 64,
+                claim_token="active-task",
+            )
+            is None
+        )
+        await postgres_store.pool.execute(
+            """
+            UPDATE file_content_claims
+            SET expires_at = NOW() + interval '23 hours 58 minutes'
+            WHERE partition_name = $1 AND content_sha256 = $2
+            """,
+            partition,
+            "b" * 64,
+        )
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="duplicate-file",
+                partition=partition,
+                content_sha256="b" * 64,
+                claim_token="duplicate-task",
+                active_claim_tokens={"active-task"},
+            )
+            == "active-file"
+        )
+
+    async def test_preserves_non_task_claim(
+        self,
+        postgres_store: PostgresStore,
+    ):
+        partition = await _seed_partition(postgres_store)
+        repo = postgres_store.document_repo
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="copy-file",
+                partition=partition,
+                content_sha256="c" * 64,
+                claim_token="copy:active-copy",
+            )
+            is None
+        )
+        await postgres_store.pool.execute(
+            """
+            UPDATE file_content_claims
+            SET expires_at = NOW() + interval '23 hours 58 minutes'
+            WHERE partition_name = $1 AND content_sha256 = $2
+            """,
+            partition,
+            "c" * 64,
+        )
+
+        assert (
+            await repo.claim_content_sha256(
+                file_id="duplicate-file",
+                partition=partition,
+                content_sha256="c" * 64,
+                claim_token="duplicate-task",
+                active_claim_tokens=set(),
+            )
+            == "copy-file"
+        )

--- a/tests/unit/api/routers/admin/test_indexing_upload_errors.py
+++ b/tests/unit/api/routers/admin/test_indexing_upload_errors.py
@@ -15,7 +15,7 @@ from api.dependencies.auth import check_user_file_quota, require_partition_edito
 from api.dependencies.files import validate_file_format, validate_file_id, validate_metadata
 from api.error_handlers import register_error_handlers
 from api.routers.admin.indexing import router as indexer_router
-from core.utils.exceptions import ConflictError
+from core.utils.exceptions import ConflictError, mark_indexing_worker_may_be_running
 from di.providers import get_config, get_indexing_service
 from fastapi import FastAPI, UploadFile
 
@@ -187,3 +187,49 @@ async def test_put_file_save_failure_returns_safe_error(
     assert resp.json() == {"detail": "Failed to save uploaded file."}
     assert "private path" not in resp.text
     assert service.dispatched is False
+
+
+class _UnknownOutcomeService(_FakeIndexingService):
+    """Dispatcher gave up on the submit RPC but a worker may already be live."""
+
+    async def add_file(self, **_kwargs):
+        exc = TimeoutError("submit timed out")
+        mark_indexing_worker_may_be_running(exc)
+        raise exc
+
+
+class _UnknownOutcomePutService(_ExistingFileService):
+    async def add_file(self, **_kwargs):
+        exc = TimeoutError("submit timed out")
+        mark_indexing_worker_may_be_running(exc)
+        raise exc
+
+
+@pytest.mark.asyncio
+async def test_add_file_keeps_upload_when_worker_may_still_be_running(tmp_path, monkeypatch):
+    """A worker launched before the submit response was lost still needs the file.
+
+    ``IndexerPool.submit`` starts ``process_file`` before it returns, and the
+    worker does not read the path until after its ref registration, so deleting
+    the upload here would fail an indexing run that could still succeed.
+    """
+    app = _build_app(tmp_path, monkeypatch, content=b"same", service=_UnknownOutcomeService())
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 500
+    assert len(list((tmp_path / "data").iterdir())) == 1
+
+
+@pytest.mark.asyncio
+async def test_put_file_keeps_upload_when_worker_may_still_be_running(tmp_path, monkeypatch):
+    app = _build_app(tmp_path, monkeypatch, content=b"same", service=_UnknownOutcomePutService())
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.put("/indexer/partition/p1/file/f1", data={"_": "1"})
+
+    assert resp.status_code == 500
+    assert len(list((tmp_path / "data").iterdir())) == 1

--- a/tests/unit/services/orchestrators/test_partition_service.py
+++ b/tests/unit/services/orchestrators/test_partition_service.py
@@ -640,6 +640,8 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": {"ref": ref}})
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
+    tsm.finish_cancellation = MagicMock()
+    tsm.finish_cancellation.remote = AsyncMock(return_value=True)
 
     with patch("ray.cancel") as cancel:
         await _svc(prepo=prepo, tsm=tsm).delete_partition("p1")
@@ -647,6 +649,7 @@ async def test_delete_partition_cancels_active_indexing_tasks_before_cleanup():
     tsm.get_matching_active_task_refs_v2.remote.assert_called_once_with(partition="p1", file_id=None)
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -676,6 +679,8 @@ async def test_delete_partition_uses_legacy_task_state_lookup_when_matching_api_
     tsm.get_object_ref.remote = AsyncMock(return_value={"ref": ref})
     tsm.set_state = MagicMock()
     tsm.set_state.remote = AsyncMock(return_value=None)
+    tsm.finish_cancellation = MagicMock()
+    tsm.finish_cancellation.remote = AsyncMock(return_value=True)
 
     with patch("ray.cancel") as cancel:
         await _svc(prepo=prepo, vstore=vstore, tsm=tsm).delete_partition("p1")
@@ -684,6 +689,7 @@ async def test_delete_partition_uses_legacy_task_state_lookup_when_matching_api_
     tsm.get_object_ref.remote.assert_called_once_with("task-1")
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
     assert vstore.deleted_filters == [{"partition": "p1"}, {"partition": "p1"}]
     assert prepo.deleted == ["p1"]
 

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from datetime import UTC, datetime
 
 import pytest
 
@@ -20,6 +21,7 @@ class _ClaimConnection:
     def __init__(self, fetch_values):
         self.fetch_values = deque(fetch_values)
         self.executed: list[tuple[str, tuple]] = []
+        self.execute_result = "DELETE 0"
 
     def transaction(self):
         return _AsyncContext(self)
@@ -28,9 +30,13 @@ class _ClaimConnection:
         self.executed.append((query, params))
         return self.fetch_values.popleft()
 
+    async def fetchrow(self, query: str, *params):
+        self.executed.append((query, params))
+        return self.fetch_values.popleft()
+
     async def execute(self, query: str, *params):
         self.executed.append((query, params))
-        return "DELETE 0"
+        return self.execute_result
 
 
 class _ClaimPool:
@@ -40,6 +46,9 @@ class _ClaimPool:
 
     def acquire(self):
         return _AsyncContext(self.conn)
+
+    async def fetchrow(self, query: str, *params):
+        return await self.conn.fetchrow(query, *params)
 
     async def execute(self, query: str, *params):
         self.executed.append((query, params))
@@ -76,7 +85,6 @@ async def test_claim_content_hash_returns_completed_duplicate() -> None:
         partition="tenant-a",
         content_sha256="abc123",
         claim_token="attempt-1",
-        active_claim_tokens=set(),
     )
 
     assert conflict == "existing-file"
@@ -102,10 +110,10 @@ async def test_claim_content_hash_returns_active_duplicate() -> None:
 
 
 @pytest.mark.asyncio
-async def test_claim_content_hash_recovers_old_claims_without_active_tasks() -> None:
+async def test_claim_content_hash_does_not_recover_nonexpired_claim_from_a_snapshot() -> None:
     from services.persistence.document_repo import PgDocumentRepository
 
-    pool = _ClaimPool([None, "new-file"])
+    pool = _ClaimPool([None, None, "abandoned-file"])
     repo = PgDocumentRepository(pool_getter=lambda: pool)
 
     conflict = await repo.claim_content_sha256(
@@ -113,14 +121,78 @@ async def test_claim_content_hash_recovers_old_claims_without_active_tasks() -> 
         partition="tenant-a",
         content_sha256="abc123",
         claim_token="attempt-2",
-        active_claim_tokens={"task:active-attempt"},
     )
 
-    assert conflict is None
-    query, params = next((query, params) for query, params in pool.conn.executed if "23 hours 59 minutes" in query)
-    assert "claim_token = ANY($3::text[])" in query
-    assert "claim_token LIKE $4" in query
-    assert params == ("tenant-a", "abc123", ["task:active-attempt"], "task:%")
+    assert conflict == "abandoned-file"
+    assert not any("23 hours 59 minutes" in query for query, _ in pool.conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_recoverable_claim_exposes_the_lease_version() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    expires_at = datetime(2026, 9, 2, tzinfo=UTC)
+    pool = _ClaimPool(
+        [
+            {
+                "file_id": "abandoned-file",
+                "partition_name": "tenant-a",
+                "content_sha256": "abc123",
+                "claim_token": "task:abandoned-task",
+                "expires_at": expires_at,
+            }
+        ]
+    )
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    lease = await repo.get_recoverable_content_sha256_claim(
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+
+    assert lease is not None
+    assert lease.file_id == "abandoned-file"
+    assert lease.claim_token == "task:abandoned-task"
+    assert lease.expires_at == expires_at
+    query, params = pool.conn.executed[0]
+    assert "claim_token LIKE" in query
+    assert "23 hours 59 minutes" in query
+    assert params == ("tenant-a", "abc123", "task:%")
+
+
+@pytest.mark.asyncio
+async def test_recoverable_claim_release_requires_the_same_lease_version() -> None:
+    from core.ports.document_repo import ContentClaimLease
+    from services.persistence.document_repo import PgDocumentRepository
+
+    expires_at = datetime(2026, 9, 2, tzinfo=UTC)
+    lease = ContentClaimLease(
+        file_id="abandoned-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="task:abandoned-task",
+        expires_at=expires_at,
+    )
+    pool = _ClaimPool([])
+    pool.conn.execute_result = "DELETE 1"
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    assert await repo.release_recoverable_content_sha256_claim(lease) is True
+
+    query, params = next(
+        (query, params) for query, params in pool.conn.executed if "DELETE FROM file_content_claims" in query
+    )
+    assert "claim_token = $4" in query
+    assert "expires_at = $5" in query
+    assert "23 hours 59 minutes" in query
+    assert params == (
+        "tenant-a",
+        "abc123",
+        "abandoned-file",
+        "task:abandoned-task",
+        expires_at,
+        "task:%",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -113,14 +113,14 @@ async def test_claim_content_hash_recovers_old_claims_without_active_tasks() -> 
         partition="tenant-a",
         content_sha256="abc123",
         claim_token="attempt-2",
-        active_claim_tokens={"active-attempt"},
+        active_claim_tokens={"task:active-attempt"},
     )
 
     assert conflict is None
     query, params = next((query, params) for query, params in pool.conn.executed if "23 hours 59 minutes" in query)
     assert "claim_token = ANY($3::text[])" in query
-    assert "claim_token NOT LIKE $4" in query
-    assert params == ("tenant-a", "abc123", ["active-attempt"], "copy:%")
+    assert "claim_token LIKE $4" in query
+    assert params == ("tenant-a", "abc123", ["task:active-attempt"], "task:%")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/persistence/test_document_content_deduplication.py
+++ b/tests/unit/services/persistence/test_document_content_deduplication.py
@@ -76,10 +76,12 @@ async def test_claim_content_hash_returns_completed_duplicate() -> None:
         partition="tenant-a",
         content_sha256="abc123",
         claim_token="attempt-1",
+        active_claim_tokens=set(),
     )
 
     assert conflict == "existing-file"
     assert not any("INSERT INTO file_content_claims" in query for query, _ in pool.conn.executed)
+    assert not any("23 hours 59 minutes" in query for query, _ in pool.conn.executed)
 
 
 @pytest.mark.asyncio
@@ -97,6 +99,28 @@ async def test_claim_content_hash_returns_active_duplicate() -> None:
     )
 
     assert conflict == "active-file"
+
+
+@pytest.mark.asyncio
+async def test_claim_content_hash_recovers_old_claims_without_active_tasks() -> None:
+    from services.persistence.document_repo import PgDocumentRepository
+
+    pool = _ClaimPool([None, "new-file"])
+    repo = PgDocumentRepository(pool_getter=lambda: pool)
+
+    conflict = await repo.claim_content_sha256(
+        file_id="new-file",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="attempt-2",
+        active_claim_tokens={"active-attempt"},
+    )
+
+    assert conflict is None
+    query, params = next((query, params) for query, params in pool.conn.executed if "23 hours 59 minutes" in query)
+    assert "claim_token = ANY($3::text[])" in query
+    assert "claim_token NOT LIKE $4" in query
+    assert params == ("tenant-a", "abc123", ["active-attempt"], "copy:%")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_bootstrap.py
+++ b/tests/unit/services/workers/test_bootstrap.py
@@ -125,7 +125,9 @@ def test_task_state_manager_without_renewable_fences_is_replaced(monkeypatch):
 def test_task_completion_tracker_is_detached_and_starts_recovery(monkeypatch):
     calls = []
     tracker = Mock()
+    tracker.supports_cancellation_recovery.remote.return_value = "capability-ref"
     monkeypatch.setattr(bootstrap, "actor_creation_map", {})
+    monkeypatch.setattr(ray, "get", Mock(return_value=True))
 
     def fake_get_or_create_actor(name, cls, **options):
         calls.append((name, cls, options))
@@ -144,6 +146,28 @@ def test_task_completion_tracker_is_detached_and_starts_recovery(monkeypatch):
     }
     tracker.recover.remote.assert_called_once_with()
     assert bootstrap.actor_creation_map["TaskCompletionTracker"]() is tracker
+
+
+def test_legacy_task_completion_tracker_is_replaced_before_recovery(monkeypatch):
+    legacy = SimpleNamespace(recover=SimpleNamespace(remote=Mock()))
+    replacement = SimpleNamespace(
+        supports_cancellation_recovery=SimpleNamespace(remote=Mock(return_value="capability-ref")),
+        recover=SimpleNamespace(remote=Mock()),
+    )
+    get_or_create = Mock(side_effect=[legacy, replacement])
+    kill = Mock()
+
+    monkeypatch.setattr(bootstrap, "actor_creation_map", {})
+    monkeypatch.setattr(bootstrap, "get_or_create_actor", get_or_create)
+    monkeypatch.setattr(ray, "kill", kill)
+    monkeypatch.setattr(ray, "get", Mock(return_value=True))
+    monkeypatch.setattr(ray, "get_actor", Mock(side_effect=ValueError("actor removed")))
+
+    assert bootstrap.get_task_completion_tracker() is replacement
+
+    kill.assert_called_once_with(legacy, no_restart=True)
+    replacement.recover.remote.assert_called_once_with()
+    assert get_or_create.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -1930,7 +1930,8 @@ async def test_delete_file_legacy_lookup_blocks_submitted_task_without_ref() -> 
             "task-1": {
                 "state": "CANCELLED",
                 "details": {"partition": "tenant-a", "file_id": "file-1"},
-                "worker_submitted": True,
+                "worker_submitted": False,
+                "submission_started_at": 100.0,
             }
         }
     )

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -800,7 +800,7 @@ async def test_dispatch_indexing_retries_without_require_existing_partition_for_
 
 
 @pytest.mark.asyncio
-async def test_dispatch_indexing_does_not_drop_required_partition_guard_for_legacy_actor() -> None:
+async def test_dispatch_indexing_keeps_required_guard_and_preserves_unknown_submission() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     legacy_error = RuntimeError("submit(task-1) failed")
@@ -835,11 +835,11 @@ async def test_dispatch_indexing_does_not_drop_required_partition_guard_for_lega
     pool.submit.remote.assert_called_once()
     assert pool.submit.remote.call_args.kwargs["require_existing_partition"] is True
     tsm.set_object_ref.remote.assert_not_called()
-    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
+async def test_dispatch_indexing_preserves_task_when_submit_outcome_is_unknown() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     pool = MagicMock()
@@ -858,10 +858,7 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
 
     with (
         patch("services.workers.dispatcher.uuid") as mock_uuid,
-        patch(
-            "services.workers.dispatcher._utc_now_iso",
-            side_effect=["2026-07-20T08:00:00+00:00", "2026-07-20T08:00:02+00:00"],
-        ),
+        patch("services.workers.dispatcher._utc_now_iso", return_value="2026-07-20T08:00:00+00:00"),
     ):
         mock_uuid.uuid4.return_value.hex = "task-1"
         with pytest.raises(RuntimeError, match="submit failed"):
@@ -876,19 +873,8 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
 
     tsm.set_queued_details.remote.assert_called_once()
     tsm.set_state.remote.assert_not_called()
-    tsm.set_details.remote.assert_awaited_once_with(
-        "task-1",
-        file_id="file-1",
-        partition="tenant-a",
-        metadata={
-            "_openrag_job_created_at": "2026-07-20T08:00:00+00:00",
-            "_openrag_job_finished_at": "2026-07-20T08:00:02+00:00",
-        },
-        user_id=42,
-    )
-    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
-    assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
-    assert "submit failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
+    tsm.set_details.remote.assert_not_awaited()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
     tsm.set_object_ref.remote.assert_not_called()
 
 
@@ -930,6 +916,44 @@ async def test_dispatch_indexing_keeps_claim_when_submission_outcome_is_unknown(
     tsm.set_details.remote.assert_not_awaited()
     tsm.set_failed_if_not_cancelled.remote.assert_not_awaited()
     repo.release_content_sha256_claim.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_preserves_unknown_submission_without_content_claim() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=TimeoutError("submit timed out"))
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with (
+        patch("services.workers.dispatcher.uuid") as mock_uuid,
+        patch("services.workers.ray_utils.ray.cancel"),
+    ):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(TimeoutError, match="submit timed out"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "source": "/data/report.txt"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.begin_worker_submission.remote.assert_awaited_once_with("task-1")
+    tsm.set_details.remote.assert_not_awaited()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -399,8 +399,76 @@ async def test_dispatch_indexing_passes_attempt_token_to_claim_and_worker() -> N
         content_sha256="abc123",
         claim_token="task-1",
         replace=False,
+        active_claim_tokens=set(),
     )
     assert pool.submit.remote.await_args.kwargs["metadata"][CONTENT_CLAIM_TOKEN_METADATA_KEY] == "task-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_preserves_only_active_content_claims() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs_v2.remote.return_value = {
+        "queued-task": object(),
+        "running-task": object(),
+    }
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "new-task"
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert repo.claim_content_sha256.await_args.kwargs["active_claim_tokens"] == {
+        "queued-task",
+        "running-task",
+    }
+    tsm.get_matching_active_task_refs_v2.remote.assert_awaited_once_with(partition="tenant-a")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_disables_claim_recovery_for_legacy_task_state_manager() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs_v2 = None
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    await dispatcher.dispatch_indexing(
+        path="/data/report.txt",
+        metadata={"file_id": "file-1", "content_sha256": "abc123"},
+        partition="tenant-a",
+        user={"id": 42},
+        workspace_ids=None,
+        replace=False,
+    )
+
+    assert repo.claim_content_sha256.await_args.kwargs["active_claim_tokens"] is None
 
 
 @pytest.mark.asyncio
@@ -435,6 +503,48 @@ async def test_dispatch_indexing_releases_claim_when_queueing_fails() -> None:
         partition="tenant-a",
         content_sha256="abc123",
         claim_token=repo.claim_content_sha256.await_args.kwargs["claim_token"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_copy_file_uses_non_task_content_claim_token() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=_task_state_manager(),
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "copy-attempt"
+        await dispatcher.copy_file(
+            "file-1",
+            {
+                "file_id": "copy-1",
+                "partition": "tenant-b",
+                "content_sha256": "abc123",
+            },
+            "tenant-a",
+            user=None,
+        )
+
+    repo.claim_content_sha256.assert_awaited_once_with(
+        file_id="copy-1",
+        partition="tenant-b",
+        content_sha256="abc123",
+        claim_token="copy:copy-attempt",
+    )
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="copy-1",
+        partition="tenant-b",
+        content_sha256="abc123",
+        claim_token="copy:copy-attempt",
     )
 
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -899,6 +899,46 @@ async def test_dispatch_indexing_marks_task_failed_when_submit_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_indexing_keeps_claim_when_submission_outcome_is_unknown() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=TimeoutError("submit timed out"))
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with (
+        patch("services.workers.dispatcher.uuid") as mock_uuid,
+        patch("services.workers.ray_utils.ray.cancel"),
+    ):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(TimeoutError, match="submit timed out"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "content_sha256": "abc123"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.begin_worker_submission.remote.assert_awaited_once_with("task-1")
+    tsm.set_details.remote.assert_not_awaited()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_awaited()
+    repo.release_content_sha256_claim.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -96,6 +96,7 @@ def _task_state_manager() -> MagicMock:
     tsm.get_content_claim_task_ids = _remote_mock(set())
     tsm.get_all_info = None
     tsm.set_queued_details = _remote_mock(True)
+    tsm.mark_worker_submitted = _remote_mock(True)
     tsm.begin_file_delete = _remote_mock()
     tsm.renew_file_delete = _remote_mock(True)
     tsm.end_file_delete = _remote_mock()
@@ -443,6 +444,47 @@ async def test_dispatch_indexing_rejects_lost_claim_before_worker_submission() -
         )
 
     assert exc.value.code == "DOCUMENT_CONTENT_CLAIM_LOST"
+    pool.submit.remote.assert_not_awaited()
+    tsm.set_failed_if_not_cancelled.remote.assert_awaited_once()
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="task:task-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_rejects_task_that_lost_submission_fence() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    pool = _pool_with_ref(object())
+    tsm = _task_state_manager()
+    tsm.mark_worker_submitted.remote.return_value = False
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError, match="rejected before worker submission"):
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "content_sha256": "abc123"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    tsm.mark_worker_submitted.remote.assert_awaited_once_with("task-1")
     pool.submit.remote.assert_not_awaited()
     tsm.set_failed_if_not_cancelled.remote.assert_awaited_once()
     repo.release_content_sha256_claim.assert_awaited_once_with(

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -65,6 +65,7 @@ def _vector_store() -> MagicMock:
 def _document_repo() -> MagicMock:
     repo = MagicMock()
     repo.claim_content_sha256 = AsyncMock(return_value=None)
+    repo.renew_content_sha256_claim = AsyncMock(return_value=True)
     repo.release_content_sha256_claim = AsyncMock()
     repo.remove_file_from_partition = AsyncMock()
     repo.update_file_metadata_in_db = AsyncMock(return_value=True)
@@ -402,7 +403,54 @@ async def test_dispatch_indexing_passes_attempt_token_to_claim_and_worker() -> N
         replace=False,
         active_claim_tokens=set(),
     )
+    repo.renew_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="task:task-1",
+    )
     assert pool.submit.remote.await_args.kwargs["metadata"][CONTENT_CLAIM_TOKEN_METADATA_KEY] == "task:task-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_rejects_lost_claim_before_worker_submission() -> None:
+    from core.utils.exceptions import ConflictError
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    repo.renew_content_sha256_claim.return_value = False
+    pool = _pool_with_ref(object())
+    tsm = _task_state_manager()
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with patch("services.workers.dispatcher.uuid") as mock_uuid, pytest.raises(ConflictError) as exc:
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert exc.value.code == "DOCUMENT_CONTENT_CLAIM_LOST"
+    pool.submit.remote.assert_not_awaited()
+    tsm.set_failed_if_not_cancelled.remote.assert_awaited_once()
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="task:task-1",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from core.utils.exceptions import ServiceUnavailableError
-from ray.exceptions import ActorUnavailableError, TaskCancelledError
+from ray.exceptions import ActorUnavailableError
 from services.workers.task_state import PENDING_TASK_DETAILS, SUBMITTED_TASK_WITHOUT_REF
 
 
@@ -28,12 +28,6 @@ def _pool_with_ref(ref: object) -> MagicMock:
 def _settled_ref() -> asyncio.Future[None]:
     ref = asyncio.get_running_loop().create_future()
     ref.set_result(None)
-    return ref
-
-
-def _cancelled_ref() -> asyncio.Future[None]:
-    ref = asyncio.get_running_loop().create_future()
-    ref.set_exception(TaskCancelledError())
     return ref
 
 
@@ -228,7 +222,7 @@ async def test_queue_registration_retries_actor_reconstruction() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> None:
+async def test_dispatch_indexing_relies_on_pool_worker_registration() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     ref = object()
@@ -298,7 +292,7 @@ async def test_dispatch_indexing_queues_worker_pool_task_and_records_ref() -> No
         embedder_name="embed-fast",
         require_existing_partition=True,
     )
-    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+    tsm.set_object_ref.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -720,7 +714,7 @@ async def test_dispatch_indexing_uses_split_queue_registration_for_legacy_task_s
         },
         user_id=42,
     )
-    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+    tsm.set_object_ref.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -760,7 +754,7 @@ async def test_dispatch_indexing_omits_false_require_existing_partition_for_lega
 
     assert task_id == "task-1"
     assert "require_existing_partition" not in pool.submit.remote.call_args.kwargs
-    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+    tsm.set_object_ref.remote.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -801,7 +795,7 @@ async def test_dispatch_indexing_retries_without_require_existing_partition_for_
     first_call, second_call = pool.submit.remote.call_args_list
     assert first_call.kwargs["require_existing_partition"] is True
     assert "require_existing_partition" not in second_call.kwargs
-    tsm.set_object_ref.remote.assert_called_once_with("task-1", {"ref": ref})
+    tsm.set_object_ref.remote.assert_not_called()
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
 
 
@@ -939,167 +933,12 @@ async def test_dispatch_indexing_keeps_claim_when_submission_outcome_is_unknown(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_indexing_cancels_worker_when_ref_registration_fails() -> None:
-    from services.workers.dispatcher import WorkerDispatcher
-
-    ref = _cancelled_ref()
-    pool = _pool_with_ref(ref)
-    tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
-    vector_store = _vector_store()
-    dispatcher = WorkerDispatcher(
-        pool=pool,
-        task_state_manager=tsm,
-        completion_tracker=_completion_tracker(),
-        vector_store=vector_store,
-        document_repo=_document_repo(),
-        workspace_repo=_workspace_repo(),
-        collection="default",
-    )
-
-    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
-        mock_uuid.uuid4.return_value.hex = "task-1"
-        with pytest.raises(RuntimeError, match="ref registration failed"):
-            await dispatcher.dispatch_indexing(
-                path="/data/report.txt",
-                metadata={"file_id": "file-1", "source": "/data/report.txt"},
-                partition="tenant-a",
-                user={"id": 42},
-                workspace_ids=None,
-                replace=False,
-            )
-
-    cancel.assert_called_once_with(ref, recursive=True)
-    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
-    assert tsm.set_failed_if_not_cancelled.remote.call_args.args[0] == "task-1"
-    assert "ref registration failed" in tsm.set_failed_if_not_cancelled.remote.call_args.args[1]
-    vector_store.delete_by_filter.assert_awaited_once_with(
-        {
-            "partition": "tenant-a",
-            "file_id": "file-1",
-            "_openrag_indexing_task_id": "task-1",
-        }
-    )
-
-
-@pytest.mark.asyncio
-async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_already_settled() -> None:
+async def test_dispatch_indexing_keeps_fast_finished_task_returned_by_pool() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     ref = _settled_ref()
     pool = _pool_with_ref(ref)
     tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(side_effect=RuntimeError("ref registration failed"))
-    vector_store = _vector_store()
-    dispatcher = WorkerDispatcher(
-        pool=pool,
-        task_state_manager=tsm,
-        completion_tracker=_completion_tracker(),
-        vector_store=vector_store,
-        document_repo=_document_repo(),
-        workspace_repo=_workspace_repo(),
-        collection="default",
-    )
-
-    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
-        mock_uuid.uuid4.return_value.hex = "task-1"
-        with pytest.raises(RuntimeError, match="ref registration failed"):
-            await dispatcher.dispatch_indexing(
-                path="/data/report.txt",
-                metadata={"file_id": "file-1", "source": "/data/report.txt"},
-                partition="tenant-a",
-                user={"id": 42},
-                workspace_ids=None,
-                replace=False,
-            )
-
-    cancel.assert_called_once_with(ref, recursive=True)
-    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
-    vector_store.delete_by_filter.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_cancel_fails() -> None:
-    from services.workers.dispatcher import WorkerDispatcher
-
-    ref = _settled_ref()
-    pool = _pool_with_ref(ref)
-    tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(return_value=False)
-    vector_store = _vector_store()
-    dispatcher = WorkerDispatcher(
-        pool=pool,
-        task_state_manager=tsm,
-        completion_tracker=_completion_tracker(),
-        vector_store=vector_store,
-        document_repo=_document_repo(),
-        workspace_repo=_workspace_repo(),
-        collection="default",
-    )
-
-    with (
-        patch("services.workers.dispatcher.uuid") as mock_uuid,
-        patch("ray.cancel", side_effect=RuntimeError("cancel failed")),
-    ):
-        mock_uuid.uuid4.return_value.hex = "task-1"
-        with pytest.raises(RuntimeError, match="Failed to cancel submitted indexing task"):
-            await dispatcher.dispatch_indexing(
-                path="/data/report.txt",
-                metadata={"file_id": "file-1", "source": "/data/report.txt"},
-                partition="tenant-a",
-                user={"id": 42},
-                workspace_ids=None,
-                replace=False,
-            )
-
-    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
-    vector_store.delete_by_filter.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_indexing_does_not_mark_failed_when_submitted_worker_cancel_times_out() -> None:
-    from services.workers.dispatcher import WorkerDispatcher
-
-    ref = asyncio.get_running_loop().create_future()
-    pool = _pool_with_ref(ref)
-    tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(return_value=False)
-    vector_store = _vector_store()
-    dispatcher = WorkerDispatcher(
-        pool=pool,
-        task_state_manager=tsm,
-        completion_tracker=_completion_tracker(),
-        vector_store=vector_store,
-        document_repo=_document_repo(),
-        workspace_repo=_workspace_repo(),
-        collection="default",
-        timeout=0.01,
-    )
-
-    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel"):
-        mock_uuid.uuid4.return_value.hex = "task-1"
-        with pytest.raises(TimeoutError, match="submitted indexing task task-1"):
-            await dispatcher.dispatch_indexing(
-                path="/data/report.txt",
-                metadata={"file_id": "file-1", "source": "/data/report.txt"},
-                partition="tenant-a",
-                user={"id": 42},
-                workspace_ids=None,
-                replace=False,
-            )
-
-    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
-    vector_store.delete_by_filter.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_indexing_keeps_fast_finished_task_when_ref_registration_is_settled() -> None:
-    from services.workers.dispatcher import WorkerDispatcher
-
-    ref = _settled_ref()
-    pool = _pool_with_ref(ref)
-    tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(return_value=True)
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
@@ -1123,49 +962,8 @@ async def test_dispatch_indexing_keeps_fast_finished_task_when_ref_registration_
 
     assert task_id == "task-1"
     cancel.assert_not_called()
+    tsm.set_object_ref.remote.assert_not_called()
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatch_indexing_cancels_worker_when_ref_registration_is_rejected() -> None:
-    from services.workers.dispatcher import WorkerDispatcher
-
-    ref = _cancelled_ref()
-    pool = _pool_with_ref(ref)
-    tsm = _task_state_manager()
-    tsm.set_object_ref.remote = AsyncMock(return_value=False)
-    vector_store = _vector_store()
-    dispatcher = WorkerDispatcher(
-        pool=pool,
-        task_state_manager=tsm,
-        completion_tracker=_completion_tracker(),
-        vector_store=vector_store,
-        document_repo=_document_repo(),
-        workspace_repo=_workspace_repo(),
-        collection="default",
-    )
-
-    with patch("services.workers.dispatcher.uuid") as mock_uuid, patch("ray.cancel") as cancel:
-        mock_uuid.uuid4.return_value.hex = "task-1"
-        with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
-            await dispatcher.dispatch_indexing(
-                path="/data/report.txt",
-                metadata={"file_id": "file-1", "source": "/data/report.txt"},
-                partition="tenant-a",
-                user={"id": 42},
-                workspace_ids=None,
-                replace=False,
-            )
-
-    cancel.assert_called_once_with(ref, recursive=True)
-    tsm.set_failed_if_not_cancelled.remote.assert_called_once()
-    vector_store.delete_by_filter.assert_awaited_once_with(
-        {
-            "partition": "tenant-a",
-            "file_id": "file-1",
-            "_openrag_indexing_task_id": "task-1",
-        }
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -2045,3 +2045,80 @@ async def test_delete_file_reports_failure_when_post_delete_cleanup_fails() -> N
     workspace_repo.remove_file_from_all_workspaces.assert_called_once_with("file-1", "tenant-a")
     document_repo.remove_file_from_partition.assert_called_once_with(file_id="file-1", partition="tenant-a")
     assert vector_store.delete_by_filter.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_marks_unknown_submission_so_upload_is_kept() -> None:
+    """An unknown submit outcome must tell the caller to keep the uploaded file.
+
+    The pool launches ``process_file`` before ``submit`` returns, so the worker
+    may still be waiting on ref registration and has not read the path yet.
+    """
+    from core.utils.exceptions import indexing_worker_may_be_running
+    from services.workers.dispatcher import WorkerDispatcher
+
+    pool = MagicMock()
+    pool.submit = MagicMock()
+    pool.submit.remote = AsyncMock(side_effect=TimeoutError("submit timed out"))
+    dispatcher = WorkerDispatcher(
+        pool=pool,
+        task_state_manager=_task_state_manager(),
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with (
+        patch("services.workers.dispatcher.uuid") as mock_uuid,
+        patch("services.workers.ray_utils.ray.cancel"),
+    ):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(TimeoutError) as excinfo:
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "content_sha256": "abc123"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    assert indexing_worker_may_be_running(excinfo.value) is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_mark_failure_before_worker_submission() -> None:
+    """A failure before the worker was submitted leaves no worker to protect."""
+    from core.utils.exceptions import indexing_worker_may_be_running
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.begin_worker_submission.remote = AsyncMock(return_value=False)
+    dispatcher = WorkerDispatcher(
+        pool=MagicMock(),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with (
+        patch("services.workers.dispatcher.uuid") as mock_uuid,
+        patch("services.workers.ray_utils.ray.cancel"),
+    ):
+        mock_uuid.uuid4.return_value.hex = "task-1"
+        with pytest.raises(RuntimeError) as excinfo:
+            await dispatcher.dispatch_indexing(
+                path="/data/report.txt",
+                metadata={"file_id": "file-1", "content_sha256": "abc123"},
+                partition="tenant-a",
+                user={"id": 42},
+                workspace_ids=None,
+                replace=False,
+            )
+
+    assert indexing_worker_may_be_running(excinfo.value) is False

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from core.utils.exceptions import ServiceUnavailableError
 from ray.exceptions import ActorUnavailableError, TaskCancelledError
-from services.workers.task_state import PENDING_TASK_DETAILS
+from services.workers.task_state import PENDING_TASK_DETAILS, SUBMITTED_TASK_WITHOUT_REF
 
 
 def _remote_mock(return_value: Any = None) -> MagicMock:
@@ -1673,6 +1673,37 @@ async def test_delete_file_fails_closed_when_pending_task_details_do_not_settle(
 
 
 @pytest.mark.asyncio
+async def test_delete_file_fails_closed_for_submitted_task_without_ref() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    tsm.get_matching_active_task_refs_v2.remote = AsyncMock(return_value={"task-1": SUBMITTED_TASK_WITHOUT_REF})
+    vector_store = _vector_store()
+    document_repo = _document_repo()
+    workspace_repo = _workspace_repo()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=vector_store,
+        document_repo=document_repo,
+        workspace_repo=workspace_repo,
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="expose worker references or settle"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+    workspace_repo.remove_file_from_all_workspaces.assert_not_called()
+    document_repo.remove_file_from_partition.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_delete_file_final_ref_recheck_stays_within_delete_timeout() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
@@ -1882,6 +1913,43 @@ async def test_delete_file_legacy_lookup_blocks_detail_less_active_task() -> Non
 
     assert tsm.get_all_info.remote.call_count == 2
     tsm.get_object_ref.remote.assert_not_called()
+    cancel.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+    tsm.set_state.remote.assert_not_called()
+    vector_store.delete_by_filter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_file_legacy_lookup_blocks_submitted_task_without_ref() -> None:
+    from services.workers.dispatcher import WorkerDispatcher
+
+    tsm = _task_state_manager()
+    del tsm.get_matching_active_task_refs_v2
+    tsm.get_all_info = _remote_mock(
+        {
+            "task-1": {
+                "state": "CANCELLED",
+                "details": {"partition": "tenant-a", "file_id": "file-1"},
+                "worker_submitted": True,
+            }
+        }
+    )
+    tsm.get_object_ref = _remote_mock(None)
+    vector_store = _vector_store()
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=vector_store,
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        timeout=0.01,
+    )
+
+    with pytest.raises(TimeoutError, match="expose worker references or settle"), patch("ray.cancel") as cancel:
+        await dispatcher.delete_file("file-1", "tenant-a")
+
     cancel.assert_not_called()
     tsm.set_failed_if_not_cancelled.remote.assert_not_called()
     tsm.set_state.remote.assert_not_called()

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -92,6 +92,7 @@ def _task_state_manager() -> MagicMock:
     tsm.get_object_ref = _remote_mock({"ref": object()})
     tsm.get_matching_active_task_refs_v2 = _remote_mock({})
     tsm.get_matching_active_task_refs = _remote_mock({})
+    tsm.get_content_claim_task_ids = _remote_mock(set())
     tsm.get_all_info = None
     tsm.set_queued_details = _remote_mock(True)
     tsm.begin_file_delete = _remote_mock()
@@ -397,11 +398,11 @@ async def test_dispatch_indexing_passes_attempt_token_to_claim_and_worker() -> N
         file_id="file-1",
         partition="tenant-a",
         content_sha256="abc123",
-        claim_token="task-1",
+        claim_token="task:task-1",
         replace=False,
         active_claim_tokens=set(),
     )
-    assert pool.submit.remote.await_args.kwargs["metadata"][CONTENT_CLAIM_TOKEN_METADATA_KEY] == "task-1"
+    assert pool.submit.remote.await_args.kwargs["metadata"][CONTENT_CLAIM_TOKEN_METADATA_KEY] == "task:task-1"
 
 
 @pytest.mark.asyncio
@@ -410,10 +411,7 @@ async def test_dispatch_indexing_preserves_only_active_content_claims() -> None:
 
     repo = _document_repo()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs_v2.remote.return_value = {
-        "queued-task": object(),
-        "running-task": object(),
-    }
+    tsm.get_content_claim_task_ids.remote.return_value = {"queued-task", "running-task", "cancelled-task"}
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -436,10 +434,11 @@ async def test_dispatch_indexing_preserves_only_active_content_claims() -> None:
         )
 
     assert repo.claim_content_sha256.await_args.kwargs["active_claim_tokens"] == {
-        "queued-task",
-        "running-task",
+        "task:queued-task",
+        "task:running-task",
+        "task:cancelled-task",
     }
-    tsm.get_matching_active_task_refs_v2.remote.assert_awaited_once_with(partition="tenant-a")
+    tsm.get_content_claim_task_ids.remote.assert_awaited_once_with(partition="tenant-a")
 
 
 @pytest.mark.asyncio
@@ -448,7 +447,7 @@ async def test_dispatch_indexing_disables_claim_recovery_for_legacy_task_state_m
 
     repo = _document_repo()
     tsm = _task_state_manager()
-    tsm.get_matching_active_task_refs_v2 = None
+    tsm.get_content_claim_task_ids = None
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -1115,7 +1114,7 @@ async def test_cancel_task_uses_stored_pool_object_ref() -> None:
 
     assert result is True
     tsm.set_cancelled_if_active.remote.assert_called_once_with("task-1")
-    tsm.finish_cancellation.remote.assert_called_once_with("task-1")
+    tsm.finish_cancellation.remote.assert_not_called()
     cancel.assert_called_once_with(ref, recursive=True)
 
 
@@ -1169,7 +1168,7 @@ async def test_cancel_task_does_not_cancel_terminal_task() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_finishes_recovered_cancellation_claim() -> None:
+async def test_cancel_task_retries_recovered_cancellation_without_finishing_it() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     ref = object()
@@ -1191,7 +1190,7 @@ async def test_cancel_task_finishes_recovered_cancellation_claim() -> None:
         assert await dispatcher.cancel_task("task-1") is True
 
     cancel.assert_called_once_with(ref, recursive=True)
-    tsm.finish_cancellation.remote.assert_called_once_with("task-1")
+    tsm.finish_cancellation.remote.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -59,6 +59,8 @@ def _vector_store() -> MagicMock:
 def _document_repo() -> MagicMock:
     repo = MagicMock()
     repo.claim_content_sha256 = AsyncMock(return_value=None)
+    repo.get_recoverable_content_sha256_claim = AsyncMock(return_value=None)
+    repo.release_recoverable_content_sha256_claim = AsyncMock(return_value=False)
     repo.renew_content_sha256_claim = AsyncMock(return_value=True)
     repo.release_content_sha256_claim = AsyncMock()
     repo.remove_file_from_partition = AsyncMock()
@@ -396,7 +398,6 @@ async def test_dispatch_indexing_passes_attempt_token_to_claim_and_worker() -> N
         content_sha256="abc123",
         claim_token="task:task-1",
         replace=False,
-        active_claim_tokens=set(),
     )
     repo.renew_content_sha256_claim.assert_awaited_once_with(
         file_id="file-1",
@@ -490,12 +491,40 @@ async def test_dispatch_indexing_rejects_task_that_lost_submission_fence() -> No
 
 
 @pytest.mark.asyncio
-async def test_dispatch_indexing_preserves_only_active_content_claims() -> None:
+async def test_dispatch_indexing_recovers_only_after_refreshing_claim_owners() -> None:
     from services.workers.dispatcher import WorkerDispatcher
 
     repo = _document_repo()
+    lease = MagicMock(
+        file_id="abandoned-file",
+        claim_token="task:abandoned-task",
+        expires_at=object(),
+    )
+    events: list[str] = []
+    claim_results = iter(["abandoned-file", None])
+
+    def claim(**_kwargs):
+        events.append("claim")
+        return next(claim_results)
+
+    def inspect_lease(**_kwargs):
+        events.append("inspect")
+        return lease
+
+    def release_lease(_lease):
+        events.append("release")
+        return True
+
+    repo.claim_content_sha256.side_effect = claim
+    repo.get_recoverable_content_sha256_claim.side_effect = inspect_lease
+    repo.release_recoverable_content_sha256_claim.side_effect = release_lease
     tsm = _task_state_manager()
-    tsm.get_content_claim_task_ids.remote.return_value = {"queued-task", "running-task", "cancelled-task"}
+
+    def active_owners(**_kwargs):
+        events.append("owners")
+        return {"queued-task", "running-task", "cancelled-task"}
+
+    tsm.get_content_claim_task_ids.remote.side_effect = active_owners
     dispatcher = WorkerDispatcher(
         pool=_pool_with_ref(object()),
         task_state_manager=tsm,
@@ -517,19 +546,107 @@ async def test_dispatch_indexing_preserves_only_active_content_claims() -> None:
             replace=False,
         )
 
-    assert repo.claim_content_sha256.await_args.kwargs["active_claim_tokens"] == {
-        "task:queued-task",
-        "task:running-task",
-        "task:cancelled-task",
-    }
+    assert repo.claim_content_sha256.await_count == 2
+    assert all("active_claim_tokens" not in call.kwargs for call in repo.claim_content_sha256.await_args_list)
+    repo.get_recoverable_content_sha256_claim.assert_awaited_once_with(
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
     tsm.get_content_claim_task_ids.remote.assert_awaited_once_with(partition="tenant-a")
+    repo.release_recoverable_content_sha256_claim.assert_awaited_once_with(lease)
+    assert events == ["claim", "inspect", "owners", "release", "claim"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_keeps_claim_when_its_owner_becomes_active() -> None:
+    from core.utils.exceptions import ConflictError
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    lease = MagicMock(
+        file_id="active-file",
+        claim_token="task:active-task",
+        expires_at=object(),
+    )
+    repo.claim_content_sha256.return_value = "active-file"
+    repo.get_recoverable_content_sha256_claim.return_value = lease
+    tsm = _task_state_manager()
+    tsm.get_content_claim_task_ids.remote.return_value = {"active-task"}
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with pytest.raises(ConflictError):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    tsm.get_content_claim_task_ids.remote.assert_awaited_once_with(partition="tenant-a")
+    repo.release_recoverable_content_sha256_claim.assert_not_awaited()
+    assert repo.claim_content_sha256.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_indexing_does_not_retry_when_claim_lease_changed() -> None:
+    from core.utils.exceptions import ConflictError
+    from services.workers.dispatcher import WorkerDispatcher
+
+    repo = _document_repo()
+    lease = MagicMock(
+        file_id="active-file",
+        claim_token="task:owner-not-yet-registered",
+        expires_at=object(),
+    )
+    repo.claim_content_sha256.return_value = "active-file"
+    repo.get_recoverable_content_sha256_claim.return_value = lease
+    repo.release_recoverable_content_sha256_claim.return_value = False
+    dispatcher = WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=_task_state_manager(),
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=repo,
+        workspace_repo=_workspace_repo(),
+        collection="default",
+    )
+
+    with pytest.raises(ConflictError):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    repo.release_recoverable_content_sha256_claim.assert_awaited_once_with(lease)
+    assert repo.claim_content_sha256.await_count == 1
 
 
 @pytest.mark.asyncio
 async def test_dispatch_indexing_disables_claim_recovery_for_legacy_task_state_manager() -> None:
+    from core.utils.exceptions import ConflictError
     from services.workers.dispatcher import WorkerDispatcher
 
     repo = _document_repo()
+    repo.claim_content_sha256.return_value = "existing-file"
+    repo.get_recoverable_content_sha256_claim.return_value = MagicMock(
+        file_id="existing-file",
+        claim_token="task:legacy-owner",
+        expires_at=object(),
+    )
     tsm = _task_state_manager()
     tsm.get_content_claim_task_ids = None
     dispatcher = WorkerDispatcher(
@@ -542,16 +659,21 @@ async def test_dispatch_indexing_disables_claim_recovery_for_legacy_task_state_m
         collection="default",
     )
 
-    await dispatcher.dispatch_indexing(
-        path="/data/report.txt",
-        metadata={"file_id": "file-1", "content_sha256": "abc123"},
-        partition="tenant-a",
-        user={"id": 42},
-        workspace_ids=None,
-        replace=False,
-    )
+    with pytest.raises(ConflictError):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1", "content_sha256": "abc123"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
 
-    assert repo.claim_content_sha256.await_args.kwargs["active_claim_tokens"] is None
+    repo.get_recoverable_content_sha256_claim.assert_awaited_once_with(
+        partition="tenant-a",
+        content_sha256="abc123",
+    )
+    repo.release_recoverable_content_sha256_claim.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -1410,6 +1410,7 @@ async def test_delete_file_cancels_active_matching_indexing_task_before_cleanup(
     tsm.get_matching_active_task_refs_v2.remote.assert_called_once_with(partition="tenant-a", file_id="file-1")
     cancel.assert_called_once_with(ref, recursive=True)
     tsm.set_state.remote.assert_any_call("task-1", "CANCELLED")
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -96,7 +96,7 @@ def _task_state_manager() -> MagicMock:
     tsm.get_content_claim_task_ids = _remote_mock(set())
     tsm.get_all_info = None
     tsm.set_queued_details = _remote_mock(True)
-    tsm.mark_worker_submitted = _remote_mock(True)
+    tsm.begin_worker_submission = _remote_mock(True)
     tsm.begin_file_delete = _remote_mock()
     tsm.renew_file_delete = _remote_mock(True)
     tsm.end_file_delete = _remote_mock()
@@ -461,7 +461,7 @@ async def test_dispatch_indexing_rejects_task_that_lost_submission_fence() -> No
     repo = _document_repo()
     pool = _pool_with_ref(object())
     tsm = _task_state_manager()
-    tsm.mark_worker_submitted.remote.return_value = False
+    tsm.begin_worker_submission.remote.return_value = False
     dispatcher = WorkerDispatcher(
         pool=pool,
         task_state_manager=tsm,
@@ -484,7 +484,7 @@ async def test_dispatch_indexing_rejects_task_that_lost_submission_fence() -> No
                 replace=False,
             )
 
-    tsm.mark_worker_submitted.remote.assert_awaited_once_with("task-1")
+    tsm.begin_worker_submission.remote.assert_awaited_once_with("task-1")
     pool.submit.remote.assert_not_awaited()
     tsm.set_failed_if_not_cancelled.remote.assert_awaited_once()
     repo.release_content_sha256_claim.assert_awaited_once_with(

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -139,12 +139,14 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
     import services.workers.indexer_pool as module
 
     calls = []
+    remote_calls = []
 
     class Options:
         def __init__(self, kwargs):
             self._kwargs = kwargs
 
-        def remote(self):
+        def remote(self, namespace):
+            remote_calls.append(namespace)
             return f"actor-{self._kwargs['name']}"
 
     def fake_options(**kwargs):
@@ -154,7 +156,7 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
     monkeypatch.setattr(module.IndexerWorkerActor, "options", fake_options)
 
     actor_class = module.IndexerPool.__ray_metadata__.modified_class
-    pool = actor_class(pool_size=3, max_tasks_per_worker=4)
+    pool = actor_class(pool_size=3, max_tasks_per_worker=4, namespace="tenant-ray")
 
     # One detached worker actor per pool_size slot, each capped at max_tasks_per_worker.
     assert len(pool._workers) == 3
@@ -167,7 +169,8 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
         assert c["lifetime"] == "detached"
         assert c["max_concurrency"] == 4
         assert c["get_if_exists"] is True
-        assert c["namespace"] == "openrag"
+        assert c["namespace"] == "tenant-ray"
+    assert remote_calls == ["tenant-ray", "tenant-ray", "tenant-ray"]
 
 
 def test_build_topic_tagger_factory_resolves_named_llm(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1377,7 +1380,7 @@ async def test_pool_keeps_content_claim_until_cancelled_task_settles() -> None:
     )
 
 
-def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_indexer_pool_wires_contextualizer_factory_and_worker_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
     import core.config
     import core.embeddings
     import services.storage.milvus_store as milvus_store
@@ -1451,11 +1454,11 @@ def test_indexer_pool_wires_contextualizer_factory(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(module, "IndexerWorker", Worker)
 
     actor_class = module.IndexerWorkerActor.__ray_metadata__.modified_class
-    actor_class()
+    actor_class(namespace="tenant-ray")
 
     assert actor_calls
     assert actor_calls[0][0][0] == "TaskStateManager"
-    assert actor_calls[0][1].get("namespace") == "openrag"
+    assert actor_calls[0][1].get("namespace") == "tenant-ray"
     assert captured["contextualizer_factory"] is contextualizer_factory
     assert captured["topic_tagger_factory"] is topic_tagger_factory
     assert captured["vlm_factory"] is vlm_factory

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1148,6 +1148,24 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_pool_finalizes_prelaunch_rejection_with_legacy_task_state_actor() -> None:
+    from services.workers.indexer_pool import _REJECTED_SUBMISSION_ERROR
+
+    pool = _bare_pool([_FakeWorker()])
+    set_failed = AsyncMock(return_value=True)
+    pool._task_state_manager = SimpleNamespace(
+        _ray_actor_method_names={"set_failed_if_not_cancelled"},
+        set_failed_if_not_cancelled=SimpleNamespace(remote=set_failed),
+    )
+
+    await pool.begin_drain()
+    with pytest.raises(RuntimeError, match="draining"):
+        await pool.submit(task_id="legacy-rejected-task")
+
+    set_failed.assert_awaited_once_with("legacy-rejected-task", _REJECTED_SUBMISSION_ERROR)
+
+
+@pytest.mark.asyncio
 async def test_pool_abort_drain_restores_acceptance() -> None:
     worker = _FakeWorker()
     pool = _bare_pool([worker])

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1152,14 +1152,46 @@ async def test_pool_cancels_worker_when_ref_registration_is_rejected(
     worker = _FakeWorker()
     pool = _bare_pool([worker])
     pool._task_state_manager.set_object_ref.remote.return_value = False
-    cancel = MagicMock()
+    cancellation_requested = asyncio.Event()
+    cancel = MagicMock(side_effect=lambda *_args, **_kwargs: cancellation_requested.set())
     monkeypatch.setattr(module.ray, "cancel", cancel)
 
-    with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
-        await pool.submit(task_id="task-1")
+    submission = asyncio.create_task(pool.submit(task_id="task-1"))
+    await asyncio.wait_for(cancellation_requested.wait(), timeout=1)
 
     cancel.assert_called_once_with(worker.futures[0], recursive=True)
-    await _settle_pool_release_tasks(pool, worker.futures[0])
+    assert submission.done() is False
+
+    worker.futures[0].set_result(None)
+    with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
+        await submission
+    await _settle_pool_release_tasks(pool)
+
+
+@pytest.mark.asyncio
+async def test_pool_waits_for_worker_when_ref_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import services.workers.indexer_pool as module
+
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    pool._task_state_manager.set_object_ref.remote.side_effect = RuntimeError("task state unavailable")
+    cancellation_requested = asyncio.Event()
+    monkeypatch.setattr(
+        module.ray,
+        "cancel",
+        MagicMock(side_effect=lambda *_args, **_kwargs: cancellation_requested.set()),
+    )
+
+    submission = asyncio.create_task(pool.submit(task_id="task-1"))
+    await asyncio.wait_for(cancellation_requested.wait(), timeout=1)
+    assert submission.done() is False
+
+    worker.futures[0].set_result(None)
+    with pytest.raises(RuntimeError, match="task state unavailable"):
+        await submission
+    await _settle_pool_release_tasks(pool)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1020,6 +1020,7 @@ def _bare_pool(workers: list) -> object:
     pool._claim_store_lock = asyncio.Lock()
     pool._namespace = "openrag"
     pool._task_state_manager = SimpleNamespace(
+        accept_worker_submission=SimpleNamespace(remote=AsyncMock(return_value=True)),
         set_object_ref=SimpleNamespace(remote=AsyncMock(return_value=True)),
         finish_rejected_submission=SimpleNamespace(remote=AsyncMock(return_value=True)),
     )
@@ -1083,6 +1084,7 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
     # The ObjectRef is passed through wrapped in a one-element list (the
     # dispatcher unwraps it; the wrapper stops Ray auto-dereferencing the ref).
     assert ref0 == [workers[0].futures[0]]
+    assert pool._task_state_manager.accept_worker_submission.remote.await_count == 3
     assert pool._task_state_manager.set_object_ref.remote.await_count == 3
     await _settle_pool_release_tasks(
         pool,
@@ -1090,6 +1092,31 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
         workers[1].futures[0],
         workers[0].futures[1],
     )
+
+
+@pytest.mark.asyncio
+async def test_pool_settles_worker_when_task_handoff_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.indexer_pool as module
+
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    pool._task_state_manager.accept_worker_submission.remote.return_value = False
+    cancellation_requested = asyncio.Event()
+    monkeypatch.setattr(
+        module.ray,
+        "cancel",
+        MagicMock(side_effect=lambda *_args, **_kwargs: cancellation_requested.set()),
+    )
+
+    submission = asyncio.create_task(pool.submit(task_id="task-1"))
+    await asyncio.wait_for(cancellation_requested.wait(), timeout=1)
+    assert len(worker.calls) == 1
+    worker.futures[0].set_result(None)
+
+    with pytest.raises(RuntimeError, match="cancelled before the pool accepted"):
+        await submission
+    assert pool._inflight == [0]
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1604,6 +1604,10 @@ def _bare_worker_actor(*, save_uploaded_files: bool, worker: _RecordingWorker):
     actor._ensure_catalog = _noop
     actor._ensure_registry_fresh = _noop
     actor._worker = worker
+    actor._task_state_manager = SimpleNamespace(
+        get_object_ref=SimpleNamespace(remote=AsyncMock(return_value={"ref": object()})),
+        set_failed_if_not_cancelled=SimpleNamespace(remote=AsyncMock(return_value=True)),
+    )
     actor._catalog_store = SimpleNamespace(
         workspace_repo=SimpleNamespace(),
         document_repo=SimpleNamespace(release_content_sha256_claim=AsyncMock()),
@@ -1637,6 +1641,29 @@ async def test_actor_uses_native_asr_prompt_when_resolution_fails() -> None:
 
     assert await actor._resolve_transcription_prompt() is None
     resolve_prompt.assert_awaited_once_with("asr_transcription")
+
+
+@pytest.mark.asyncio
+async def test_actor_does_not_start_without_registered_worker_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import services.workers.indexer_pool as module
+
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"x")
+    worker = _RecordingWorker()
+    actor = _bare_worker_actor(save_uploaded_files=True, worker=worker)
+    actor._task_state_manager.get_object_ref.remote.return_value = None
+    monkeypatch.setattr(module, "_WORKER_REF_REGISTRATION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(module, "_WORKER_REF_REGISTRATION_POLL_SECONDS", 0.001)
+
+    with pytest.raises(RuntimeError, match="registered task reference"):
+        await actor.process_file(task_id="t", path=str(path), metadata={"file_id": "f"}, partition="p")
+
+    worker_ref_error = module._MISSING_WORKER_REF_ERROR
+    actor._task_state_manager.set_failed_if_not_cancelled.remote.assert_awaited_once_with("t", worker_ref_error)
+    assert worker.calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1195,6 +1195,33 @@ async def test_pool_waits_for_worker_when_ref_registration_fails(
 
 
 @pytest.mark.asyncio
+async def test_rejected_worker_settlement_survives_submit_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import services.workers.indexer_pool as module
+
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    pool._task_state_manager.set_object_ref.remote.return_value = False
+    cancellation_requested = asyncio.Event()
+    monkeypatch.setattr(
+        module.ray,
+        "cancel",
+        MagicMock(side_effect=lambda *_args, **_kwargs: cancellation_requested.set()),
+    )
+
+    submission = asyncio.create_task(pool.submit(task_id="task-1"))
+    await asyncio.wait_for(cancellation_requested.wait(), timeout=1)
+    submission.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await submission
+
+    assert worker.futures[0].done() is False
+    await _settle_pool_release_tasks(pool, worker.futures[0])
+    assert pool._inflight == [0]
+
+
+@pytest.mark.asyncio
 async def test_pool_releases_inflight_when_task_settles() -> None:
     workers = [_FakeWorker(), _FakeWorker()]
     pool = _bare_pool(workers)

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1020,7 +1020,6 @@ def _bare_pool(workers: list) -> object:
     pool._claim_store_lock = asyncio.Lock()
     pool._namespace = "openrag"
     pool._task_state_manager = SimpleNamespace(
-        accept_worker_submission=SimpleNamespace(remote=AsyncMock(return_value=True)),
         set_object_ref=SimpleNamespace(remote=AsyncMock(return_value=True)),
         finish_rejected_submission=SimpleNamespace(remote=AsyncMock(return_value=True)),
     )
@@ -1084,7 +1083,6 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
     # The ObjectRef is passed through wrapped in a one-element list (the
     # dispatcher unwraps it; the wrapper stops Ray auto-dereferencing the ref).
     assert ref0 == [workers[0].futures[0]]
-    assert pool._task_state_manager.accept_worker_submission.remote.await_count == 3
     assert pool._task_state_manager.set_object_ref.remote.await_count == 3
     await _settle_pool_release_tasks(
         pool,
@@ -1092,31 +1090,6 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
         workers[1].futures[0],
         workers[0].futures[1],
     )
-
-
-@pytest.mark.asyncio
-async def test_pool_settles_worker_when_task_handoff_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
-    import services.workers.indexer_pool as module
-
-    worker = _FakeWorker()
-    pool = _bare_pool([worker])
-    pool._task_state_manager.accept_worker_submission.remote.return_value = False
-    cancellation_requested = asyncio.Event()
-    monkeypatch.setattr(
-        module.ray,
-        "cancel",
-        MagicMock(side_effect=lambda *_args, **_kwargs: cancellation_requested.set()),
-    )
-
-    submission = asyncio.create_task(pool.submit(task_id="task-1"))
-    await asyncio.wait_for(cancellation_requested.wait(), timeout=1)
-    assert len(worker.calls) == 1
-    worker.futures[0].set_result(None)
-
-    with pytest.raises(RuntimeError, match="cancelled before the pool accepted"):
-        await submission
-    assert pool._inflight == [0]
-    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1096,6 +1096,8 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
 async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
     worker = _FakeWorker()
     pool = _bare_pool([worker])
+    repo = SimpleNamespace(release_content_sha256_claim=AsyncMock())
+    pool._claim_store = SimpleNamespace(document_repo=repo)
 
     await pool.submit(task_id="accepted-before-drain")
 
@@ -1106,8 +1108,23 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
         "worker_names": ["test-worker-0"],
     }
     with pytest.raises(RuntimeError, match="draining"):
-        await pool.submit(task_id="rejected-after-drain")
+        await pool.submit(
+            task_id="rejected-after-drain",
+            partition="tenant-a",
+            metadata={
+                "file_id": "file-1",
+                "content_sha256": "abc123",
+                CONTENT_CLAIM_TOKEN_METADATA_KEY: "attempt-1",
+            },
+        )
     assert len(worker.calls) == 1
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("rejected-after-drain")
+    repo.release_content_sha256_claim.assert_awaited_once_with(
+        file_id="file-1",
+        partition="tenant-a",
+        content_sha256="abc123",
+        claim_token="attempt-1",
+    )
 
     await _settle_pool_release_tasks(pool, worker.futures[0])
     assert await pool.status() == {

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1269,8 +1269,7 @@ async def test_pool_rolls_back_inflight_when_submission_raises() -> None:
         await pool.submit(task_id="a")
 
     assert pool._inflight == [0]
-
-    assert pool._inflight == [0]
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("a")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1093,7 +1093,9 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
+async def test_pool_drain_rejects_new_work_and_reports_accepted_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    import services.workers.indexer_pool as module
+
     worker = _FakeWorker()
     pool = _bare_pool([worker])
     repo = SimpleNamespace(release_content_sha256_claim=AsyncMock())
@@ -1107,6 +1109,12 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
         "inflight_jobs": 1,
         "worker_names": ["test-worker-0"],
     }
+    recovered_task_state_manager = SimpleNamespace(
+        finish_rejected_submission=SimpleNamespace(remote=AsyncMock(return_value=True))
+    )
+    pool._task_state_manager = None
+    get_actor = MagicMock(return_value=recovered_task_state_manager)
+    monkeypatch.setattr(module.ray, "get_actor", get_actor)
     with pytest.raises(RuntimeError, match="draining"):
         await pool.submit(
             task_id="rejected-after-drain",
@@ -1118,7 +1126,8 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work() -> None:
             },
         )
     assert len(worker.calls) == 1
-    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("rejected-after-drain")
+    get_actor.assert_called_once_with("TaskStateManager", namespace="openrag")
+    recovered_task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("rejected-after-drain")
     repo.release_content_sha256_claim.assert_awaited_once_with(
         file_id="file-1",
         partition="tenant-a",

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1019,7 +1019,10 @@ def _bare_pool(workers: list) -> object:
     pool._claim_store = None
     pool._claim_store_lock = asyncio.Lock()
     pool._namespace = "openrag"
-    pool._task_state_manager = SimpleNamespace(set_object_ref=SimpleNamespace(remote=AsyncMock(return_value=True)))
+    pool._task_state_manager = SimpleNamespace(
+        set_object_ref=SimpleNamespace(remote=AsyncMock(return_value=True)),
+        finish_rejected_submission=SimpleNamespace(remote=AsyncMock(return_value=True)),
+    )
     return pool
 
 
@@ -1165,6 +1168,7 @@ async def test_pool_cancels_worker_when_ref_registration_is_rejected(
     worker.futures[0].set_result(None)
     with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
         await submission
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("task-1")
     await _settle_pool_release_tasks(pool)
 
 
@@ -1191,6 +1195,7 @@ async def test_pool_waits_for_worker_when_ref_registration_fails(
     worker.futures[0].set_result(None)
     with pytest.raises(RuntimeError, match="task state unavailable"):
         await submission
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("task-1")
     await _settle_pool_release_tasks(pool)
 
 
@@ -1218,6 +1223,7 @@ async def test_rejected_worker_settlement_survives_submit_cancellation(
 
     assert worker.futures[0].done() is False
     await _settle_pool_release_tasks(pool, worker.futures[0])
+    pool._task_state_manager.finish_rejected_submission.remote.assert_awaited_once_with("task-1")
     assert pool._inflight == [0]
 
 

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from core.config.model_endpoints import ModelEndpointConfig
@@ -1018,6 +1018,8 @@ def _bare_pool(workers: list) -> object:
     pool._release_tasks = set()
     pool._claim_store = None
     pool._claim_store_lock = asyncio.Lock()
+    pool._namespace = "openrag"
+    pool._task_state_manager = SimpleNamespace(set_object_ref=SimpleNamespace(remote=AsyncMock(return_value=True)))
     return pool
 
 
@@ -1078,6 +1080,7 @@ async def test_pool_dispatches_to_least_loaded_and_passes_ref_through() -> None:
     # The ObjectRef is passed through wrapped in a one-element list (the
     # dispatcher unwraps it; the wrapper stops Ray auto-dereferencing the ref).
     assert ref0 == [workers[0].futures[0]]
+    assert pool._task_state_manager.set_object_ref.remote.await_count == 3
     await _settle_pool_release_tasks(
         pool,
         workers[0].futures[0],
@@ -1138,6 +1141,25 @@ async def test_pool_reports_current_protocol_version() -> None:
     pool = _bare_pool([_FakeWorker()])
 
     assert await pool.protocol_version() == "v5"
+
+
+@pytest.mark.asyncio
+async def test_pool_cancels_worker_when_ref_registration_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import services.workers.indexer_pool as module
+
+    worker = _FakeWorker()
+    pool = _bare_pool([worker])
+    pool._task_state_manager.set_object_ref.remote.return_value = False
+    cancel = MagicMock()
+    monkeypatch.setattr(module.ray, "cancel", cancel)
+
+    with pytest.raises(RuntimeError, match="cancelled before worker ref registration"):
+        await pool.submit(task_id="task-1")
+
+    cancel.assert_called_once_with(worker.futures[0], recursive=True)
+    await _settle_pool_release_tasks(pool, worker.futures[0])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -214,6 +214,28 @@ async def test_process_file_success_sets_state_and_returns_count(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_process_file_stops_when_task_was_cancelled_before_start(tmp_path: Path) -> None:
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    pipeline = AsyncMock()
+    tsm = _fake_tsm()
+    tsm.set_state.remote.return_value = False
+
+    worker = IndexerWorker(pipeline=pipeline, task_state_manager=tsm)
+
+    with pytest.raises(RuntimeError, match="cancelled before indexing started"):
+        await worker.process_file(
+            task_id="t1",
+            path=str(path),
+            metadata={"file_id": "f1"},
+            partition="p",
+        )
+
+    pipeline.run.assert_not_called()
+    tsm.set_failed_if_not_cancelled.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_process_file_retries_state_write_during_actor_reconstruction(tmp_path: Path) -> None:
     path = tmp_path / "doc.txt"
     path.write_bytes(b"content")

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -127,6 +127,40 @@ async def test_tracker_keeps_recovered_cancellation_tracked_until_worker_settles
 
 
 @pytest.mark.asyncio
+async def test_tracker_keeps_submitted_refless_cancellation_pending() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    details = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"_openrag_job_created_at": "2026-07-20T08:00:00+00:00"},
+        "user_id": 42,
+    }
+    tsm = _task_state_manager(
+        all_info={
+            "task-1": {
+                "state": "CANCELLED",
+                "details": details,
+                "worker_submitted": True,
+            }
+        },
+        object_ref=None,
+    )
+    tracker_handle = MagicMock()
+
+    def get_actor(name: str, namespace: str):
+        assert namespace == "openrag"
+        return tsm if name == "TaskStateManager" else tracker_handle
+
+    with patch("services.workers.task_completion.ray.get_actor", side_effect=get_actor):
+        tracker = TaskCompletionTracker()
+        await tracker.recover()
+
+    tracker_handle.recover_refless.remote.assert_called_once_with("task-1", preserve_cancelled_submission=True)
+    tsm.set_details.remote.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_tracker_retries_active_task_without_stored_ref_after_restart() -> None:
     from services.workers.task_completion import TaskCompletionTracker
 
@@ -188,6 +222,39 @@ async def test_tracker_records_recovered_refless_task_when_it_reaches_terminal_s
 
 
 @pytest.mark.asyncio
+async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    ref = asyncio.get_running_loop().create_future()
+    ref.set_result(None)
+    details = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"_openrag_job_created_at": "2026-07-20T08:00:00+00:00"},
+        "user_id": 42,
+    }
+    tsm = _task_state_manager(state="CANCELLED")
+    tsm.get_details.remote.return_value = details
+    tsm.get_object_ref.remote.side_effect = [None, {"ref": ref}]
+
+    with (
+        patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
+        patch("services.workers.task_completion._utc_now_iso", return_value="2026-07-20T08:01:05+00:00"),
+        patch("services.workers.task_completion.asyncio.sleep", AsyncMock()),
+    ):
+        tracker = TaskCompletionTracker()
+        await tracker.recover_refless(
+            "task-1",
+            poll_interval=0,
+            preserve_cancelled_submission=True,
+        )
+
+    assert tsm.get_object_ref.remote.await_count == 2
+    tsm.set_details.remote.assert_awaited_once()
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
+
+
+@pytest.mark.asyncio
 async def test_tracker_expires_recovered_refless_task_after_registration_grace() -> None:
     from services.workers.task_completion import TaskCompletionTracker
 
@@ -215,18 +282,38 @@ async def test_tracker_bounds_refless_expiration_actor_call() -> None:
 
     tsm = _task_state_manager(object_ref=None)
     tsm.get_details.remote.return_value = {"metadata": {}}
-    bounded_call = AsyncMock(side_effect=TimeoutError)
+    bounded_call = AsyncMock(side_effect=[{"metadata": {}}, TimeoutError])
 
     with (
         patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
-        patch("services.workers.task_completion.call_ray_actor_method_with_timeout", bounded_call),
     ):
         tracker = TaskCompletionTracker()
+        tracker._call_task_state = bounded_call
         await tracker.recover_refless("task-1", poll_interval=0)
 
     assert "task-1" not in tracker._tracked_task_ids
-    assert bounded_call.await_args.kwargs["timeout"] == 30.0
-    assert bounded_call.await_args.kwargs["task_description"] == "expire_refless_task_if_stale(task-1)"
+    assert bounded_call.await_count == 2
+    assert bounded_call.await_args.args[1] == "expire_refless_task_if_stale(task-1)"
+
+
+@pytest.mark.asyncio
+async def test_tracker_bounds_cancelled_worker_ref_lookup() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    tsm = _task_state_manager(all_info={"task-1": {"state": "CANCELLED"}})
+    tracker_handle = MagicMock()
+
+    def get_actor(name: str, namespace: str):
+        assert namespace == "openrag"
+        return tsm if name == "TaskStateManager" else tracker_handle
+
+    with patch("services.workers.task_completion.ray.get_actor", side_effect=get_actor):
+        tracker = TaskCompletionTracker()
+        tracker._call_task_state = AsyncMock(side_effect=[{"task-1": {"state": "CANCELLED"}}, TimeoutError])
+        await tracker.recover()
+
+    assert tracker._call_task_state.await_count == 2
+    assert tracker._call_task_state.await_args.args[1] == "get_object_ref(task-1) for cancellation recovery"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -210,6 +210,44 @@ async def test_tracker_expires_recovered_refless_task_after_registration_grace()
 
 
 @pytest.mark.asyncio
+async def test_tracker_bounds_refless_expiration_actor_call() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    tsm = _task_state_manager(object_ref=None)
+    tsm.get_details.remote.return_value = {"metadata": {}}
+    bounded_call = AsyncMock(side_effect=TimeoutError)
+
+    with (
+        patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
+        patch("services.workers.task_completion.call_ray_actor_method_with_timeout", bounded_call),
+    ):
+        tracker = TaskCompletionTracker()
+        await tracker.recover_refless("task-1", poll_interval=0)
+
+    assert "task-1" not in tracker._tracked_task_ids
+    assert bounded_call.await_args.kwargs["timeout"] == 30.0
+    assert bounded_call.await_args.kwargs["task_description"] == "expire_refless_task_if_stale(task-1)"
+
+
+@pytest.mark.asyncio
+async def test_tracker_bounds_cancellation_finalization_actor_call() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    tsm = _task_state_manager()
+    bounded_call = AsyncMock(side_effect=TimeoutError)
+
+    with (
+        patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
+        patch("services.workers.task_completion.call_ray_actor_method_with_timeout", bounded_call),
+    ):
+        tracker = TaskCompletionTracker()
+        await tracker._finish_cancellation("task-1")
+
+    assert bounded_call.await_args.kwargs["timeout"] == 30.0
+    assert bounded_call.await_args.kwargs["task_description"] == "finish_cancellation(task-1)"
+
+
+@pytest.mark.asyncio
 async def test_tracker_backfills_terminal_task_missed_during_api_restart() -> None:
     from services.workers.task_completion import TaskCompletionTracker
 

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -25,6 +25,7 @@ def _task_state_manager(
     tsm.get_state = _remote_mock(state)
     tsm.get_details = _remote_mock()
     tsm.set_details = _remote_mock()
+    tsm.finish_cancellation = _remote_mock()
     return tsm
 
 
@@ -62,6 +63,7 @@ async def test_tracker_records_completion_after_worker_settles() -> None:
         },
         user_id=42,
     )
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -80,6 +82,34 @@ async def test_tracker_recovers_active_task_after_restart() -> None:
         object_ref={"ref": ref},
     )
     tsm.get_details.remote.return_value = details
+    tracker_handle = MagicMock()
+
+    def get_actor(name: str, namespace: str):
+        assert namespace == "openrag"
+        return tsm if name == "TaskStateManager" else tracker_handle
+
+    with patch("services.workers.task_completion.ray.get_actor", side_effect=get_actor):
+        tracker = TaskCompletionTracker()
+        await tracker.recover()
+
+    tsm.get_object_ref.remote.assert_awaited_once_with("task-1")
+    tracker_handle.track.remote.assert_called_once_with("task-1", {"ref": ref})
+
+
+@pytest.mark.asyncio
+async def test_tracker_keeps_recovered_cancellation_tracked_until_worker_settles() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    ref = asyncio.get_running_loop().create_future()
+    details = {
+        "metadata": {
+            "_openrag_job_finished_at": "2026-07-20T08:01:05+00:00",
+        }
+    }
+    tsm = _task_state_manager(
+        all_info={"task-1": {"state": "CANCELLED", "details": details}},
+        object_ref={"ref": ref},
+    )
     tracker_handle = MagicMock()
 
     def get_actor(name: str, namespace: str):

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -26,6 +26,7 @@ def _task_state_manager(
     tsm.get_details = _remote_mock()
     tsm.set_details = _remote_mock()
     tsm.finish_cancellation = _remote_mock()
+    tsm.expire_refless_task_if_stale = _remote_mock(False)
     return tsm
 
 
@@ -96,8 +97,9 @@ async def test_tracker_recovers_active_task_after_restart() -> None:
     tracker_handle.track.remote.assert_called_once_with("task-1", {"ref": ref})
 
 
+@pytest.mark.parametrize("bare_ref", [False, True], ids=["wrapped-ref", "bare-ref"])
 @pytest.mark.asyncio
-async def test_tracker_keeps_recovered_cancellation_tracked_until_worker_settles() -> None:
+async def test_tracker_keeps_recovered_cancellation_tracked_until_worker_settles(bare_ref: bool) -> None:
     from services.workers.task_completion import TaskCompletionTracker
 
     ref = asyncio.get_running_loop().create_future()
@@ -108,7 +110,7 @@ async def test_tracker_keeps_recovered_cancellation_tracked_until_worker_settles
     }
     tsm = _task_state_manager(
         all_info={"task-1": {"state": "CANCELLED", "details": details}},
-        object_ref={"ref": ref},
+        object_ref=ref if bare_ref else {"ref": ref},
     )
     tracker_handle = MagicMock()
 
@@ -183,6 +185,28 @@ async def test_tracker_records_recovered_refless_task_when_it_reaches_terminal_s
         },
         user_id=42,
     )
+
+
+@pytest.mark.asyncio
+async def test_tracker_expires_recovered_refless_task_after_registration_grace() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    details = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+        "user_id": 42,
+    }
+    tsm = _task_state_manager(object_ref=None)
+    tsm.get_details.remote.return_value = details
+    tsm.expire_refless_task_if_stale.remote.return_value = True
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = TaskCompletionTracker()
+        await tracker.recover_refless("task-1", poll_interval=0)
+
+    tsm.expire_refless_task_if_stale.remote.assert_awaited_once_with("task-1")
+    tsm.set_details.remote.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -27,6 +27,7 @@ def _task_state_manager(
     tsm.set_details = _remote_mock()
     tsm.finish_cancellation = _remote_mock()
     tsm.expire_refless_task_if_stale = _remote_mock(False)
+    tsm.has_unsettled_cancelled_worker = _remote_mock(False)
     return tsm
 
 
@@ -236,6 +237,7 @@ async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
     tsm = _task_state_manager(state="CANCELLED")
     tsm.get_details.remote.return_value = details
     tsm.get_object_ref.remote.side_effect = [None, {"ref": ref}]
+    tsm.has_unsettled_cancelled_worker.remote.return_value = True
 
     with (
         patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
@@ -250,6 +252,37 @@ async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
         )
 
     assert tsm.get_object_ref.remote.await_count == 2
+    tsm.set_details.remote.assert_awaited_once()
+    tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
+
+
+@pytest.mark.asyncio
+async def test_tracker_finishes_cancelled_submission_after_pool_clears_fence() -> None:
+    from services.workers.task_completion import TaskCompletionTracker
+
+    details = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {"_openrag_job_created_at": "2026-07-20T08:00:00+00:00"},
+        "user_id": 42,
+    }
+    tsm = _task_state_manager(state="CANCELLED")
+    tsm.get_details.remote.return_value = details
+    tsm.has_unsettled_cancelled_worker.remote.side_effect = [True, False]
+
+    with (
+        patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
+        patch("services.workers.task_completion._utc_now_iso", return_value="2026-07-20T08:01:05+00:00"),
+        patch("services.workers.task_completion.asyncio.sleep", AsyncMock()),
+    ):
+        tracker = TaskCompletionTracker()
+        await tracker.recover_refless(
+            "task-1",
+            poll_interval=0,
+            preserve_cancelled_submission=True,
+        )
+
+    assert tsm.has_unsettled_cancelled_worker.remote.await_count == 2
     tsm.set_details.remote.assert_awaited_once()
     tsm.finish_cancellation.remote.assert_awaited_once_with("task-1")
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -138,13 +138,15 @@ async def test_delete_cleanup_still_fences_legacy_indexing_states() -> None:
 
 
 @pytest.mark.asyncio
-async def test_content_claim_owners_include_unsettled_cancellations() -> None:
+async def test_content_claim_owners_include_only_unsettled_workers(monkeypatch) -> None:
     manager = _task_state_manager()
 
     for task_id, partition in (
         ("active-task", "tenant-a"),
         ("cancelled-task", "tenant-a"),
         ("settled-cancelled-task", "tenant-a"),
+        ("finished-active-task", "tenant-a"),
+        ("ready-active-task", "tenant-a"),
         ("completed-task", "tenant-a"),
         ("other-partition-task", "tenant-b"),
     ):
@@ -152,15 +154,24 @@ async def test_content_claim_owners_include_unsettled_cancellations() -> None:
             task_id,
             file_id=f"{task_id}-file",
             partition=partition,
-            metadata={},
+            metadata=(
+                {"_openrag_job_finished_at": "2026-08-28T08:00:00+00:00"} if task_id == "finished-active-task" else {}
+            ),
             user_id=None,
         )
 
     cancelled_ref = {"ref": object()}
+    ready_ref = object()
     await manager.set_object_ref("cancelled-task", cancelled_ref)
+    await manager.set_object_ref("ready-active-task", {"ref": ready_ref})
     await manager.set_cancelled_if_active("cancelled-task")
     await manager.set_cancelled_if_active("settled-cancelled-task")
     await manager.set_state("completed-task", "COMPLETED")
+    monkeypatch.setattr(
+        task_state_module.ray,
+        "wait",
+        lambda refs, **_kwargs: ([ready_ref], []) if refs == [ready_ref] else ([], refs),
+    )
 
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == {
         "active-task",

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -360,36 +360,7 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_cancellation_settlement_deadline_is_assigned_once(monkeypatch) -> None:
-    now = 100.0
-    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
-    manager = _task_state_manager()
-    await manager.set_queued_details(
-        "task-1",
-        file_id="file-1",
-        partition="tenant-a",
-        metadata={},
-        user_id=42,
-    )
-    assert await manager.set_object_ref("task-1", {"ref": object()}) is True
-
-    assert await manager.set_cancelled_if_active("task-1") is True
-    expected_deadline = 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
-    assert manager.tasks["task-1"].cancellation_settlement_expires_at == expected_deadline
-
-    now = 200.0
-    await manager.set_details(
-        "task-1",
-        file_id="file-1",
-        partition="tenant-a",
-        metadata={"updated": True},
-        user_id=42,
-    )
-    assert manager.tasks["task-1"].cancellation_settlement_expires_at == expected_deadline
-
-
-@pytest.mark.asyncio
-async def test_expired_cancellation_releases_live_worker_fences(monkeypatch) -> None:
+async def test_elapsed_time_does_not_release_unready_worker_fences(monkeypatch) -> None:
     now = 100.0
     monkeypatch.setattr(task_state_module.time, "time", lambda: now)
     manager = _task_state_manager()
@@ -411,13 +382,16 @@ async def test_expired_cancellation_releases_live_worker_fences(monkeypatch) -> 
         "task-1": {"ref": worker_ref}
     }
 
-    now += task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS + 1
+    now += task_state_module._CANCELLATION_TOMBSTONE_TTL_SECONDS + 1
 
-    assert await manager.has_unsettled_cancelled_worker("task-1") is False
-    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
-    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == {}
-    assert await manager.get_object_ref("task-1") is None
-    assert manager.tasks["task-1"].worker_submitted is False
+    assert await manager.finish_cancellation("task-1") is False
+    assert await manager.has_unsettled_cancelled_worker("task-1") is True
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == {
+        "task-1": {"ref": worker_ref}
+    }
+    assert await manager.get_object_ref("task-1") == {"ref": worker_ref}
+    assert manager.tasks["task-1"].worker_submitted is True
 
 
 @pytest.mark.asyncio
@@ -753,7 +727,7 @@ async def test_cancellation_tombstone_survives_actor_reconstruction(monkeypatch)
     assert stored["task-1"].state == "CANCELLED"
 
 
-def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_with_fixed_expiry() -> None:
+def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_without_expiry() -> None:
     info = TaskInfo(
         state="CANCELLED",
         error="private traceback",
@@ -769,9 +743,8 @@ def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_with_fix
         details=info.details,
         object_ref=info.object_ref,
         worker_submitted=True,
-        cancellation_settlement_expires_at=100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS,
     )
-    assert expires_at == 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
+    assert expires_at is None
 
 
 def test_settled_cancellation_recovery_snapshot_expires() -> None:
@@ -784,7 +757,7 @@ def test_settled_cancellation_recovery_snapshot_expires() -> None:
     assert expires_at == 100.0 + task_state_module._CANCELLATION_TOMBSTONE_TTL_SECONDS
 
 
-def test_expired_unsettled_cancellation_is_removed_during_recovery(monkeypatch) -> None:
+def test_expired_unsettled_cancellation_is_preserved_during_recovery(monkeypatch) -> None:
     import ray.cloudpickle as cloudpickle
     from ray.experimental import internal_kv
 
@@ -808,11 +781,37 @@ def test_expired_unsettled_cancellation_is_removed_during_recovery(monkeypatch) 
         lambda candidate, **_kwargs: deleted.append(candidate),
     )
 
+    recovered = task_state_module._load_recoverable_tasks()
+
+    assert recovered["task-1"].state == "CANCELLED"
+    assert recovered["task-1"].worker_submitted is True
+    assert deleted == []
+
+
+def test_expired_settled_cancellation_is_removed_during_recovery(monkeypatch) -> None:
+    import ray.cloudpickle as cloudpickle
+    from ray.experimental import internal_kv
+
+    key = task_state_module._recoverable_task_key("task-1")
+    payload = cloudpickle.dumps(("task-1", TaskInfo(state="CANCELLED"), 99.0))
+    deleted: list[bytes] = []
+
+    monkeypatch.setattr(task_state_module, "_task_state_storage_available", lambda: True)
+    monkeypatch.setattr(task_state_module, "_task_state_kv_namespace", lambda: b"test")
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(internal_kv, "_internal_kv_list", lambda *_args, **_kwargs: [key])
+    monkeypatch.setattr(internal_kv, "_internal_kv_get", lambda *_args, **_kwargs: payload)
+    monkeypatch.setattr(
+        internal_kv,
+        "_internal_kv_del",
+        lambda candidate, **_kwargs: deleted.append(candidate),
+    )
+
     assert task_state_module._load_recoverable_tasks() == {}
     assert deleted == [key]
 
 
-def test_legacy_unsettled_cancellation_gets_one_persisted_deadline(monkeypatch) -> None:
+def test_legacy_unsettled_cancellation_remains_unexpired(monkeypatch) -> None:
     import ray.cloudpickle as cloudpickle
     from ray.experimental import internal_kv
 
@@ -830,27 +829,15 @@ def test_legacy_unsettled_cancellation_gets_one_persisted_deadline(monkeypatch) 
             )
         )
     }
-    now = 100.0
-
     monkeypatch.setattr(task_state_module, "_task_state_storage_available", lambda: True)
     monkeypatch.setattr(task_state_module, "_task_state_kv_namespace", lambda: b"test")
-    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
     monkeypatch.setattr(internal_kv, "_internal_kv_list", lambda *_args, **_kwargs: list(storage))
     monkeypatch.setattr(internal_kv, "_internal_kv_get", lambda candidate, **_kwargs: storage.get(candidate))
-    monkeypatch.setattr(
-        internal_kv,
-        "_internal_kv_put",
-        lambda candidate, payload, **_kwargs: storage.__setitem__(candidate, payload),
-    )
     monkeypatch.setattr(internal_kv, "_internal_kv_del", lambda candidate, **_kwargs: storage.pop(candidate, None))
 
-    first = task_state_module._load_recoverable_tasks()["task-1"]
-    expected_deadline = 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
-    assert first.cancellation_settlement_expires_at == expected_deadline
+    recovered = task_state_module._load_recoverable_tasks()["task-1"]
 
-    now = 200.0
-    second = task_state_module._load_recoverable_tasks()["task-1"]
-    assert second.cancellation_settlement_expires_at == expected_deadline
+    assert getattr(recovered, "cancellation_settlement_expires_at", None) is None
 
 
 @pytest.mark.asyncio
@@ -906,7 +893,6 @@ async def test_finished_cancellation_drops_recoverable_worker_reference(monkeypa
 async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeypatch) -> None:
     saved: list[TaskInfo] = []
     monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
-    monkeypatch.setattr(task_state_module.time, "time", lambda: 100.0)
     manager = _task_state_manager()
     ref = object()
     manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref})
@@ -915,9 +901,26 @@ async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeyp
     assert await manager.finish_cancellation("task-1") is False
 
     assert manager.tasks["task-1"].object_ref == {"ref": ref}
-    assert saved[-1].cancellation_settlement_expires_at == (
-        100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
+    assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_ref_less_submitted_cancellation_stays_fenced_until_settlement_is_proven(monkeypatch) -> None:
+    saved: list[TaskInfo] = []
+    monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
+    manager = _task_state_manager()
+    manager.tasks["task-1"] = TaskInfo(
+        state="CANCELLED",
+        details={"partition": "tenant-a", "file_id": "file-1"},
+        worker_submitted=True,
     )
+
+    assert await manager.finish_cancellation("task-1") is False
+
+    assert manager.tasks["task-1"].worker_submitted is True
+    assert await manager.has_unsettled_cancelled_worker("task-1") is True
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+    assert saved == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -204,6 +204,36 @@ async def test_stale_refless_task_rejects_late_worker_registration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_submitted_refless_task_keeps_claim_through_cancellation_and_registration() -> None:
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+        user_id=None,
+    )
+
+    assert await manager.mark_worker_submitted("task-1") is True
+    await manager.set_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+        user_id=None,
+    )
+    assert await manager.expire_refless_task_if_stale("task-1") is False
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+
+    assert await manager.set_cancelled_if_active("task-1") is True
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+
+    worker_ref = {"ref": object()}
+    assert await manager.set_object_ref("task-1", worker_ref) is False
+    assert await manager.get_object_ref("task-1") == worker_ref
+
+
+@pytest.mark.asyncio
 async def test_file_delete_fence_rejects_matching_queued_details() -> None:
     manager = _task_state_manager()
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -138,6 +138,37 @@ async def test_delete_cleanup_still_fences_legacy_indexing_states() -> None:
 
 
 @pytest.mark.asyncio
+async def test_content_claim_owners_include_unsettled_cancellations() -> None:
+    manager = _task_state_manager()
+
+    for task_id, partition in (
+        ("active-task", "tenant-a"),
+        ("cancelled-task", "tenant-a"),
+        ("settled-cancelled-task", "tenant-a"),
+        ("completed-task", "tenant-a"),
+        ("other-partition-task", "tenant-b"),
+    ):
+        await manager.set_queued_details(
+            task_id,
+            file_id=f"{task_id}-file",
+            partition=partition,
+            metadata={},
+            user_id=None,
+        )
+
+    cancelled_ref = {"ref": object()}
+    await manager.set_object_ref("cancelled-task", cancelled_ref)
+    await manager.set_cancelled_if_active("cancelled-task")
+    await manager.set_cancelled_if_active("settled-cancelled-task")
+    await manager.set_state("completed-task", "COMPLETED")
+
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {
+        "active-task",
+        "cancelled-task",
+    }
+
+
+@pytest.mark.asyncio
 async def test_file_delete_fence_rejects_matching_queued_details() -> None:
     manager = _task_state_manager()
 
@@ -429,9 +460,27 @@ async def test_finished_cancellation_drops_recoverable_worker_reference(monkeypa
     saved: list[TaskInfo] = []
     monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
     manager = _task_state_manager()
-    manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": object()})
+    ref = object()
+    manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref})
 
-    await manager.finish_cancellation("task-1")
+    monkeypatch.setattr(task_state_module.ray, "wait", lambda *_args, **_kwargs: ([ref], []))
+
+    assert await manager.finish_cancellation("task-1") is True
 
     assert manager.tasks["task-1"].object_ref is None
     assert saved[-1].object_ref is None
+
+
+@pytest.mark.asyncio
+async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeypatch) -> None:
+    saved: list[TaskInfo] = []
+    monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
+    manager = _task_state_manager()
+    ref = object()
+    manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref})
+    monkeypatch.setattr(task_state_module.ray, "wait", lambda *_args, **_kwargs: ([], [ref]))
+
+    assert await manager.finish_cancellation("task-1") is False
+
+    assert manager.tasks["task-1"].object_ref == {"ref": ref}
+    assert saved == []

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -134,9 +134,9 @@ async def test_matching_active_task_refs_preserve_submitted_tasks_without_refs()
     expected = {"task-1": SUBMITTED_TASK_WITHOUT_REF}
     assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
 
-    assert await manager.set_state("task-1", "SERIALIZING") is True
+    assert await manager.set_state("task-1", "SERIALIZING") is False
     assert await manager.set_cancelled_if_active("task-1") is True
-    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == {}
 
 
 @pytest.mark.asyncio
@@ -230,7 +230,7 @@ async def test_stale_refless_task_rejects_late_worker_registration() -> None:
 
 
 @pytest.mark.asyncio
-async def test_submitted_refless_task_keeps_claim_through_cancellation_and_registration() -> None:
+async def test_worker_cannot_enter_serializing_before_ref_registration() -> None:
     manager = _task_state_manager()
     await manager.set_queued_details(
         "task-1",
@@ -241,22 +241,10 @@ async def test_submitted_refless_task_keeps_claim_through_cancellation_and_regis
     )
 
     assert await manager.begin_worker_submission("task-1") is True
-    assert await manager.set_state("task-1", "SERIALIZING") is True
-    await manager.set_details(
-        "task-1",
-        file_id="file-1",
-        partition="tenant-a",
-        metadata={"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
-        user_id=None,
-    )
-    assert await manager.expire_refless_task_if_stale("task-1") is False
-    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
-
-    assert await manager.set_cancelled_if_active("task-1") is True
-    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
-
     worker_ref = {"ref": object()}
-    assert await manager.set_object_ref("task-1", worker_ref) is False
+    assert await manager.set_state("task-1", "SERIALIZING") is False
+    assert await manager.set_object_ref("task-1", worker_ref) is True
+    assert await manager.set_state("task-1", "SERIALIZING") is True
     assert await manager.get_object_ref("task-1") == worker_ref
 
 
@@ -274,6 +262,8 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
     )
 
     assert await manager.begin_worker_submission("task-1") is True
+    worker_ref = {"ref": object()}
+    assert await manager.set_object_ref("task-1", worker_ref) is True
     assert await manager.set_state("task-1", "SERIALIZING") is True
     await manager.set_details(
         "task-1",
@@ -685,7 +675,7 @@ def test_expired_unsettled_cancellation_is_recovered(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_submitted_refless_cancellation_keeps_claim_after_reconstruction(monkeypatch) -> None:
+async def test_submitted_cancellation_keeps_claim_after_reconstruction(monkeypatch) -> None:
     stored: dict[str, TaskInfo] = {}
     monkeypatch.setattr(task_state_module, "_load_recoverable_tasks", lambda: dict(stored))
 
@@ -705,6 +695,7 @@ async def test_submitted_refless_cancellation_keeps_claim_after_reconstruction(m
         user_id=42,
     )
     assert await first_incarnation.begin_worker_submission("task-1") is True
+    assert await first_incarnation.set_object_ref("task-1", {"ref": object()}) is True
     assert await first_incarnation.set_state("task-1", "SERIALIZING") is True
     assert await first_incarnation.set_cancelled_if_active("task-1") is True
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -214,7 +214,8 @@ async def test_submitted_refless_task_keeps_claim_through_cancellation_and_regis
         user_id=None,
     )
 
-    assert await manager.mark_worker_submitted("task-1") is True
+    assert await manager.begin_worker_submission("task-1") is True
+    assert await manager.set_state("task-1", "SERIALIZING") is True
     await manager.set_details(
         "task-1",
         file_id="file-1",
@@ -231,6 +232,33 @@ async def test_submitted_refless_task_keeps_claim_through_cancellation_and_regis
     worker_ref = {"ref": object()}
     assert await manager.set_object_ref("task-1", worker_ref) is False
     assert await manager.get_object_ref("task-1") == worker_ref
+
+
+@pytest.mark.asyncio
+async def test_unaccepted_submission_fence_expires(monkeypatch) -> None:
+    now = 100.0
+    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+        user_id=None,
+    )
+
+    assert await manager.begin_worker_submission("task-1") is True
+    await manager.set_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+        user_id=None,
+    )
+    now += task_state_module._CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS + 1
+
+    assert await manager.expire_refless_task_if_stale("task-1") is True
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 
 
 @pytest.mark.asyncio
@@ -506,18 +534,55 @@ async def test_cancellation_tombstone_survives_actor_reconstruction(monkeypatch)
     assert stored["task-1"].state == "CANCELLED"
 
 
-def test_cancellation_recovery_snapshot_is_sanitized_and_expires() -> None:
+def test_cancellation_recovery_snapshot_preserves_claim_owner_and_expires() -> None:
     info = TaskInfo(
         state="CANCELLED",
         error="private traceback",
         details={"user_id": 42, "metadata": {"secret": "value"}},
         object_ref={"ref": object()},
+        worker_submitted=True,
     )
 
     snapshot, expires_at = task_state_module._recovery_snapshot(info, now=100.0)
 
-    assert snapshot == TaskInfo(state="CANCELLED", object_ref=info.object_ref)
+    assert snapshot == TaskInfo(
+        state="CANCELLED",
+        details=info.details,
+        object_ref=info.object_ref,
+        worker_submitted=True,
+    )
     assert expires_at == 100.0 + task_state_module._CANCELLATION_TOMBSTONE_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_submitted_refless_cancellation_keeps_claim_after_reconstruction(monkeypatch) -> None:
+    stored: dict[str, TaskInfo] = {}
+    monkeypatch.setattr(task_state_module, "_load_recoverable_tasks", lambda: dict(stored))
+
+    def save(task_id: str, info: TaskInfo) -> None:
+        if info.state in task_state_module.RECOVERABLE_TASK_STATES:
+            stored[task_id] = task_state_module._recovery_snapshot(info)[0]
+        else:
+            stored.pop(task_id, None)
+
+    monkeypatch.setattr(task_state_module, "_save_recoverable_task", save)
+    first_incarnation = _task_state_manager()
+    await first_incarnation.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+        user_id=42,
+    )
+    assert await first_incarnation.begin_worker_submission("task-1") is True
+    assert await first_incarnation.set_state("task-1", "SERIALIZING") is True
+    assert await first_incarnation.set_cancelled_if_active("task-1") is True
+
+    reconstructed = _task_state_manager()
+
+    assert await reconstructed.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+    assert (await reconstructed.get_all_info())["task-1"]["worker_submitted"] is True
+    assert (await reconstructed.get_details("task-1"))["file_id"] == "file-1"
 
 
 @pytest.mark.asyncio
@@ -526,13 +591,14 @@ async def test_finished_cancellation_drops_recoverable_worker_reference(monkeypa
     monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
     manager = _task_state_manager()
     ref = object()
-    manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref})
+    manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref}, worker_submitted=True)
 
     monkeypatch.setattr(task_state_module.ray, "wait", lambda *_args, **_kwargs: ([ref], []))
 
     assert await manager.finish_cancellation("task-1") is True
 
     assert manager.tasks["task-1"].object_ref is None
+    assert manager.tasks["task-1"].worker_submitted is False
     assert saved[-1].object_ref is None
 
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -254,6 +254,56 @@ async def test_stale_refless_task_rejects_late_worker_registration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pending_count_expires_stale_refless_submission_after_grace(monkeypatch) -> None:
+    manager = _task_state_manager()
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 1_000.0)
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.begin_worker_submission("task-1") is True
+
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 1_059.0)
+    assert await manager.get_user_pending_task_count(42) == 1
+
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 1_060.0)
+    assert await manager.get_user_pending_task_count(42) == 0
+    assert await manager.get_state("task-1") == "FAILED"
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_state", "get_all_states", "get_all_info", "get_all_user_info"],
+)
+@pytest.mark.asyncio
+async def test_queue_views_expire_stale_refless_submissions(monkeypatch, method_name: str) -> None:
+    manager = _task_state_manager()
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 1_000.0)
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.begin_worker_submission("task-1") is True
+
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 1_060.0)
+    method = getattr(manager, method_name)
+    if method_name == "get_state":
+        state = await method("task-1")
+    else:
+        result = await method(42) if method_name == "get_all_user_info" else await method()
+        task = result["task-1"]
+        state = task if method_name == "get_all_states" else task["state"]
+
+    assert state == "FAILED"
+
+
+@pytest.mark.asyncio
 async def test_worker_cannot_enter_serializing_before_ref_registration() -> None:
     manager = _task_state_manager()
     await manager.set_queued_details(

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 import services.workers.task_state as task_state_module
-from services.workers.task_state import PENDING_TASK_DETAILS, TaskInfo, TaskStateManager
+from services.workers.task_state import (
+    PENDING_TASK_DETAILS,
+    SUBMITTED_TASK_WITHOUT_REF,
+    TaskInfo,
+    TaskStateManager,
+)
 
 
 def _task_state_manager() -> Any:
@@ -111,6 +116,26 @@ async def test_matching_active_task_refs_treat_detail_less_queued_tasks_as_pendi
     expected = {"queued-without-details": PENDING_TASK_DETAILS}
 
     assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == expected
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
+
+
+@pytest.mark.asyncio
+async def test_matching_active_task_refs_preserve_submitted_tasks_without_refs() -> None:
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.begin_worker_submission("task-1") is True
+    assert await manager.set_state("task-1", "SERIALIZING") is True
+
+    expected = {"task-1": SUBMITTED_TASK_WITHOUT_REF}
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
+
+    assert await manager.set_cancelled_if_active("task-1") is True
     assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
 
 
@@ -534,7 +559,7 @@ async def test_cancellation_tombstone_survives_actor_reconstruction(monkeypatch)
     assert stored["task-1"].state == "CANCELLED"
 
 
-def test_cancellation_recovery_snapshot_preserves_claim_owner_and_expires() -> None:
+def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_without_expiry() -> None:
     info = TaskInfo(
         state="CANCELLED",
         error="private traceback",
@@ -551,7 +576,45 @@ def test_cancellation_recovery_snapshot_preserves_claim_owner_and_expires() -> N
         object_ref=info.object_ref,
         worker_submitted=True,
     )
+    assert expires_at is None
+
+
+def test_settled_cancellation_recovery_snapshot_expires() -> None:
+    snapshot, expires_at = task_state_module._recovery_snapshot(
+        TaskInfo(state="CANCELLED", details={"user_id": 42}),
+        now=100.0,
+    )
+
+    assert snapshot == TaskInfo(state="CANCELLED", details={"user_id": 42})
     assert expires_at == 100.0 + task_state_module._CANCELLATION_TOMBSTONE_TTL_SECONDS
+
+
+def test_expired_unsettled_cancellation_is_recovered(monkeypatch) -> None:
+    import ray.cloudpickle as cloudpickle
+    from ray.experimental import internal_kv
+
+    key = task_state_module._recoverable_task_key("task-1")
+    info = TaskInfo(
+        state="CANCELLED",
+        details={"partition": "tenant-a", "file_id": "file-1"},
+        worker_submitted=True,
+    )
+    payload = cloudpickle.dumps(("task-1", info, 99.0))
+    deleted: list[bytes] = []
+
+    monkeypatch.setattr(task_state_module, "_task_state_storage_available", lambda: True)
+    monkeypatch.setattr(task_state_module, "_task_state_kv_namespace", lambda: b"test")
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(internal_kv, "_internal_kv_list", lambda *_args, **_kwargs: [key])
+    monkeypatch.setattr(internal_kv, "_internal_kv_get", lambda *_args, **_kwargs: payload)
+    monkeypatch.setattr(
+        internal_kv,
+        "_internal_kv_del",
+        lambda candidate, **_kwargs: deleted.append(candidate),
+    )
+
+    assert task_state_module._load_recoverable_tasks() == {"task-1": info}
+    assert deleted == []
 
 
 @pytest.mark.asyncio
@@ -615,3 +678,23 @@ async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeyp
 
     assert manager.tasks["task-1"].object_ref == {"ref": ref}
     assert saved == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_submission_is_only_unfenced_after_worker_settlement(monkeypatch) -> None:
+    saved: list[TaskInfo] = []
+    monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
+    manager = _task_state_manager()
+    manager.tasks["task-1"] = TaskInfo(
+        state="SERIALIZING",
+        details={"partition": "tenant-a", "file_id": "file-1"},
+        worker_submitted=True,
+    )
+
+    assert await manager.finish_rejected_submission("task-1") is True
+
+    info = manager.tasks["task-1"]
+    assert info.state == "FAILED"
+    assert info.worker_submitted is False
+    assert info.object_ref is None
+    assert saved[-1] is info

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -140,6 +141,11 @@ async def test_delete_cleanup_still_fences_legacy_indexing_states() -> None:
 @pytest.mark.asyncio
 async def test_content_claim_owners_include_only_unsettled_workers(monkeypatch) -> None:
     manager = _task_state_manager()
+    metadata_by_task = {
+        "finished-active-task": {"_openrag_job_finished_at": "2026-08-28T08:00:00+00:00"},
+        "recent-refless-task": {"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+        "stale-refless-task": {"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+    }
 
     for task_id, partition in (
         ("active-task", "tenant-a"),
@@ -147,6 +153,8 @@ async def test_content_claim_owners_include_only_unsettled_workers(monkeypatch) 
         ("settled-cancelled-task", "tenant-a"),
         ("finished-active-task", "tenant-a"),
         ("ready-active-task", "tenant-a"),
+        ("recent-refless-task", "tenant-a"),
+        ("stale-refless-task", "tenant-a"),
         ("completed-task", "tenant-a"),
         ("other-partition-task", "tenant-b"),
     ):
@@ -154,9 +162,7 @@ async def test_content_claim_owners_include_only_unsettled_workers(monkeypatch) 
             task_id,
             file_id=f"{task_id}-file",
             partition=partition,
-            metadata=(
-                {"_openrag_job_finished_at": "2026-08-28T08:00:00+00:00"} if task_id == "finished-active-task" else {}
-            ),
+            metadata=metadata_by_task.get(task_id, {}),
             user_id=None,
         )
 
@@ -176,7 +182,25 @@ async def test_content_claim_owners_include_only_unsettled_workers(monkeypatch) 
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == {
         "active-task",
         "cancelled-task",
+        "recent-refless-task",
     }
+
+
+@pytest.mark.asyncio
+async def test_stale_refless_task_rejects_late_worker_registration() -> None:
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+        user_id=None,
+    )
+
+    assert await manager.expire_refless_task_if_stale("task-1") is True
+    assert await manager.set_object_ref("task-1", {"ref": object()}) is False
+    assert await manager.get_state("task-1") == "FAILED"
+    assert await manager.get_object_ref("task-1") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
 
@@ -71,6 +72,29 @@ async def test_set_object_ref_accepts_terminal_states_without_reopening_task() -
     assert await manager.get_state("completed-task") == "COMPLETED"
     assert await manager.get_state("failed-task") == "FAILED"
     assert await manager.get_state("cancelled-task") == "CANCELLED"
+
+
+@pytest.mark.asyncio
+async def test_late_worker_registration_does_not_reopen_a_settled_cancellation(monkeypatch) -> None:
+    manager = _task_state_manager()
+    worker_ref = object()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.set_object_ref("task-1", {"ref": worker_ref}) is True
+    assert await manager.set_cancelled_if_active("task-1") is True
+    monkeypatch.setattr(task_state_module.ray, "wait", lambda *_args, **_kwargs: ([worker_ref], []))
+    assert await manager.finish_cancellation("task-1") is True
+    before = deepcopy(manager.tasks["task-1"])
+
+    assert await manager.set_object_ref("task-1", {"ref": object()}) is False
+
+    assert manager.tasks["task-1"] == before
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 
 
 @pytest.mark.asyncio
@@ -156,7 +180,7 @@ async def test_delete_cleanup_still_fences_legacy_indexing_states() -> None:
     ):
         await manager.set_details(task_id, file_id="file-1", partition="tenant-a", metadata={}, user_id=1)
         await manager.set_state(task_id, state)
-        await manager.set_object_ref(task_id, ref)
+        assert await manager.set_object_ref(task_id, ref) is True
 
     expected = {"chunking-task": chunking_ref, "inserting-task": inserting_ref}
     assert await manager.get_matching_active_task_refs(partition="tenant-a", file_id="file-1") == expected
@@ -283,6 +307,67 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
     assert await manager.get_state("task-1") == "CANCELLED"
     assert await manager.has_unsettled_cancelled_worker("task-1") is False
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_settlement_deadline_is_assigned_once(monkeypatch) -> None:
+    now = 100.0
+    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.set_object_ref("task-1", {"ref": object()}) is True
+
+    assert await manager.set_cancelled_if_active("task-1") is True
+    expected_deadline = 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
+    assert manager.tasks["task-1"].cancellation_settlement_expires_at == expected_deadline
+
+    now = 200.0
+    await manager.set_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"updated": True},
+        user_id=42,
+    )
+    assert manager.tasks["task-1"].cancellation_settlement_expires_at == expected_deadline
+
+
+@pytest.mark.asyncio
+async def test_expired_cancellation_releases_live_worker_fences(monkeypatch) -> None:
+    now = 100.0
+    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
+    manager = _task_state_manager()
+    worker_ref = object()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={},
+        user_id=42,
+    )
+    assert await manager.set_object_ref("task-1", {"ref": worker_ref}) is True
+    assert await manager.set_cancelled_if_active("task-1") is True
+    monkeypatch.setattr(task_state_module.ray, "wait", lambda refs, **_kwargs: ([], refs))
+
+    assert await manager.has_unsettled_cancelled_worker("task-1") is True
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == {
+        "task-1": {"ref": worker_ref}
+    }
+
+    now += task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS + 1
+
+    assert await manager.has_unsettled_cancelled_worker("task-1") is False
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
+    assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == {}
+    assert await manager.get_object_ref("task-1") is None
+    assert manager.tasks["task-1"].worker_submitted is False
 
 
 @pytest.mark.asyncio
@@ -616,7 +701,7 @@ async def test_cancellation_tombstone_survives_actor_reconstruction(monkeypatch)
     assert stored["task-1"].state == "CANCELLED"
 
 
-def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_without_expiry() -> None:
+def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_with_fixed_expiry() -> None:
     info = TaskInfo(
         state="CANCELLED",
         error="private traceback",
@@ -632,8 +717,9 @@ def test_cancellation_recovery_snapshot_preserves_unsettled_claim_owner_without_
         details=info.details,
         object_ref=info.object_ref,
         worker_submitted=True,
+        cancellation_settlement_expires_at=100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS,
     )
-    assert expires_at is None
+    assert expires_at == 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
 
 
 def test_settled_cancellation_recovery_snapshot_expires() -> None:
@@ -646,7 +732,7 @@ def test_settled_cancellation_recovery_snapshot_expires() -> None:
     assert expires_at == 100.0 + task_state_module._CANCELLATION_TOMBSTONE_TTL_SECONDS
 
 
-def test_expired_unsettled_cancellation_is_recovered(monkeypatch) -> None:
+def test_expired_unsettled_cancellation_is_removed_during_recovery(monkeypatch) -> None:
     import ray.cloudpickle as cloudpickle
     from ray.experimental import internal_kv
 
@@ -670,8 +756,49 @@ def test_expired_unsettled_cancellation_is_recovered(monkeypatch) -> None:
         lambda candidate, **_kwargs: deleted.append(candidate),
     )
 
-    assert task_state_module._load_recoverable_tasks() == {"task-1": info}
-    assert deleted == []
+    assert task_state_module._load_recoverable_tasks() == {}
+    assert deleted == [key]
+
+
+def test_legacy_unsettled_cancellation_gets_one_persisted_deadline(monkeypatch) -> None:
+    import ray.cloudpickle as cloudpickle
+    from ray.experimental import internal_kv
+
+    key = task_state_module._recoverable_task_key("task-1")
+    storage = {
+        key: cloudpickle.dumps(
+            (
+                "task-1",
+                TaskInfo(
+                    state="CANCELLED",
+                    details={"partition": "tenant-a", "file_id": "file-1"},
+                    worker_submitted=True,
+                ),
+                None,
+            )
+        )
+    }
+    now = 100.0
+
+    monkeypatch.setattr(task_state_module, "_task_state_storage_available", lambda: True)
+    monkeypatch.setattr(task_state_module, "_task_state_kv_namespace", lambda: b"test")
+    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
+    monkeypatch.setattr(internal_kv, "_internal_kv_list", lambda *_args, **_kwargs: list(storage))
+    monkeypatch.setattr(internal_kv, "_internal_kv_get", lambda candidate, **_kwargs: storage.get(candidate))
+    monkeypatch.setattr(
+        internal_kv,
+        "_internal_kv_put",
+        lambda candidate, payload, **_kwargs: storage.__setitem__(candidate, payload),
+    )
+    monkeypatch.setattr(internal_kv, "_internal_kv_del", lambda candidate, **_kwargs: storage.pop(candidate, None))
+
+    first = task_state_module._load_recoverable_tasks()["task-1"]
+    expected_deadline = 100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
+    assert first.cancellation_settlement_expires_at == expected_deadline
+
+    now = 200.0
+    second = task_state_module._load_recoverable_tasks()["task-1"]
+    assert second.cancellation_settlement_expires_at == expected_deadline
 
 
 @pytest.mark.asyncio
@@ -727,6 +854,7 @@ async def test_finished_cancellation_drops_recoverable_worker_reference(monkeypa
 async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeypatch) -> None:
     saved: list[TaskInfo] = []
     monkeypatch.setattr(task_state_module, "_save_recoverable_task", lambda _task_id, info: saved.append(info))
+    monkeypatch.setattr(task_state_module.time, "time", lambda: 100.0)
     manager = _task_state_manager()
     ref = object()
     manager.tasks["task-1"] = TaskInfo(state="CANCELLED", object_ref={"ref": ref})
@@ -735,7 +863,9 @@ async def test_unsettled_cancellation_keeps_recoverable_worker_reference(monkeyp
     assert await manager.finish_cancellation("task-1") is False
 
     assert manager.tasks["task-1"].object_ref == {"ref": ref}
-    assert saved == []
+    assert saved[-1].cancellation_settlement_expires_at == (
+        100.0 + task_state_module._CANCELLATION_SETTLEMENT_TTL_SECONDS
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -273,6 +273,7 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
     )
 
     assert await manager.begin_worker_submission("task-1") is True
+    assert await manager.accept_worker_submission("task-1") is True
     await manager.set_details(
         "task-1",
         file_id="file-1",
@@ -285,8 +286,37 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
     assert await manager.expire_refless_task_if_stale("task-1") is False
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
 
+    assert await manager.set_cancelled_if_active("task-1") is True
+    assert await manager.has_unsettled_cancelled_worker("task-1") is True
     assert await manager.finish_rejected_submission("task-1") is True
-    assert await manager.get_state("task-1") == "FAILED"
+    assert await manager.get_state("task-1") == "CANCELLED"
+    assert await manager.has_unsettled_cancelled_worker("task-1") is False
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
+
+
+@pytest.mark.asyncio
+async def test_unaccepted_submission_fence_expires_after_handoff_grace(monkeypatch) -> None:
+    now = 100.0
+    monkeypatch.setattr(task_state_module.time, "time", lambda: now)
+    manager = _task_state_manager()
+    for task_id, file_id in (("claim-task", "file-1"), ("delete-task", "file-2")):
+        await manager.set_queued_details(
+            task_id,
+            file_id=file_id,
+            partition="tenant-a",
+            metadata={"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+            user_id=None,
+        )
+        assert await manager.begin_worker_submission(task_id) is True
+    now += task_state_module._CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS + 1
+
+    assert await manager.accept_worker_submission("claim-task") is False
+    assert await manager.get_state("claim-task") == "FAILED"
+    assert await manager.get_matching_active_task_refs_v2(
+        partition="tenant-a",
+        file_id="file-2",
+    ) == {}
+    assert await manager.get_state("delete-task") == "FAILED"
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -462,10 +462,12 @@ async def test_file_delete_fence_rejects_late_object_ref_registration() -> None:
         metadata={},
         user_id=None,
     )
+    assert await manager.begin_worker_submission("task-1") is True
     await manager.begin_file_delete(partition="tenant-a", file_id="file-1")
+    before = deepcopy(manager.tasks["task-1"])
 
     assert await manager.set_object_ref("task-1", {"ref": object()}) is False
-    assert await manager.get_state("task-1") == "CANCELLED"
+    assert manager.tasks["task-1"] == before
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -130,11 +130,11 @@ async def test_matching_active_task_refs_preserve_submitted_tasks_without_refs()
         user_id=42,
     )
     assert await manager.begin_worker_submission("task-1") is True
-    assert await manager.set_state("task-1", "SERIALIZING") is True
 
     expected = {"task-1": SUBMITTED_TASK_WITHOUT_REF}
     assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
 
+    assert await manager.set_state("task-1", "SERIALIZING") is True
     assert await manager.set_cancelled_if_active("task-1") is True
     assert await manager.get_matching_active_task_refs_v2(partition="tenant-a", file_id="file-1") == expected
 
@@ -260,7 +260,7 @@ async def test_submitted_refless_task_keeps_claim_through_cancellation_and_regis
 
 
 @pytest.mark.asyncio
-async def test_unaccepted_submission_fence_expires(monkeypatch) -> None:
+async def test_submission_fence_persists_until_pool_reports_settlement(monkeypatch) -> None:
     now = 100.0
     monkeypatch.setattr(task_state_module.time, "time", lambda: now)
     manager = _task_state_manager()
@@ -282,7 +282,11 @@ async def test_unaccepted_submission_fence_expires(monkeypatch) -> None:
     )
     now += task_state_module._CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS + 1
 
-    assert await manager.expire_refless_task_if_stale("task-1") is True
+    assert await manager.expire_refless_task_if_stale("task-1") is False
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {"task-1"}
+
+    assert await manager.finish_rejected_submission("task-1") is True
+    assert await manager.get_state("task-1") == "FAILED"
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -308,6 +308,17 @@ async def test_unaccepted_submission_fence_expires_after_handoff_grace(monkeypat
             user_id=None,
         )
         assert await manager.begin_worker_submission(task_id) is True
+    await manager.set_details(
+        "claim-task",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": "2000-01-01T00:00:00+00:00"},
+        user_id=None,
+    )
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == {
+        "claim-task",
+        "delete-task",
+    }
     now += task_state_module._CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS + 1
 
     assert await manager.accept_worker_submission("claim-task") is False
@@ -317,6 +328,24 @@ async def test_unaccepted_submission_fence_expires_after_handoff_grace(monkeypat
         file_id="file-2",
     ) == {}
     assert await manager.get_state("delete-task") == "FAILED"
+    assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_unaccepted_handoff_does_not_keep_content_claim() -> None:
+    manager = _task_state_manager()
+    await manager.set_queued_details(
+        "task-1",
+        file_id="file-1",
+        partition="tenant-a",
+        metadata={"_openrag_job_created_at": datetime.now(UTC).isoformat()},
+        user_id=None,
+    )
+
+    assert await manager.begin_worker_submission("task-1") is True
+    assert await manager.set_cancelled_if_active("task-1") is True
+
+    assert await manager.has_unsettled_cancelled_worker("task-1") is False
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 
 

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -224,6 +224,7 @@ async def test_stale_refless_task_rejects_late_worker_registration() -> None:
 
     assert await manager.expire_refless_task_if_stale("task-1") is True
     assert await manager.set_object_ref("task-1", {"ref": object()}) is False
+    assert await manager.set_state("task-1", "SERIALIZING") is False
     assert await manager.get_state("task-1") == "FAILED"
     assert await manager.get_object_ref("task-1") is None
 
@@ -273,7 +274,7 @@ async def test_submission_fence_persists_until_pool_reports_settlement(monkeypat
     )
 
     assert await manager.begin_worker_submission("task-1") is True
-    assert await manager.accept_worker_submission("task-1") is True
+    assert await manager.set_state("task-1", "SERIALIZING") is True
     await manager.set_details(
         "task-1",
         file_id="file-1",
@@ -321,7 +322,7 @@ async def test_unaccepted_submission_fence_expires_after_handoff_grace(monkeypat
     }
     now += task_state_module._CONTENT_CLAIM_REGISTRATION_GRACE_SECONDS + 1
 
-    assert await manager.accept_worker_submission("claim-task") is False
+    assert await manager.expire_refless_task_if_stale("claim-task") is True
     assert await manager.get_state("claim-task") == "FAILED"
     assert await manager.get_matching_active_task_refs_v2(
         partition="tenant-a",

--- a/tests/unit/services/workers/test_task_state.py
+++ b/tests/unit/services/workers/test_task_state.py
@@ -324,10 +324,13 @@ async def test_unaccepted_submission_fence_expires_after_handoff_grace(monkeypat
 
     assert await manager.expire_refless_task_if_stale("claim-task") is True
     assert await manager.get_state("claim-task") == "FAILED"
-    assert await manager.get_matching_active_task_refs_v2(
-        partition="tenant-a",
-        file_id="file-2",
-    ) == {}
+    assert (
+        await manager.get_matching_active_task_refs_v2(
+            partition="tenant-a",
+            file_id="file-2",
+        )
+        == {}
+    )
     assert await manager.get_state("delete-task") == "FAILED"
     assert await manager.get_content_claim_task_ids(partition="tenant-a") == set()
 


### PR DESCRIPTION
## Context

Content reservations can outlive a cancelled indexing task when OpenRAG restarts before cleanup finishes. This leaves no document or vectors to remove, but still blocks the same content from being uploaded again.

## Fix

Re-upload now recovers abandoned indexing reservations after a short registration grace while continuing to protect active jobs and synchronous copies. Existing indexed documents remain duplicate-protected.

## Validation

The full unit suite and lint checks pass. PostgreSQL regression tests cover abandoned, active, newly registered, and non-task reservations.

Fixes #868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task cancellation handling, including delayed finalization until processing settles.
  - Automatically expires stale tasks that never begin processing.
  - Prevented cancelled or stale tasks from starting or registering late.
  - Improved recovery of interrupted tasks and abandoned content claims.
  - Preserved active indexing claims during recovery.
  - Improved content deduplication during concurrent activity.
  - Improved cleanup when deleting partitions with active tasks.
  - Added safeguards for failed worker submissions, claim renewal, and cancellation recovery.
  - Prevented indexing from starting after cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->