### PR TITLE
feat(workspaces): add keep_files option to workspace deletion

### DIFF
--- a/docs/content/docs/documentation/workspaces.md
+++ b/docs/content/docs/documentation/workspaces.md
@@ -59,7 +59,7 @@ All workspace endpoints live under `/partition/{partition}/workspaces`.
 | POST | `/partition/{partition}/workspaces` | Editor | Create a workspace |
 | GET | `/partition/{partition}/workspaces` | Viewer | List all workspaces in partition |
 | GET | `/partition/{partition}/workspaces/{workspace_id}` | Viewer | Get workspace details |
-| DELETE | `/partition/{partition}/workspaces/{workspace_id}` | Owner | Delete workspace and orphaned files |
+| DELETE | `/partition/{partition}/workspaces/{workspace_id}` | Owner | Delete workspace (and orphaned files, unless `keep_files=true`) |
 
 ### Workspace File Management
 
@@ -126,10 +126,28 @@ curl -X DELETE "$BASE_URL/partition/my-partition/workspaces/project-alpha" \
 ```
 
 ```json
-{"status": "deleted", "orphaned_files_deleted": 1}
+{"status": "deleted", "orphaned_files_deleted": 1, "orphaned_files_failed": [], "kept_files": 0}
 ```
 
 Files that belonged **only** to the deleted workspace are automatically removed from the partition. Files shared with other workspaces are preserved.
+
+#### Keeping Orphaned Files (`keep_files=true`)
+
+Pass `?keep_files=true` to delete the workspace and its membership rows **without** touching any files, even ones that would otherwise be orphaned:
+
+```bash
+curl -X DELETE "$BASE_URL/partition/my-partition/workspaces/project-alpha?keep_files=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{"status": "deleted", "orphaned_files_deleted": 0, "orphaned_files_failed": [], "kept_files": 1}
+```
+
+- `kept_files` reports how many files would have been orphaned and were left indexed in the partition instead of being deleted.
+- The workspace and its `workspace_files` rows are still removed as usual — only the file-deletion step is skipped.
+- Default behavior (parameter absent or `keep_files=false`) is unchanged: orphaned files are purged as before.
+- Useful when files may be shared outside of the workspace model (e.g. referenced by an external system) and must never be deleted as a side effect of removing a workspace.
 
 ---
 
@@ -199,7 +217,9 @@ flowchart LR
     A[Delete workspace] --> B[Find workspace files]
     B --> C{File in other workspaces?}
     C -->|Yes| D[Keep file]
-    C -->|No| E[Delete orphaned file from partition]
+    C -->|No| G{keep_files=true?}
+    G -->|Yes| D
+    G -->|No| E[Delete orphaned file from partition]
     D --> F[Done]
     E --> F
 ```

--- a/openrag/api/routers/admin/workspaces.py
+++ b/openrag/api/routers/admin/workspaces.py
@@ -82,10 +82,11 @@ async def get_workspace(ws=Depends(require_workspace_in_partition)):
 async def delete_workspace(
     partition: str,
     workspace_id: str,
+    keep_files: bool = False,
     _ws=Depends(require_workspace_in_partition),
     service=Depends(get_workspace_service),
 ):
-    result = await service.delete_workspace(partition, workspace_id)
+    result = await service.delete_workspace(partition, workspace_id, keep_files=keep_files)
     return {"status": "deleted", **result}
 
 

--- a/openrag/services/orchestrators/workspace_service.py
+++ b/openrag/services/orchestrators/workspace_service.py
@@ -131,7 +131,7 @@ class WorkspaceService:
     # Cross-cutting: delete workspace + clean up orphaned files
     # ------------------------------------------------------------------
 
-    async def delete_workspace(self, partition: str, workspace_id: str) -> dict:
+    async def delete_workspace(self, partition: str, workspace_id: str, keep_files: bool = False) -> dict:
         """Delete the workspace, then fully delete any files it orphaned.
 
         ``workspace_repo.delete_workspace`` removes the workspace and its
@@ -140,12 +140,22 @@ class WorkspaceService:
         vector store and the relational catalog — concurrently, with
         per-file failures collected rather than raised, matching the
         legacy router's ``asyncio.gather(..., return_exceptions=True)``.
+
+        With ``keep_files=True`` the orphan cleanup is skipped entirely:
+        the workspace and its membership rows are still removed, but the
+        files stay indexed in the partition and are reported under
+        ``kept_files``.
         """
         orphaned = await self._workspace_repo.delete_workspace(workspace_id)
 
         deleted_count = 0
         failed_file_ids: list[str] = []
-        if orphaned:
+        kept_files = 0
+        if orphaned and keep_files:
+            # Orphaned files stay indexed in the partition; only the workspace
+            # and its membership rows are removed.
+            kept_files = len(orphaned)
+        elif orphaned:
             results = await asyncio.gather(
                 *[self._delete_file(file_id, partition) for file_id in orphaned],
                 return_exceptions=True,
@@ -164,6 +174,7 @@ class WorkspaceService:
         return {
             "orphaned_files_deleted": deleted_count,
             "orphaned_files_failed": failed_file_ids,
+            "kept_files": kept_files,
         }
 
     async def _delete_file(self, file_id: str, partition: str) -> None:

--- a/tests/integration/api/test_workspaces.py
+++ b/tests/integration/api/test_workspaces.py
@@ -148,6 +148,62 @@ class TestWorkspaceFiles:
         assert "shared-file" in files1
         assert "shared-file" in files2
 
+    def test_delete_workspace_default_purges_orphaned_files(self, api_client, workspace_partition, workspace_id):
+        """Unchanged default: an orphaned file is purged, kept_files is 0."""
+        file_id = f"file-{uuid.uuid4().hex[:8]}"
+        self._upload_file(api_client, workspace_partition, file_id)
+        api_client.post(
+            f"/partition/{workspace_partition}/workspaces",
+            json={"workspace_id": workspace_id},
+        )
+        api_client.post(
+            f"/partition/{workspace_partition}/workspaces/{workspace_id}/files",
+            json={"file_ids": [file_id]},
+        )
+
+        response = api_client.delete(f"/partition/{workspace_partition}/workspaces/{workspace_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "deleted"
+        assert body["orphaned_files_deleted"] == 1
+        assert body["kept_files"] == 0
+
+    def test_delete_workspace_keep_files(self, api_client, workspace_partition, workspace_id):
+        """keep_files=true removes the workspace/membership but leaves the file indexed."""
+        file_id = f"file-{uuid.uuid4().hex[:8]}"
+        probe_content = "Unique keep files probe content"
+        self._upload_file(api_client, workspace_partition, file_id, content=probe_content)
+        api_client.post(
+            f"/partition/{workspace_partition}/workspaces",
+            json={"workspace_id": workspace_id},
+        )
+        api_client.post(
+            f"/partition/{workspace_partition}/workspaces/{workspace_id}/files",
+            json={"file_ids": [file_id]},
+        )
+
+        response = api_client.delete(
+            f"/partition/{workspace_partition}/workspaces/{workspace_id}",
+            params={"keep_files": "true"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "deleted"
+        assert body["orphaned_files_deleted"] == 0
+        assert body["kept_files"] == 1
+
+        # The workspace is gone.
+        ws_response = api_client.get(f"/partition/{workspace_partition}/workspaces/{workspace_id}")
+        assert ws_response.status_code == 404
+
+        # But the file's chunks are still indexed and searchable in the partition.
+        search_response = api_client.get(
+            f"/partition/{workspace_partition}/file/{file_id}",
+            params={"text": probe_content, "similarity_threshold": 0},
+        )
+        assert search_response.status_code == 200
+        assert len(search_response.json()["documents"]) > 0
+
 
 class TestWorkspaceSearch:
     def test_search_empty_workspace_returns_empty(self, api_client, workspace_partition, workspace_id):

--- a/tests/unit/api/routers/admin/test_workspace_routes.py
+++ b/tests/unit/api/routers/admin/test_workspace_routes.py
@@ -1,0 +1,83 @@
+"""HTTP-level tests for the workspace admin router.
+
+Route-level concerns only — request parsing, what reaches the service and
+what comes back in the response body. The orphan-cleanup decision itself
+lives in :class:`services.orchestrators.workspace_service.WorkspaceService`
+(see ``tests/unit/services/orchestrators/test_workspace_service.py``), and
+``tests/unit/api/routers/admin/test_admin_workspaces.py`` covers the
+request schemas without importing this router.
+"""
+
+from __future__ import annotations
+
+import pytest
+from api.dependencies.auth import require_partition_owner
+from api.routers.admin import workspaces
+from di.providers import get_workspace_service
+from fastapi import FastAPI
+
+
+class _FakeWorkspaceService:
+    """Records the delete call and echoes a fixed result."""
+
+    def __init__(self, *, orphaned: list[str] | None = None) -> None:
+        self._orphaned = orphaned if orphaned is not None else []
+        self.delete_calls: list[tuple[str, str, bool]] = []
+
+    async def get_workspace(self, workspace_id: str) -> dict:
+        return {"workspace_id": workspace_id, "partition_name": "p1"}
+
+    async def delete_workspace(self, partition: str, workspace_id: str, keep_files: bool = False) -> dict:
+        self.delete_calls.append((partition, workspace_id, keep_files))
+        if keep_files:
+            return {
+                "orphaned_files_deleted": 0,
+                "orphaned_files_failed": [],
+                "kept_files": len(self._orphaned),
+            }
+        return {
+            "orphaned_files_deleted": len(self._orphaned),
+            "orphaned_files_failed": [],
+            "kept_files": 0,
+        }
+
+
+def _build_app(service: _FakeWorkspaceService) -> FastAPI:
+    app = FastAPI()
+    app.include_router(workspaces.router)
+    app.dependency_overrides[get_workspace_service] = lambda: service
+    app.dependency_overrides[require_partition_owner] = lambda: {"id": 1, "is_admin": True}
+    return app
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestDeleteWorkspace:
+    async def test_default_purges_orphans(self, async_client_factory):
+        service = _FakeWorkspaceService(orphaned=["file-a", "file-b"])
+        async with async_client_factory(_build_app(service)) as client:
+            resp = await client.delete("/partition/p1/workspaces/ws1")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "deleted",
+            "orphaned_files_deleted": 2,
+            "orphaned_files_failed": [],
+            "kept_files": 0,
+        }
+        assert service.delete_calls == [("p1", "ws1", False)]
+
+    async def test_keep_files_true_is_forwarded(self, async_client_factory):
+        service = _FakeWorkspaceService(orphaned=["file-a"])
+        async with async_client_factory(_build_app(service)) as client:
+            resp = await client.delete("/partition/p1/workspaces/ws1", params={"keep_files": "true"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "deleted",
+            "orphaned_files_deleted": 0,
+            "orphaned_files_failed": [],
+            "kept_files": 1,
+        }
+        assert service.delete_calls == [("p1", "ws1", True)]

--- a/tests/unit/services/orchestrators/test_workspace_service.py
+++ b/tests/unit/services/orchestrators/test_workspace_service.py
@@ -123,7 +123,7 @@ async def test_delete_workspace_no_orphans():
     drepo = FakeDocumentRepo()
     vstore = FakeVectorStore()
     out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1")
-    assert out == {"orphaned_files_deleted": 0, "orphaned_files_failed": []}
+    assert out == {"orphaned_files_deleted": 0, "orphaned_files_failed": [], "kept_files": 0}
     assert wrepo.deleted == ["w1"]
     assert vstore.deleted == []
     assert drepo.removed == []
@@ -136,7 +136,7 @@ async def test_delete_workspace_cleans_orphans_vectors_and_rows():
     vstore = FakeVectorStore(ids_by_file={"fA": ["c1", "c2"], "fB": []})
     out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1")
 
-    assert out == {"orphaned_files_deleted": 2, "orphaned_files_failed": []}
+    assert out == {"orphaned_files_deleted": 2, "orphaned_files_failed": [], "kept_files": 0}
     # fA had chunks -> a delete call; fB had none -> no delete call.
     assert vstore.deleted == [["c1", "c2"]]
     assert set(drepo.removed) == {("fA", "p"), ("fB", "p")}
@@ -152,6 +152,47 @@ async def test_delete_workspace_collects_per_file_failures():
 
     assert out["orphaned_files_deleted"] == 1
     assert out["orphaned_files_failed"] == ["bad"]
+    assert out["kept_files"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# keep_files — opt out of the orphan cleanup
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_keep_files_skips_file_deletion():
+    """The workspace still goes, but the orphans stay indexed and are counted."""
+    wrepo = FakeWorkspaceRepo(orphaned=["fA", "fB"])
+    drepo = FakeDocumentRepo()
+    vstore = FakeVectorStore(ids_by_file={"fA": ["c1"], "fB": ["c2"]})
+    svc = _svc(wrepo=wrepo, drepo=drepo, vstore=vstore)
+
+    out = await svc.delete_workspace("p", "w1", keep_files=True)
+
+    assert out == {"orphaned_files_deleted": 0, "orphaned_files_failed": [], "kept_files": 2}
+    assert wrepo.deleted == ["w1"]
+    # No file touched: no vector delete, no catalog row removal, no detach.
+    assert vstore.deleted == []
+    assert drepo.removed == []
+    assert wrepo.removed_from_all == []
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_keep_files_with_no_orphans():
+    wrepo = FakeWorkspaceRepo(orphaned=[])
+    out = await _svc(wrepo=wrepo).delete_workspace("p", "w1", keep_files=True)
+    assert out == {"orphaned_files_deleted": 0, "orphaned_files_failed": [], "kept_files": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_workspace_keep_files_false_matches_default():
+    wrepo = FakeWorkspaceRepo(orphaned=["fA"])
+    drepo = FakeDocumentRepo()
+    vstore = FakeVectorStore(ids_by_file={"fA": ["c1"]})
+    out = await _svc(wrepo=wrepo, drepo=drepo, vstore=vstore).delete_workspace("p", "w1", keep_files=False)
+    assert out == {"orphaned_files_deleted": 1, "orphaned_files_failed": [], "kept_files": 0}
+    assert vstore.deleted == [["c1"]]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Introduce `keep_files` API param on workspace deletion, to control whether or not orphaned files inside a workspace should be deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace deletion now supports an optional `keep_files=true` option to retain orphaned files while removing the workspace and memberships.
  * Deletion responses report retained files alongside deleted or failed cleanup counts.
* **Documentation**
  * Updated workspace deletion guidance and flowchart to explain the file-retention option.
* **Bug Fixes**
  * Preserved the default behavior of removing orphaned files during workspace deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->