### PR TITLE
fix(vectordb): make BM25 lexical search case-insensitive

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -66,7 +66,7 @@ vectordb:
   hybrid_search: true
   enable: true
   timeout: 120.0 # per-request timeout (s) for the Milvus sync/async clients
-  schema_version: 1 # Increment when the collection schema changes and a migration is required
+  schema_version: 2 # Increment when the collection schema changes and a migration is required
 
 # --- Relational Database (PostgreSQL) ---
 # Env: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD,

--- a/docs/content/docs/documentation/milvus_migration.mdx
+++ b/docs/content/docs/documentation/milvus_migration.mdx
@@ -238,6 +238,40 @@ Migrations are versioned. The runner reads the current schema version stored in 
 Stop the OpenRAG application before running any migration.
 :::
 
+### Version 2 — case-insensitive BM25 analyzer
+
+Schema version 2 adds the `lowercase` filter to the `text` analyzer, so BM25 stops treating `Rapport` and `rapport` as different terms. Milvus applies the analyzer to the query as well as to the indexed text, so before this fix a case mismatch scored zero on the lexical leg.
+
+It **rebuilds** the collection rather than altering it: Milvus 3.0 refuses to change `analyzer_params` while `enable_match` is set (and `enable_match` is itself immutable), and [attaching a BM25 function](https://milvus.io/docs/add-fields-to-an-existing-collection.md) to an existing collection — which would backfill the sparse column — requires [Storage V3](https://milvus.io/docs/storage-v3.md), off by default. The migration copies the rows into `<collection>_v2_rebuild`, checks the counts, then swaps the names, keeping the old collection as `<collection>_v1_backup`.
+
+:::caution[Plan for the rebuild]
+- **Disk** — both copies exist at once; allow roughly twice the collection size until the backup is dropped.
+- **No re-embedding** — dense vectors are copied verbatim and the sparse ones are regenerated server-side on insert, which is what applies the new analyzer.
+- **Chunk IDs change** — `_id` is `auto_id`. Postgres keys on `file_id`, but a chunk ID handed out earlier by the MCP `get_chunk_by_id` tool no longer resolves.
+- **`hybrid_search: false`** deployments have no BM25 leg and are only re-stamped — no rebuild.
+- A failed copy leaves the original untouched; drop the partial `<collection>_v2_rebuild` and retry.
+- The version check runs on the indexing path only. An un-migrated deployment still boots and still answers searches — with the old analyzer — and fails the first upload with `Collection ... is at schema version 1 but the application requires version 2`.
+:::
+
+Once validated, drop the backup:
+
+```python
+from pymilvus import MilvusClient
+
+MilvusClient(uri="http://localhost:19530").drop_collection("<collection>_v1_backup")
+```
+
+:::note[Where to run these]
+The commands below run from `infra/compose/`. From the repo root, point Compose at the file (and at your project name, if you use one):
+
+```bash
+docker compose -p <project> -f infra/compose/docker-compose.yaml run --no-deps --rm --build --entrypoint "" openrag \
+    uv run python services/persistence/migrations/milvus/migrate.py --dry-run
+```
+
+The migration runner is a file, not a package — pass the full path to `migrate.py`, and keep Milvus running.
+:::
+
 ### Step 1 — Start only the Milvus container
 
 ```bash
@@ -267,7 +301,7 @@ docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-
   </TabItem>
 </Tabs>
 
-Review the output to confirm which migrations are pending and what changes they would apply.
+Review the output to confirm which migrations are pending and what changes they would apply. The migration scripts ship **inside the image**, which is why `--build` is there: if the `Discovered N migration(s)` line does not list the migration you expect, the image is stale — and on a shared host another checkout may have rebuilt the same `linagoraai/openrag` tag, so add `--build` to the apply step too.
 
 ### Step 3 — Apply all pending migrations
 
@@ -337,7 +371,10 @@ docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
 
 ### Rollback
 
-Milvus does not support dropping fields. A downgrade only removes indexes and resets the version stamp — fields remain in the schema but are unused by the application:
+What a downgrade can undo depends on the migration:
+
+- **Version 2 → 1** swaps the `<collection>_v1_backup` collection back into place and sets the version stamp to 1. The version-2 collection is kept aside as `<collection>_v2_rolled_back` rather than dropped, so nothing is lost — but this is a point-in-time rollback: **rows indexed after the upgrade exist only in the collection set aside**. The rollback needs that backup collection; if it has already been dropped, the only way back is to recreate the collection with the old analyzer and re-index.
+- **Version 1 → 0** only removes indexes and resets the version stamp, since Milvus does not support dropping fields — they remain in the schema but are unused by the application.
 
 <Tabs>
   <TabItem label="GPU">

--- a/openrag/core/config/infrastructure.py
+++ b/openrag/core/config/infrastructure.py
@@ -22,7 +22,7 @@ class VectorDBConfig(ConfigMixin):
     enable: bool = True
     # Per-request timeout (s) applied to the Milvus sync and async clients.
     timeout: float = Field(default=120.0, gt=0)
-    schema_version: int = 1
+    schema_version: int = 2
 
 
 # ---------------------------------------------------------------------------

--- a/openrag/services/persistence/migrations/milvus/2.lowercase_bm25_analyzer.py
+++ b/openrag/services/persistence/migrations/milvus/2.lowercase_bm25_analyzer.py
@@ -1,0 +1,450 @@
+"""
+Milvus migration: case-insensitive BM25 analyzer  (schema version 1 → 2)
+========================================================================
+Adds the ``lowercase`` filter to the ``text`` analyzer so BM25 stops treating
+``Rapport`` and ``rapport`` as distinct terms.
+
+Rebuilds the collection rather than altering it: Milvus 3.0 refuses to alter
+``analyzer_params`` while ``enable_match`` is set (and ``enable_match`` is itself
+immutable), and ``add_function_field`` — which would re-attach BM25 with a
+backfill — requires Storage V3, off by default. Both were probed against 3.0.0.
+
+Copies rows into ``<collection>_v2_rebuild``, verifies the counts, then swaps
+names, keeping the old collection as ``<collection>_v1_backup`` (never dropped
+automatically). Dense vectors are copied verbatim and the sparse vectors are
+regenerated server-side on insert, so nothing is re-embedded. Collections with
+no ``sparse`` field are only re-stamped.
+
+``_id`` is ``auto_id``, so the copy assigns new chunk IDs. Postgres keys on
+``file_id``, but a chunk ID handed out earlier by MCP no longer resolves.
+
+Usage — prefer the generic runner (from repo root, inside the container):
+    docker compose run --no-deps --rm --entrypoint "" openrag \\
+        uv run python services/persistence/migrations/milvus/migrate.py [--dry-run]
+
+This script also runs standalone with ``--dry-run`` / ``--downgrade``.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from typing import Any
+
+from core.config import load_config
+from core.utils.logging import get_logger
+from pymilvus import DataType, Function, FunctionType, MilvusClient
+from services.storage.milvus_store import SCHEMA_VERSION_PROPERTY_KEY
+
+TARGET_VERSION = 2  # The schema version this migration brings the collection to.
+
+# Frozen snapshot of the v2 schema — importing the live one would let a later
+# analyzer change rewrite what this migration produces.
+ANALYZER_PARAMS_V2: dict[str, Any] = {
+    "tokenizer": "standard",
+    "filter": [
+        "lowercase",
+        {
+            "type": "stop",
+            "stop_words": [
+                "<image_description>",
+                "</image_description>",
+                "[Image Placeholder]",
+                "_english_",
+                "_french_",
+                "[CHUNK_START]",
+                "[CHUNK_END]",
+                "[CONTEXT]",
+            ],
+        },
+    ],
+}
+
+MAX_LENGTH = 65_535
+INDEXED_TIME_FIELDS = ["created_at"]
+
+REBUILD_SUFFIX = "_v2_rebuild"
+BACKUP_SUFFIX = "_v1_backup"
+ROLLBACK_ASIDE_SUFFIX = "_v2_rolled_back"
+
+#: Upper bound on rows per copy batch, further capped by the vector payload.
+MAX_COPY_BATCH = 1_000
+
+#: Keys that must never be written back on insert: ``_id`` is an ``auto_id``
+#: primary key and ``sparse`` is a BM25 ``Function`` output — Milvus rejects
+#: caller-supplied values for both.
+_UNSETTABLE_KEYS = frozenset({"_id", "sparse"})
+
+logger = get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_stored_version(client: MilvusClient, collection_name: str) -> int:
+    desc = client.describe_collection(collection_name)
+    raw = desc.get("properties", {}).get(SCHEMA_VERSION_PROPERTY_KEY)
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def _field_map(desc: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {f["name"]: f for f in desc.get("fields", [])}
+
+
+def _is_hybrid(desc: dict[str, Any]) -> bool:
+    """True when the collection carries the BM25 sparse field."""
+    return "sparse" in _field_map(desc)
+
+
+def _vector_dim(desc: dict[str, Any]) -> int:
+    field = _field_map(desc).get("vector")
+    if field is None:
+        raise RuntimeError("Collection has no `vector` field — not an OpenRAG collection.")
+    dim = field.get("params", {}).get("dim")
+    if not dim:
+        raise RuntimeError("Could not read the `vector` field dimension from the collection schema.")
+    return int(dim)
+
+
+def _max_length(desc: dict[str, Any], field_name: str) -> int:
+    field = _field_map(desc).get(field_name, {})
+    return int(field.get("params", {}).get("max_length", MAX_LENGTH))
+
+
+def _analyzer_has_lowercase(desc: dict[str, Any]) -> bool:
+    """True when the live ``text`` analyzer already applies the lowercase filter."""
+    raw = _field_map(desc).get("text", {}).get("params", {}).get("analyzer_params")
+    if not raw:
+        return False
+    try:
+        params = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return False
+    return any(f == "lowercase" for f in params.get("filter", []) if isinstance(f, str))
+
+
+def _row_count(client: MilvusClient, collection_name: str) -> int:
+    client.load_collection(collection_name)
+    rows = client.query(collection_name=collection_name, filter="", output_fields=["count(*)"])
+    return int(rows[0]["count(*)"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# Schema construction (v2)
+# ---------------------------------------------------------------------------
+
+
+def _build_v2_schema(client: MilvusClient, desc: dict[str, Any]):
+    """Rebuild the OpenRAG schema with the corrected analyzer.
+
+    Per-deployment values (vector dimension, VARCHAR lengths, whether the
+    collection is hybrid) are read from the live collection rather than
+    assumed, so a collection created with non-default settings round-trips.
+    """
+    schema = client.create_schema(enable_dynamic_field=True)
+    schema.add_field(field_name="_id", datatype=DataType.INT64, is_primary=True, auto_id=True)
+    schema.add_field(
+        field_name="text",
+        datatype=DataType.VARCHAR,
+        enable_analyzer=True,
+        enable_match=True,
+        max_length=_max_length(desc, "text"),
+        analyzer_params=ANALYZER_PARAMS_V2,
+    )
+    schema.add_field(
+        field_name="partition",
+        datatype=DataType.VARCHAR,
+        max_length=_max_length(desc, "partition"),
+        is_partition_key=True,
+    )
+    schema.add_field(
+        field_name="file_id",
+        datatype=DataType.VARCHAR,
+        max_length=_max_length(desc, "file_id"),
+    )
+    schema.add_field(field_name="vector", datatype=DataType.FLOAT_VECTOR, dim=_vector_dim(desc))
+
+    for time_field in INDEXED_TIME_FIELDS:
+        schema.add_field(field_name=time_field, datatype=DataType.TIMESTAMPTZ, nullable=True)
+
+    if _is_hybrid(desc):
+        schema.add_field(
+            field_name="sparse",
+            datatype=DataType.SPARSE_FLOAT_VECTOR,
+            index_type="SPARSE_INVERTED_INDEX",
+        )
+        schema.add_function(
+            Function(
+                name="text_bm25_emb",
+                function_type=FunctionType.BM25,
+                input_field_names=["text"],
+                output_field_names=["sparse"],
+            )
+        )
+    return schema
+
+
+def _build_v2_index_params(client: MilvusClient, desc: dict[str, Any]):
+    index_params = client.prepare_index_params()
+    index_params.add_index(field_name="file_id", index_type="INVERTED", index_name="file_id_idx")
+    index_params.add_index(field_name="partition", index_type="INVERTED", index_name="partition_idx")
+    index_params.add_index(
+        field_name="vector",
+        index_type="HNSW",
+        metric_type="COSINE",
+        index_params={"M": 128, "efConstruction": 256, "metric_type": "COSINE"},
+    )
+    if _is_hybrid(desc):
+        index_params.add_index(
+            field_name="sparse",
+            index_name="sparse_idx",
+            index_type="SPARSE_INVERTED_INDEX",
+            index_params={
+                "metric_type": "BM25",
+                "inverted_index_algo": "DAAT_MAXSCORE",
+                "bm25_k1": 1.2,
+                "bm25_b": 0.75,
+            },
+        )
+    for time_field in INDEXED_TIME_FIELDS:
+        index_params.add_index(
+            field_name=time_field,
+            index_type="STL_SORT",
+            index_name=f"{time_field}_idx",
+        )
+    return index_params
+
+
+def _assert_no_field_loss(source_desc: dict[str, Any], rebuilt_desc: dict[str, Any]) -> None:
+    """Fail loudly if the rebuild would drop a declared field.
+
+    Dynamic (undeclared) fields travel with the row payload, but a *declared*
+    field this migration does not know about would be silently lost.
+    """
+    missing = set(_field_map(source_desc)) - set(_field_map(rebuilt_desc))
+    if missing:
+        raise RuntimeError(
+            f"Rebuilt schema is missing declared field(s) {sorted(missing)} present in the source "
+            "collection. This migration predates them — update it before running."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Row copy
+# ---------------------------------------------------------------------------
+
+
+def _copy_batch_size(dim: int) -> int:
+    """Rows per page, kept under Milvus's result-size cap for wide vectors."""
+    budget = 32 * 1024 * 1024
+    per_row = dim * 4 + 6_144
+    return max(1, min(MAX_COPY_BATCH, budget // per_row))
+
+
+def _prepare_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Strip server-owned keys and normalise values for re-insertion."""
+    out: dict[str, Any] = {}
+    for key, value in row.items():
+        if key in _UNSETTABLE_KEYS:
+            continue
+        out[key] = value.isoformat() if isinstance(value, datetime) else value
+    return out
+
+
+def _copy_rows(client: MilvusClient, source: str, target: str, dim: int) -> int:
+    """Stream every row from ``source`` into ``target``. Returns rows inserted."""
+    batch_size = _copy_batch_size(dim)
+    client.load_collection(source)
+    iterator = client.query_iterator(
+        collection_name=source,
+        filter="",
+        batch_size=batch_size,
+        output_fields=["*"],
+    )
+    copied = 0
+    try:
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            rows = [_prepare_row(r) for r in batch]
+            client.insert(collection_name=target, data=rows)
+            copied += len(rows)
+            logger.info(f"  copied {copied} rows...")
+    finally:
+        iterator.close()
+    client.flush(target)
+    return copied
+
+
+# ---------------------------------------------------------------------------
+# Upgrade / downgrade
+# ---------------------------------------------------------------------------
+
+
+def _stamp_version(client: MilvusClient, collection_name: str, version: int) -> None:
+    client.alter_collection_properties(
+        collection_name=collection_name,
+        properties={SCHEMA_VERSION_PROPERTY_KEY: str(version)},
+    )
+    logger.info(f"Stamped schema version {version} on '{collection_name}'.")
+
+
+def upgrade(client: MilvusClient, collection_name: str, dry_run: bool = False) -> None:
+    stored_version = _get_stored_version(client, collection_name)
+    if stored_version >= TARGET_VERSION:
+        logger.info(f"Collection is already at version {stored_version} — nothing to do.")
+        return
+
+    desc = client.describe_collection(collection_name)
+
+    # Nothing to rebuild when there is no BM25 leg, or when the analyzer is
+    # already correct — only the version stamp is missing.
+    if not _is_hybrid(desc):
+        logger.info("Collection has no `sparse` field (hybrid search disabled) — no BM25 analyzer to fix.")
+        if not dry_run:
+            _stamp_version(client, collection_name, TARGET_VERSION)
+        return
+    if _analyzer_has_lowercase(desc):
+        logger.info("The `text` analyzer already applies the lowercase filter — no rebuild needed.")
+        if not dry_run:
+            _stamp_version(client, collection_name, TARGET_VERSION)
+        return
+
+    rebuild_name = f"{collection_name}{REBUILD_SUFFIX}"
+    backup_name = f"{collection_name}{BACKUP_SUFFIX}"
+    for name in (rebuild_name, backup_name):
+        if client.has_collection(name):
+            raise RuntimeError(
+                f"Collection '{name}' already exists — a previous run of this migration was "
+                "interrupted. Inspect it and drop it before retrying."
+            )
+
+    dim = _vector_dim(desc)
+    source_count = _row_count(client, collection_name)
+    logger.info(
+        f"Rebuilding '{collection_name}' ({source_count} rows, dim={dim}) with the corrected analyzer.\n"
+        f"  new collection : {rebuild_name}\n"
+        f"  old kept as    : {backup_name}"
+    )
+
+    if dry_run:
+        logger.info(f"[DRY-RUN] Would copy {source_count} rows and swap the collection names.")
+        logger.info("[DRY-RUN] Dry-run complete. No changes were made.")
+        return
+
+    schema = _build_v2_schema(client, desc)
+    index_params = _build_v2_index_params(client, desc)
+    client.create_collection(
+        collection_name=rebuild_name,
+        schema=schema,
+        consistency_level="Strong",
+        index_params=index_params,
+        enable_dynamic_field=True,
+    )
+    logger.info(f"Created '{rebuild_name}'.")
+
+    try:
+        _assert_no_field_loss(desc, client.describe_collection(rebuild_name))
+        copied = _copy_rows(client, collection_name, rebuild_name, dim)
+        target_count = _row_count(client, rebuild_name)
+        logger.info(f"Copied {copied} rows; target collection reports {target_count} (source: {source_count}).")
+        if target_count != source_count:
+            raise RuntimeError(
+                f"Row-count mismatch after copy: source={source_count}, target={target_count}. "
+                f"The source collection is untouched; drop '{rebuild_name}' and retry."
+            )
+        _stamp_version(client, rebuild_name, TARGET_VERSION)
+    except Exception:
+        logger.error(
+            f"Rebuild failed — '{collection_name}' is untouched. "
+            f"Drop the partial collection '{rebuild_name}' before retrying."
+        )
+        raise
+
+    client.rename_collection(collection_name, backup_name)
+    client.rename_collection(rebuild_name, collection_name)
+    client.load_collection(collection_name)
+    logger.info(
+        f"Migration complete. '{collection_name}' now uses the case-insensitive analyzer.\n"
+        f"  The previous collection is kept as '{backup_name}' — drop it once validated:\n"
+        f"    client.drop_collection('{backup_name}')"
+    )
+
+
+def downgrade(client: MilvusClient, collection_name: str, dry_run: bool = False) -> None:
+    """Swap the v1 backup collection back into place.
+
+    Rows indexed after the upgrade live only in the v2 collection, so this is a
+    point-in-time rollback: the v2 collection is kept aside rather than dropped.
+    """
+    backup_name = f"{collection_name}{BACKUP_SUFFIX}"
+    aside_name = f"{collection_name}{ROLLBACK_ASIDE_SUFFIX}"
+
+    if not client.has_collection(backup_name):
+        logger.error(
+            f"No backup collection '{backup_name}' found — this rollback needs the collection "
+            "the upgrade set aside. Without it the only way back is to re-create the collection "
+            "with the old analyzer and re-index."
+        )
+        return
+    if client.has_collection(aside_name):
+        raise RuntimeError(f"Collection '{aside_name}' already exists — inspect and drop it before rolling back.")
+
+    logger.info(
+        f"{'[DRY-RUN] ' if dry_run else ''}Rolling back:\n"
+        f"  '{collection_name}' → '{aside_name}' (v2, kept aside)\n"
+        f"  '{backup_name}' → '{collection_name}' (v1, restored)"
+    )
+    if dry_run:
+        logger.info("[DRY-RUN] Dry-run complete. No changes were made.")
+        return
+
+    client.rename_collection(collection_name, aside_name)
+    client.rename_collection(backup_name, collection_name)
+    _stamp_version(client, collection_name, TARGET_VERSION - 1)
+    client.load_collection(collection_name)
+    logger.warning(
+        f"Rollback complete. Rows indexed after the upgrade remain only in '{aside_name}' and are NOT "
+        "in the restored collection."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Milvus migration: case-insensitive BM25 analyzer (v1 → v2)")
+    parser.add_argument("--dry-run", action="store_true", help="Inspect only, make no changes")
+    parser.add_argument(
+        "--downgrade",
+        action="store_true",
+        help="Swap the v1 backup collection back into place",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config()
+    host = cfg.vectordb.host
+    port = cfg.vectordb.port
+    collection_name = cfg.vectordb.collection_name
+    uri = f"http://{host}:{port}"
+
+    logger.info(f"Connecting to Milvus at {uri}, collection='{collection_name}'")
+    client = MilvusClient(uri=uri)
+
+    if not client.has_collection(collection_name):
+        logger.error(f"Collection '{collection_name}' does not exist. Aborting.")
+        sys.exit(1)
+
+    if args.downgrade:
+        downgrade(client, collection_name, dry_run=args.dry_run)
+    else:
+        upgrade(client, collection_name, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -115,12 +115,17 @@ _SEARCH_RESULT_DROPPED_KEYS = frozenset({"vector"})
 #: stays under Milvus's result-size cap for any realistic embedder.
 _UNKNOWN_VECTOR_DIM = 4096
 
-#: BM25 analyzer params for the ``text`` field — standard tokenizer plus
-#: OpenRAG-specific stop words so chunk-boundary / image-placeholder markers
-#: don't pollute lexical scores.
+#: BM25 analyzer for the ``text`` field. A custom analyzer (``tokenizer`` +
+#: ``filter``) inherits nothing, unlike the built-in ``{"type": "standard"}``,
+#: so ``lowercase`` is listed explicitly and must come first: Milvus runs this
+#: analyzer on the query too, and the ``_english_`` / ``_french_`` lists are
+#: lowercase. The marker stop words are inert — the tokenizer splits
+#: ``<image_description>`` into ``image`` + ``description`` — and are left as a
+#: no-op rather than stop-listed as those (far too common) words.
 analyzer_params: dict[str, Any] = {
     "tokenizer": "standard",
     "filter": [
+        "lowercase",
         {
             "type": "stop",
             "stop_words": [
@@ -133,7 +138,7 @@ analyzer_params: dict[str, Any] = {
                 "[CHUNK_END]",
                 "[CONTEXT]",
             ],
-        }
+        },
     ],
 }
 

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -21,7 +21,7 @@ from pymilvus import MilvusException
 from openrag.core.config.infrastructure import VectorDBConfig
 from openrag.core.models.chunk import Chunk, ChunkType
 from openrag.core.utils.exceptions import VDBSearchError
-from openrag.services.storage.milvus_store import MilvusVectorStore
+from openrag.services.storage.milvus_store import MilvusVectorStore, analyzer_params
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -727,3 +727,33 @@ class TestParseSearchResponse:
 
     def test_empty_response_is_empty_list(self, store: MilvusVectorStore) -> None:
         assert store._parse_search_response([]) == []
+
+
+# ---------------------------------------------------------------------------
+# BM25 text analyzer
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzerParams:
+    """A missing filter here silently skews BM25 rather than raising."""
+
+    def test_declares_a_lowercase_filter(self) -> None:
+        # A custom analyzer inherits nothing; without this, `Rapport` and
+        # `rapport` are distinct BM25 terms.
+        assert "lowercase" in analyzer_params["filter"]
+
+    def test_lowercase_precedes_the_stop_filter(self) -> None:
+        # The `_english_` / `_french_` lists are lowercase, so they only match
+        # folded tokens.
+        filters = analyzer_params["filter"]
+        stop_index = next(i for i, f in enumerate(filters) if isinstance(f, dict) and f.get("type") == "stop")
+        assert filters.index("lowercase") < stop_index
+
+    def test_wired_onto_the_text_field(self, store: MilvusVectorStore) -> None:
+        store._embedding_dimension = 8
+        store._create_schema()
+
+        add_field = store._client.create_schema.return_value.add_field
+        text_calls = [c for c in add_field.call_args_list if c.kwargs.get("field_name") == "text"]
+        assert len(text_calls) == 1
+        assert text_calls[0].kwargs["analyzer_params"] is analyzer_params


### PR DESCRIPTION
Closes #870.

`analyzer_params` declared a **custom** analyzer (`"tokenizer": "standard"` plus an explicit filter chain) instead of the built-in `{"type": "standard"}`. A custom analyzer inherits nothing, so this silently dropped the `lowercase` filter the built-in one bundles: `Rapport` and `rapport` were distinct BM25 terms, and since Milvus applies the same analyzer to the query, a case mismatch scored zero on the lexical leg of hybrid search. Dense retrieval was unaffected, which is why it went unnoticed. Present since cef0e878.

Fix: `lowercase` first in the chain — order matters, the `_english_` / `_french_` stop-word lists are lowercase, so today `the` is stripped but `The` is not. The marker stop words (`<image_description>`, `[CHUNK_START]`, ...) are left alone and documented as inert: the tokenizer splits them, and their split forms are ordinary words that would strip real content.

## Migration

`analyzer_params` can't be altered while `enable_match` is set (and `enable_match` is immutable), and `add_function_field` — which would re-attach BM25 and backfill the sparse column in place — needs Storage V3, off by default. Both probed against Milvus 3.0.0; transcript in the comment below.

So `schema_version` goes 1 → 2 and `2.lowercase_bm25_analyzer.py` copies the rows into `<collection>_v2_rebuild`, verifies the counts and swaps the names, keeping the old collection as `<collection>_v1_backup`. Nothing is re-embedded — dense vectors are copied verbatim, sparse ones regenerated server-side on insert. Dense-only deployments are only re-stamped. Chunk `_id`s change (`auto_id`); Postgres keys on `file_id`, so only MCP chunk IDs handed out earlier go stale.

## Testing

2542 unit tests, ruff, layer-import guard. New unit tests cover the filter, its ordering and the wiring onto `text`. The migration was run end to end against a real Milvus 3.0.0 on a throwaway 25-row collection with dynamic fields, nulls and a `TIMESTAMPTZ`:

| | rows | `bm25("rapport")` | `bm25("RAPPORT")` | `bm25("Le")` |
|---|---|---|---|---|
| v1 | 25 | 12 | 0 | 13 |
| upgraded | 25 | 25 | 25 | 0 |
| downgraded | 25 | 12 | 0 | 13 |

Dry-run changed nothing, re-running the upgrade was a no-op, rollback restored the collection.

**Where the mismatch bites:** the check lives in `ensure_collection`, which only the indexing store stage calls — so an un-migrated deployment still boots and still answers searches (with the old analyzer), and fails the first upload with `Collection ... is at schema version 1 but the application requires version 2`. Verified against a live v1 collection. The rebuild, its ~2× disk need and the backup cleanup are documented in `milvus_migration.mdx`.
