### PR TITLE
chore(milvus): enable Storage V3

### DIFF
--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -271,7 +271,11 @@ For an opt-in named-volume profile, copy the values from `infra/compose/.env.nam
 | `MINIO_VOLUME` | `minio` | Milvus object storage named volume, used only with `MILVUS_COMPOSE=milvus/milvus.named-volumes.yaml`. |
 | `MILVUS_VOLUME` | `milvus` | Milvus named volume, used only with `MILVUS_COMPOSE=milvus/milvus.named-volumes.yaml`. |
 
-Milvus *server* settings are not env vars: they live in `infra/compose/milvus/user.yaml`, mounted at `/milvus/configs/user.yaml`. That file enables Storage V3 — see [Milvus Migrations](/openrag/documentation/milvus_migration/) before changing it, as it is irreversible.
+Milvus *server* settings are not env vars. They live in two places that must stay aligned:
+`infra/compose/milvus/user.yaml` for every compose stack (mounted at `/milvus/configs/user.yaml`), and
+`milvus.extraConfigFiles."user.yaml"` in `infra/charts/openrag-stack/values.yaml` for Helm, which cannot
+read a file outside its chart. Change both — a unit test fails if they drift. These files enable Storage V3;
+see [Milvus Migrations](/openrag/documentation/milvus_migration/) before changing them, as it is irreversible.
 
 ## Chat Pipeline
 ### LLM & VLM Configuration

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -271,6 +271,8 @@ For an opt-in named-volume profile, copy the values from `infra/compose/.env.nam
 | `MINIO_VOLUME` | `minio` | Milvus object storage named volume, used only with `MILVUS_COMPOSE=milvus/milvus.named-volumes.yaml`. |
 | `MILVUS_VOLUME` | `milvus` | Milvus named volume, used only with `MILVUS_COMPOSE=milvus/milvus.named-volumes.yaml`. |
 
+Milvus *server* settings are not env vars: they live in `infra/compose/milvus/user.yaml`, mounted at `/milvus/configs/user.yaml`. That file enables Storage V3 — see [Milvus Migrations](/openrag/documentation/milvus_migration/) before changing it, as it is irreversible.
+
 ## Chat Pipeline
 ### LLM & VLM Configuration
 The system uses two types of language models:

--- a/docs/content/docs/documentation/milvus_migration.mdx
+++ b/docs/content/docs/documentation/milvus_migration.mdx
@@ -226,6 +226,30 @@ docker inspect milvus-standalone --format '{{ .Config.Image }}'
 
 After verifying that the collections are readable and searchable on 2.6.11, continue with the 2.6-to-3.0 procedure above.
 
+## Storage V3
+
+Milvus 3.0 ships a versioned storage layout, "Storage V3" (Loon), which is **off by default**.
+OpenRAG turns it on because it gates `add_function_field` — the API that re-attaches the BM25
+function to an existing collection and backfills its sparse column through background
+compaction. Without it, changing the text analyzer means rebuilding the collection and copying
+every row; with it, the same change is three calls and a short backfill.
+
+The settings live in `infra/compose/milvus/user.yaml`, mounted read-only at
+`/milvus/configs/user.yaml` (the image merges `user.yaml` over its own `milvus.yaml`). Every
+compose stack — deployment, integration tests, load tests — mounts that one file; Helm carries
+the same content in `milvus.extraConfigFiles`, and a unit test asserts the two never drift.
+
+:::danger[Enabling Storage V3 is irreversible]
+Milvus writes the new on-disk format and cannot be downgraded to a version that does not
+understand it. Disabling the flag later does not convert data already written. Before the first
+start with V3 enabled, stop the stack and back up the `milvus`, `etcd` and `minio` volumes **as
+one set** — a partial copy leaves metadata and segments inconsistent.
+:::
+
+Existing collections do not need to be reindexed or recreated: a collection created before the
+flag was turned on accepts the new schema operations as soon as the server restarts with V3.
+New writes and compaction output adopt the new format; older segments convert in the background.
+
 ## Schema Migrations
 
 OpenRAG ships a generic migration runner that discovers and applies all pending Milvus schema migrations in order. You never need to invoke individual migration scripts by hand.

--- a/docs/content/docs/documentation/milvus_migration.mdx
+++ b/docs/content/docs/documentation/milvus_migration.mdx
@@ -236,8 +236,10 @@ every row; with it, the same change is three calls and a short backfill.
 
 The settings live in `infra/compose/milvus/user.yaml`, mounted read-only at
 `/milvus/configs/user.yaml` (the image merges `user.yaml` over its own `milvus.yaml`). Every
-compose stack — deployment, integration tests, load tests — mounts that one file; Helm carries
-the same content in `milvus.extraConfigFiles`, and a unit test asserts the two never drift.
+compose stack — deployment, integration tests, load tests — mounts that one file; Helm cannot read a
+file outside its chart, so it carries the same content in `milvus.extraConfigFiles."user.yaml"` in
+`infra/charts/openrag-stack/values.yaml`. **Changing one means changing the other** — a unit test
+fails if they drift.
 
 :::danger[Enabling Storage V3 is irreversible]
 Milvus writes the new on-disk format and cannot be downgraded to a version that does not

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -182,6 +182,21 @@ milvus:
   securityContext:
     fsGroup: 999
     fsGroupChangePolicy: Always
+  # Server config overrides, merged over the image's milvus.yaml by the sub-chart.
+  # Must stay identical to infra/compose/milvus/user.yaml, which is the source of
+  # truth for every compose stack (a unit test asserts the two agree). Storage V3
+  # is irreversible: back the volumes up before the first upgrade that enables it.
+  extraConfigFiles:
+    user.yaml: |+
+      common:
+        storage:
+          useLoonFFI: true
+      dataCoord:
+        compaction:
+          bumpSchemaVersion:
+            enabled: true
+          storageVersion:
+            enabled: true
   cluster: { enabled: true }
   pulsarv3: { enabled: false }
   woodpecker: { enabled: true }

--- a/infra/compose/milvus/milvus.named-volumes.yaml
+++ b/infra/compose/milvus/milvus.named-volumes.yaml
@@ -70,6 +70,9 @@ services:
       MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME:-milvus}:/var/lib/milvus
+      # Server config overrides (Storage V3). Read-only: Milvus only reads it
+      # at startup, and the init container must not have to chown it.
+      - ./user.yaml:/milvus/configs/user.yaml:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 30s

--- a/infra/compose/milvus/milvus.yaml
+++ b/infra/compose/milvus/milvus.yaml
@@ -72,6 +72,9 @@ services:
       MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in your .env}
     volumes:
       - ${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus
+      # Server config overrides (Storage V3). Read-only: Milvus only reads it
+      # at startup, and the init container must not have to chown it.
+      - ./user.yaml:/milvus/configs/user.yaml:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 30s

--- a/infra/compose/milvus/user.yaml
+++ b/infra/compose/milvus/user.yaml
@@ -1,0 +1,25 @@
+# Milvus server overrides, merged over the image's own /milvus/configs/milvus.yaml.
+# Mounted at /milvus/configs/user.yaml by every compose stack that runs Milvus;
+# the Helm path carries the same content in milvus.extraConfigFiles.
+#
+# Storage V3 ("Loon") is off by default in Milvus 3.0. It gates the schema
+# evolution OpenRAG's Milvus migrations rely on — chiefly `add_function_field`,
+# which re-attaches the BM25 function and backfills its sparse column over
+# existing rows through background compaction, instead of rebuilding the
+# collection.
+#
+# WARNING: enabling this is irreversible. Milvus writes the new on-disk format
+# and cannot be downgraded to a version that does not understand it. Back up the
+# milvus, etcd and minio volumes as one set before the first start.
+common:
+  storage:
+    useLoonFFI: true
+
+# Both compaction settings are required for the backfill: without them Milvus
+# rejects adding a function field to an existing collection.
+dataCoord:
+  compaction:
+    bumpSchemaVersion:
+      enabled: true
+    storageVersion:
+      enabled: true

--- a/infra/compose/milvus/user.yaml
+++ b/infra/compose/milvus/user.yaml
@@ -1,6 +1,8 @@
 # Milvus server overrides, merged over the image's own /milvus/configs/milvus.yaml.
-# Mounted at /milvus/configs/user.yaml by every compose stack that runs Milvus;
-# the Helm path carries the same content in milvus.extraConfigFiles.
+# Mounted at /milvus/configs/user.yaml by every compose stack that runs Milvus.
+# Helm cannot read a file outside its chart, so the same content is duplicated in
+# infra/charts/openrag-stack/values.yaml under milvus.extraConfigFiles."user.yaml":
+# edit both, or tests/unit/infra/test_compose_storage.py fails.
 #
 # Storage V3 ("Loon") is off by default in Milvus 3.0. It gates the schema
 # evolution OpenRAG's Milvus migrations rely on — chiefly `add_function_field`,

--- a/tests/integration/api/api_run/docker-compose.yaml
+++ b/tests/integration/api/api_run/docker-compose.yaml
@@ -62,6 +62,9 @@ services:
       ETCD_ENDPOINTS: etcd:2379
       ETCD_AUTH_ENABLED: "false"
       MINIO_ADDRESS: minio:9000
+    # Storage V3 overrides, shared with the deployment stacks (single source of truth).
+    volumes:
+      - ../../../../infra/compose/milvus/user.yaml:/milvus/configs/user.yaml:ro
     depends_on:
       etcd:
         condition: service_healthy

--- a/tests/integration/repos/docker-compose.yaml
+++ b/tests/integration/repos/docker-compose.yaml
@@ -34,6 +34,9 @@ services:
       ETCD_ENDPOINTS: etcd:2379
       ETCD_AUTH_ENABLED: "false"
       MINIO_ADDRESS: minio:9000
+    # Storage V3 overrides, shared with the deployment stacks (single source of truth).
+    volumes:
+      - ../../../infra/compose/milvus/user.yaml:/milvus/configs/user.yaml:ro
     ports:
       - "19530:19530"
       - "9091:9091"

--- a/tests/load/workspace/docker-compose.yml
+++ b/tests/load/workspace/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       MINIO_ADDRESS: minio:9000
     volumes:
       - milvus_data:/var/lib/milvus
+      # Storage V3 overrides, shared with the deployment stacks (single source of truth).
+      - ../../../infra/compose/milvus/user.yaml:/milvus/configs/user.yaml:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
       interval: 30s

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -33,7 +33,10 @@ def _assert_milvus_initializer(services: dict) -> None:
     assert initializer["user"] == "0:0"
     assert initializer["environment"]["LD_PRELOAD"] == ""
     assert initializer["entrypoint"] == ["/bin/sh", "-ec"]
-    assert initializer["volumes"] == milvus["volumes"]
+    # The initializer exists to chown the data volume, so that mount must match.
+    # It deliberately does not carry the milvus service's server-config mount.
+    data_mounts = [v for v in milvus["volumes"] if v.endswith(":/var/lib/milvus")]
+    assert initializer["volumes"] == data_mounts
     assert initializer["read_only"] is True
     assert initializer["cap_drop"] == ["ALL"]
     assert initializer["cap_add"] == ["CHOWN", "DAC_READ_SEARCH"]
@@ -74,7 +77,7 @@ def test_milvus_compose_defaults_preserve_existing_host_paths() -> None:
 
     assert services["etcd"]["volumes"] == ["${MILVUS_VOLUME_DIRECTORY:-./volumes}/etcd:/etcd"]
     assert services["minio"]["volumes"] == ["${MILVUS_VOLUME_DIRECTORY:-./volumes}/minio:/minio_data"]
-    assert services["milvus"]["volumes"] == ["${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus"]
+    assert "${MILVUS_VOLUME_DIRECTORY:-./volumes}/milvus:/var/lib/milvus" in services["milvus"]["volumes"]
 
     _assert_milvus_initializer(services)
     assert services["milvus"]["environment"]["ETCD_AUTH_ENABLED"] == "false"
@@ -99,7 +102,7 @@ def test_named_volume_profile_is_opt_in() -> None:
 
     assert named_milvus["services"]["etcd"]["volumes"] == ["${ETCD_VOLUME:-etcd}:/etcd"]
     assert named_milvus["services"]["minio"]["volumes"] == ["${MINIO_VOLUME:-minio}:/minio_data"]
-    assert named_milvus["services"]["milvus"]["volumes"] == ["${MILVUS_VOLUME:-milvus}:/var/lib/milvus"]
+    assert "${MILVUS_VOLUME:-milvus}:/var/lib/milvus" in named_milvus["services"]["milvus"]["volumes"]
     assert named_milvus["services"]["milvus"]["image"] == "milvusdb/milvus:v3.0.0"
     assert named_milvus["services"]["milvus"]["environment"]["ETCD_AUTH_ENABLED"] == "false"
     assert named_milvus["services"]["milvus"]["environment"]["MQ_TYPE"] == "${MILVUS_MQ_TYPE:-default}"
@@ -144,3 +147,44 @@ def test_helm_storage_is_pvc_based_without_host_paths() -> None:
     assert values["postgresql"]["primary"]["persistence"]["enabled"] is True
     assert values["milvus"]["minio"]["persistence"]["enabled"] is True
     assert values["milvus"]["etcd"]["persistence"]["enabled"] is True
+
+
+def test_storage_v3_is_enabled_for_every_milvus_stack() -> None:
+    """Storage V3 gates `add_function_field`, which the Milvus migrations rely on.
+
+    It has to be on wherever Milvus runs — including CI, so migrations are
+    exercised on the same storage engine production uses.
+    """
+    config = _load_yaml(COMPOSE_DIR / "milvus" / "user.yaml")
+
+    assert config["common"]["storage"]["useLoonFFI"] is True
+    # Both compaction settings are required for the function-field backfill.
+    assert config["dataCoord"]["compaction"]["bumpSchemaVersion"]["enabled"] is True
+    assert config["dataCoord"]["compaction"]["storageVersion"]["enabled"] is True
+
+    stacks = {
+        COMPOSE_DIR / "milvus" / "milvus.yaml": "./user.yaml",
+        COMPOSE_DIR / "milvus" / "milvus.named-volumes.yaml": "./user.yaml",
+        ROOT / "tests" / "integration" / "repos" / "docker-compose.yaml": "../../../infra/compose/milvus/user.yaml",
+        ROOT
+        / "tests"
+        / "integration"
+        / "api"
+        / "api_run"
+        / "docker-compose.yaml": "../../../../infra/compose/milvus/user.yaml",
+        ROOT / "tests" / "load" / "workspace" / "docker-compose.yml": "../../../infra/compose/milvus/user.yaml",
+    }
+    for path, source in stacks.items():
+        volumes = _load_yaml(path)["services"]["milvus"]["volumes"]
+        assert f"{source}:/milvus/configs/user.yaml:ro" in volumes, path
+
+
+def test_helm_milvus_config_matches_the_compose_one() -> None:
+    """Helm cannot read a file outside the chart, so the content is duplicated.
+
+    Compare the parsed documents rather than the text: the two must not drift.
+    """
+    compose_config = _load_yaml(COMPOSE_DIR / "milvus" / "user.yaml")
+    values = _load_yaml(CHART_DIR / "values.yaml")
+
+    assert yaml.safe_load(values["milvus"]["extraConfigFiles"]["user.yaml"]) == compose_config


### PR DESCRIPTION
Enables Milvus Storage V3 ("Loon") across every stack that runs Milvus. Standalone infrastructure change — it does not fix or depend on anything else, and nothing in the app behaves differently once it is on.

## Why

Storage V3 is off by default in Milvus 3.0. It gates `add_function_field` — the API that attaches a function (BM25, MinHash) to an **existing** collection and backfills its generated column through background compaction. Without it, any change to a text analyzer or a function field means rebuilding the collection and copying every row (PR #871 was 450 lines of exactly that). With it, the same change is three calls and a short backfill.

That makes it the prerequisite for the schema evolution we want next — the BM25 analyzer fix (#870) and, later, changing embeddings without a full re-ingest (#762) — but it is worth having on its own: it is the storage format Milvus 3 is moving to, and turning it on later costs the same as turning it on now, only with more data to convert.

## What changed

There was no Milvus **server** config anywhere in the repo — every path configured it through env vars, and `common.storage.*` has no env template. So this adds one file and wires it into every stack:

- `infra/compose/milvus/user.yaml` — the settings, mounted read-only at `/milvus/configs/user.yaml`, where the image merges it over its own `milvus.yaml`.
- Mounted by all five stacks that run Milvus: both deployment profiles (bind-mount and named-volume), both CI stacks, and the load bench. CI therefore exercises the same storage engine production runs.
- Helm can't read a file outside its chart, so the same content is duplicated into `milvus.extraConfigFiles`. A unit test parses both and asserts they never drift.
- The `milvus` service now carries a second mount, so the two compose guards that asserted exact volume lists are narrowed to the data mount they actually guard. The init container still has to chown the same `/var/lib/milvus` volume, and that equality is kept.

Three settings are needed, not one: `common.storage.useLoonFFI` plus `dataCoord.compaction.bumpSchemaVersion.enabled` and `dataCoord.compaction.storageVersion.enabled` — Milvus refuses to add a function field to an existing collection without the latter two.

## Verification

Probed against an isolated Milvus 3.0.0 (own compose project, ephemeral volumes, torn down after):

| Question | Answer |
|---|---|
| Does a collection created **before** the flag accept `add_function_field`? | **Yes** — immediately after the server restart, no forced compaction |
| Does `drop_function_field` → `alter_collection_field(analyzer_params=…)` → `add_function_field` work? | **Yes** |
| Does the backfill reprocess pre-existing rows? | **Yes** — a BM25 query for `rapport` went 10/20 → **20/20 in 25s** on pre-V3 data (40s on post-V3 data); `RAPPORT` 0 → 20 |
| Is `enable_match` alterable under V3? | **No** — refused on both pre- and post-V3 collections, so shedding it still costs one rebuild |

Also in this repo:

- `uv run pytest tests/unit/` — 2545 passed (3 new); ruff clean.
- `docker compose config` on all five stacks resolves the mount to the same single file.
- The vendored milvus subchart renders our values into a ConfigMap mounted at `/milvus/configs/user.yaml` via `subPath` — same target as the compose mount. (The parent chart does not `helm template` locally for a pre-existing reason: its vendored deps are stale versus `Chart.lock`, and CI runs `helm dependency update` first.)

## Operator impact

**Enabling Storage V3 is irreversible.** Milvus writes the new on-disk format and cannot be downgraded to a version that cannot read it; disabling the flag later does not convert data already written. Before the first start after this merges, stop the stack and back up the `milvus`, `etcd` and `minio` volumes **as one set** — a partial copy leaves metadata and segments inconsistent. Documented in `milvus_migration.mdx` under a new `## Storage V3` section.

No reindex is needed: existing collections stay readable, new writes and compaction output adopt the new format, and older segments convert in the background.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Milvus Storage V3 to support schema-evolution migrations and background sparse-data backfilling.
  * Applied consistent Storage V3 configuration across Compose, Helm, and test environments.

* **Documentation**
  * Added migration guidance, backup requirements, configuration details, and reversibility warnings.
  * Clarified that existing collections do not need to be recreated or reindexed.

* **Tests**
  * Added coverage verifying Storage V3 configuration and consistency across deployment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
