### PR TITLE
feat(ui): mark new features with a badge that expires on its own

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,54 @@ jobs:
             exit 1
           fi
 
+      # A NEW badge is data, not markup: each entry in ui/src/lib/whats-new.ts
+      # records the version its feature shipped in, and the badge expires on its
+      # own once the running version is far enough past it. An entry still
+      # reading UNRELEASED has no version to expire against, so it badges every
+      # user forever — and silently, because nobody inspects a dropdown
+      # expecting an option *not* to say NEW. Resolving them belongs to the
+      # release branch, in the same commit that bumps pyproject.toml (see
+      # "Releases" in CONTRIBUTING.md). This is the gate that turns forgetting
+      # that step into a failed release rather than a permanent badge.
+      - name: Verify every NEW badge has been resolved to a version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          registry=ui/src/lib/whats-new.ts
+
+          # A registry we cannot read is not a clean registry. Asked as an `if`
+          # condition, grep's "file missing" (exit 2) is indistinguishable from
+          # "no matches" (exit 1), so a moved or renamed file would report OK
+          # here and the backstop would be gone without anyone noticing.
+          if [ ! -r "$registry" ]; then
+            echo "::error::$registry is missing or unreadable, so the NEW badge gate cannot run. If the registry moved, update this step."
+            exit 1
+          fi
+
+          # Anchored to a whole registry line — indent, quoted key, colon, and
+          # an optional trailing comma, which the last entry in the object may
+          # legally omit — so the sentinel's own definition and the prose that
+          # explains it cannot trip the gate, and an entry written without the
+          # comma cannot slip past it.
+          set +e
+          unresolved=$(grep -nE '^ *"[^"]+": *"UNRELEASED",? *$' "$registry")
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            echo "::error::$registry has unresolved NEW badge entries; they would badge forever. Set them to ${TAG_NAME#v} on the release branch (CONTRIBUTING.md -> Releases) before tagging."
+            echo "$unresolved"
+            exit 1
+          fi
+
+          # Only exit 1 means a genuine no-match; anything else is grep failing.
+          if [ "$status" -ne 1 ]; then
+            echo "::error::could not search $registry for unresolved NEW badge entries (grep exited $status)."
+            exit 1
+          fi
+
+          echo "OK: no unresolved NEW badge entries"
+
   build-and-push-image:
     needs: verify-tag
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,46 @@ Once cut:
 - `release/X.Y.Z` takes **only** release preparation — bug fixes, version bumps, changelog, docs. **No new features.**
 - `develop` reopens immediately for the next cycle's features (they proceed in parallel).
 
+#### Bumping the version
+
+The version is typed in exactly one place, `pyproject.toml` — `/version` is served from that file's
+installed metadata, so it is also the number the running app reports.
+
+One other file has to follow it. `ui/src/lib/whats-new.ts` drives the **NEW** badges in the admin UI
+([FEATURE_TAG.md](FEATURE_TAG.md) explains the mechanism and how to tag a feature):
+each entry records the version its feature shipped in, and the badge expires on its own a couple of
+minors later, so nobody has to remember to delete it. A feature PR cannot know its release number —
+this branch is where that number is chosen — so feature PRs write `UNRELEASED` and the release
+resolves it.
+
+Do both in the `chore(release): bump version to X.Y.Z` commit, and read the second from the first
+rather than typing the number twice:
+
+```bash
+# 1. edit pyproject.toml's `version` to X.Y.Z, then read it back:
+VER=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)
+[ -n "$VER" ] || { echo "no version found in pyproject.toml — aborting"; exit 1; }
+
+# 2. resolve every pending NEW badge to it
+registry=ui/src/lib/whats-new.ts
+sed -E "s/^( *\"[^\"]+\": *)\"UNRELEASED\"(,?) *\$/\1\"$VER\"\2/" "$registry" > "$registry.new" \
+  && mv "$registry.new" "$registry"
+```
+
+The guard is not ceremony: an empty `$VER` — a renamed field, a moved `version` line — would otherwise
+write `""` into every pending entry, which parses as nothing and silences the badges it was meant to
+switch on. The rewrite goes through a temporary file rather than `sed -i`, whose in-place flag differs
+between GNU and BSD `sed` and fails outright on macOS.
+
+The pattern is anchored to a whole registry line — indent, quoted key, colon, and an optional
+trailing comma (the last entry in the object may legally omit it, and the replacement keeps whichever
+form was there) — so it cannot touch the `UNRELEASED` constant itself or this paragraph. A looser
+match on the bare string corrupts both, silently.
+
+An entry left unresolved badges every user forever, and nobody notices, because nobody inspects a
+dropdown expecting an option *not* to say NEW. So `verify-tag` in `.github/workflows/build.yml`
+refuses to publish GA images while any entry is still unresolved.
+
 When the release is ready:
 
 1. Merge `release/X.Y.Z` into `main`.

--- a/FEATURE_TAG.md
+++ b/FEATURE_TAG.md
@@ -1,0 +1,260 @@
+# Feature tagging — the **NEW** badge
+
+A small marker that tells a reader of the admin UI "this wasn't here last time you looked", and
+that **removes itself**.
+
+## The idea
+
+A NEW marker is only useful if someone takes it down. Nobody does. Written as markup, it becomes
+permanent decoration: it tells the reader nothing, and the cleanup lands in a release that has no
+other reason to touch the file.
+
+So the marker is *data*. One registry — [`ui/src/lib/whats-new.ts`](ui/src/lib/whats-new.ts) — maps
+a **feature key** to the version that feature shipped in, and the badge stops rendering once the
+running app is far enough past that version. Forgetting to delete an entry costs nothing: it expires
+on its own, and the dead line can be swept up whenever anyone happens to notice.
+
+Two consequences worth knowing up front:
+
+- **Nothing decides "which feature is newest."** Each entry carries its own anchor and answers the
+  same independent question: *is the running version within the window of the version I shipped in?*
+  Entries never interact, so adding one is never a re-ordering exercise.
+- **Marking a feature is a one-line data change.** The JSX that renders a badge asks about a key; it
+  does not know which keys are live. Adding an entry lights it up, and removing one puts it out.
+
+## When a badge shows
+
+The window is `NEW_FOR_MINORS` (currently **2**) minor releases wide, counted from the version in the
+registry. For an entry pinned to `2.2.0`:
+
+| app reports | badge | why |
+|---|---|---|
+| `2.1.1` | ✅ | older than the feature — it isn't there at all, so nothing renders anyway |
+| `2.2.0` → `2.3.0` | ✅ | inside the window |
+| `2.4.0` | ❌ | window passed |
+| `3.0.0` | ❌ | a major bump always expires it |
+| `UNRELEASED` entry | ✅ | merged but untagged — new to everyone running a build that has it |
+| `unknown` / unreadable | ❌ | fails closed |
+
+Failing closed is deliberate: one unbadged new feature beats *every* feature badged forever on a
+deployment whose `/version` cannot be read. "Unreadable" means the whole string has to be a version,
+not merely start like one — `2.2rubbish` is rejected rather than read as `2.2`. What counts is wider
+than SemVer, because `/version` serves `importlib.metadata` and therefore PEP 440: `2.2.0rc1`,
+`2.1.1.post1` and `2.2.0.dev3` all compare normally, so badges do not blank out on an RC deployment.
+
+## Two markers: the dot and the word
+
+The same registry entry can surface in two shapes, and which one you reach for is a question about
+*where* the marker sits, not about the feature.
+
+| | shape | says | use it on |
+|---|---|---|---|
+| **word** | `NEW` pill in the brand accent | *this, here, is the new thing* | the thing itself: an option in an open list, a tab, a nav item, a card header |
+| **dot** | 6px amber circle, sitting high | *there is something in here* | a **collapsed** control's label, where the new thing is out of sight until the reader opens it |
+
+A collapsed control is the case that needs both:
+
+```text
+Strategy •                     ← dot on the label: something inside is new
+┌──────────────────────┐
+│ recursive_splitter   │       ← closed trigger stays clean
+└──────────────────────┘
+   ▼ opened
+   ┌────────────────────────────────┐
+   │ recursive_splitter             │
+   │ structured_section  [NEW]      │  ← the word, on the thing itself
+   └────────────────────────────────┘
+```
+
+The dot gets the reader to open the list; the word tells them what they came for. A dot alone would
+never say *what* is new, and the word alone would be invisible until they had already found it —
+which is the discovery problem the marker exists to solve.
+
+Three properties of the dot worth knowing:
+
+- **It has a name.** It renders as `role="img"` with an accessible name (`"New options available"` by
+  default, overridable with `label`), because a bare dot tells a screen reader nothing and a sighted
+  reader not much more. It is also its own `title`, so hovering explains it.
+- **It is amber, not the brand accent.** A crimson dot beside a form label reads as *required* or
+  *invalid* — the red-asterisk convention — which is the one thing it must not mean. Amber is not
+  free of associations either (this UI uses yellow for `QUEUED`/`PENDING` and amber for the
+  super-admin banner), so if that collides in a new context, the colour is one class in `NewDot`.
+- **It positions itself.** `inline-block` so that its 6px survives outside a flex row (width and
+  height do not apply to an inline element); then `self-start` in a flex label and `align-super` in
+  an inline one, each ignored in the other context, so it sits high either way without the caller
+  arranging anything.
+
+Both come from the same entry and expire on the same day. Nothing here animates: a 6px dot that
+pulses in a settings form reads as an alert, not a hint.
+
+## Feature keys
+
+A key is any stable dotted string. Two conventions:
+
+- **An option inside a control** → `"<group>.<value>"`, e.g. `"chunking.structured_section"`. The
+  group scoping matters: two dropdowns can legitimately offer the same option string, and a bare key
+  would badge both the day that happens.
+- **Anything else** (a page, a tab, a section, an action) → whatever names it stably, e.g.
+  `"models.reranker"`, `"nav.workspaces"`, `"presets.tab.retrieval"`.
+
+## Tagging something
+
+### 1. Register the key
+
+```ts
+// ui/src/lib/whats-new.ts
+export const NEW_SINCE: Readonly<Record<string, string>> = {
+  "chunking.structured_section": "UNRELEASED",
+};
+```
+
+Always `UNRELEASED`, never a guessed version — see [Release time](#release-time) below.
+
+### 2. Attach it
+
+Everything below comes from [`ui/src/components/shared/new-badge.tsx`](ui/src/components/shared/new-badge.tsx).
+
+#### A new option in a dropdown
+
+The awkward case, and the only one with a rule of its own: a badge that lives *inside* an unopened
+dropdown aids no discovery, because the reader has to be looking at it already. So the marker goes on
+the collapsed control **as well as** the option. `useNewOptions` gives you both, and derives each
+option's key from the group named once:
+
+```tsx
+const newChunking = useNewOptions("chunking", chunkingStrategies);
+
+<Label className="flex items-center gap-1.5 text-xs">
+  Strategy
+  {newChunking.dot}             {/* set when *any* option below is new */}
+</Label>
+<Select value={…} onValueChange={…}>
+  <SelectTrigger size="sm"><SelectValue /></SelectTrigger>
+  <SelectContent>
+    {chunkingStrategies.map((s) => (
+      <SelectItem key={s} value={s} textValue={s}>
+        <span className="flex items-center gap-1.5">
+          {s}
+          {newChunking.badgeFor(s)}
+        </span>
+      </SelectItem>
+    ))}
+  </SelectContent>
+</Select>
+```
+
+`dot` keeps a dense form row narrow; swap in `badge` where there is room for the word on the
+collapsed control — the two are interchangeable and expire together (see
+[Two markers](#two-markers-the-dot-and-the-word)).
+
+Two details that are easy to get wrong:
+
+- **`textValue={s}`.** Radix derives an item's typeahead text from its children, so without it the
+  badge joins the search string and the option answers to `"structured_sectionNEW"`.
+- **`values` comes from what the surface actually renders** — here the API's option list — so an
+  option this backend doesn't offer is never badged, even while the registry carries its key.
+
+You do *not* need to keep the badge out of the closed trigger by hand. Radix mirrors the selected
+option's children into the trigger; the marker hides that copy itself, which is what lets it be a
+plain child here instead of being threaded through a slot on the select.
+
+#### A new tab, section, page or action
+
+Nothing special: render the marker where it belongs. It returns `null` when the feature isn't new, so
+it can be dropped in unconditionally. (An unreadable version silences a *pinned* entry, since there is
+nothing to compare it against; an `UNRELEASED` one still shows, having no version to compare in the
+first place.)
+
+A new model type in the endpoints page:
+
+```tsx
+// ui/src/pages/admin/models.tsx — MODEL_TYPES gained "reranker"
+<TabsTrigger key={t} value={t} className="capitalize">
+  {t}
+  <NewBadge feature={`models.${t}`} />
+</TabsTrigger>
+```
+
+…and the same component on a card header, a page header, or a sidebar entry:
+
+```tsx
+<CardTitle className="text-base">Endpoints <NewBadge feature="models.endpoints" /></CardTitle>
+```
+
+```tsx
+<span className="truncate">{item.title}</span>
+<NewBadge feature={`nav.${item.href}`} />
+```
+
+A dot outside a dropdown — a nav entry whose new page is one click away, say — is the same component
+gated by the key yourself:
+
+```tsx
+{useIsNew("nav.workspaces") && <NewDot label="New page" />}
+```
+
+#### Checking your work
+
+An `UNRELEASED` entry badges regardless of what `/version` reports, so `npm run dev` in `ui/` shows
+the marker on its own — no backend needed. A *pinned* entry needs a readable version to compare
+against, and renders nothing without one.
+
+#### Just the decision
+
+For a surface that wants to mark itself some other way — a dot, an ordering nudge, an expanded-by-
+default section:
+
+```tsx
+const isNew = useIsNew("models.reranker");
+```
+
+## Release time
+
+The version a feature ships in **is not knowable when its PR is written**: a `release/X.Y.Z` branch is
+cut once the features for that version are complete, so the number is chosen afterwards, sometimes
+weeks later. Any pin written during development is a prediction, and wrong the moment the release plan
+moves.
+
+So entries are authored as `UNRELEASED` and resolved by the release branch, in the same commit that
+bumps `pyproject.toml` — reading the version back from that file rather than retyping it, so the two
+cannot diverge. The command lives in **CONTRIBUTING.md → Releases → Bumping the version**, and only
+there, so the two cannot drift.
+
+An unresolved entry badges every user forever, and silently — nobody inspects a dropdown expecting an
+option *not* to say NEW. So `verify-tag` in [`.github/workflows/build.yml`](.github/workflows/build.yml)
+refuses to publish GA images while any entry still reads `UNRELEASED`. Forgetting the step fails the
+release instead of shipping a permanent badge.
+
+### What the gate does not cover
+
+`verify-tag` runs on GA tags only (`refs/tags/v*`, RC tags excluded — `build_rc.yml` owns those). So an
+`UNRELEASED` entry badges freely on `develop`, on RC images and on anything self-built, and nothing
+stops it there.
+
+That is the design rather than a hole: `UNRELEASED` means *merged but not yet in a release*, and
+everyone running such a build is in fact seeing the feature for the first time. What the gate
+guarantees is narrower and is the part that matters — an unresolved entry cannot reach a GA release,
+where it would badge forever. Between merge and release the marker is correct; the exposure is bounded
+by the next GA tag, which cannot happen while any entry is still unresolved.
+
+Both the release one-liner and the gate anchor on a whole registry line — indent, quoted key, colon,
+and an optional trailing comma, since the last entry in the object may legally omit it. That is why
+the commented examples in `whats-new.ts` are invisible to them, and why a looser pattern must not be
+substituted: it would rewrite the `UNRELEASED` constant itself, turning the
+sentinel into a version and breaking every future entry.
+
+## Retiring an entry
+
+Optional, and never urgent — an expired entry renders nothing. Delete the line whenever you notice it;
+no test or workflow depends on any particular key being present.
+
+## Where the pieces live
+
+| file | role |
+|---|---|
+| `ui/src/lib/whats-new.ts` | the registry, the window rule, and nothing about the UI |
+| `ui/src/components/shared/new-badge.tsx` | `NewBadge`, `NewDot`, `useNewOptions`, `useIsNew` — attaching a marker |
+| `ui/src/lib/whats-new.test.ts` | the window rule and the registry lookup |
+| `ui/src/components/shared/new-badge.test.tsx` | attachment, including the select-trigger case |
+| `.github/workflows/build.yml` | the `UNRELEASED` gate on GA tags |
+| `CONTRIBUTING.md` | the release-time command that resolves entries |

--- a/ui/src/components/shared/new-badge.test.tsx
+++ b/ui/src/components/shared/new-badge.test.tsx
@@ -1,0 +1,221 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getVersion } from "@/lib/api/system";
+import { hasNewIn, isNew } from "@/lib/whats-new";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { NewBadge, NewDot, useIsNew, useNewOptions } from "./new-badge";
+
+// The registry itself is covered by lib/whats-new.test.ts. These tests are
+// about attachment: that any surface gets the marker from a feature key alone,
+// that the key it asks about is the one the surface declares, and that a marker
+// dropped into a select does not surface twice.
+vi.mock("@/lib/whats-new", () => ({ isNew: vi.fn(), hasNewIn: vi.fn() }));
+vi.mock("@/lib/api/system", () => ({ getVersion: vi.fn() }));
+
+const isNewMock = vi.mocked(isNew);
+const hasNewInMock = vi.mocked(hasNewIn);
+const getVersionMock = vi.mocked(getVersion);
+
+/** Render under a fresh QueryClient, since every test drives `/version` itself. */
+function renderWithQuery(ui: React.ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+beforeAll(() => {
+  // Radix needs these to open a select under jsdom.
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getVersionMock.mockResolvedValue({ version: "2.2.0" });
+});
+
+describe("NewBadge", () => {
+  it("marks a feature that is still new, whatever surface it is dropped on", async () => {
+    isNewMock.mockReturnValue(true);
+    renderWithQuery(<NewBadge feature="nav.workspaces" />);
+
+    expect(await screen.findByText("NEW")).not.toBeNull();
+    await waitFor(() => expect(isNewMock).toHaveBeenCalledWith("nav.workspaces", "2.2.0"));
+  });
+
+  it("renders nothing once the feature has expired", async () => {
+    isNewMock.mockReturnValue(false);
+    renderWithQuery(<NewBadge feature="nav.workspaces" />);
+
+    await waitFor(() => expect(getVersionMock).toHaveBeenCalled());
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+
+  it("renders nothing while the app version is unknown", () => {
+    // The version query has not resolved (and may never, on a deployment whose
+    // /version cannot be read): the rule fails closed on `undefined`.
+    isNewMock.mockImplementation((_feature, version) => version === "2.2.0");
+    renderWithQuery(<NewBadge feature="nav.workspaces" />);
+
+    expect(screen.queryByText("NEW")).toBeNull();
+  });
+});
+
+describe("NewDot", () => {
+  // The documented pattern for a dot outside a dropdown: the caller gates it on
+  // the key, so the dot itself is presentational.
+  /**
+   * A surface outside any dropdown, written the way FEATURE_TAG.md documents it:
+   * the caller gates on the key, so the dot itself stays presentational.
+   */
+  function NavEntry() {
+    return <>{useIsNew("nav.workspaces") && <NewDot label="New page" />}</>;
+  }
+
+  it("renders under a caller-supplied name", () => {
+    isNewMock.mockReturnValue(true);
+    renderWithQuery(<NavEntry />);
+
+    const dot = screen.getByRole("img", { name: "New page" });
+    expect(dot).not.toBeNull();
+    // The dot is sized, not filled, so it needs a box: width and height do not
+    // apply to a non-replaced inline element, and this surface is not a flex
+    // row. jsdom does no layout, so the class carrying that is what is
+    // observable here.
+    expect(dot.className).toContain("inline-block");
+  });
+
+  it("is absent when the feature is not new", () => {
+    isNewMock.mockReturnValue(false);
+    renderWithQuery(<NavEntry />);
+
+    expect(screen.queryByRole("img", { name: "New page" })).toBeNull();
+  });
+});
+
+describe("useNewOptions", () => {
+  /** A group of options rendered with both markers the hook hands back. */
+  function Options({ values }: { values: string[] }) {
+    const options = useNewOptions("chunking", values);
+    return (
+      <div>
+        <span data-testid="group">
+          group{options.dot}
+          {options.badge}
+        </span>
+        {values.map((value) => (
+          <span key={value} data-testid={`option-${value}`}>
+            {value}
+            {options.badgeFor(value)}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  it("marks the collapsed control when any option inside is new, and only the new option", async () => {
+    // Version-sensitive, so the assertions below only pass once the version the
+    // query fetched has actually reached the rule.
+    hasNewInMock.mockImplementation((_group, _values, version) => version === "2.2.0");
+    isNewMock.mockImplementation(
+      (feature, version) => version === "2.2.0" && feature === "chunking.structured_section"
+    );
+    renderWithQuery(<Options values={["recursive_splitter", "structured_section"]} />);
+
+    await waitFor(() => expect(screen.getByTestId("group").textContent).toBe("groupNEW"));
+    // The quiet marker for a collapsed control, and it says what it means to a
+    // reader who cannot see that it is a dot.
+    expect(screen.getByRole("img", { name: /new options available/i })).not.toBeNull();
+    expect(screen.getByTestId("option-structured_section").textContent).toBe("structured_sectionNEW");
+    expect(screen.getByTestId("option-recursive_splitter").textContent).toBe("recursive_splitter");
+    // The key each option asks about is derived from the group named once.
+    expect(hasNewInMock).toHaveBeenCalledWith(
+      "chunking",
+      ["recursive_splitter", "structured_section"],
+      "2.2.0"
+    );
+    expect(isNewMock).toHaveBeenCalledWith("chunking.structured_section", "2.2.0");
+  });
+
+  it("leaves the control unmarked when nothing inside is new", async () => {
+    hasNewInMock.mockReturnValue(false);
+    isNewMock.mockReturnValue(false);
+    renderWithQuery(<Options values={["recursive_splitter"]} />);
+
+    await waitFor(() => expect(hasNewInMock).toHaveBeenCalledWith("chunking", ["recursive_splitter"], "2.2.0"));
+    expect(screen.getByTestId("group").textContent).toBe("group");
+    expect(screen.queryByRole("img", { name: /new options available/i })).toBeNull();
+  });
+});
+
+describe("the documented dropdown example (FEATURE_TAG.md)", () => {
+  /**
+   * The snippet the guide tells people to copy, rendered as written: the group
+   * named once, the collapsed control carrying the marker for what is inside,
+   * `textValue` keeping the marker out of Radix's typeahead text, and the marker
+   * itself as a plain child of the item.
+   */
+  function StrategyField({ values }: { values: string[] }) {
+    const newChunking = useNewOptions("chunking", values);
+    return (
+      <>
+        <label htmlFor="strategy" data-testid="label">
+          Strategy
+          {newChunking.dot}
+        </label>
+        <Select defaultValue="structured_section">
+          <SelectTrigger id="strategy" aria-label="Strategy">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {values.map((s) => (
+              <SelectItem key={s} value={s} textValue={s}>
+                <span>
+                  {s}
+                  {newChunking.badgeFor(s)}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </>
+    );
+  }
+
+  beforeEach(() => {
+    hasNewInMock.mockImplementation((_group, _values, version) => version === "2.2.0");
+    isNewMock.mockImplementation(
+      (feature, version) => version === "2.2.0" && feature === "chunking.structured_section"
+    );
+  });
+
+  it("marks the collapsed control and the option, and hides the copy Radix mirrors into the trigger", async () => {
+    renderWithQuery(<StrategyField values={["recursive_splitter", "structured_section"]} />);
+
+    // The label is the discoverable half: a marker only inside an unopened
+    // dropdown would need the reader to already be looking at it.
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("label")).getByRole("img", { name: /new options available/i })
+      ).not.toBeNull()
+    );
+
+    // Radix drives the closed trigger from the selected option's children, so
+    // the marker is mirrored there too. jsdom loads no stylesheet, so what is
+    // observable is the class whose rule hides it —
+    // `[data-slot=select-value] .…:hidden { display: none }`.
+    const trigger = screen.getByRole("combobox", { name: /strategy/i });
+    const mirrored = within(trigger).getByText("NEW");
+    expect(mirrored.className).toContain("[[data-slot=select-value]_&]:hidden");
+
+    await userEvent.click(trigger);
+    const newOption = await screen.findByRole("option", { name: /structured_section/ });
+    expect(within(newOption).getByText("NEW")).not.toBeNull();
+    expect(screen.getByRole("option", { name: /recursive_splitter/ }).textContent).toBe(
+      "recursive_splitter"
+    );
+  });
+});

--- a/ui/src/components/shared/new-badge.tsx
+++ b/ui/src/components/shared/new-badge.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getVersion } from "@/lib/api/system";
+import { hasNewIn, isNew } from "@/lib/whats-new";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+/**
+ * Attaching a "NEW" marker. When one is shown is `lib/whats-new.ts`; the worked
+ * guide, with examples for each kind of surface, is FEATURE_TAG.md at the repo
+ * root.
+ *
+ * Nothing here is tied to a page or a control:
+ *
+ *   - `<NewBadge feature="models.reranker" />` renders the marker, or nothing,
+ *     wherever an element can go — a nav item, a tab, a card title, a field
+ *     label, a button.
+ *   - `useNewOptions(group, values)` covers a list of options, where the marker
+ *     has to appear twice: on each new option, and on the collapsed control,
+ *     since a marker that only exists inside an opened dropdown aids no
+ *     discovery. The group is named once and each option's key is derived from
+ *     it, so registering an option in `whats-new.ts` is the whole change. Its
+ *     `dot` is the collapsed-control marker for a dense form label, `badge` the
+ *     same thing spelled out where there is room.
+ *   - `useIsNew(feature)` is the same decision as a plain boolean, for a surface
+ *     that marks itself some other way.
+ */
+
+/**
+ * The running app version, shared across every badge on the page.
+ *
+ * `staleTime: Infinity` because the version cannot change without a reload, and
+ * the query key matches the one already used by the overview page so the two
+ * share a single request.
+ */
+function useAppVersion(): string | undefined {
+  const { data } = useQuery({
+    queryKey: ["version"],
+    queryFn: getVersion,
+    staleTime: Infinity,
+    retry: false,
+  });
+  return data?.version;
+}
+
+/**
+ * Shared sizing for the marker. `default` is the brand accent (`--primary`,
+ * `#c71f45`) — the same red as the primary action button, so the badge reads as
+ * "ours" rather than as a warning. Note `--primary` is only red in the light
+ * theme; `.dark` redefines it to a blue-violet, so the badge follows the accent
+ * rather than staying literally red across both.
+ *
+ * The last rule is what lets the marker be a plain child anywhere, selects
+ * included. Radix drives a closed select trigger from the selected option's
+ * own children, so a marker on an option is mirrored into the trigger as well
+ * — a second NEW beside the one on the control's label. Rather than give every
+ * such control a slot to thread the marker past, the marker hides the mirrored
+ * copy itself: `[data-slot=select-value] .…:hidden`. Pair it with `textValue`
+ * on the item, which keeps the marker out of Radix's typeahead text.
+ */
+const BADGE_CLASS =
+  "px-1.5 py-0 text-[10px] font-semibold tracking-wide [[data-slot=select-value]_&]:hidden";
+
+/**
+ * The marker itself, shared by every entry point above so that "NEW" is spelled,
+ * sized and coloured in exactly one place.
+ */
+function NewMarker({ className }: { className?: string }) {
+  return (
+    <Badge variant="default" className={cn(BADGE_CLASS, className)}>
+      NEW
+    </Badge>
+  );
+}
+
+/**
+ * The quiet variant: a dot rather than a word, for a *label* whose control is
+ * collapsed. It says "there is something in here" without widening the label or
+ * competing with the field beside it, and the reader gets the word itself — the
+ * NEW on the option — the moment they open the list.
+ *
+ * Amber rather than the brand accent: a crimson dot beside a form label reads as
+ * "required" or "invalid" (the red-asterisk convention), which is the one thing
+ * it must not mean. It carries a label of its own, because a bare dot tells a
+ * screen reader nothing and a sighted reader not much more.
+ */
+export function NewDot({
+  className,
+  label = "New options available",
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      // `inline-block` is load-bearing: width and height do not apply to a
+      // non-replaced inline element, so a bare span would render 0x0 anywhere
+      // its parent is not a flex or grid container. It costs nothing where the
+      // parent *is* one — a flex item is blockified regardless.
+      //
+      // Then `self-start` positions it in a flex label and `align-super` in an
+      // inline one; each is ignored in the other context, so it sits high
+      // either way without the caller arranging anything.
+      className={cn(
+        "inline-block size-1.5 shrink-0 self-start rounded-full bg-amber-400 align-super dark:bg-amber-300",
+        className
+      )}
+    />
+  );
+}
+
+/** Whether `feature` is still new on this deployment. */
+export function useIsNew(feature: string): boolean {
+  return isNew(feature, useAppVersion());
+}
+
+/**
+ * A "NEW" marker that expires on its own — see `lib/whats-new.ts`.
+ *
+ * Renders nothing when the feature is no longer new or when the registry has no
+ * entry for it. An unreadable app version silences a *pinned* entry — there is
+ * nothing to compare it against — but not an `UNRELEASED` one, which has no
+ * version to compare in the first place.
+ */
+export function NewBadge({ feature, className }: { feature: string; className?: string }) {
+  return useIsNew(feature) ? <NewMarker className={className} /> : null;
+}
+
+/**
+ * Markers for a list of options belonging to `group` — the keys looked up are
+ * `"<group>.<value>"`.
+ *
+ * `badge` is for the collapsed control (the label of a select, the summary of a
+ * disclosure): present when *any* option is new, so the reader learns there is
+ * something to find without opening it. `badgeFor(value)` is for the option
+ * itself. Both are `null` when there is nothing new, so a caller can drop them
+ * in unconditionally.
+ *
+ * `values` comes from whatever the surface actually renders — usually the API's
+ * option list — so an option this backend doesn't offer is never badged, even
+ * while the registry carries a key for it.
+ */
+export function useNewOptions(
+  group: string,
+  values: string[]
+): {
+  anyNew: boolean;
+  dot: ReactNode;
+  badge: ReactNode;
+  badgeFor: (value: string) => ReactNode;
+} {
+  const version = useAppVersion();
+  const anyNew = hasNewIn(group, values, version);
+  return {
+    anyNew,
+    dot: anyNew ? <NewDot /> : null,
+    badge: anyNew ? <NewMarker /> : null,
+    badgeFor: (value: string) => (isNew(`${group}.${value}`, version) ? <NewMarker /> : null),
+  };
+}

--- a/ui/src/lib/whats-new.test.ts
+++ b/ui/src/lib/whats-new.test.ts
@@ -62,6 +62,10 @@ describe("isNewSince — the version window", () => {
     // so a repeated or out-of-order run is as malformed as a bare typo.
     expect(isNewSince("2.2.0", "2.2.0.dev1.post1.dev5")).toBe(false);
     expect(isNewSince("2.2.0", "2.2.0.post1a1")).toBe(false);
+    // The two grammars are alternatives, not a menu: a string wearing a PEP 440
+    // marker *and* a SemVer pre-release belongs to neither scheme.
+    expect(isNewSince("2.2.0", "2.2.0rc1-beta")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0.post1-rc.1")).toBe(false);
     expect(isNewSince("2.2.0", "2.2.0.x9")).toBe(false);
     expect(isNewSince("2.2.0", "2.2.0 wat")).toBe(false);
     expect(isNewSince("2.2.0", "2.2.0-")).toBe(false);
@@ -82,6 +86,9 @@ describe("isNewSince — the version window", () => {
     expect(isNewSince("2.2.0", "2.2.0.1")).toBe(true);
     expect(isNewSince("2.2.0", "2.2.0a1.post2.dev3")).toBe(true);
     expect(isNewSince("2.2.0", "2.2.0-next.3")).toBe(true);
+    // A `+build` segment is legal after either grammar, so the alternation must
+    // leave it outside itself.
+    expect(isNewSince("2.2.0", "2.2.0-rc.1+build.7")).toBe(true);
   });
 
   it("tolerates a v prefix, a missing patch, and pre-release suffixes", () => {

--- a/ui/src/lib/whats-new.test.ts
+++ b/ui/src/lib/whats-new.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasNewIn,
+  hasNewInRegistry,
+  isNew,
+  isNewInRegistry,
+  isNewSince,
+  NEW_FOR_MINORS,
+  NEW_SINCE,
+  UNRELEASED,
+} from "./whats-new";
+
+/**
+ * A synthetic `major.minor.0`. The window rule is tested through `isNewSince`
+ * with these rather than through the registry, so the tests never need editing
+ * when an entry is added, pinned by a release, or retired; `isNew` / `hasNewIn`
+ * are tested only for the lookup.
+ */
+const v = (major: number, minor: number) => `${major}.${minor}.0`;
+
+describe("isNewSince — the version window", () => {
+  it("badges the release the feature shipped in", () => {
+    expect(isNewSince("2.2.0", v(2, 2))).toBe(true);
+  });
+
+  it("keeps the badge for NEW_FOR_MINORS - 1 further minors", () => {
+    expect(isNewSince("2.2.0", v(2, 2 + NEW_FOR_MINORS - 1))).toBe(true);
+  });
+
+  it("drops the badge once the window has passed — no manual cleanup needed", () => {
+    expect(isNewSince("2.2.0", v(2, 2 + NEW_FOR_MINORS))).toBe(false);
+    expect(isNewSince("2.2.0", v(2, 2 + NEW_FOR_MINORS + 5))).toBe(false);
+  });
+
+  it("drops the badge on a major bump, however close the minor", () => {
+    expect(isNewSince("2.2.0", v(3, 2))).toBe(false);
+    expect(isNewSince("2.2.0", v(3, 0))).toBe(false);
+  });
+
+  it("still badges on an older deployment that predates the feature", () => {
+    // Reading an older version must not mark a feature stale — it is not
+    // shipped there at all, so the option will simply be absent.
+    expect(isNewSince("2.2.0", v(2, 1))).toBe(true);
+    expect(isNewSince("2.2.0", v(1, 9))).toBe(true);
+  });
+
+  it("rejects a string that merely starts like a version", () => {
+    // A prefix match would read these as 2.2 and badge on them; the contract is
+    // to fail closed on anything that is not a version.
+    expect(isNewSince("2.2.0", "2.2rubbish")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2 (build 7)")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.")).toBe(false);
+    expect(isNewSince("2.2.0", "version 2.2.0")).toBe(false);
+    expect(isNewSince("2.2rubbish", v(2, 2))).toBe(false);
+  });
+
+  it("rejects a malformed suffix, dotted or otherwise", () => {
+    // Admitting "some dotted thing after the digits" is the prefix hole one dot
+    // along: 2.2.0.wat would read as 2.2 and badge on a corrupt version.
+    expect(isNewSince("2.2.0", "2.2.0.wat")).toBe(false);
+    // Version-shaped but not versions: PEP 440 fixes the order of its markers,
+    // so a repeated or out-of-order run is as malformed as a bare typo.
+    expect(isNewSince("2.2.0", "2.2.0.dev1.post1.dev5")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0.post1a1")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0.x9")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0 wat")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0-")).toBe(false);
+    expect(isNewSince("2.2.0", "2.2.0+")).toBe(false);
+    // A pin is read by the same parser, so a corrupt one badges nothing either.
+    expect(isNewSince("2.2.0.wat", v(2, 2))).toBe(false);
+  });
+
+  it("reads the PEP 440 forms /version actually serves", () => {
+    // The endpoint returns importlib.metadata's version, which is normalized to
+    // PEP 440: an RC is `2.2.0rc1`, not `2.2.0-rc.1`. Refusing those would blank
+    // every badge on an RC or dev deployment.
+    expect(isNewSince("2.2.0", "2.2.0rc1")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0b2")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0.post1")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0.dev3")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0.dev3+local.7")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0.1")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0a1.post2.dev3")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0-next.3")).toBe(true);
+  });
+
+  it("tolerates a v prefix, a missing patch, and pre-release suffixes", () => {
+    expect(isNewSince("2.2.0", "v2.2.0")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0-rc.1")).toBe(true);
+    expect(isNewSince("2.2.0", "2.2.0+build.7")).toBe(true);
+    expect(isNewSince("v2.2", v(2, 2))).toBe(true);
+  });
+
+  it("fails closed when a pinned version cannot be compared", () => {
+    // An unbadged new feature beats every feature badged forever on a
+    // deployment whose /version cannot be read.
+    expect(isNewSince("2.2.0", undefined)).toBe(false);
+    expect(isNewSince("2.2.0", null)).toBe(false);
+    expect(isNewSince("2.2.0", "")).toBe(false);
+    expect(isNewSince("2.2.0", "unknown")).toBe(false);
+    expect(isNewSince("nonsense", v(2, 2))).toBe(false);
+  });
+
+  it("returns false for a feature with no registry entry", () => {
+    expect(isNewSince(undefined, v(2, 2))).toBe(false);
+  });
+});
+
+describe("isNewSince — UNRELEASED", () => {
+  it("badges unconditionally, since the reader is ahead of the last release", () => {
+    // A merged-but-untagged feature has no version to compare against: the
+    // reader is running a build newer than any release that mentions it.
+    expect(isNewSince(UNRELEASED, v(2, 1))).toBe(true);
+    expect(isNewSince(UNRELEASED, v(9, 9))).toBe(true);
+  });
+
+  it("badges even when the app version is unreadable", () => {
+    expect(isNewSince(UNRELEASED, undefined)).toBe(true);
+    expect(isNewSince(UNRELEASED, "unknown")).toBe(true);
+  });
+});
+
+// A lint on the registry's *content*, so it has nothing to check while the
+// registry is empty. The rules it applies are covered above against fixtures.
+describe("NEW_SINCE registry hygiene", () => {
+  it("holds only UNRELEASED or a parseable major.minor", () => {
+    // Catches a typo'd pin ("2..2", "v2", "next") at test time rather than
+    // silently badging nothing forever, since isNewSince fails closed.
+    // Judged by the parser that will actually read the pin: a value only counts
+    // as parseable if the rule can compare a deployment against it, and a
+    // version is trivially inside its own window.
+    for (const [key, value] of Object.entries(NEW_SINCE)) {
+      expect(value === UNRELEASED || isNewSince(value, value), `${key} -> ${value}`).toBe(true);
+    }
+  });
+
+  it("uses group-scoped keys, so a same-named option elsewhere is not badged", () => {
+    for (const key of Object.keys(NEW_SINCE)) {
+      expect(key, `${key} should be "<group>.<value>"`).toMatch(/^[a-z0-9_]+\.[a-z0-9_]+/i);
+    }
+  });
+});
+
+// The lookup, exercised against fixtures rather than against whatever the real
+// registry happens to hold. Reaching into `NEW_SINCE` for a key to try means the
+// tests can only run on days when something is registered — and the registry is
+// legitimately empty between the last entry expiring and the next feature
+// registering one, which is exactly when a regression here would go unnoticed.
+describe("isNewInRegistry / hasNewInRegistry — the lookup", () => {
+  const registry = {
+    "chunking.structured_section": "2.2.0",
+    "models.reranker": UNRELEASED,
+    "parsing.typo": "next",
+  };
+
+  it("reads a pin back and applies the window to it", () => {
+    expect(isNewInRegistry(registry, "chunking.structured_section", v(2, 2))).toBe(true);
+    expect(isNewInRegistry(registry, "chunking.structured_section", v(2, 3))).toBe(true);
+    expect(isNewInRegistry(registry, "chunking.structured_section", v(2, 4))).toBe(false);
+  });
+
+  it("badges an UNRELEASED entry whatever the deployment reports", () => {
+    expect(isNewInRegistry(registry, "models.reranker", v(9, 9))).toBe(true);
+    expect(isNewInRegistry(registry, "models.reranker", undefined)).toBe(true);
+  });
+
+  it("badges nothing for a key the registry does not carry", () => {
+    expect(isNewInRegistry(registry, "chunking.recursive_splitter", v(2, 2))).toBe(false);
+    expect(isNewInRegistry({}, "chunking.structured_section", v(2, 2))).toBe(false);
+  });
+
+  it("scopes a key to its group, so the same option elsewhere is untouched", () => {
+    expect(isNewInRegistry(registry, "parsing.structured_section", v(2, 2))).toBe(false);
+  });
+
+  it("fails closed on a typo'd pin rather than badging on it", () => {
+    expect(isNewInRegistry(registry, "parsing.typo", v(2, 2))).toBe(false);
+  });
+
+  it("marks a collapsed control when any option inside it is new", () => {
+    const options = ["recursive_splitter", "structured_section"];
+    expect(hasNewInRegistry(registry, "chunking", options, v(2, 2))).toBe(true);
+    expect(hasNewInRegistry(registry, "chunking", ["recursive_splitter"], v(2, 2))).toBe(false);
+    expect(hasNewInRegistry(registry, "chunking", options, v(2, 4))).toBe(false);
+    expect(hasNewInRegistry(registry, "chunking", [], v(2, 2))).toBe(false);
+  });
+
+  it("derives each option's key from the group it was given", () => {
+    // The one thing the group form adds over a bare lookup.
+    expect(hasNewInRegistry(registry, "models", ["reranker"], v(2, 2))).toBe(true);
+    expect(hasNewInRegistry(registry, "chunking", ["reranker"], v(2, 2))).toBe(false);
+  });
+});
+
+describe("isNew / hasNewIn — bound to NEW_SINCE", () => {
+  it("answers for the real registry, and badges nothing outside it", () => {
+    expect(isNew("definitely.not.registered", v(2, 2))).toBe(false);
+    expect(hasNewIn("definitely", ["not_registered"], v(2, 2))).toBe(false);
+    // Whatever the registry holds today, the two entry points agree with the
+    // lookup they delegate to — including when it holds nothing.
+    for (const key of Object.keys(NEW_SINCE)) {
+      expect(isNew(key, v(2, 2))).toBe(isNewInRegistry(NEW_SINCE, key, v(2, 2)));
+    }
+  });
+});

--- a/ui/src/lib/whats-new.ts
+++ b/ui/src/lib/whats-new.ts
@@ -1,0 +1,179 @@
+/**
+ * "NEW" badge registry.
+ *
+ * A badge is data, not markup, so that removing it is never a manual step that
+ * someone has to remember in a release which otherwise doesn't touch the file.
+ * Each entry records the version a feature shipped in; `isNew` compares that
+ * against the running app version and stops returning true once the feature is
+ * `NEW_FOR_MINORS` minor releases old. Forgetting to delete an entry therefore
+ * costs nothing — the badge disappears on its own, and the line can be swept up
+ * whenever anyone happens to notice.
+ *
+ * A key is any stable dotted string — `nav.workspaces`, `presets.tab.retrieval`,
+ * `chunking.structured_section` — and nothing here knows what surface it names.
+ * For an option inside a control the convention is `"<group>.<value>"` rather
+ * than the bare option value, so that `useNewOptions(group, values)` can derive
+ * every key from the group alone, and so that two dropdowns offering the same
+ * string do not badge each other the day that happens.
+ *
+ * Attaching one is components/shared/new-badge.tsx. FEATURE_TAG.md, at the repo
+ * root, is the worked guide: registering a key, the two ways to attach it, and
+ * what the release branch does with it.
+ */
+
+/** How many minor releases a feature keeps its badge. */
+export const NEW_FOR_MINORS = 2;
+
+/**
+ * Placeholder for a feature that has merged but is not in a tagged release yet.
+ *
+ * The version a feature ships in is not knowable when the feature PR is
+ * written: a `release/X.Y.Z` branch is cut once the features intended for that
+ * version are complete, so the number is chosen after the feature merges —
+ * sometimes weeks later. Any pin written during development is a prediction,
+ * and wrong the moment the release plan moves. Author entries with this
+ * sentinel instead, and let the release branch resolve them in the same commit
+ * that bumps `pyproject.toml`, reading the version back from there rather than
+ * retyping it. See "Releases" in CONTRIBUTING.md for the command; it is kept
+ * there alone so the two cannot drift.
+ *
+ * Entries are written as the string literal, not as a reference to the constant
+ * below, so that a one-liner can find them. That one-liner anchors on a whole
+ * registry line — indent, quoted key, colon, and an optional trailing comma,
+ * since the last entry in the object may legally omit it — so it matches
+ * nothing else. A looser pattern silently corrupts two things at once: this
+ * constant's own definition, turning the sentinel into a version and breaking
+ * every future entry, and any prose that mentions the sentinel while explaining
+ * the step.
+ *
+ * An unresolved entry badges unconditionally, which is correct — everyone
+ * running a build that contains the feature is seeing it for the first time —
+ * but it also never expires. Forgetting the step is therefore silent and
+ * permanent, so `verify-tag` in .github/workflows/build.yml refuses to publish
+ * GA images while any entry is still unresolved.
+ */
+export const UNRELEASED = "UNRELEASED";
+
+/**
+ * Feature key -> the app version it first shipped in (`major.minor[.patch]`),
+ * or `UNRELEASED` until a release pins it.
+ */
+export const NEW_SINCE: Readonly<Record<string, string>> = {
+  // Nothing is marked right now. Entries look like this — see FEATURE_TAG.md:
+  //   "chunking.structured_section": "UNRELEASED",
+  //   "models.reranker": "2.4.0",
+  // A commented example is invisible to both the release one-liner and the CI
+  // gate: each anchors on a whole registry line, which starts with the quoted
+  // key and nothing else.
+};
+
+type Version = { major: number; minor: number };
+
+/**
+ * Parse `major.minor` out of a version string. Returns null for anything
+ * unparseable so callers fail closed (no badge) rather than badging everything.
+ *
+ * The whole string has to be a version, not merely start like one: a prefix
+ * match reads `2.2rubbish` as `2.2` and badges on it, which is the opposite of
+ * failing closed.
+ *
+ * What counts as a version is wider than SemVer, because `/version` serves
+ * `importlib.metadata`, which reports **PEP 440**: a release candidate arrives
+ * as `2.2.0rc1`, not `2.2.0-rc.1`, and `.post1` / `.dev0` builds are legal too.
+ * Rejecting those would blank every badge on an RC deployment.
+ *
+ * Each accepted suffix is spelled out rather than admitted as "some dotted
+ * thing after the digits" — that shortcut lets `2.2.0.wat` through and reads it
+ * as 2.2, which is the prefix hole again, one dot along. In order:
+ *
+ *   1. numeric segments — `2.2`, `2.2.0`, or more;
+ *   2. PEP 440 markers in their defined order — at most one pre-release
+ *      (`a` `b` `rc`), then at most one `post`, then at most one `dev`, each
+ *      attached or separated by `.` `-` `_` (`2.2.0rc1`, `2.1.1.post1`,
+ *      `2.2.0a1.post2.dev3`). Ordering them is what makes the grammar reject
+ *      `2.2.0.dev1.post1.dev5` and `2.2.0.post1a1`, which are version-shaped but
+ *      not versions;
+ *   3. an optional SemVer pre-release — `-` then dot-separated alphanumerics,
+ *      which is how a hand-written registry pin spells `2.2.0-rc.1`;
+ *   4. an optional `+` build or local segment (`+build.7`, `+local.7`).
+ */
+const VERSION_PATTERN =
+  /^\s*v?(\d+)\.(\d+)(?:\.\d+)*(?:[._-]?(?:a|b|rc)\d*)?(?:[._-]?post\d*)?(?:[._-]?dev\d*)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\s*$/i;
+
+function parseVersion(raw: string | undefined | null): Version | null {
+  if (!raw) return null;
+  const match = VERSION_PATTERN.exec(raw);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+/**
+ * Whether `featureKey` should still be badged when the app reports
+ * `appVersion`.
+ *
+ * False when either version is unknown or unparseable: an unbadged new feature
+ * is a much smaller problem than every feature being badged forever on a
+ * deployment whose `/version` we can't read.
+ *
+ * A major bump always expires the badge — 3.0 is not "two minors after 2.2" in
+ * any sense a reader would accept.
+ */
+export function isNew(featureKey: string, appVersion: string | undefined | null): boolean {
+  return isNewInRegistry(NEW_SINCE, featureKey, appVersion);
+}
+
+/**
+ * The lookup itself, over any registry — `isNew` is this against `NEW_SINCE`.
+ *
+ * Separate for the same reason `isNewSince` is separate from the registry: the
+ * registry is *data*, and legitimately empty between the day the last entry
+ * expires and the day the next feature registers one. A test that reaches into
+ * `NEW_SINCE` for a key to try can only skip itself on those days — which is
+ * precisely when a regression in the lookup would go unnoticed. Given a
+ * registry, this can be tested against a fixture on any day.
+ */
+export function isNewInRegistry(
+  registry: Readonly<Record<string, string>>,
+  featureKey: string,
+  appVersion: string | undefined | null
+): boolean {
+  return isNewSince(registry[featureKey], appVersion);
+}
+
+/**
+ * The window rule itself, independent of the registry — `isNew` is this plus a
+ * lookup. Separate so the rule can be tested against arbitrary versions without
+ * the tests having to be edited every time a registry entry is added, pinned by
+ * a release, or retired.
+ */
+export function isNewSince(since: string | undefined, appVersion: string | undefined | null): boolean {
+  if (since === undefined) return false;
+  // Merged but not yet tagged: new to everyone running a build that has it, and
+  // there is no version to compare against — not even the reader's own, since
+  // they are ahead of the last release rather than behind it.
+  if (since === UNRELEASED) return true;
+  const from = parseVersion(since);
+  const current = parseVersion(appVersion);
+  if (!from || !current) return false;
+  if (current.major !== from.major) return current.major < from.major;
+  return current.minor - from.minor < NEW_FOR_MINORS;
+}
+
+/**
+ * Whether any of `values` is still new within `group` — so a collapsed control
+ * can carry the badge for options the reader would otherwise have to open a
+ * dropdown to discover.
+ */
+export function hasNewIn(group: string, values: string[], appVersion: string | undefined | null): boolean {
+  return hasNewInRegistry(NEW_SINCE, group, values, appVersion);
+}
+
+/** `hasNewIn` over any registry — see `isNewInRegistry` for why it is separate. */
+export function hasNewInRegistry(
+  registry: Readonly<Record<string, string>>,
+  group: string,
+  values: string[],
+  appVersion: string | undefined | null
+): boolean {
+  return values.some((value) => isNewInRegistry(registry, `${group}.${value}`, appVersion));
+}

--- a/ui/src/lib/whats-new.ts
+++ b/ui/src/lib/whats-new.ts
@@ -87,18 +87,23 @@ type Version = { major: number; minor: number };
  * as 2.2, which is the prefix hole again, one dot along. In order:
  *
  *   1. numeric segments — `2.2`, `2.2.0`, or more;
- *   2. PEP 440 markers in their defined order — at most one pre-release
- *      (`a` `b` `rc`), then at most one `post`, then at most one `dev`, each
- *      attached or separated by `.` `-` `_` (`2.2.0rc1`, `2.1.1.post1`,
- *      `2.2.0a1.post2.dev3`). Ordering them is what makes the grammar reject
- *      `2.2.0.dev1.post1.dev5` and `2.2.0.post1a1`, which are version-shaped but
- *      not versions;
- *   3. an optional SemVer pre-release — `-` then dot-separated alphanumerics,
- *      which is how a hand-written registry pin spells `2.2.0-rc.1`;
- *   4. an optional `+` build or local segment (`+build.7`, `+local.7`).
+ *   2. then **either** grammar's pre-release notation, never both — they are
+ *      alternatives, not a menu, and a string wearing one of each belongs to
+ *      neither scheme:
+ *      - PEP 440 markers in their defined order — at most one pre-release
+ *        (`a` `b` `rc`), then at most one `post`, then at most one `dev`, each
+ *        attached or separated by `.` `-` `_` (`2.2.0rc1`, `2.1.1.post1`,
+ *        `2.2.0a1.post2.dev3`). Ordering them is what rejects
+ *        `2.2.0.dev1.post1.dev5` and `2.2.0.post1a1`;
+ *      - or a SemVer pre-release — `-` then dot-separated alphanumerics, which
+ *        is how a hand-written registry pin spells `2.2.0-rc.1`.
+ *      Making these alternatives is what rejects `2.2.0rc1-beta` and
+ *      `2.2.0.post1-rc.1`, hybrids that are version-shaped but not versions;
+ *   3. an optional `+` build or local segment, legal after either
+ *      (`2.2.0.dev3+local.7`, `2.2.0-rc.1+build.7`).
  */
 const VERSION_PATTERN =
-  /^\s*v?(\d+)\.(\d+)(?:\.\d+)*(?:[._-]?(?:a|b|rc)\d*)?(?:[._-]?post\d*)?(?:[._-]?dev\d*)?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\s*$/i;
+  /^\s*v?(\d+)\.(\d+)(?:\.\d+)*(?:(?:[._-]?(?:a|b|rc)\d*)?(?:[._-]?post\d*)?(?:[._-]?dev\d*)?|-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\s*$/i;
 
 function parseVersion(raw: string | undefined | null): Version | null {
   if (!raw) return null;


### PR DESCRIPTION
## Why

A "NEW" marker is only useful if someone removes it. Nobody does — it becomes permanent decoration, and the cleanup lands in a release that has no other reason to touch the file.

So the marker is data. `ui/src/lib/whats-new.ts` maps a feature key to the version it shipped in, and the marker stops rendering `NEW_FOR_MINORS` (2) minors later. Forgetting to delete an entry costs nothing: it expires on its own. Entries never interact — each answers the same independent question, *is the running version inside the window of the version I shipped in?*

## What ships here

The mechanism, its guide and its tests — **deliberately without a call site**. `NEW_SINCE` is empty and no page renders a marker yet.

The first candidate, `chunking.structured_section`, belongs to #861, which isn't on `develop`; registering it here would badge nothing (the form takes `chunking_strategies` from the API, so an option the backend doesn't offer renders none) and would tie this PR's merge order to that one. An empty registry is also the state the design keeps returning to, every time entries expire and get swept up — so it is worth supporting and testing, not a gap. Adoption is one registry line plus one hook call.

| file | role |
|---|---|
| `ui/src/lib/whats-new.ts` | the registry, the window rule, and nothing about the UI |
| `ui/src/components/shared/new-badge.tsx` | `NewBadge`, `NewDot`, `useNewOptions`, `useIsNew` |
| `FEATURE_TAG.md` | the guide: concept, the two markers, worked examples per surface |
| `CONTRIBUTING.md` | the release-time command that resolves pending entries |
| `.github/workflows/build.yml` | the gate that blocks GA images with unresolved entries |

## How it behaves

For an entry pinned to `2.2.0`:

| app reports | marker | why |
|---|---|---|
| 2.1.1 | ✅ | predates the feature — the option isn't there anyway |
| 2.2.0 → 2.3.0 | ✅ | inside the window |
| 2.4.0 | ❌ | window passed |
| 3.0.0 | ❌ | a major bump always expires it |
| `UNRELEASED` entry | ✅ | merged but untagged — new to everyone running that build |
| unreadable / not a version | ❌ | fails closed |

Failing closed is deliberate: one unbadged feature beats every feature badged forever on a deployment whose `/version` can't be read. "Not a version" means the whole string — `2.2rubbish`, `2.2.0.wat` and out-of-order PEP 440 (`2.2.0.post1a1`) are rejected, not read as 2.2. What *is* accepted is wider than SemVer, because `/version` comes from `importlib.metadata` and reports PEP 440: `2.2.0rc1`, `2.1.1.post1`, `2.2.0.dev3` all compare, so badges don't blank out on an RC deployment.

Keys are `"<group>.<value>"` for an option inside a control — two dropdowns can offer the same string, and a bare key would badge both — and any stable dotted string elsewhere (`nav.workspaces`).

## Two markers

The **word** (`NEW` pill) goes on the thing itself: an option in an open list, a tab, a nav item. The **dot** (small amber circle) goes on a *collapsed* control's label, where the new thing is out of sight. A dropdown needs both — the dot gets the reader to open the list, the word tells them what they came for. The dot carries an accessible name, and is amber because a crimson dot beside a form label reads as *required*.

Radix mirrors a selected option's children into the closed trigger, which would show a second marker there; the marker hides that copy itself, which is what keeps it a plain child on any surface.

## Release step and gate

A feature PR can't know its release number — the release branch chooses it — so entries are authored as `UNRELEASED` and resolved by that branch, in the commit that bumps `pyproject.toml`, reading the version back from it (**CONTRIBUTING.md → Releases**).

An unresolved entry badges forever and silently, so `verify-tag` refuses to publish GA images while any entry is unresolved, and fails loudly when the registry is missing or unreadable rather than reporting success. It covers GA tags only; `develop`, RC and self-built images badge `UNRELEASED` entries freely, which is what `UNRELEASED` means — FEATURE_TAG.md says so.

## Testing

31 tests across `whats-new.test.ts` (window rule, `UNRELEASED`, malformed and PEP 440 versions, the registry lookup against fixtures) and `new-badge.test.tsx` (attachment on any surface, the dot's accessible name, the group hook, and the documented dropdown example rendered as written, including the Radix trigger case).

The lookup is tested through `isNewInRegistry` / `hasNewInRegistry`, which take the registry as an argument, rather than by reaching into `NEW_SINCE` for a key — the registry is legitimately empty, and that is exactly when a regression there would go unnoticed. No test skips itself.

Full UI suite: **243 passed, 0 skipped** (29 files). `tsc --noEmit`, eslint and `npm run build` clean. The release command and the gate were verified by extracting them verbatim from the files and running them against fixtures — entries with and without a trailing comma, a missing `version` line, and a missing or unreadable registry.