### PR TITLE
feat(admin): add release notes dialog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,15 @@ An entry left unresolved badges every user forever, and nobody notices, because 
 dropdown expecting an option *not* to say NEW. So `verify-tag` in `.github/workflows/build.yml`
 refuses to publish GA images while any entry is still unresolved.
 
+#### Writing the release notes
+
+`ui/src/lib/release-notes.ts` backs the Release Notes dialog in the admin sidebar. Unlike
+`whats-new.ts`, it can't be resolved mechanically: its `version`, `summary`, and `newFeatures`
+describe the shipped release in prose, and only a human can write that. Feature PRs leave those
+fields empty; writing them is release-preparation work, done on `release/X.Y.Z` once the feature
+set for `X.Y.Z` is actually final — so the notes describe what shipped, not what a feature PR
+predicted would ship.
+
 When the release is ready:
 
 1. Merge `release/X.Y.Z` into `main`.

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -31,6 +31,9 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
     expect(dialog.textContent).toContain("Released: August 31, 2026");
     expect(dialog.textContent).toContain("What's New");
+    expect(dialog.textContent).toContain("Milvus 3.0 is now required");
+    expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
+    expect(dialog.textContent).toContain("image captions next to placeholders");
     expect(screen.queryByRole("heading", { name: "Improvements" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Bug Fixes" })).toBeNull();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes } from "@/lib/release-notes";
+import { ReleaseNotes } from "./release-notes";
+
+function renderReleaseNotes() {
+  return render(
+    <ul>
+      <ReleaseNotes className="release-notes-nav-item" />
+    </ul>,
+  );
+}
+
+describe("ReleaseNotes", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("opens the current release without navigating and remembers it as viewed", async () => {
+    const user = userEvent.setup();
+    renderReleaseNotes();
+
+    const button = screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) });
+    expect(button.textContent).toContain(`Release Notes · v${releaseNotes.version}`);
+    expect(button.textContent).toContain("New");
+
+    await user.click(button);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
+    expect(dialog.textContent).toContain("Released: August 31, 2026");
+    expect(dialog.textContent).toContain("What's New");
+    expect(dialog.textContent).toContain("Bug Fixes");
+    expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
+    expect(button.textContent).not.toContain("New");
+  });
+
+  it("does not show the new badge after the current version was viewed", () => {
+    localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes.version);
+    renderReleaseNotes();
+
+    expect(screen.getByRole("button", { name: `Open Release Notes · v${releaseNotes.version}` }).textContent).not.toContain("New");
+  });
+
+  it("closes with Escape", async () => {
+    const user = userEvent.setup();
+    renderReleaseNotes();
+
+    await user.click(screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) }));
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -32,15 +32,13 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain("Latest release");
     expect(dialog.textContent).toContain("Released August 31, 2026");
     expect(dialog.textContent).toContain("What's New");
-    expect(dialog.textContent).toContain("Highlights");
+    expect(dialog.textContent).toContain("New Features");
     expect(dialog.textContent).toContain("Breaking Changes");
     expect(dialog.textContent).toContain("Milvus 3.0 migration required");
-    expect(dialog.textContent).toContain("OpenAI API");
-    expect(dialog.textContent).toContain("Indexing");
-    expect(dialog.textContent).toContain("Improvements");
+    expect(dialog.textContent).toContain("structure-aware chunking strategy");
     expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
-    expect(dialog.textContent).toContain("image captions next to placeholders");
     expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "New Features" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Fixes" })).toBeNull();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -38,10 +38,10 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain("OpenAI API");
     expect(dialog.textContent).toContain("Indexing");
     expect(dialog.textContent).toContain("Improvements");
-    expect(dialog.textContent).toContain("Fixes");
     expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
     expect(dialog.textContent).toContain("image captions next to placeholders");
     expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Fixes" })).toBeNull();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");
   });

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes } from "@/lib/release-notes";
@@ -58,10 +58,12 @@ describe("ReleaseNotes", () => {
     const user = userEvent.setup();
     renderReleaseNotes();
 
-    await user.click(screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) }));
+    const button = screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) });
+    await user.click(button);
     await screen.findByRole("dialog");
     await user.keyboard("{Escape}");
 
     expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(button));
   });
 });

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -31,7 +31,8 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
     expect(dialog.textContent).toContain("Released: August 31, 2026");
     expect(dialog.textContent).toContain("What's New");
-    expect(dialog.textContent).toContain("Bug Fixes");
+    expect(screen.queryByRole("heading", { name: "Improvements" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Bug Fixes" })).toBeNull();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");
   });

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -35,8 +35,11 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain("New Features");
     expect(dialog.textContent).toContain("Breaking Changes");
     expect(dialog.textContent).toContain("Milvus 3.0 migration required");
-    expect(dialog.textContent).toContain("structure-aware chunking strategy");
-    expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
+    expect(dialog.textContent).toContain("structured_section chunking strategy");
+    expect(dialog.textContent).toContain("OpenAI-compatible STT endpoints");
+    expect(dialog.textContent).toContain("transcription prompts in the prompt library");
+    expect(dialog.textContent).toContain("per indexation preset");
+    expect(dialog.textContent).toContain("MOSS diarized transcripts");
     expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "New Features" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Fixes" })).toBeNull();

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -29,13 +29,18 @@ describe("ReleaseNotes", () => {
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
-    expect(dialog.textContent).toContain("Released: August 31, 2026");
-    expect(dialog.textContent).toContain("What's New");
-    expect(dialog.textContent).toContain("Milvus 3.0 is now required");
+    expect(dialog.textContent).toContain("Latest release");
+    expect(dialog.textContent).toContain("Released August 31, 2026");
+    expect(dialog.textContent).toContain("Highlights");
+    expect(dialog.textContent).toContain("Breaking Changes");
+    expect(dialog.textContent).toContain("Milvus 3.0 migration required");
+    expect(dialog.textContent).toContain("OpenAI API");
+    expect(dialog.textContent).toContain("Indexing");
+    expect(dialog.textContent).toContain("Improvements");
+    expect(dialog.textContent).toContain("Fixes");
     expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
     expect(dialog.textContent).toContain("image captions next to placeholders");
-    expect(screen.queryByRole("heading", { name: "Improvements" })).toBeNull();
-    expect(screen.queryByRole("heading", { name: "Bug Fixes" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "What's New" })).toBeNull();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");
   });

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -31,6 +31,7 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
     expect(dialog.textContent).toContain("Latest release");
     expect(dialog.textContent).toContain("Released August 31, 2026");
+    expect(dialog.textContent).toContain("What's New");
     expect(dialog.textContent).toContain("Highlights");
     expect(dialog.textContent).toContain("Breaking Changes");
     expect(dialog.textContent).toContain("Milvus 3.0 migration required");
@@ -40,7 +41,7 @@ describe("ReleaseNotes", () => {
     expect(dialog.textContent).toContain("Fixes");
     expect(dialog.textContent).toContain("custom HTTPS LLM endpoint");
     expect(dialog.textContent).toContain("image captions next to placeholders");
-    expect(screen.queryByRole("heading", { name: "What's New" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");
   });

--- a/ui/src/components/layout/release-notes.test.tsx
+++ b/ui/src/components/layout/release-notes.test.tsx
@@ -1,16 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
-import { LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes } from "@/lib/release-notes";
+import { formatReleaseDate, LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes } from "@/lib/release-notes";
 import { ReleaseNotes } from "./release-notes";
 
-function renderReleaseNotes() {
-  return render(
-    <ul>
-      <ReleaseNotes className="release-notes-nav-item" />
-    </ul>,
-  );
-}
+const triggerLabel = `Open Release Notes · v${releaseNotes.version}`;
 
 describe("ReleaseNotes", () => {
   beforeEach(() => {
@@ -19,46 +13,58 @@ describe("ReleaseNotes", () => {
 
   it("opens the current release without navigating and remembers it as viewed", async () => {
     const user = userEvent.setup();
-    renderReleaseNotes();
+    render(<ReleaseNotes />);
 
-    const button = screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) });
+    const button = screen.getByRole("button", { name: `${triggerLabel}, new` });
     expect(button.textContent).toContain(`Release Notes · v${releaseNotes.version}`);
     expect(button.textContent).toContain("New");
 
     await user.click(button);
 
     const dialog = await screen.findByRole("dialog");
-    expect(dialog.textContent).toContain(`OpenRAG v${releaseNotes.version}`);
-    expect(dialog.textContent).toContain("Latest release");
-    expect(dialog.textContent).toContain("Released August 31, 2026");
-    expect(dialog.textContent).toContain("What's New");
-    expect(dialog.textContent).toContain("New Features");
-    expect(dialog.textContent).toContain("Breaking Changes");
-    expect(dialog.textContent).toContain("Milvus 3.0 migration required");
-    expect(dialog.textContent).toContain("structured_section chunking strategy");
-    expect(dialog.textContent).toContain("OpenAI-compatible STT endpoints");
-    expect(dialog.textContent).toContain("transcription prompts in the prompt library");
-    expect(dialog.textContent).toContain("per indexation preset");
-    expect(dialog.textContent).toContain("MOSS diarized transcripts");
-    expect(screen.getByRole("heading", { name: "What's New" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "New Features" })).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Fixes" })).toBeNull();
+    expect(within(dialog).getByRole("heading", { name: `OpenRAG v${releaseNotes.version}` })).toBeTruthy();
+    expect(within(dialog).getByRole("heading", { name: "What's New" })).toBeTruthy();
+    expect(within(dialog).getByRole("heading", { name: "New Features" })).toBeTruthy();
+    expect(dialog.textContent).toContain(releaseNotes.summary);
+    expect(dialog.textContent).toContain(`Released ${formatReleaseDate(releaseNotes.date)}`);
+    expect(within(dialog).getAllByRole("listitem").map((item) => item.textContent)).toEqual([
+      ...releaseNotes.newFeatures,
+    ]);
+
     expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe(releaseNotes.version);
     expect(button.textContent).not.toContain("New");
   });
 
-  it("does not show the new badge after the current version was viewed", () => {
-    localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes.version);
-    renderReleaseNotes();
+  it("renders the breaking-change callout from the release data", async () => {
+    const user = userEvent.setup();
+    const { breakingChange } = releaseNotes;
+    expect(breakingChange).toBeTruthy();
+    render(<ReleaseNotes />);
 
-    expect(screen.getByRole("button", { name: `Open Release Notes · v${releaseNotes.version}` }).textContent).not.toContain("New");
+    await user.click(screen.getByRole("button", { name: /^Open Release Notes/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    const callout = within(dialog).getByRole("alert");
+    expect(callout.textContent).toContain("Breaking Changes");
+    if (breakingChange) {
+      expect(callout.textContent).toContain(breakingChange.title);
+      expect(callout.textContent).toContain(breakingChange.description);
+      expect(callout.textContent).toContain(breakingChange.action);
+    }
   });
 
-  it("closes with Escape", async () => {
-    const user = userEvent.setup();
-    renderReleaseNotes();
+  it("does not show the new badge after the current version was viewed", () => {
+    localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, releaseNotes.version);
+    render(<ReleaseNotes />);
 
-    const button = screen.getByRole("button", { name: new RegExp(`Open Release Notes · v${releaseNotes.version}`) });
+    expect(screen.getByRole("button", { name: triggerLabel }).textContent).not.toContain("New");
+  });
+
+  it("closes with Escape and returns focus to the trigger", async () => {
+    const user = userEvent.setup();
+    render(<ReleaseNotes />);
+
+    const button = screen.getByRole("button", { name: /^Open Release Notes/ });
     await user.click(button);
     await screen.findByRole("dialog");
     await user.keyboard("{Escape}");

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -16,7 +16,6 @@ import {
   hasViewedRelease,
   markReleaseAsViewed,
   releaseNotes,
-  type ReleaseNoteSection,
 } from "@/lib/release-notes";
 
 interface ReleaseNotesButtonProps {
@@ -60,45 +59,7 @@ interface ReleaseNotesDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-interface ReleaseNotesSectionProps {
-  section: ReleaseNoteSection;
-  featured?: boolean;
-  className?: string;
-}
-
-function ReleaseNotesSection({ section, featured = false, className = "" }: ReleaseNotesSectionProps) {
-  const headingId = `release-notes-${section.id}`;
-
-  return (
-    <article
-      aria-labelledby={headingId}
-      className={`rounded-xl p-5 sm:p-6 ${
-        featured ? "border border-primary/15 bg-primary/[0.04]" : "border border-border/60 bg-muted/35"
-      } ${className}`}
-    >
-      {featured && <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">Featured</p>}
-      <h4 id={headingId} className={`${featured ? "mt-2 text-lg" : "text-sm"} font-semibold text-foreground`}>
-        {section.title}
-      </h4>
-      <ul className={`${featured ? "mt-4 grid gap-3 sm:grid-cols-2" : "mt-3 space-y-3"} text-sm leading-6 text-muted-foreground`}>
-        {section.items.map((entry) => (
-          <li key={entry} className="flex gap-2.5">
-            <span
-              aria-hidden="true"
-              className={`mt-2 size-1.5 shrink-0 rounded-full ${featured ? "bg-primary" : "bg-muted-foreground/55"}`}
-            />
-            <span>{entry}</span>
-          </li>
-        ))}
-      </ul>
-    </article>
-  );
-}
-
 export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
-  const highlights = releaseNotes.sections.find((section) => section.id === "highlights");
-  const supportingSections = releaseNotes.sections.filter((section) => section.id !== "highlights");
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
@@ -125,18 +86,19 @@ export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogPro
               <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
                 What's New
               </h3>
-              <div className="mt-4 space-y-4">
-                {highlights && <ReleaseNotesSection section={highlights} featured />}
-                <div className="grid gap-4 sm:grid-cols-2">
-                  {supportingSections.map((section) => (
-                    <ReleaseNotesSection
-                      key={section.id}
-                      section={section}
-                      className={section.id === "openai-api" ? "sm:col-span-2" : ""}
-                    />
+              <article aria-labelledby="release-notes-new-features" className="mt-4 rounded-xl border border-border/60 bg-muted/30 p-5 sm:p-6">
+                <h4 id="release-notes-new-features" className="text-lg font-semibold text-foreground">
+                  New Features
+                </h4>
+                <ul className="mt-4 space-y-3 text-sm leading-6 text-muted-foreground">
+                  {releaseNotes.newFeatures.map((feature) => (
+                    <li key={feature} className="flex gap-3">
+                      <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary" />
+                      <span>{feature}</span>
+                    </li>
                   ))}
-                </div>
-              </div>
+                </ul>
+              </article>
             </section>
 
             <section aria-labelledby="release-notes-breaking-changes">

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ComponentProps, type ReactNode, useState } from "react";
+import { useState } from "react";
 import { AlertTriangle, CalendarDays, Sparkles } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -11,60 +11,41 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { SidebarMenuItem } from "@/components/ui/sidebar";
 import {
   formatReleaseDate,
   hasViewedRelease,
   markReleaseAsViewed,
   releaseNotes,
 } from "@/lib/release-notes";
+import { sidebarItemInactiveClassName } from "./sidebar-item";
 
-interface ReleaseNotesButtonProps extends ComponentProps<"button"> {
-  hasNew: boolean;
-  isOpen: boolean;
-}
+const triggerClassName = `flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors ${sidebarItemInactiveClassName} data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground data-[state=open]:shadow-sm`;
 
-export const ReleaseNotesButton = forwardRef<HTMLButtonElement, ReleaseNotesButtonProps>(function ReleaseNotesButton(
-  { hasNew, isOpen, className, ...buttonProps },
-  ref,
-) {
+export function ReleaseNotes() {
+  const [hasNew, setHasNew] = useState(() => !hasViewedRelease(releaseNotes.version));
   const label = `Release Notes · v${releaseNotes.version}`;
+  const { breakingChange } = releaseNotes;
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) return;
+    markReleaseAsViewed(releaseNotes.version);
+    setHasNew(false);
+  };
 
   return (
-    <button
-      ref={ref}
-      type="button"
-      title={hasNew ? `${label} — New` : label}
-      aria-label={hasNew ? `Open ${label}, new` : `Open ${label}`}
-      aria-haspopup="dialog"
-      aria-expanded={isOpen}
-      {...buttonProps}
-      className={`${className} ${
-        isOpen
-          ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
-          : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
-      }`}
-    >
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {hasNew && (
-        <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary">
-          New
-        </span>
-      )}
-    </button>
-  );
-});
-
-interface ReleaseNotesDialogProps {
-  children: ReactNode;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}
-
-export function ReleaseNotesDialog({ children, open, onOpenChange }: ReleaseNotesDialogProps) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      {children}
+    <Dialog onOpenChange={handleOpenChange}>
+      <DialogTrigger
+        className={triggerClassName}
+        title={hasNew ? `${label} — New` : label}
+        aria-label={hasNew ? `Open ${label}, new` : `Open ${label}`}
+      >
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        {hasNew && (
+          <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary">
+            New
+          </span>
+        )}
+      </DialogTrigger>
       <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
         <DialogHeader className="shrink-0 border-b bg-gradient-to-br from-primary/10 via-background to-background px-6 py-6 pr-14 sm:px-8">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -83,74 +64,46 @@ export function ReleaseNotesDialog({ children, open, onOpenChange }: ReleaseNote
           <DialogDescription className="max-w-2xl text-sm leading-6">{releaseNotes.summary}</DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-6 sm:px-8" data-testid="release-notes-content">
-          <div className="space-y-6">
-            <section aria-labelledby="release-notes-whats-new">
-              <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
-                What's New
-              </h3>
-              <article aria-labelledby="release-notes-new-features" className="mt-4 rounded-xl border border-border/60 bg-muted/30 p-5 sm:p-6">
-                <h4 id="release-notes-new-features" className="text-lg font-semibold text-foreground">
-                  New Features
-                </h4>
-                <ul className="mt-4 space-y-3 text-sm leading-6 text-muted-foreground">
-                  {releaseNotes.newFeatures.map((feature) => (
-                    <li key={feature} className="flex gap-3">
-                      <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary" />
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            </section>
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto overscroll-contain px-6 py-6 sm:px-8">
+          <section aria-labelledby="release-notes-whats-new">
+            <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
+              What's New
+            </h3>
+            <article aria-labelledby="release-notes-new-features" className="mt-4 rounded-xl border border-border/60 bg-muted/30 p-5 sm:p-6">
+              <h4 id="release-notes-new-features" className="text-lg font-semibold text-foreground">
+                New Features
+              </h4>
+              <ul className="mt-4 space-y-3 text-sm leading-6 text-muted-foreground">
+                {releaseNotes.newFeatures.map((feature) => (
+                  <li key={feature} className="flex gap-3">
+                    <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          </section>
 
+          {breakingChange && (
             <section aria-labelledby="release-notes-breaking-changes">
               <Alert className="border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
                 <AlertTriangle aria-hidden="true" className="text-amber-700 dark:text-amber-300" />
                 <AlertTitle id="release-notes-breaking-changes" className="text-amber-950 dark:text-amber-100">
-                  {releaseNotes.breakingChanges.title}
+                  Breaking Changes
                 </AlertTitle>
                 <AlertDescription className="text-amber-900/90 dark:text-amber-100/90">
                   <p>
-                    <span className="font-semibold">{releaseNotes.breakingChanges.calloutTitle}.</span>{" "}
-                    {releaseNotes.breakingChanges.description}
+                    <span className="font-semibold">{breakingChange.title}.</span> {breakingChange.description}
                   </p>
-                  <p className="font-medium">{releaseNotes.breakingChanges.action}</p>
+                  <p className="font-medium">{breakingChange.action}</p>
                 </AlertDescription>
               </Alert>
             </section>
-          </div>
+          )}
         </div>
 
         <DialogFooter className="shrink-0 border-t bg-background px-6 py-4 sm:px-8" showCloseButton />
       </DialogContent>
     </Dialog>
-  );
-}
-
-interface ReleaseNotesProps {
-  className: string;
-}
-
-export function ReleaseNotes({ className }: ReleaseNotesProps) {
-  const [open, setOpen] = useState(false);
-  const [hasNew, setHasNew] = useState(() => !hasViewedRelease(releaseNotes.version));
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    setOpen(nextOpen);
-    if (nextOpen) {
-      markReleaseAsViewed(releaseNotes.version);
-      setHasNew(false);
-    }
-  };
-
-  return (
-    <ReleaseNotesDialog open={open} onOpenChange={handleOpenChange}>
-      <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
-        <DialogTrigger asChild>
-          <ReleaseNotesButton hasNew={hasNew} isOpen={open} className={className} />
-        </DialogTrigger>
-      </SidebarMenuItem>
-    </ReleaseNotesDialog>
   );
 }

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { AlertTriangle, Braces, Bug, CalendarDays, FileSearch, Gauge, Sparkles } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -13,7 +17,17 @@ import {
   hasViewedRelease,
   markReleaseAsViewed,
   releaseNotes,
+  type ReleaseNoteSection,
+  type ReleaseNoteSectionId,
 } from "@/lib/release-notes";
+
+const releaseNoteSectionIcons: Record<ReleaseNoteSectionId, LucideIcon> = {
+  highlights: Sparkles,
+  "openai-api": Braces,
+  indexing: FileSearch,
+  improvements: Gauge,
+  fixes: Bug,
+};
 
 interface ReleaseNotesButtonProps {
   hasNew: boolean;
@@ -56,32 +70,87 @@ interface ReleaseNotesDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+function ReleaseNotesSection({ section }: { section: ReleaseNoteSection }) {
+  const Icon = releaseNoteSectionIcons[section.id];
+  const headingId = `release-notes-${section.id}`;
+
+  return (
+    <section aria-labelledby={headingId} className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-start gap-3">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon aria-hidden="true" className="size-4" />
+        </span>
+        <div className="min-w-0">
+          <h3 id={headingId} className="text-sm font-semibold text-foreground">
+            {section.title}
+          </h3>
+          <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
+            {section.items.map((entry) => (
+              <li key={entry} className="flex gap-2">
+                <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" />
+                <span>{entry}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
+  const highlights = releaseNotes.sections.find((section) => section.id === "highlights");
+  const remainingSections = releaseNotes.sections.filter((section) => section.id !== "highlights");
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
-        <DialogHeader className="shrink-0 border-b px-6 py-5 pr-14">
-          <DialogTitle>OpenRAG v{releaseNotes.version}</DialogTitle>
-          <DialogDescription>{releaseNotes.summary}</DialogDescription>
-          <p className="text-xs font-medium text-muted-foreground">Released: {formatReleaseDate(releaseNotes.date)}</p>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="shrink-0 border-b bg-gradient-to-br from-primary/10 via-background to-background px-6 py-6 pr-14 sm:px-8">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            <Badge className="bg-primary text-primary-foreground">
+              <Sparkles aria-hidden="true" />
+              Latest release
+            </Badge>
+            <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <CalendarDays aria-hidden="true" className="size-3.5" />
+              Released {formatReleaseDate(releaseNotes.date)}
+            </p>
+          </div>
+          <DialogTitle className="mt-3 text-2xl tracking-tight sm:text-3xl">
+            OpenRAG <span className="text-primary">v{releaseNotes.version}</span>
+          </DialogTitle>
+          <DialogDescription className="max-w-2xl text-sm leading-6">{releaseNotes.summary}</DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5" data-testid="release-notes-content">
-          <section aria-labelledby="release-notes-whats-new">
-            <h3 id="release-notes-whats-new" className="text-sm font-semibold text-foreground">
-              What's New
-            </h3>
-            <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
-              {releaseNotes.whatsNew.map((entry) => (
-                <li key={entry} className="relative pl-4 before:absolute before:left-0 before:text-sidebar-primary before:content-['•']">
-                  {entry}
-                </li>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-6 sm:px-8" data-testid="release-notes-content">
+          <div className="space-y-4">
+            {highlights && <ReleaseNotesSection section={highlights} />}
+
+            <section aria-labelledby="release-notes-breaking-changes">
+              <Alert className="border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+                <AlertTriangle aria-hidden="true" className="text-amber-700 dark:text-amber-300" />
+                <AlertTitle id="release-notes-breaking-changes" className="text-amber-950 dark:text-amber-100">
+                  {releaseNotes.breakingChanges.title}
+                </AlertTitle>
+                <AlertDescription className="text-amber-900/90 dark:text-amber-100/90">
+                  <p>
+                    <span className="font-semibold">{releaseNotes.breakingChanges.calloutTitle}.</span>{" "}
+                    {releaseNotes.breakingChanges.description}
+                  </p>
+                  <p className="font-medium">{releaseNotes.breakingChanges.action}</p>
+                </AlertDescription>
+              </Alert>
+            </section>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {remainingSections.map((section) => (
+                <ReleaseNotesSection key={section.id} section={section} />
               ))}
-            </ul>
-          </section>
+            </div>
+          </div>
         </div>
 
-        <DialogFooter className="shrink-0 border-t px-6 py-4" showCloseButton />
+        <DialogFooter className="shrink-0 border-t bg-background px-6 py-4 sm:px-8" showCloseButton />
       </DialogContent>
     </Dialog>
   );

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -13,21 +13,7 @@ import {
   hasViewedRelease,
   markReleaseAsViewed,
   releaseNotes,
-  type ReleaseNotes,
 } from "@/lib/release-notes";
-
-interface ReleaseNoteSection {
-  id: string;
-  title: string;
-  entries: readonly string[];
-}
-
-const releaseNoteSections = (notes: ReleaseNotes): ReleaseNoteSection[] => [
-  { id: "whats-new", title: "What's New", entries: notes.features },
-  { id: "improvements", title: "Improvements", entries: notes.improvements },
-  { id: "bug-fixes", title: "Bug Fixes", entries: notes.fixes },
-  { id: "breaking-changes", title: "Breaking Changes", entries: notes.breakingChanges },
-];
 
 interface ReleaseNotesButtonProps {
   hasNew: boolean;
@@ -81,27 +67,18 @@ export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogPro
         </DialogHeader>
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5" data-testid="release-notes-content">
-          <div className="space-y-6">
-            {releaseNoteSections(releaseNotes)
-              .filter((section) => section.entries.length > 0)
-              .map((section) => (
-                <section key={section.id} aria-labelledby={`release-notes-${section.id}`}>
-                  <h3
-                    id={`release-notes-${section.id}`}
-                    className="text-sm font-semibold text-foreground"
-                  >
-                    {section.title}
-                  </h3>
-                  <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
-                    {section.entries.map((entry) => (
-                      <li key={entry} className="relative pl-4 before:absolute before:left-0 before:text-sidebar-primary before:content-['•']">
-                        {entry}
-                      </li>
-                    ))}
-                  </ul>
-                </section>
+          <section aria-labelledby="release-notes-whats-new">
+            <h3 id="release-notes-whats-new" className="text-sm font-semibold text-foreground">
+              What's New
+            </h3>
+            <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
+              {releaseNotes.whatsNew.map((entry) => (
+                <li key={entry} className="relative pl-4 before:absolute before:left-0 before:text-sidebar-primary before:content-['•']">
+                  {entry}
+                </li>
               ))}
-          </div>
+            </ul>
+          </section>
         </div>
 
         <DialogFooter className="shrink-0 border-t px-6 py-4" showCloseButton />

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { ScrollText } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -41,7 +40,7 @@ export function ReleaseNotesButton({ hasNew, isOpen, onOpen, className }: Releas
   const label = `Release Notes · v${releaseNotes.version}`;
 
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
       <button
         type="button"
         title={hasNew ? `${label} — New` : label}
@@ -55,10 +54,9 @@ export function ReleaseNotesButton({ hasNew, isOpen, onOpen, className }: Releas
             : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
         }`}
       >
-        <ScrollText className="h-4.5 w-4.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">{label}</span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
         {hasNew && (
-          <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary group-data-[collapsible=icon]:hidden">
+          <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary">
             New
           </span>
         )}

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -70,38 +70,33 @@ interface ReleaseNotesDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-function ReleaseNotesSection({ section }: { section: ReleaseNoteSection }) {
+function ReleaseNotesCategory({ section }: { section: ReleaseNoteSection }) {
   const Icon = releaseNoteSectionIcons[section.id];
   const headingId = `release-notes-${section.id}`;
 
   return (
-    <section aria-labelledby={headingId} className="rounded-xl border bg-card p-4 shadow-sm">
-      <div className="flex items-start gap-3">
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Icon aria-hidden="true" className="size-4" />
-        </span>
-        <div className="min-w-0">
-          <h3 id={headingId} className="text-sm font-semibold text-foreground">
-            {section.title}
-          </h3>
-          <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
-            {section.items.map((entry) => (
-              <li key={entry} className="flex gap-2">
-                <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" />
-                <span>{entry}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+    <article aria-labelledby={headingId} className="flex gap-3 py-4 first:pt-0 last:pb-0">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        <Icon aria-hidden="true" className="size-4" />
+      </span>
+      <div className="min-w-0">
+        <h4 id={headingId} className="text-sm font-semibold text-foreground">
+          {section.title}
+        </h4>
+        <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
+          {section.items.map((entry) => (
+            <li key={entry} className="flex gap-2">
+              <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" />
+              <span>{entry}</span>
+            </li>
+          ))}
+        </ul>
       </div>
-    </section>
+    </article>
   );
 }
 
 export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
-  const highlights = releaseNotes.sections.find((section) => section.id === "highlights");
-  const remainingSections = releaseNotes.sections.filter((section) => section.id !== "highlights");
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
@@ -123,8 +118,22 @@ export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogPro
         </DialogHeader>
 
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-6 sm:px-8" data-testid="release-notes-content">
-          <div className="space-y-4">
-            {highlights && <ReleaseNotesSection section={highlights} />}
+          <div className="space-y-6">
+            <section aria-labelledby="release-notes-whats-new">
+              <div className="flex items-center gap-2">
+                <span className="flex size-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Sparkles aria-hidden="true" className="size-4" />
+                </span>
+                <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
+                  What's New
+                </h3>
+              </div>
+              <div className="mt-4 divide-y border-y">
+                {releaseNotes.sections.map((section) => (
+                  <ReleaseNotesCategory key={section.id} section={section} />
+                ))}
+              </div>
+            </section>
 
             <section aria-labelledby="release-notes-breaking-changes">
               <Alert className="border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
@@ -141,12 +150,6 @@ export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogPro
                 </AlertDescription>
               </Alert>
             </section>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              {remainingSections.map((section) => (
-                <ReleaseNotesSection key={section.id} section={section} />
-              ))}
-            </div>
           </div>
         </div>
 

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import type { LucideIcon } from "lucide-react";
-import { AlertTriangle, Braces, Bug, CalendarDays, FileSearch, Gauge, Sparkles } from "lucide-react";
+import { AlertTriangle, CalendarDays, Sparkles } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -18,16 +17,7 @@ import {
   markReleaseAsViewed,
   releaseNotes,
   type ReleaseNoteSection,
-  type ReleaseNoteSectionId,
 } from "@/lib/release-notes";
-
-const releaseNoteSectionIcons: Record<ReleaseNoteSectionId, LucideIcon> = {
-  highlights: Sparkles,
-  "openai-api": Braces,
-  indexing: FileSearch,
-  improvements: Gauge,
-  fixes: Bug,
-};
 
 interface ReleaseNotesButtonProps {
   hasNew: boolean;
@@ -70,33 +60,45 @@ interface ReleaseNotesDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-function ReleaseNotesCategory({ section }: { section: ReleaseNoteSection }) {
-  const Icon = releaseNoteSectionIcons[section.id];
+interface ReleaseNotesSectionProps {
+  section: ReleaseNoteSection;
+  featured?: boolean;
+  className?: string;
+}
+
+function ReleaseNotesSection({ section, featured = false, className = "" }: ReleaseNotesSectionProps) {
   const headingId = `release-notes-${section.id}`;
 
   return (
-    <article aria-labelledby={headingId} className="flex gap-3 py-4 first:pt-0 last:pb-0">
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-        <Icon aria-hidden="true" className="size-4" />
-      </span>
-      <div className="min-w-0">
-        <h4 id={headingId} className="text-sm font-semibold text-foreground">
-          {section.title}
-        </h4>
-        <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
-          {section.items.map((entry) => (
-            <li key={entry} className="flex gap-2">
-              <span aria-hidden="true" className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/70" />
-              <span>{entry}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
+    <article
+      aria-labelledby={headingId}
+      className={`rounded-xl p-5 sm:p-6 ${
+        featured ? "border border-primary/15 bg-primary/[0.04]" : "border border-border/60 bg-muted/35"
+      } ${className}`}
+    >
+      {featured && <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">Featured</p>}
+      <h4 id={headingId} className={`${featured ? "mt-2 text-lg" : "text-sm"} font-semibold text-foreground`}>
+        {section.title}
+      </h4>
+      <ul className={`${featured ? "mt-4 grid gap-3 sm:grid-cols-2" : "mt-3 space-y-3"} text-sm leading-6 text-muted-foreground`}>
+        {section.items.map((entry) => (
+          <li key={entry} className="flex gap-2.5">
+            <span
+              aria-hidden="true"
+              className={`mt-2 size-1.5 shrink-0 rounded-full ${featured ? "bg-primary" : "bg-muted-foreground/55"}`}
+            />
+            <span>{entry}</span>
+          </li>
+        ))}
+      </ul>
     </article>
   );
 }
 
 export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
+  const highlights = releaseNotes.sections.find((section) => section.id === "highlights");
+  const supportingSections = releaseNotes.sections.filter((section) => section.id !== "highlights");
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
@@ -120,18 +122,20 @@ export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogPro
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-6 sm:px-8" data-testid="release-notes-content">
           <div className="space-y-6">
             <section aria-labelledby="release-notes-whats-new">
-              <div className="flex items-center gap-2">
-                <span className="flex size-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <Sparkles aria-hidden="true" className="size-4" />
-                </span>
-                <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
-                  What's New
-                </h3>
-              </div>
-              <div className="mt-4 divide-y border-y">
-                {releaseNotes.sections.map((section) => (
-                  <ReleaseNotesCategory key={section.id} section={section} />
-                ))}
+              <h3 id="release-notes-whats-new" className="text-base font-semibold text-foreground">
+                What's New
+              </h3>
+              <div className="mt-4 space-y-4">
+                {highlights && <ReleaseNotesSection section={highlights} featured />}
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {supportingSections.map((section) => (
+                    <ReleaseNotesSection
+                      key={section.id}
+                      section={section}
+                      className={section.id === "openai-api" ? "sm:col-span-2" : ""}
+                    />
+                  ))}
+                </div>
               </div>
             </section>
 

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { ScrollText } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SidebarMenuItem } from "@/components/ui/sidebar";
+import {
+  formatReleaseDate,
+  hasViewedRelease,
+  markReleaseAsViewed,
+  releaseNotes,
+  type ReleaseNotes,
+} from "@/lib/release-notes";
+
+interface ReleaseNoteSection {
+  id: string;
+  title: string;
+  entries: readonly string[];
+}
+
+const releaseNoteSections = (notes: ReleaseNotes): ReleaseNoteSection[] => [
+  { id: "whats-new", title: "What's New", entries: notes.features },
+  { id: "improvements", title: "Improvements", entries: notes.improvements },
+  { id: "bug-fixes", title: "Bug Fixes", entries: notes.fixes },
+  { id: "breaking-changes", title: "Breaking Changes", entries: notes.breakingChanges },
+];
+
+interface ReleaseNotesButtonProps {
+  hasNew: boolean;
+  isOpen: boolean;
+  onOpen: () => void;
+  className: string;
+}
+
+export function ReleaseNotesButton({ hasNew, isOpen, onOpen, className }: ReleaseNotesButtonProps) {
+  const label = `Release Notes · v${releaseNotes.version}`;
+
+  return (
+    <SidebarMenuItem>
+      <button
+        type="button"
+        title={hasNew ? `${label} — New` : label}
+        aria-label={hasNew ? `Open ${label}, new` : `Open ${label}`}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        onClick={onOpen}
+        className={`${className} ${
+          isOpen
+            ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
+            : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+        }`}
+      >
+        <ScrollText className="h-4.5 w-4.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">{label}</span>
+        {hasNew && (
+          <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary group-data-[collapsible=icon]:hidden">
+            New
+          </span>
+        )}
+      </button>
+    </SidebarMenuItem>
+  );
+}
+
+interface ReleaseNotesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="shrink-0 border-b px-6 py-5 pr-14">
+          <DialogTitle>OpenRAG v{releaseNotes.version}</DialogTitle>
+          <DialogDescription>{releaseNotes.summary}</DialogDescription>
+          <p className="text-xs font-medium text-muted-foreground">Released: {formatReleaseDate(releaseNotes.date)}</p>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5" data-testid="release-notes-content">
+          <div className="space-y-6">
+            {releaseNoteSections(releaseNotes)
+              .filter((section) => section.entries.length > 0)
+              .map((section) => (
+                <section key={section.id} aria-labelledby={`release-notes-${section.id}`}>
+                  <h3
+                    id={`release-notes-${section.id}`}
+                    className="text-sm font-semibold text-foreground"
+                  >
+                    {section.title}
+                  </h3>
+                  <ul className="mt-2 space-y-2 text-sm leading-6 text-muted-foreground">
+                    {section.entries.map((entry) => (
+                      <li key={entry} className="relative pl-4 before:absolute before:left-0 before:text-sidebar-primary before:content-['•']">
+                        {entry}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+          </div>
+        </div>
+
+        <DialogFooter className="shrink-0 border-t px-6 py-4" showCloseButton />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ReleaseNotesProps {
+  className: string;
+}
+
+export function ReleaseNotes({ className }: ReleaseNotesProps) {
+  const [open, setOpen] = useState(false);
+  const [hasNew, setHasNew] = useState(() => !hasViewedRelease(releaseNotes.version));
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      markReleaseAsViewed(releaseNotes.version);
+      setHasNew(false);
+    }
+  };
+
+  return (
+    <>
+      <ReleaseNotesButton hasNew={hasNew} isOpen={open} onOpen={() => handleOpenChange(true)} className={className} />
+      <ReleaseNotesDialog open={open} onOpenChange={handleOpenChange} />
+    </>
+  );
+}

--- a/ui/src/components/layout/release-notes.tsx
+++ b/ui/src/components/layout/release-notes.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { forwardRef, type ComponentProps, type ReactNode, useState } from "react";
 import { AlertTriangle, CalendarDays, Sparkles } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import { SidebarMenuItem } from "@/components/ui/sidebar";
 import {
@@ -18,50 +19,52 @@ import {
   releaseNotes,
 } from "@/lib/release-notes";
 
-interface ReleaseNotesButtonProps {
+interface ReleaseNotesButtonProps extends ComponentProps<"button"> {
   hasNew: boolean;
   isOpen: boolean;
-  onOpen: () => void;
-  className: string;
 }
 
-export function ReleaseNotesButton({ hasNew, isOpen, onOpen, className }: ReleaseNotesButtonProps) {
+export const ReleaseNotesButton = forwardRef<HTMLButtonElement, ReleaseNotesButtonProps>(function ReleaseNotesButton(
+  { hasNew, isOpen, className, ...buttonProps },
+  ref,
+) {
   const label = `Release Notes · v${releaseNotes.version}`;
 
   return (
-    <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
-      <button
-        type="button"
-        title={hasNew ? `${label} — New` : label}
-        aria-label={hasNew ? `Open ${label}, new` : `Open ${label}`}
-        aria-haspopup="dialog"
-        aria-expanded={isOpen}
-        onClick={onOpen}
-        className={`${className} ${
-          isOpen
-            ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
-            : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
-        }`}
-      >
-        <span className="min-w-0 flex-1 truncate">{label}</span>
-        {hasNew && (
-          <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary">
-            New
-          </span>
-        )}
-      </button>
-    </SidebarMenuItem>
+    <button
+      ref={ref}
+      type="button"
+      title={hasNew ? `${label} — New` : label}
+      aria-label={hasNew ? `Open ${label}, new` : `Open ${label}`}
+      aria-haspopup="dialog"
+      aria-expanded={isOpen}
+      {...buttonProps}
+      className={`${className} ${
+        isOpen
+          ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
+          : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+      }`}
+    >
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {hasNew && (
+        <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary/15 px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none text-sidebar-primary">
+          New
+        </span>
+      )}
+    </button>
   );
-}
+});
 
 interface ReleaseNotesDialogProps {
+  children: ReactNode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export function ReleaseNotesDialog({ open, onOpenChange }: ReleaseNotesDialogProps) {
+export function ReleaseNotesDialog({ children, open, onOpenChange }: ReleaseNotesDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      {children}
       <DialogContent className="flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
         <DialogHeader className="shrink-0 border-b bg-gradient-to-br from-primary/10 via-background to-background px-6 py-6 pr-14 sm:px-8">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -142,9 +145,12 @@ export function ReleaseNotes({ className }: ReleaseNotesProps) {
   };
 
   return (
-    <>
-      <ReleaseNotesButton hasNew={hasNew} isOpen={open} onOpen={() => handleOpenChange(true)} className={className} />
-      <ReleaseNotesDialog open={open} onOpenChange={handleOpenChange} />
-    </>
+    <ReleaseNotesDialog open={open} onOpenChange={handleOpenChange}>
+      <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+        <DialogTrigger asChild>
+          <ReleaseNotesButton hasNew={hasNew} isOpen={open} className={className} />
+        </DialogTrigger>
+      </SidebarMenuItem>
+    </ReleaseNotesDialog>
   );
 }

--- a/ui/src/components/layout/sidebar-item.ts
+++ b/ui/src/components/layout/sidebar-item.ts
@@ -1,0 +1,2 @@
+export const sidebarItemInactiveClassName =
+  "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground";

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -120,3 +120,15 @@ describe("AppSidebar Jobs badge", () => {
     expect(screen.getByLabelText("Current route").textContent).toBe("/jobs");
   });
 });
+
+describe("AppSidebar", () => {
+  it("keeps Release Notes directly above the unchanged Settings link", () => {
+    renderSidebar();
+
+    const releaseNotes = screen.getByRole("button", { name: /open release notes/i });
+    const settings = screen.getByRole("link", { name: "Settings" });
+
+    expect(releaseNotes.closest("li")?.nextElementSibling).toBe(settings.closest("li"));
+    expect(settings.getAttribute("href")).toBe("/settings");
+  });
+});

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -128,7 +128,12 @@ describe("AppSidebar", () => {
     const releaseNotes = screen.getByRole("button", { name: /open release notes/i });
     const settings = screen.getByRole("link", { name: "Settings" });
 
-    expect(releaseNotes.closest("li")?.nextElementSibling).toBe(settings.closest("li"));
+    expect(releaseNotes.querySelector("svg")).toBeNull();
+    expect(releaseNotes.className).toContain("h-7");
+    expect(releaseNotes.closest("[data-slot='sidebar-release-notes']")?.nextElementSibling).toBe(
+      screen.getByTestId("sidebar-footer"),
+    );
+    expect(screen.getByTestId("sidebar-content").compareDocumentPosition(releaseNotes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(settings.getAttribute("href")).toBe("/settings");
   });
 });

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -6,29 +6,30 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "./sidebar";
 
 const activeJobs = vi.hoisted(() => ({ count: 7 }));
+const permissions = vi.hoisted(() => ({
+  isAdmin: true,
+  superAdmin: true,
+  superAdminModeResolved: true,
+  canViewPlatform: true,
+  canViewSystem: true,
+  canManageUsers: true,
+  canManageModels: true,
+  canManagePresets: true,
+  canManagePrompts: true,
+  canManagePartitions: true,
+  canCreatePartition: true,
+  canRead: () => true,
+  canWrite: () => true,
+  canManageMembers: () => true,
+  canConfigurePartition: () => true,
+}));
 
 vi.mock("@/lib/jobs-queries", () => ({
   useActiveJobsCount: () => activeJobs.count,
 }));
 
 vi.mock("@/lib/permissions", () => ({
-  usePermissions: () => ({
-    isAdmin: true,
-    superAdmin: true,
-    superAdminModeResolved: true,
-    canViewPlatform: true,
-    canViewSystem: true,
-    canManageUsers: true,
-    canManageModels: true,
-    canManagePresets: true,
-    canManagePrompts: true,
-    canManagePartitions: true,
-    canCreatePartition: true,
-    canRead: () => true,
-    canWrite: () => true,
-    canManageMembers: () => true,
-    canConfigurePartition: () => true,
-  }),
+  usePermissions: () => permissions,
 }));
 
 function LocationProbe() {
@@ -67,6 +68,7 @@ beforeAll(() => {
 describe("AppSidebar Jobs badge", () => {
   beforeEach(() => {
     activeJobs.count = 7;
+    permissions.isAdmin = true;
   });
 
   it.each([
@@ -122,7 +124,11 @@ describe("AppSidebar Jobs badge", () => {
 });
 
 describe("AppSidebar", () => {
-  it("keeps Release Notes directly above the unchanged Settings link", () => {
+  beforeEach(() => {
+    permissions.isAdmin = true;
+  });
+
+  it("keeps the compact Release Notes button above the Settings separator", () => {
     renderSidebar();
 
     const releaseNotes = screen.getByRole("button", { name: /open release notes/i });
@@ -135,5 +141,12 @@ describe("AppSidebar", () => {
     );
     expect(screen.getByTestId("sidebar-content").compareDocumentPosition(releaseNotes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(settings.getAttribute("href")).toBe("/settings");
+  });
+
+  it("hides Release Notes from non-admin users", () => {
+    permissions.isAdmin = false;
+    renderSidebar();
+
+    expect(screen.queryByRole("button", { name: /open release notes/i })).toBeNull();
   });
 });

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -136,6 +136,7 @@ describe("AppSidebar", () => {
 
     expect(releaseNotes.querySelector("svg")).toBeNull();
     expect(releaseNotes.className).toContain("h-7");
+    expect(releaseNotes.closest("[data-slot='sidebar-release-notes']")?.className).toContain("group-data-[collapsible=icon]:hidden");
     expect(releaseNotes.closest("[data-slot='sidebar-release-notes']")?.nextElementSibling).toBe(
       screen.getByTestId("sidebar-footer"),
     );

--- a/ui/src/components/layout/sidebar.test.tsx
+++ b/ui/src/components/layout/sidebar.test.tsx
@@ -128,20 +128,15 @@ describe("AppSidebar", () => {
     permissions.isAdmin = true;
   });
 
-  it("keeps the compact Release Notes button above the Settings separator", () => {
+  it("keeps the Release Notes button above the Settings separator", () => {
     renderSidebar();
 
     const releaseNotes = screen.getByRole("button", { name: /open release notes/i });
-    const settings = screen.getByRole("link", { name: "Settings" });
 
-    expect(releaseNotes.querySelector("svg")).toBeNull();
-    expect(releaseNotes.className).toContain("h-7");
-    expect(releaseNotes.closest("[data-slot='sidebar-release-notes']")?.className).toContain("group-data-[collapsible=icon]:hidden");
-    expect(releaseNotes.closest("[data-slot='sidebar-release-notes']")?.nextElementSibling).toBe(
-      screen.getByTestId("sidebar-footer"),
-    );
-    expect(screen.getByTestId("sidebar-content").compareDocumentPosition(releaseNotes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(settings.getAttribute("href")).toBe("/settings");
+    expect(
+      releaseNotes.closest("[data-slot='sidebar-release-notes']")?.nextElementSibling?.getAttribute("data-slot"),
+    ).toBe("sidebar-footer");
+    expect(screen.getByRole("link", { name: "Settings" }).getAttribute("href")).toBe("/settings");
   });
 
   it("hides Release Notes from non-admin users", () => {

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { APP_NAME } from "@/lib/brand";
 import { useActiveJobsCount } from "@/lib/jobs-queries";
 import { usePermissions, type Permissions } from "@/lib/permissions";
+import { ReleaseNotes } from "./release-notes";
 
 interface NavItem {
   title: string;
@@ -49,6 +50,10 @@ const navItems: NavItem[] = [
 ];
 
 const settingsItem: NavItem = { title: "Settings", href: "/settings", icon: UserCog };
+
+const sidebarItemClassName =
+  "relative flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium transition-colors overflow-hidden group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0";
+const sidebarItemInactiveClassName = "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground";
 
 export function AppSidebar() {
   const location = useLocation();
@@ -77,12 +82,12 @@ export function AppSidebar() {
               ? `${item.title}, ${badgeCount} active job${badgeCount === 1 ? "" : "s"}`
               : undefined
           }
-          className={`relative flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium transition-colors overflow-hidden group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 ${
+          className={`${sidebarItemClassName} ${
             badgeCount > 0 ? "pr-11 group-data-[collapsible=icon]:pr-0" : ""
           } ${
             active
               ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
-              : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+              : sidebarItemInactiveClassName
           }`}
         >
           <item.icon className="h-4.5 w-4.5 shrink-0" />
@@ -127,7 +132,10 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
       <SidebarFooter className="px-3 py-3 border-t border-sidebar-border group-data-[collapsible=icon]:px-1.5">
-        <SidebarMenu>{renderItem(settingsItem)}</SidebarMenu>
+        <SidebarMenu>
+          <ReleaseNotes className={sidebarItemClassName} />
+          {renderItem(settingsItem)}
+        </SidebarMenu>
       </SidebarFooter>
     </Sidebar>
   );

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -136,7 +136,7 @@ export function AppSidebar() {
       {perms.isAdmin && (
         <div
           data-slot="sidebar-release-notes"
-          className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:px-1.5"
+          className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:hidden"
         >
           <SidebarMenu>
             <ReleaseNotes className={releaseNotesItemClassName} />

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -133,14 +133,16 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <div
-        data-slot="sidebar-release-notes"
-        className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:px-1.5"
-      >
-        <SidebarMenu>
-          <ReleaseNotes className={releaseNotesItemClassName} />
-        </SidebarMenu>
-      </div>
+      {perms.isAdmin && (
+        <div
+          data-slot="sidebar-release-notes"
+          className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:px-1.5"
+        >
+          <SidebarMenu>
+            <ReleaseNotes className={releaseNotesItemClassName} />
+          </SidebarMenu>
+        </div>
+      )}
       <SidebarFooter className="px-3 py-3 border-t border-sidebar-border group-data-[collapsible=icon]:px-1.5">
         <SidebarMenu>{renderItem(settingsItem)}</SidebarMenu>
       </SidebarFooter>

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -26,6 +26,7 @@ import { APP_NAME } from "@/lib/brand";
 import { useActiveJobsCount } from "@/lib/jobs-queries";
 import { usePermissions, type Permissions } from "@/lib/permissions";
 import { ReleaseNotes } from "./release-notes";
+import { sidebarItemInactiveClassName } from "./sidebar-item";
 
 interface NavItem {
   title: string;
@@ -53,9 +54,6 @@ const settingsItem: NavItem = { title: "Settings", href: "/settings", icon: User
 
 const sidebarItemClassName =
   "relative flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium transition-colors overflow-hidden group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0";
-const sidebarItemInactiveClassName = "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground";
-const releaseNotesItemClassName =
-  "flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors";
 
 export function AppSidebar() {
   const location = useLocation();
@@ -138,9 +136,7 @@ export function AppSidebar() {
           data-slot="sidebar-release-notes"
           className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:hidden"
         >
-          <SidebarMenu>
-            <ReleaseNotes className={releaseNotesItemClassName} />
-          </SidebarMenu>
+          <ReleaseNotes />
         </div>
       )}
       <SidebarFooter className="px-3 py-3 border-t border-sidebar-border group-data-[collapsible=icon]:px-1.5">

--- a/ui/src/components/layout/sidebar.tsx
+++ b/ui/src/components/layout/sidebar.tsx
@@ -54,6 +54,8 @@ const settingsItem: NavItem = { title: "Settings", href: "/settings", icon: User
 const sidebarItemClassName =
   "relative flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium transition-colors overflow-hidden group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0";
 const sidebarItemInactiveClassName = "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground";
+const releaseNotesItemClassName =
+  "flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors";
 
 export function AppSidebar() {
   const location = useLocation();
@@ -131,11 +133,16 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter className="px-3 py-3 border-t border-sidebar-border group-data-[collapsible=icon]:px-1.5">
+      <div
+        data-slot="sidebar-release-notes"
+        className="shrink-0 px-3 pb-3 group-data-[collapsible=icon]:px-1.5"
+      >
         <SidebarMenu>
-          <ReleaseNotes className={sidebarItemClassName} />
-          {renderItem(settingsItem)}
+          <ReleaseNotes className={releaseNotesItemClassName} />
         </SidebarMenu>
+      </div>
+      <SidebarFooter className="px-3 py-3 border-t border-sidebar-border group-data-[collapsible=icon]:px-1.5">
+        <SidebarMenu>{renderItem(settingsItem)}</SidebarMenu>
       </SidebarFooter>
     </Sidebar>
   );

--- a/ui/src/lib/release-notes.test.ts
+++ b/ui/src/lib/release-notes.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formatReleaseDate,
+  hasViewedRelease,
+  LAST_VIEWED_RELEASE_NOTES_KEY,
+  markReleaseAsViewed,
+} from "./release-notes";
+
+describe("release notes storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("tracks the viewed version rather than hiding future release notes", () => {
+    markReleaseAsViewed("2.2.0");
+
+    expect(localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY)).toBe("2.2.0");
+    expect(hasViewedRelease("2.2.0")).toBe(true);
+    expect(hasViewedRelease("2.3.0")).toBe(false);
+  });
+
+  it("formats the ISO release date for the dialog", () => {
+    expect(formatReleaseDate("2026-08-31")).toBe("August 31, 2026");
+  });
+});

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -18,10 +18,13 @@ export interface Release {
  * dialog content are derived from it.
  */
 export const releaseNotes: Release = {
-  version: "2.2.0",
-  date: "2026-08-31",
+  // Placeholder — the real version and date are set on the release/X.Y.Z
+  // branch when the version is actually chosen. See CONTRIBUTING.md § Writing
+  // the release notes.
+  version: "2.X.X",
+  date: "2026-01-01",
   summary:
-    "OpenRAG 2.2 gives administrators more control over document chunking and speech-to-text configuration directly from the Admin Console.",
+    "OpenRAG 2.X.X gives administrators more control over document chunking and speech-to-text configuration directly from the Admin Console.",
   newFeatures: [
     "Choose the new structured_section chunking strategy from indexation presets to keep document sections, headings, tables, and captions together.",
     "Register, validate, and choose OpenAI-compatible STT endpoints such as Whisper or MOSS from Model Endpoints.",
@@ -32,7 +35,7 @@ export const releaseNotes: Release = {
   ],
   breakingChange: {
     title: "Milvus 3.0 migration required",
-    description: "OpenRAG 2.2 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
+    description: "OpenRAG 2.X.X requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
     action: "Back up your data and follow the Milvus migration guide before starting the new version.",
   },
 };

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -1,0 +1,63 @@
+/**
+ * The single source of truth for the release notes shown in the Admin Console.
+ * Update this object for each release; the sidebar label, unread state, and
+ * dialog content are derived from it.
+ */
+export interface ReleaseNotes {
+  version: string;
+  date: string;
+  summary: string;
+  features: readonly string[];
+  improvements: readonly string[];
+  fixes: readonly string[];
+  breakingChanges: readonly string[];
+}
+
+export const releaseNotes: ReleaseNotes = {
+  version: "2.2.0",
+  date: "2026-08-31",
+  summary: "OpenRAG 2.2 gives administrators more control over external audio transcription and indexing configuration.",
+  features: [
+    "Manage transcription prompts directly from the Admin Console.",
+    "Configure OpenAI-compatible speech-to-text endpoints, including MOSS.",
+    "Choose the STT endpoint and transcription prompt for each indexation preset.",
+    "Select raw, timestamped, or speaker-aware output for MOSS transcripts.",
+  ],
+  improvements: [
+    "Show clearer validation feedback while configuring transcription endpoints.",
+    "Allow an empty transcription prompt to use the provider's native behavior.",
+  ],
+  fixes: ["Preserve unrecognized MOSS transcript responses instead of partially rewriting them."],
+  breakingChanges: [],
+};
+
+export const LAST_VIEWED_RELEASE_NOTES_KEY = "openrag:last-viewed-release-notes-version";
+
+export function hasViewedRelease(version: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY) === version;
+  } catch {
+    // Local storage can be disabled by the browser. The dialog remains usable;
+    // the badge simply stays visible until storage is available again.
+    return false;
+  }
+}
+
+export function markReleaseAsViewed(version: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, version);
+  } catch {
+    // Treat storage as an enhancement rather than blocking access to notes.
+  }
+}
+
+export function formatReleaseDate(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
+}

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -3,14 +3,6 @@
  * Update this object for each release; the sidebar label, unread state, and
  * dialog content are derived from it.
  */
-export type ReleaseNoteSectionId = "highlights" | "openai-api" | "indexing" | "improvements";
-
-export interface ReleaseNoteSection {
-  id: ReleaseNoteSectionId;
-  title: string;
-  items: readonly string[];
-}
-
 export interface ReleaseBreakingChanges {
   title: string;
   calloutTitle: string;
@@ -23,47 +15,26 @@ export interface ReleaseNotes {
   date: string;
   summary: string;
   breakingChanges: ReleaseBreakingChanges;
-  sections: readonly ReleaseNoteSection[];
+  newFeatures: readonly string[];
 }
 
 export const releaseNotes: ReleaseNotes = {
   version: "2.2.0",
   date: "2026-08-31",
   summary:
-    "OpenRAG 2.2 strengthens OpenAI API compatibility, makes retrieval more precise, and improves indexing quality while giving applications more control over prompts and LLM routing.",
+    "OpenRAG 2.2 introduces structure-aware chunking, strengthens OpenAI API compatibility, and gives applications more precise retrieval and control over prompts and LLM routing.",
   breakingChanges: {
     title: "Breaking Changes",
     calloutTitle: "Milvus 3.0 migration required",
     description: "OpenRAG 2.2 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
     action: "Back up your data and follow the Milvus migration guide before starting the new version.",
   },
-  sections: [
-    {
-      id: "highlights",
-      title: "Highlights",
-      items: [
-        "Limit retrieval to selected indexed file IDs in OpenAI chat requests.",
-        "Safely include client-provided system instructions in RAG prompts.",
-      ],
-    },
-    {
-      id: "openai-api",
-      title: "OpenAI API",
-      items: [
-        "Forward OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields to the model.",
-        "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
-      ],
-    },
-    {
-      id: "indexing",
-      title: "Indexing",
-      items: ["Preserve meaningful image captions next to placeholders for more complete indexed content."],
-    },
-    {
-      id: "improvements",
-      title: "Improvements",
-      items: ["Keep custom HTTPS LLM overrides isolated from the shared LLM circuit breaker."],
-    },
+  newFeatures: [
+    "Add structured_section, an opt-in, structure-aware chunking strategy that keeps headings, tables, captions, and page boundaries together.",
+    "Limit retrieval to selected indexed file IDs in OpenAI chat requests.",
+    "Safely include client-provided system instructions in RAG prompts.",
+    "Forward OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields to the model.",
+    "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
   ],
 };
 

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -22,7 +22,7 @@ export const releaseNotes: ReleaseNotes = {
   version: "2.2.0",
   date: "2026-08-31",
   summary:
-    "OpenRAG 2.2 introduces structure-aware chunking, strengthens OpenAI API compatibility, and gives applications more precise retrieval and control over prompts and LLM routing.",
+    "OpenRAG 2.2 gives administrators more control over document chunking and speech-to-text configuration directly from the Admin Console.",
   breakingChanges: {
     title: "Breaking Changes",
     calloutTitle: "Milvus 3.0 migration required",
@@ -30,11 +30,11 @@ export const releaseNotes: ReleaseNotes = {
     action: "Back up your data and follow the Milvus migration guide before starting the new version.",
   },
   newFeatures: [
-    "Add structured_section, an opt-in, structure-aware chunking strategy that keeps headings, tables, captions, and page boundaries together.",
-    "Limit retrieval to selected indexed file IDs in OpenAI chat requests.",
-    "Safely include client-provided system instructions in RAG prompts.",
-    "Forward OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields to the model.",
-    "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
+    "Choose the new structured_section chunking strategy from indexation presets to keep document sections, headings, tables, and captions together.",
+    "Register, validate, and choose OpenAI-compatible STT endpoints such as Whisper or MOSS from Model Endpoints.",
+    "Create and update transcription prompts in the prompt library without restarting OpenRAG.",
+    "Set an STT endpoint and transcription prompt per indexation preset, so each partition can use the appropriate speech-to-text behavior.",
+    "Choose how MOSS diarized transcripts are formatted: raw output, timestamped speaker lines, or speaker-aware lines.",
   ],
 };
 

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -3,7 +3,7 @@
  * Update this object for each release; the sidebar label, unread state, and
  * dialog content are derived from it.
  */
-export type ReleaseNoteSectionId = "highlights" | "openai-api" | "indexing" | "improvements" | "fixes";
+export type ReleaseNoteSectionId = "highlights" | "openai-api" | "indexing" | "improvements";
 
 export interface ReleaseNoteSection {
   id: ReleaseNoteSectionId;
@@ -63,11 +63,6 @@ export const releaseNotes: ReleaseNotes = {
       id: "improvements",
       title: "Improvements",
       items: ["Keep custom HTTPS LLM overrides isolated from the shared LLM circuit breaker."],
-    },
-    {
-      id: "fixes",
-      title: "Fixes",
-      items: ["Do not send disabled log-probability parameters to strict OpenAI-compatible providers."],
     },
   ],
 };

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -1,49 +1,47 @@
+export interface ReleaseBreakingChange {
+  title: string;
+  description: string;
+  action: string;
+}
+
+export interface Release {
+  version: string;
+  date: string;
+  summary: string;
+  newFeatures: readonly string[];
+  breakingChange?: ReleaseBreakingChange;
+}
+
 /**
  * The single source of truth for the release notes shown in the Admin Console.
  * Update this object for each release; the sidebar label, unread state, and
  * dialog content are derived from it.
  */
-export interface ReleaseBreakingChanges {
-  title: string;
-  calloutTitle: string;
-  description: string;
-  action: string;
-}
-
-export interface ReleaseNotes {
-  version: string;
-  date: string;
-  summary: string;
-  breakingChanges: ReleaseBreakingChanges;
-  newFeatures: readonly string[];
-}
-
-export const releaseNotes: ReleaseNotes = {
+export const releaseNotes: Release = {
   version: "2.2.0",
   date: "2026-08-31",
   summary:
     "OpenRAG 2.2 gives administrators more control over document chunking and speech-to-text configuration directly from the Admin Console.",
-  breakingChanges: {
-    title: "Breaking Changes",
-    calloutTitle: "Milvus 3.0 migration required",
-    description: "OpenRAG 2.2 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
-    action: "Back up your data and follow the Milvus migration guide before starting the new version.",
-  },
   newFeatures: [
     "Choose the new structured_section chunking strategy from indexation presets to keep document sections, headings, tables, and captions together.",
     "Register, validate, and choose OpenAI-compatible STT endpoints such as Whisper or MOSS from Model Endpoints.",
     "Create and update transcription prompts in the prompt library without restarting OpenRAG.",
     "Set an STT endpoint and transcription prompt per indexation preset, so each partition can use the appropriate speech-to-text behavior.",
     "Choose how MOSS diarized transcripts are formatted: raw output, timestamped speaker lines, or speaker-aware lines.",
+    "Read what shipped in each release from the new Release Notes entry in the sidebar.",
   ],
+  breakingChange: {
+    title: "Milvus 3.0 migration required",
+    description: "OpenRAG 2.2 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
+    action: "Back up your data and follow the Milvus migration guide before starting the new version.",
+  },
 };
 
 export const LAST_VIEWED_RELEASE_NOTES_KEY = "openrag:last-viewed-release-notes-version";
 
 export function hasViewedRelease(version: string): boolean {
-  if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY) === version;
+    return localStorage.getItem(LAST_VIEWED_RELEASE_NOTES_KEY) === version;
   } catch {
     // Local storage can be disabled by the browser. The dialog remains usable;
     // the badge simply stays visible until storage is available again.
@@ -52,9 +50,8 @@ export function hasViewedRelease(version: string): boolean {
 }
 
 export function markReleaseAsViewed(version: string): void {
-  if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, version);
+    localStorage.setItem(LAST_VIEWED_RELEASE_NOTES_KEY, version);
   } catch {
     // Treat storage as an enhancement rather than blocking access to notes.
   }

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -3,25 +3,72 @@
  * Update this object for each release; the sidebar label, unread state, and
  * dialog content are derived from it.
  */
+export type ReleaseNoteSectionId = "highlights" | "openai-api" | "indexing" | "improvements" | "fixes";
+
+export interface ReleaseNoteSection {
+  id: ReleaseNoteSectionId;
+  title: string;
+  items: readonly string[];
+}
+
+export interface ReleaseBreakingChanges {
+  title: string;
+  calloutTitle: string;
+  description: string;
+  action: string;
+}
+
 export interface ReleaseNotes {
   version: string;
   date: string;
   summary: string;
-  whatsNew: readonly string[];
+  breakingChanges: ReleaseBreakingChanges;
+  sections: readonly ReleaseNoteSection[];
 }
 
 export const releaseNotes: ReleaseNotes = {
   version: "2.2.0",
   date: "2026-08-31",
-  summary: "OpenRAG 2.2 improves deployment compatibility, OpenAI API support, and indexing quality while giving applications finer control over prompts, retrieval, and LLM routing.",
-  whatsNew: [
-    "Milvus 3.0 is now required. Follow the migration guide before upgrading an existing Milvus 2.x deployment.",
-    "Client-provided system instructions are preserved and safely integrated into RAG prompts.",
-    "Scope retrieval to selected indexed file IDs in OpenAI chat requests.",
-    "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
-    "OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields are forwarded to the model.",
-    "Strict OpenAI-compatible providers no longer receive disabled log-probability parameters.",
-    "Meaningful image captions next to placeholders are preserved during indexing.",
+  summary:
+    "OpenRAG 2.2 strengthens OpenAI API compatibility, makes retrieval more precise, and improves indexing quality while giving applications more control over prompts and LLM routing.",
+  breakingChanges: {
+    title: "Breaking Changes",
+    calloutTitle: "Milvus 3.0 migration required",
+    description: "OpenRAG 2.2 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading.",
+    action: "Back up your data and follow the Milvus migration guide before starting the new version.",
+  },
+  sections: [
+    {
+      id: "highlights",
+      title: "Highlights",
+      items: [
+        "Limit retrieval to selected indexed file IDs in OpenAI chat requests.",
+        "Safely include client-provided system instructions in RAG prompts.",
+      ],
+    },
+    {
+      id: "openai-api",
+      title: "OpenAI API",
+      items: [
+        "Forward OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields to the model.",
+        "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
+      ],
+    },
+    {
+      id: "indexing",
+      title: "Indexing",
+      items: ["Preserve meaningful image captions next to placeholders for more complete indexed content."],
+    },
+    {
+      id: "improvements",
+      title: "Improvements",
+      items: ["Keep custom HTTPS LLM overrides isolated from the shared LLM circuit breaker."],
+    },
+    {
+      id: "fixes",
+      title: "Fixes",
+      items: ["Do not send disabled log-probability parameters to strict OpenAI-compatible providers."],
+    },
   ],
 };
 

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -13,12 +13,15 @@ export interface ReleaseNotes {
 export const releaseNotes: ReleaseNotes = {
   version: "2.2.0",
   date: "2026-08-31",
-  summary: "OpenRAG 2.2 gives administrators more control over external audio transcription and indexing configuration.",
+  summary: "OpenRAG 2.2 improves deployment compatibility, OpenAI API support, and indexing quality while giving applications finer control over prompts, retrieval, and LLM routing.",
   whatsNew: [
-    "Manage transcription prompts directly from the Admin Console.",
-    "Configure OpenAI-compatible speech-to-text endpoints, including MOSS.",
-    "Choose the STT endpoint and transcription prompt for each indexation preset.",
-    "Select raw, timestamped, or speaker-aware output for MOSS transcripts.",
+    "Milvus 3.0 is now required. Follow the migration guide before upgrading an existing Milvus 2.x deployment.",
+    "Client-provided system instructions are preserved and safely integrated into RAG prompts.",
+    "Scope retrieval to selected indexed file IDs in OpenAI chat requests.",
+    "Optionally route a request to a custom HTTPS LLM endpoint, model, and credentials after enabling LLM_OVERRIDE_ALLOW_CUSTOM_ENDPOINT.",
+    "OpenAI-compatible tool calls, function calls, message names, and vendor-specific fields are forwarded to the model.",
+    "Strict OpenAI-compatible providers no longer receive disabled log-probability parameters.",
+    "Meaningful image captions next to placeholders are preserved during indexing.",
   ],
 };
 

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -7,28 +7,19 @@ export interface ReleaseNotes {
   version: string;
   date: string;
   summary: string;
-  features: readonly string[];
-  improvements: readonly string[];
-  fixes: readonly string[];
-  breakingChanges: readonly string[];
+  whatsNew: readonly string[];
 }
 
 export const releaseNotes: ReleaseNotes = {
   version: "2.2.0",
   date: "2026-08-31",
   summary: "OpenRAG 2.2 gives administrators more control over external audio transcription and indexing configuration.",
-  features: [
+  whatsNew: [
     "Manage transcription prompts directly from the Admin Console.",
     "Configure OpenAI-compatible speech-to-text endpoints, including MOSS.",
     "Choose the STT endpoint and transcription prompt for each indexation preset.",
     "Select raw, timestamped, or speaker-aware output for MOSS transcripts.",
   ],
-  improvements: [
-    "Show clearer validation feedback while configuring transcription endpoints.",
-    "Allow an empty transcription prompt to use the provider's native behavior.",
-  ],
-  fixes: ["Preserve unrecognized MOSS transcript responses instead of partially rewriting them."],
-  breakingChanges: [],
 };
 
 export const LAST_VIEWED_RELEASE_NOTES_KEY = "openrag:last-viewed-release-notes-version";


### PR DESCRIPTION
## Context

Admins need a concise way to discover the changes delivered in a release without leaving the console.

## Expected behavior

The sidebar keeps release notes beside Settings. Opening it shows the current release in an accessible dialog, and a New marker is remembered locally for each release version.

## Release dependency

The v2.2.0 notes describe the Admin Console capabilities delivered by #861 and #872–#875. Merge this PR after those feature PRs so it never announces a control that has not shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin-only Release Notes entry to the sidebar.
  - Added release notes for version 2.2.0, including migration requirements and Admin Console navigation.
  - Release notes open in a keyboard-friendly dialog with focus restoration.
  - Added conditional breaking-change callouts and viewed-state tracking.
  - Added active job count badges to the Jobs sidebar link, capped at `99+`.

- **Bug Fixes**
  - Release Notes are hidden from non-admin users and collapsed sidebar mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->