### PR TITLE
fix(vectordb): make BM25 lexical search case-insensitive

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -66,7 +66,7 @@ vectordb:
   hybrid_search: true
   enable: true
   timeout: 120.0 # per-request timeout (s) for the Milvus sync/async clients
-  schema_version: 1 # Increment when the collection schema changes and a migration is required
+  schema_version: 2 # Increment when the collection schema changes and a migration is required
 
 # --- Relational Database (PostgreSQL) ---
 # Env: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD,

--- a/docs/content/docs/documentation/milvus_migration.mdx
+++ b/docs/content/docs/documentation/milvus_migration.mdx
@@ -238,6 +238,47 @@ Migrations are versioned. The runner reads the current schema version stored in 
 Stop the OpenRAG application before running any migration.
 :::
 
+### Version 2 — case-insensitive BM25 analyzer
+
+Schema version 2 makes two changes to the `text` field:
+
+- adds the `lowercase` filter to the analyzer, so BM25 stops treating `Rapport` and `rapport` as different terms. Milvus applies the analyzer to the query as well as to the indexed text, so before this fix a case mismatch scored zero on the lexical leg;
+- drops `enable_match`. Nothing in OpenRAG issues a `TEXT_MATCH` query, and while it is set Milvus refuses to alter the analyzer.
+
+It **rebuilds** the collection rather than altering it, because both changes are refused in place: `analyzer_params` cannot change while text match is enabled, and `enable_match` itself cannot be turned off. The migration copies the rows into `<collection>_v2_rebuild`, checks the counts, then swaps the names, keeping the old collection as `<collection>_v1_backup`.
+
+This is the last rebuild. Once `enable_match` is gone, a later analyzer change is [three calls on the live collection](https://milvus.io/docs/add-fields-to-an-existing-collection.md) with the sparse column backfilled by compaction — provided [Storage V3](https://milvus.io/docs/storage-v3.md) is enabled.
+
+:::caution[Plan for the rebuild]
+- **Disk** — both copies exist at once; allow roughly twice the collection size until the backup is dropped.
+- **Memory** — checking the row counts loads both collections, and a rename does not unload one, so the migration releases the backup from query-node memory after the swap. The doubling above is disk, not RAM.
+- **No re-embedding** — dense vectors are copied verbatim and the sparse ones are regenerated server-side on insert, which is what applies the new analyzer.
+- **Chunk IDs are preserved** — `_id` is `auto_id`, which normally refuses caller-supplied keys, so the rebuild collection carries `allow_insert_auto_id` for the duration of the copy and drops it again before the swap. A chunk ID handed out earlier by the MCP `get_chunk_by_id` tool still resolves.
+- **Stop OpenRAG first**, as the banner above says — the copy reads a snapshot, so a row written while it runs would be missing from the rebuild. The migration re-counts the source afterwards and aborts, leaving the original untouched, if the count moved.
+- **`hybrid_search: false`** deployments have no BM25 leg and are only re-stamped — no rebuild, and no backup collection, in either direction.
+- A failed copy leaves the original untouched; drop the partial `<collection>_v2_rebuild` and retry.
+- The version check runs on the indexing path only. An un-migrated deployment still boots and still answers searches — with the old analyzer — and fails the first upload with `Collection ... is at schema version 1 but the application requires version 2`.
+:::
+
+Once validated, drop the backup:
+
+```python
+from pymilvus import MilvusClient
+
+MilvusClient(uri="http://localhost:19530").drop_collection("<collection>_v1_backup")
+```
+
+:::note[Where to run these]
+The commands below run from `infra/compose/`. From the repo root, point Compose at the file (and at your project name, if you use one):
+
+```bash
+docker compose -p <project> -f infra/compose/docker-compose.yaml run --no-deps --rm --build --entrypoint "" openrag \
+    uv run python services/persistence/migrations/milvus/migrate.py --dry-run
+```
+
+The migration runner is a file, not a package — pass the full path to `migrate.py`, and keep Milvus running.
+:::
+
 ### Step 1 — Start only the Milvus container
 
 ```bash
@@ -267,20 +308,20 @@ docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-
   </TabItem>
 </Tabs>
 
-Review the output to confirm which migrations are pending and what changes they would apply.
+Review the output to confirm which migrations are pending and what changes they would apply. The migration scripts ship **inside the image**, which is why `--build` is there: if the `Discovered N migration(s)` line does not list the migration you expect, the image is stale — and on a shared host another checkout may have rebuilt the same `linagoraai/openrag` tag, so add `--build` to the apply step too.
 
 ### Step 3 — Apply all pending migrations
 
 <Tabs>
   <TabItem label="GPU">
 ```bash
-docker compose run --no-deps --rm --entrypoint "" openrag \
+docker compose run --no-deps --rm --build --entrypoint "" openrag \
     uv run python services/persistence/migrations/milvus/migrate.py
 ```
   </TabItem>
   <TabItem label="CPU">
 ```bash
-docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
+docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-cpu \
     uv run python services/persistence/migrations/milvus/migrate.py
 ```
   </TabItem>
@@ -314,22 +355,22 @@ To upgrade or downgrade to a specific schema version rather than the latest:
   <TabItem label="GPU">
 ```bash
 # Upgrade to version 2 only
-docker compose run --no-deps --rm --entrypoint "" openrag \
+docker compose run --no-deps --rm --build --entrypoint "" openrag \
     uv run python services/persistence/migrations/milvus/migrate.py --target 2
 
 # Downgrade to version 0 (resets version stamp and drops indexes)
-docker compose run --no-deps --rm --entrypoint "" openrag \
+docker compose run --no-deps --rm --build --entrypoint "" openrag \
     uv run python services/persistence/migrations/milvus/migrate.py --downgrade --target 0
 ```
   </TabItem>
   <TabItem label="CPU">
 ```bash
 # Upgrade to version 2 only
-docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
+docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-cpu \
     uv run python services/persistence/migrations/milvus/migrate.py --target 2
 
 # Downgrade to version 0 (resets version stamp and drops indexes)
-docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
+docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-cpu \
     uv run python services/persistence/migrations/milvus/migrate.py --downgrade --target 0
 ```
   </TabItem>
@@ -337,18 +378,29 @@ docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
 
 ### Rollback
 
-Milvus does not support dropping fields. A downgrade only removes indexes and resets the version stamp — fields remain in the schema but are unused by the application:
+What a downgrade can undo depends on the migration:
+
+- **Version 2 → 1** swaps the `<collection>_v1_backup` collection back into place and sets the version stamp to 1. The version-2 collection is kept aside as `<collection>_v2_rolled_back` rather than dropped, so nothing is lost — but this is a point-in-time rollback: **rows indexed after the upgrade exist only in the collection set aside**.
+
+  The rollback needs that backup collection. If it is gone, the downgrade fails rather than reporting a rollback it did not perform, and there are three ways forward:
+
+  - Restore `<collection>_v1_backup` from a Milvus backup and re-run the downgrade.
+  - Re-create the collection with the v1 schema and re-index it.
+  - Move the version stamp back by hand — but **only** if you know this collection was re-stamped rather than rebuilt. A collection that already had the v2 analyzer and no text match before the upgrade was moved to version 2 by the stamp alone, so it correctly has no backup. Afterwards it is indistinguishable from one that was rebuilt and lost its backup, which is why the migration refuses to guess between them.
+
+  A `hybrid_search: false` collection never had a backup — it was only re-stamped on the way up, so the rollback moves its stamp back and nothing else.
+- **Version 1 → 0** only removes indexes and resets the version stamp, since Milvus does not support dropping fields — they remain in the schema but are unused by the application.
 
 <Tabs>
   <TabItem label="GPU">
 ```bash
-docker compose run --no-deps --rm --entrypoint "" openrag \
+docker compose run --no-deps --rm --build --entrypoint "" openrag \
     uv run python services/persistence/migrations/milvus/migrate.py --downgrade
 ```
   </TabItem>
   <TabItem label="CPU">
 ```bash
-docker compose --profile cpu run --no-deps --rm --entrypoint "" openrag-cpu \
+docker compose --profile cpu run --no-deps --rm --build --entrypoint "" openrag-cpu \
     uv run python services/persistence/migrations/milvus/migrate.py --downgrade
 ```
   </TabItem>
@@ -368,9 +420,10 @@ Files must follow the pattern `N.short_description.py`, where `N` is the **targe
 
 ```
 openrag/services/persistence/migrations/milvus/
-  1.add_temporal_fields.py    ← brings the schema to version 1
-  2.your_new_migration.py     ← brings the schema to version 2
-  migrate.py                  ← generic runner (do not rename)
+  1.add_created_at_temporal_fields.py  ← brings the schema to version 1
+  2.rebuild_text_analyzer.py           ← brings the schema to version 2
+  3.your_new_migration.py              ← brings the schema to version 3
+  migrate.py                           ← generic runner (do not rename)
 ```
 
 The numeric prefix determines execution order. Never reuse or change an existing version number.
@@ -383,7 +436,7 @@ Each migration script must expose the following at module level:
 |------|------|-------------|
 | `TARGET_VERSION` | `int` | The schema version this script brings the collection to |
 | `upgrade(client, collection_name, dry_run)` | `function` | Applies the migration |
-| `downgrade(client, collection_name, dry_run)` | `function` | Reverts the migration (indexes only — fields cannot be dropped) |
+| `downgrade(client, collection_name, dry_run)` | `function` | Reverts the migration, as far as Milvus allows — a field added in `upgrade` cannot be dropped, so such a migration only removes its indexes and resets the stamp |
 
 ### Minimal template
 

--- a/openrag/core/config/infrastructure.py
+++ b/openrag/core/config/infrastructure.py
@@ -22,7 +22,7 @@ class VectorDBConfig(ConfigMixin):
     enable: bool = True
     # Per-request timeout (s) applied to the Milvus sync and async clients.
     timeout: float = Field(default=120.0, gt=0)
-    schema_version: int = 1
+    schema_version: int = 2
 
 
 # ---------------------------------------------------------------------------

--- a/openrag/services/persistence/migrations/milvus/2.rebuild_text_analyzer.py
+++ b/openrag/services/persistence/migrations/milvus/2.rebuild_text_analyzer.py
@@ -1,0 +1,613 @@
+"""
+Milvus migration: rebuild the ``text`` field  (schema version 1 → 2)
+====================================================================
+Two changes to the same field, in one pass:
+
+* adds the ``lowercase`` filter to the analyzer, so BM25 stops treating
+  ``Rapport`` and ``rapport`` as distinct terms;
+* drops ``enable_match``, which nothing in OpenRAG queries — no code path
+  issues ``TEXT_MATCH`` — and which is what makes the analyzer immutable.
+
+Both need a rebuild: Milvus 3.0 refuses to alter ``analyzer_params`` while text
+match is enabled, and refuses to turn ``enable_match`` off ("enable_match does
+not allow update in collection field param"). Probed against 3.0.0, on
+collections created both before and after Storage V3.
+
+This is the last rebuild. Once ``enable_match`` is gone, a later analyzer change
+is ``drop_function_field`` → ``alter_collection_field`` → ``add_function_field``
+on the live collection, with the sparse column backfilled by compaction.
+
+Copies rows into ``<collection>_v2_rebuild``, verifies the counts, then swaps
+names, keeping the old collection as ``<collection>_v1_backup`` — never dropped
+automatically, but released from query-node memory so it does not sit there at
+full size next to the live one. Dense vectors are copied verbatim and the
+sparse vectors are regenerated server-side on insert, so nothing is
+re-embedded. Collections with no ``sparse`` field have no BM25 leg and are only
+re-stamped, in either direction.
+
+``_id`` is ``auto_id``, which normally rejects caller-supplied keys; the rebuild
+collection carries ``allow_insert_auto_id`` for the duration of the copy so the
+original chunk IDs survive, and the property is dropped again before the swap.
+
+OpenRAG must be stopped: rows written to the source while the copy runs are not
+picked up, so the migration re-counts the source afterwards and aborts if it
+moved.
+
+Usage — prefer the generic runner (from repo root, inside the container):
+    docker compose run --no-deps --rm --entrypoint "" openrag \\
+        uv run python services/persistence/migrations/milvus/migrate.py [--dry-run]
+
+This script also runs standalone with ``--dry-run`` / ``--downgrade``.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from typing import Any
+
+from core.config import load_config
+from core.utils.logging import get_logger
+from pymilvus import DataType, Function, FunctionType, MilvusClient
+from services.storage.milvus_store import SCHEMA_VERSION_PROPERTY_KEY
+
+TARGET_VERSION = 2  # The schema version this migration brings the collection to.
+
+# Frozen snapshot of the v2 schema — importing the live one would let a later
+# analyzer change rewrite what this migration produces.
+ANALYZER_PARAMS_V2: dict[str, Any] = {
+    "tokenizer": "standard",
+    "filter": [
+        "lowercase",
+        {
+            "type": "stop",
+            "stop_words": [
+                "<image_description>",
+                "</image_description>",
+                "[Image Placeholder]",
+                "_english_",
+                "_french_",
+                "[CHUNK_START]",
+                "[CHUNK_END]",
+                "[CONTEXT]",
+            ],
+        },
+    ],
+}
+
+MAX_LENGTH = 65_535
+INDEXED_TIME_FIELDS = ["created_at"]
+
+REBUILD_SUFFIX = "_v2_rebuild"
+BACKUP_SUFFIX = "_v1_backup"
+ROLLBACK_ASIDE_SUFFIX = "_v2_rolled_back"
+
+#: Upper bound on rows per copy batch, further capped by the row payload.
+MAX_COPY_BATCH = 1_000
+
+#: Wire budget per copy page, comfortably under Milvus's result-size cap.
+_COPY_PAGE_BUDGET_BYTES = 32 * 1024 * 1024
+
+#: Per-row allowance for dynamic (undeclared) fields travelling in ``$meta``.
+#: The one part of a row with no declared width to read, so it is the one part
+#: that has to be guessed; sized well above the chunk metadata OpenRAG writes.
+_COPY_DYNAMIC_FIELD_BYTES = 8_192
+
+#: Per-row allowance for a declared field whose params carry no size — the
+#: INT64 primary key, a timestamp, a bool.
+_COPY_FIXED_FIELD_BYTES = 16
+
+#: Keys that must never be written back on insert: ``sparse`` is a BM25
+#: ``Function`` output, which Milvus generates itself and rejects from a caller.
+#: ``_id`` *is* written back — see :data:`ALLOW_INSERT_AUTO_ID`.
+_UNSETTABLE_KEYS = frozenset({"sparse"})
+
+#: Collection property that lets an ``auto_id`` primary key accept the values
+#: the copy supplies. Without it Milvus rejects the row outright ("more
+#: fieldData has pass in"), and chunk IDs would be reassigned by the rebuild.
+#: Set on the rebuild collection for the copy only, then dropped so the
+#: collection ends up with the same semantics as a freshly created one.
+ALLOW_INSERT_AUTO_ID = "allow_insert_auto_id"
+
+logger = get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_stored_version(client: MilvusClient, collection_name: str) -> int:
+    desc = client.describe_collection(collection_name)
+    raw = desc.get("properties", {}).get(SCHEMA_VERSION_PROPERTY_KEY)
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def _field_map(desc: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {f["name"]: f for f in desc.get("fields", [])}
+
+
+def _is_hybrid(desc: dict[str, Any]) -> bool:
+    """True when the collection carries the BM25 sparse field."""
+    return "sparse" in _field_map(desc)
+
+
+def _vector_dim(desc: dict[str, Any]) -> int:
+    field = _field_map(desc).get("vector")
+    if field is None:
+        raise RuntimeError("Collection has no `vector` field — not an OpenRAG collection.")
+    dim = field.get("params", {}).get("dim")
+    if not dim:
+        raise RuntimeError("Could not read the `vector` field dimension from the collection schema.")
+    return int(dim)
+
+
+def _max_length(desc: dict[str, Any], field_name: str) -> int:
+    field = _field_map(desc).get(field_name, {})
+    return int(field.get("params", {}).get("max_length", MAX_LENGTH))
+
+
+def _analyzer_has_lowercase(desc: dict[str, Any]) -> bool:
+    """True when the live ``text`` analyzer already applies the lowercase filter."""
+    raw = _field_map(desc).get("text", {}).get("params", {}).get("analyzer_params")
+    if not raw:
+        return False
+    try:
+        params = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return False
+    return any(f == "lowercase" for f in params.get("filter", []) if isinstance(f, str))
+
+
+def _has_text_match(desc: dict[str, Any]) -> bool:
+    """True when ``enable_match`` is still set on ``text``.
+
+    ``describe_collection`` hands back type params as strings, so ``"true"`` is
+    what a live collection reports; a bool is accepted for hand-built descs.
+    """
+    raw = _field_map(desc).get("text", {}).get("params", {}).get("enable_match")
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).strip().lower() == "true"
+
+
+def _needs_rebuild(desc: dict[str, Any]) -> bool:
+    """Whether :func:`upgrade` rebuilds this collection or only re-stamps it.
+
+    Only a collection with a BM25 leg has an analyzer worth fixing, and only
+    one whose ``text`` field is still in its v1 shape needs the copy. Kept in
+    one place because :func:`downgrade` has to reach the same verdict — a
+    collection that was never rebuilt has no backup to restore, and that is not
+    the same thing as a lost backup.
+    """
+    return _is_hybrid(desc) and (not _analyzer_has_lowercase(desc) or _has_text_match(desc))
+
+
+def _row_count(client: MilvusClient, collection_name: str) -> int:
+    client.load_collection(collection_name)
+    rows = client.query(collection_name=collection_name, filter="", output_fields=["count(*)"])
+    return int(rows[0]["count(*)"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# Schema construction (v2)
+# ---------------------------------------------------------------------------
+
+
+def _build_v2_schema(client: MilvusClient, desc: dict[str, Any]):
+    """Rebuild the OpenRAG schema with the corrected analyzer and no text match.
+
+    Per-deployment values (vector dimension, VARCHAR lengths, whether the
+    collection is hybrid) are read from the live collection rather than
+    assumed, so a collection created with non-default settings round-trips.
+    """
+    schema = client.create_schema(enable_dynamic_field=True)
+    schema.add_field(field_name="_id", datatype=DataType.INT64, is_primary=True, auto_id=True)
+    schema.add_field(
+        field_name="text",
+        datatype=DataType.VARCHAR,
+        enable_analyzer=True,
+        max_length=_max_length(desc, "text"),
+        analyzer_params=ANALYZER_PARAMS_V2,
+    )
+    schema.add_field(
+        field_name="partition",
+        datatype=DataType.VARCHAR,
+        max_length=_max_length(desc, "partition"),
+        is_partition_key=True,
+    )
+    schema.add_field(
+        field_name="file_id",
+        datatype=DataType.VARCHAR,
+        max_length=_max_length(desc, "file_id"),
+    )
+    schema.add_field(field_name="vector", datatype=DataType.FLOAT_VECTOR, dim=_vector_dim(desc))
+
+    for time_field in INDEXED_TIME_FIELDS:
+        schema.add_field(field_name=time_field, datatype=DataType.TIMESTAMPTZ, nullable=True)
+
+    if _is_hybrid(desc):
+        schema.add_field(
+            field_name="sparse",
+            datatype=DataType.SPARSE_FLOAT_VECTOR,
+            index_type="SPARSE_INVERTED_INDEX",
+        )
+        schema.add_function(
+            Function(
+                name="text_bm25_emb",
+                function_type=FunctionType.BM25,
+                input_field_names=["text"],
+                output_field_names=["sparse"],
+            )
+        )
+    return schema
+
+
+def _build_v2_index_params(client: MilvusClient, desc: dict[str, Any]):
+    index_params = client.prepare_index_params()
+    index_params.add_index(field_name="file_id", index_type="INVERTED", index_name="file_id_idx")
+    index_params.add_index(field_name="partition", index_type="INVERTED", index_name="partition_idx")
+    index_params.add_index(
+        field_name="vector",
+        index_type="HNSW",
+        metric_type="COSINE",
+        index_params={"M": 128, "efConstruction": 256, "metric_type": "COSINE"},
+    )
+    if _is_hybrid(desc):
+        index_params.add_index(
+            field_name="sparse",
+            index_name="sparse_idx",
+            index_type="SPARSE_INVERTED_INDEX",
+            index_params={
+                "metric_type": "BM25",
+                "inverted_index_algo": "DAAT_MAXSCORE",
+                "bm25_k1": 1.2,
+                "bm25_b": 0.75,
+            },
+        )
+    for time_field in INDEXED_TIME_FIELDS:
+        index_params.add_index(
+            field_name=time_field,
+            index_type="STL_SORT",
+            index_name=f"{time_field}_idx",
+        )
+    return index_params
+
+
+def _assert_no_field_loss(source_desc: dict[str, Any], rebuilt_desc: dict[str, Any]) -> None:
+    """Fail loudly if the rebuild would drop a declared field.
+
+    Dynamic (undeclared) fields travel with the row payload, but a *declared*
+    field this migration does not know about would be silently lost.
+    """
+    missing = set(_field_map(source_desc)) - set(_field_map(rebuilt_desc))
+    if missing:
+        raise RuntimeError(
+            f"Rebuilt schema is missing declared field(s) {sorted(missing)} present in the source "
+            "collection. This migration predates them — update it before running."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Row copy
+# ---------------------------------------------------------------------------
+
+
+def _copy_batch_size(desc: dict[str, Any]) -> int:
+    """Rows per page, kept under Milvus's result-size cap.
+
+    Sized on the *declared* widths rather than the observed ones: a page of
+    maximally long rows has to fit too. Every VARCHAR contributes its declared
+    ``max_length`` — ``text``, but also ``partition`` and ``file_id``, which
+    OpenRAG declares just as wide — and the dense vector its full width.
+    ``sparse`` comes back over the wire even though it is never written back,
+    and is charged at the width of the ``text`` it is derived from: a BM25 row
+    holds one entry per *unique* term, so that is generous.
+    """
+    per_row = _COPY_DYNAMIC_FIELD_BYTES
+    text_max_length = _max_length(desc, "text")
+    for name, field in _field_map(desc).items():
+        if name == "sparse":
+            per_row += text_max_length
+            continue
+        params = field.get("params", {})
+        if "max_length" in params:
+            per_row += int(params["max_length"])
+        elif "dim" in params:
+            per_row += int(params["dim"]) * 4
+        else:
+            per_row += _COPY_FIXED_FIELD_BYTES
+    return max(1, min(MAX_COPY_BATCH, _COPY_PAGE_BUDGET_BYTES // per_row))
+
+
+def _prepare_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Strip function-generated keys and normalise values for re-insertion.
+
+    ``_id`` is deliberately kept: the rebuild collection accepts it while
+    :data:`ALLOW_INSERT_AUTO_ID` is set, which is what preserves chunk IDs.
+    """
+    out: dict[str, Any] = {}
+    for key, value in row.items():
+        if key in _UNSETTABLE_KEYS:
+            continue
+        out[key] = value.isoformat() if isinstance(value, datetime) else value
+    return out
+
+
+def _copy_rows(client: MilvusClient, source: str, target: str, source_desc: dict[str, Any]) -> int:
+    """Stream every row from ``source`` into ``target``. Returns rows inserted."""
+    batch_size = _copy_batch_size(source_desc)
+    client.load_collection(source)
+    iterator = client.query_iterator(
+        collection_name=source,
+        filter="",
+        batch_size=batch_size,
+        output_fields=["*"],
+    )
+    copied = 0
+    try:
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            rows = [_prepare_row(r) for r in batch]
+            client.insert(collection_name=target, data=rows)
+            copied += len(rows)
+            logger.info(f"  copied {copied} rows...")
+    finally:
+        iterator.close()
+    client.flush(target)
+    return copied
+
+
+# ---------------------------------------------------------------------------
+# Upgrade / downgrade
+# ---------------------------------------------------------------------------
+
+
+def _stamp_version(client: MilvusClient, collection_name: str, version: int) -> None:
+    client.alter_collection_properties(
+        collection_name=collection_name,
+        properties={SCHEMA_VERSION_PROPERTY_KEY: str(version)},
+    )
+    logger.info(f"Stamped schema version {version} on '{collection_name}'.")
+
+
+def _swap_collections(client: MilvusClient, live_name: str, incoming_name: str, aside_name: str) -> None:
+    """Move the live collection aside, then rename ``incoming_name`` into its place.
+
+    Both directions do this — the upgrade swaps the rebuild in, the rollback
+    swaps the backup back — and both have the same hazard: the window between
+    the two renames is the one moment the configured collection name resolves
+    to nothing. If the second rename fails, put the collection that was moved
+    aside back, so the deployment is never left headless.
+    """
+    client.rename_collection(live_name, aside_name)
+    try:
+        client.rename_collection(incoming_name, live_name)
+    except Exception:
+        logger.error(f"Could not rename '{incoming_name}' into place — restoring '{aside_name}'.")
+        try:
+            client.rename_collection(aside_name, live_name)
+        except Exception:
+            logger.error(
+                f"Restore failed too. '{live_name}' does not exist right now: one collection is in "
+                f"'{aside_name}' and the other in '{incoming_name}'. Rename one back by hand before "
+                "starting the application."
+            )
+        raise
+
+
+def _release(client: MilvusClient, collection_name: str) -> None:
+    """Drop a collection out of QueryNode memory. Best effort.
+
+    Counting rows loads a collection and a rename does not unload it, so
+    without this the collection left aside stays resident next to the live one
+    — twice the memory the deployment is sized for, on a deployment large
+    enough for that to matter. Not worth failing a finished migration over.
+    """
+    try:
+        client.release_collection(collection_name)
+        logger.info(f"Released '{collection_name}' from query-node memory.")
+    except Exception as exc:
+        logger.warning(
+            f"Could not release '{collection_name}' ({exc}). It stays loaded until Milvus is restarted or "
+            "the collection is dropped."
+        )
+
+
+def upgrade(client: MilvusClient, collection_name: str, dry_run: bool = False) -> None:
+    stored_version = _get_stored_version(client, collection_name)
+    if stored_version >= TARGET_VERSION:
+        logger.info(f"Collection is already at version {stored_version} — nothing to do.")
+        return
+
+    desc = client.describe_collection(collection_name)
+
+    # Nothing to rebuild when there is no BM25 leg, or when the field is already
+    # in its v2 shape — only the version stamp is missing.
+    if not _is_hybrid(desc):
+        logger.info("Collection has no `sparse` field (hybrid search disabled) — no BM25 analyzer to fix.")
+        if not dry_run:
+            _stamp_version(client, collection_name, TARGET_VERSION)
+        return
+    if not _needs_rebuild(desc):
+        logger.info("The `text` field already has the lowercase filter and no text match — no rebuild needed.")
+        if not dry_run:
+            _stamp_version(client, collection_name, TARGET_VERSION)
+        return
+
+    rebuild_name = f"{collection_name}{REBUILD_SUFFIX}"
+    backup_name = f"{collection_name}{BACKUP_SUFFIX}"
+    for name in (rebuild_name, backup_name):
+        if client.has_collection(name):
+            raise RuntimeError(
+                f"Collection '{name}' already exists — a previous run of this migration was "
+                "interrupted. Inspect it and drop it before retrying."
+            )
+
+    dim = _vector_dim(desc)
+    source_count = _row_count(client, collection_name)
+    changes = []
+    if not _analyzer_has_lowercase(desc):
+        changes.append("lowercase analyzer filter")
+    if _has_text_match(desc):
+        changes.append("drop enable_match")
+    logger.info(
+        f"Rebuilding '{collection_name}' ({source_count} rows, dim={dim}): {', '.join(changes)}.\n"
+        f"  new collection : {rebuild_name}\n"
+        f"  old kept as    : {backup_name}"
+    )
+
+    if dry_run:
+        logger.info(f"[DRY-RUN] Would copy {source_count} rows and swap the collection names.")
+        logger.info("[DRY-RUN] Dry-run complete. No changes were made.")
+        return
+
+    schema = _build_v2_schema(client, desc)
+    index_params = _build_v2_index_params(client, desc)
+    client.create_collection(
+        collection_name=rebuild_name,
+        schema=schema,
+        consistency_level="Strong",
+        index_params=index_params,
+        enable_dynamic_field=True,
+    )
+    logger.info(f"Created '{rebuild_name}'.")
+
+    try:
+        _assert_no_field_loss(desc, client.describe_collection(rebuild_name))
+        # Lets the copy carry the original `_id` values through an `auto_id`
+        # primary key. Dropped again below, before the swap.
+        client.alter_collection_properties(rebuild_name, properties={ALLOW_INSERT_AUTO_ID: "true"})
+        copied = _copy_rows(client, collection_name, rebuild_name, desc)
+
+        # The copy reads a snapshot: anything written to the source while it ran
+        # is missing from the rebuild, and a delete would leave a row behind. The
+        # runbook says to stop OpenRAG first — check that it was.
+        final_source_count = _row_count(client, collection_name)
+        if final_source_count != source_count:
+            raise RuntimeError(
+                f"The source collection changed during the copy: {source_count} rows before, "
+                f"{final_source_count} after. Something is still writing to "
+                f"'{collection_name}' — stop OpenRAG, drop '{rebuild_name}', and retry."
+            )
+
+        target_count = _row_count(client, rebuild_name)
+        logger.info(f"Copied {copied} rows; target collection reports {target_count} (source: {source_count}).")
+        if target_count != source_count:
+            raise RuntimeError(
+                f"Row-count mismatch after copy: source={source_count}, target={target_count}. "
+                f"The source collection is untouched; drop '{rebuild_name}' and retry."
+            )
+        client.drop_collection_properties(rebuild_name, property_keys=[ALLOW_INSERT_AUTO_ID])
+        _stamp_version(client, rebuild_name, TARGET_VERSION)
+    except Exception:
+        logger.error(
+            f"Rebuild failed — '{collection_name}' is untouched. "
+            f"Drop the partial collection '{rebuild_name}' before retrying."
+        )
+        raise
+
+    _swap_collections(client, collection_name, rebuild_name, backup_name)
+    _release(client, backup_name)
+    client.load_collection(collection_name)
+    logger.info(
+        f"Migration complete. '{collection_name}' now uses the case-insensitive analyzer.\n"
+        f"  The previous collection is kept as '{backup_name}' — drop it once validated:\n"
+        f"    client.drop_collection('{backup_name}')"
+    )
+
+
+def downgrade(client: MilvusClient, collection_name: str, dry_run: bool = False) -> None:
+    """Swap the v1 backup collection back into place.
+
+    Rows indexed after the upgrade live only in the v2 collection, so this is a
+    point-in-time rollback: the v2 collection is kept aside rather than dropped.
+    """
+    backup_name = f"{collection_name}{BACKUP_SUFFIX}"
+    aside_name = f"{collection_name}{ROLLBACK_ASIDE_SUFFIX}"
+
+    if not client.has_collection(backup_name):
+        # A collection with no BM25 leg was upgraded by moving the stamp alone
+        # — it had no analyzer to fix, so it correctly has no backup and its
+        # rollback is the stamp going back. Every other collection reaching
+        # here was rebuilt and has lost its backup, which is a different thing
+        # entirely: say so rather than report a rollback that did not happen.
+        desc = client.describe_collection(collection_name)
+        if _is_hybrid(desc):
+            raise RuntimeError(
+                f"No backup collection '{backup_name}' found, but '{collection_name}' has a `sparse` "
+                "field, so the upgrade rebuilt it and left one behind. Restore that collection from a "
+                "Milvus backup, or re-create this one with the v1 schema and re-index. (If you know it "
+                "was only re-stamped — it already had the v2 analyzer and no text match before the "
+                f"upgrade — move the stamp back by hand instead.) '{collection_name}' is left at "
+                f"version {_get_stored_version(client, collection_name)}."
+            )
+        logger.info(
+            f"{'[DRY-RUN] ' if dry_run else ''}'{collection_name}' has no `sparse` field, so the upgrade "
+            "only moved its version stamp — rolling back does the same."
+        )
+        if not dry_run:
+            _stamp_version(client, collection_name, TARGET_VERSION - 1)
+        return
+    if client.has_collection(aside_name):
+        raise RuntimeError(f"Collection '{aside_name}' already exists — inspect and drop it before rolling back.")
+
+    logger.info(
+        f"{'[DRY-RUN] ' if dry_run else ''}Rolling back:\n"
+        f"  '{collection_name}' → '{aside_name}' (v2, kept aside)\n"
+        f"  '{backup_name}' → '{collection_name}' (v1, restored)"
+    )
+    if dry_run:
+        logger.info("[DRY-RUN] Dry-run complete. No changes were made.")
+        return
+
+    _swap_collections(client, collection_name, backup_name, aside_name)
+    _release(client, aside_name)
+    _stamp_version(client, collection_name, TARGET_VERSION - 1)
+    client.load_collection(collection_name)
+    logger.warning(
+        f"Rollback complete. Rows indexed after the upgrade remain only in '{aside_name}' and are NOT "
+        "in the restored collection."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Milvus migration: rebuild the `text` field — lowercase BM25 analyzer, no text match (v1 → v2)"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Inspect only, make no changes")
+    parser.add_argument(
+        "--downgrade",
+        action="store_true",
+        help="Swap the v1 backup collection back into place",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config()
+    host = cfg.vectordb.host
+    port = cfg.vectordb.port
+    collection_name = cfg.vectordb.collection_name
+    uri = f"http://{host}:{port}"
+
+    logger.info(f"Connecting to Milvus at {uri}, collection='{collection_name}'")
+    client = MilvusClient(uri=uri)
+
+    if not client.has_collection(collection_name):
+        logger.error(f"Collection '{collection_name}' does not exist. Aborting.")
+        sys.exit(1)
+
+    if args.downgrade:
+        downgrade(client, collection_name, dry_run=args.dry_run)
+    else:
+        upgrade(client, collection_name, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -109,18 +109,30 @@ RRF_K = 100
 #: noisy and large; ``text`` stays in the payload (callers need it).
 _SEARCH_RESULT_DROPPED_KEYS = frozenset({"vector"})
 
+#: Per-call timeout for the construction-time schema-version probe. Deliberately
+#: short and independent of ``VectorDBConfig.timeout``: the probe only produces a
+#: log line, so a slow metadata RPC must not hold up building the store. An
+#: *unreachable* server is already handled — ``MilvusClient`` connects eagerly in
+#: ``__init__`` and raises :class:`VDBConnectionError` before the probe runs.
+_SCHEMA_PROBE_TIMEOUT = 5.0
+
 #: Fallback dense-vector dimension for page sizing when the real one is
 #: unknown — i.e. a read-only process that never ran ``initialize`` AND the
 #: collection-schema probe also failed. Conservatively large so a vector page
 #: stays under Milvus's result-size cap for any realistic embedder.
 _UNKNOWN_VECTOR_DIM = 4096
 
-#: BM25 analyzer params for the ``text`` field — standard tokenizer plus
-#: OpenRAG-specific stop words so chunk-boundary / image-placeholder markers
-#: don't pollute lexical scores.
+#: BM25 analyzer for the ``text`` field. A custom analyzer (``tokenizer`` +
+#: ``filter``) inherits nothing, unlike the built-in ``{"type": "standard"}``,
+#: so ``lowercase`` is listed explicitly and must come first: Milvus runs this
+#: analyzer on the query too, and the ``_english_`` / ``_french_`` lists are
+#: lowercase. The marker stop words are inert — the tokenizer splits
+#: ``<image_description>`` into ``image`` + ``description`` — and are left as a
+#: no-op rather than stop-listed as those (far too common) words.
 analyzer_params: dict[str, Any] = {
     "tokenizer": "standard",
     "filter": [
+        "lowercase",
         {
             "type": "stop",
             "stop_words": [
@@ -133,7 +145,7 @@ analyzer_params: dict[str, Any] = {
                 "[CHUNK_END]",
                 "[CONTEXT]",
             ],
-        }
+        },
     ],
 }
 
@@ -141,10 +153,11 @@ analyzer_params: dict[str, Any] = {
 class MilvusVectorStore(VectorStore):
     """Milvus 3.0 implementation of :class:`VectorStore`.
 
-    The store is constructed cheaply (no I/O); the collection is materialised
-    on the first :meth:`initialize` call. ``initialize`` is idempotent and
-    takes the embedding dimension as an argument so the schema does not need
-    to import the embedder.
+    Construction is cheap — one best-effort, short-timeout schema-version probe
+    to report a pending migration in the startup logs, and nothing else; the
+    collection is materialised on the first :meth:`initialize` call.
+    ``initialize`` is idempotent and takes the embedding dimension as an
+    argument so the schema does not need to import the embedder.
     """
 
     def __init__(self, config: VectorDBConfig) -> None:
@@ -177,6 +190,12 @@ class MilvusVectorStore(VectorStore):
         # channel's internal handling, same as the legacy MilvusDB. If
         # production drops surface a real issue, revisit with evidence
         # rather than racing pymilvus's internal channel state.
+
+        # One describe_collection at construction so a pending migration shows
+        # up in the startup logs. The API process builds this store while
+        # wiring the container and never calls `initialize` afterwards, so
+        # without this the mismatch stays invisible until the first upload.
+        self.warn_if_migration_pending()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -280,7 +299,6 @@ class MilvusVectorStore(VectorStore):
             field_name="text",
             datatype=DataType.VARCHAR,
             enable_analyzer=True,
-            enable_match=True,
             max_length=MAX_LENGTH,
             analyzer_params=analyzer_params,
         )
@@ -376,22 +394,76 @@ class MilvusVectorStore(VectorStore):
             properties={SCHEMA_VERSION_PROPERTY_KEY: str(self._config.schema_version)},
         )
 
+    def _read_schema_version(self, *, timeout: float | None = None) -> int:
+        """The schema version stamped on the live collection.
+
+        Missing or unparseable values read as ``0`` so existing pre-versioning
+        collections always look out of date rather than silently passing.
+        ``timeout`` overrides the client default for callers that must not
+        block, such as the construction-time probe.
+        """
+        desc = self._client.describe_collection(self._collection_name, timeout=timeout)
+        raw = desc.get("properties", {}).get(SCHEMA_VERSION_PROPERTY_KEY)
+        try:
+            return int(raw) if raw is not None else 0
+        except (ValueError, TypeError):
+            return 0
+
+    def _schema_mismatch_warning(self, stored_version: int, expected_version: int) -> str:
+        """Operator-facing description of a schema-version mismatch."""
+        if stored_version < expected_version:
+            return (
+                f"Collection `{self._collection_name}` is at schema version {stored_version}, but this build "
+                f"expects {expected_version}. Indexing fails until the pending migration(s) are applied. "
+                "Run, with OpenRAG stopped: uv run python "
+                "services/persistence/migrations/milvus/migrate.py --dry-run (then without --dry-run)."
+            )
+        return (
+            f"Collection `{self._collection_name}` is at schema version {stored_version}, ahead of the "
+            f"{expected_version} this build expects. It was migrated by a newer OpenRAG: run that version, "
+            "or downgrade the collection with the migration runner."
+        )
+
+    def warn_if_migration_pending(self) -> None:
+        """Log a warning when the collection is not at the configured version.
+
+        The non-raising counterpart to :meth:`_check_schema_version`, for
+        callers that want the mismatch visible in the logs without failing —
+        a startup probe, say. Best-effort throughout: a collection that does
+        not exist yet is not a mismatch, and an unreachable or unreadable
+        Milvus is logged and swallowed, because a warning must never be the
+        thing that stops the caller. Both RPCs carry
+        :data:`_SCHEMA_PROBE_TIMEOUT`, so a server that answers slowly cannot
+        hold up construction either.
+        """
+        try:
+            if not self._client.has_collection(self._collection_name, timeout=_SCHEMA_PROBE_TIMEOUT):
+                return
+            stored_version = self._read_schema_version(timeout=_SCHEMA_PROBE_TIMEOUT)
+        except Exception as e:
+            logger.warning(
+                f"Could not read the schema version of collection `{self._collection_name}`: {e!s}. "
+                "Skipping the schema-version check."
+            )
+            return
+
+        expected_version = self._config.schema_version
+        if stored_version == expected_version:
+            logger.info(f"Collection `{self._collection_name}` is at schema version {expected_version}.")
+            return
+        logger.warning(self._schema_mismatch_warning(stored_version, expected_version))
+
     def _check_schema_version(self) -> None:
         """Compare stored vs. configured schema version; raise on mismatch.
 
-        Missing or unparseable values default to ``0`` so existing
-        pre-versioning collections always trigger an explicit migration step
-        rather than silently working on a stale schema.
+        Logs the mismatch before raising: the exception surfaces to the caller
+        as an API error, while the log line carries the command that fixes it.
         """
         expected_version = self._config.schema_version
-        desc = self._client.describe_collection(self._collection_name)
-        raw = desc.get("properties", {}).get(SCHEMA_VERSION_PROPERTY_KEY)
-        try:
-            stored_version = int(raw) if raw is not None else 0
-        except (ValueError, TypeError):
-            stored_version = 0
+        stored_version = self._read_schema_version()
 
         if stored_version != expected_version:
+            logger.warning(self._schema_mismatch_warning(stored_version, expected_version))
             raise VDBSchemaMigrationRequiredError(
                 f"Collection `{self._collection_name}` is at schema version "
                 f"{stored_version} but the application requires version "

--- a/tests/integration/repos/test_milvus_store_integration.py
+++ b/tests/integration/repos/test_milvus_store_integration.py
@@ -29,7 +29,7 @@ import pytest
 
 from openrag.core.config.infrastructure import VectorDBConfig
 from openrag.core.models.chunk import Chunk, ChunkType
-from openrag.services.storage.milvus_store import MilvusVectorStore
+from openrag.services.storage.milvus_store import MilvusVectorStore, analyzer_params
 
 pytestmark = pytest.mark.integration
 
@@ -329,6 +329,46 @@ class TestHybridSearch:
         )
 
         assert hits == []
+
+
+class TestCaseInsensitiveBM25:
+    """The lexical leg must fold case — issue #870.
+
+    Milvus runs the analyzer on the query as well as on the indexed text, so a
+    missing ``lowercase`` filter makes a lowercase query score zero against
+    capitalised source text instead of raising.
+    """
+
+    @pytest.mark.asyncio
+    async def test_analyzer_folds_case(self, hybrid_store: MilvusVectorStore) -> None:
+        tokens = hybrid_store._client.run_analyzer(
+            ["Le Rapport annuel de PARIS"],
+            analyzer_params=analyzer_params,
+        )[0].tokens
+
+        assert tokens == [t.lower() for t in tokens]
+        assert "rapport" in tokens
+        assert "paris" in tokens
+        # `le` / `de` are only stripped because the fold runs before the
+        # `_french_` stop list, which is itself lowercase.
+        assert "le" not in tokens
+
+    @pytest.mark.asyncio
+    async def test_lowercase_query_matches_capitalised_text(self, hybrid_store: MilvusVectorStore) -> None:
+        await hybrid_store.initialize(_EMBEDDING_DIM)
+        await hybrid_store.upsert([_chunk("Le Rapport annuel de PARIS", "p1", 1.0)])
+
+        # The dense leg is range-filtered out (far vector, threshold 0.99), so
+        # anything returned came from BM25 alone.
+        hits = await hybrid_store.search(
+            [-1.0, -1.1, -1.2, -1.3],
+            query_text="rapport paris",
+            top_k=5,
+            filters={"partition": "p1"},
+            similarity_threshold=0.99,
+        )
+
+        assert [hit["text"] for hit in hits] == ["Le Rapport annuel de PARIS"]
 
 
 class TestDeleteByFilter:

--- a/tests/load/workspace/workspace.py
+++ b/tests/load/workspace/workspace.py
@@ -171,7 +171,6 @@ def setup_milvus(client: MilvusClient):
         DataType.VARCHAR,
         max_length=65535,
         enable_analyzer=True,
-        enable_match=True,
     )
     schema.add_field("partition", DataType.VARCHAR, max_length=65535, is_partition_key=True)
     schema.add_field("file_id", DataType.VARCHAR, max_length=65535)

--- a/tests/unit/services/persistence/test_bm25_rebuild_migration.py
+++ b/tests/unit/services/persistence/test_bm25_rebuild_migration.py
@@ -1,0 +1,492 @@
+"""Unit tests for the v1 → v2 Milvus rebuild migration.
+
+The migration is a numbered script loaded by path, so it is imported the same
+way the runner imports it. Every Milvus call goes through a fake client that
+records what the migration would do.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "openrag"
+    / "services"
+    / "persistence"
+    / "migrations"
+    / "milvus"
+    / "2.rebuild_text_analyzer.py"
+)
+
+
+@pytest.fixture(scope="module")
+def migration():
+    spec = importlib.util.spec_from_file_location("milvus_migration_v2", _MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+#: The analyzer OpenRAG shipped at schema version 1 — no `lowercase` filter.
+_V1_ANALYZER = json.dumps({"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": ["_english_"]}]})
+_V2_ANALYZER = json.dumps({"tokenizer": "standard", "filter": ["lowercase", {"type": "stop", "stop_words": []}]})
+
+
+def _desc(
+    *,
+    version: str | None = "1",
+    analyzer: str = _V1_ANALYZER,
+    enable_match: str | None = "true",
+    hybrid: bool = True,
+    dim: int = 8,
+    text_max_length: int = 65_535,
+) -> dict[str, Any]:
+    """A describe_collection payload in the shape pymilvus returns one.
+
+    Type params come back from the server as strings, which is what the
+    migration's introspection helpers have to cope with.
+    """
+    text_params: dict[str, Any] = {
+        "max_length": text_max_length,
+        "enable_analyzer": "true",
+        "analyzer_params": analyzer,
+    }
+    if enable_match is not None:
+        text_params["enable_match"] = enable_match
+
+    fields = [
+        {"name": "_id", "params": {}},
+        {"name": "text", "params": text_params},
+        {"name": "partition", "params": {"max_length": 65535}},
+        {"name": "file_id", "params": {"max_length": 65535}},
+        {"name": "vector", "params": {"dim": dim}},
+        {"name": "created_at", "params": {}},
+    ]
+    if hybrid:
+        fields.append({"name": "sparse", "params": {}})
+
+    properties = {} if version is None else {"openrag.schema_version": version}
+    return {"fields": fields, "properties": properties}
+
+
+class _SchemaRecorder:
+    def __init__(self) -> None:
+        self.fields: list[dict[str, Any]] = []
+        self.functions: list[Any] = []
+
+    def add_field(self, **kwargs) -> None:
+        self.fields.append(kwargs)
+
+    def add_function(self, function) -> None:
+        self.functions.append(function)
+
+
+class _IndexRecorder:
+    def __init__(self) -> None:
+        self.indexes: list[dict[str, Any]] = []
+
+    def add_index(self, **kwargs) -> None:
+        self.indexes.append(kwargs)
+
+
+class _Iterator:
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self._batches = list(batches)
+        self.closed = False
+
+    def next(self) -> list[dict[str, Any]]:
+        return self._batches.pop(0) if self._batches else []
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeClient:
+    """Records calls; returns descs keyed by collection name."""
+
+    def __init__(
+        self,
+        source_desc: dict[str, Any],
+        *,
+        rows: list[dict[str, Any]] | None = None,
+        existing: tuple[str, ...] = ("openrag",),
+        target_count: int | None = None,
+        source_count_after_copy: int | None = None,
+    ) -> None:
+        self._descs = {"openrag": source_desc}
+        self._rows = rows if rows is not None else [{"_id": 1, "text": "Rapport", "vector": [0.1] * 8}]
+        self._existing = set(existing)
+        self._target_count = target_count
+        self._source_count_after_copy = source_count_after_copy
+        self._copied = False
+        self.schema = _SchemaRecorder()
+        self.index_params = _IndexRecorder()
+        self.created: list[str] = []
+        self.inserted: list[dict[str, Any]] = []
+        self.renames: list[tuple[str, str]] = []
+        self.properties: list[tuple[str, dict[str, str]]] = []
+        self.dropped_properties: list[tuple[str, list[str]]] = []
+        self.rename_failures: set[str] = set()
+        self.released: list[str] = []
+        self.calls: list[str] = []
+
+    # -- introspection ------------------------------------------------
+    def describe_collection(self, collection_name: str) -> dict[str, Any]:
+        return self._descs[collection_name]
+
+    def has_collection(self, collection_name: str) -> bool:
+        return collection_name in self._existing
+
+    def load_collection(self, collection_name: str) -> None:
+        pass
+
+    def release_collection(self, collection_name: str) -> None:
+        self.released.append(collection_name)
+        self.calls.append(f"release:{collection_name}")
+
+    def query(self, collection_name: str, filter: str, output_fields: list[str]) -> list[dict[str, Any]]:  # noqa: A002
+        if collection_name == "openrag":
+            if self._copied and self._source_count_after_copy is not None:
+                return [{"count(*)": self._source_count_after_copy}]
+            return [{"count(*)": len(self._rows)}]
+        count = self._target_count if self._target_count is not None else len(self.inserted)
+        return [{"count(*)": count}]
+
+    def query_iterator(self, **kwargs) -> _Iterator:
+        self.batch_size = kwargs["batch_size"]
+        self._copied = True
+        return _Iterator([self._rows])
+
+    # -- mutation -----------------------------------------------------
+    def create_schema(self, **kwargs) -> _SchemaRecorder:
+        return self.schema
+
+    def prepare_index_params(self) -> _IndexRecorder:
+        return self.index_params
+
+    def create_collection(self, collection_name: str, **kwargs) -> None:
+        self.created.append(collection_name)
+        self._existing.add(collection_name)
+        self._descs[collection_name] = _desc(analyzer=_V2_ANALYZER, enable_match=None)
+
+    def insert(self, collection_name: str, data: list[dict[str, Any]]) -> None:
+        self.inserted.extend(data)
+        self.calls.append(f"insert:{collection_name}:{len(data)}")
+
+    def flush(self, collection_name: str) -> None:
+        pass
+
+    def alter_collection_properties(self, collection_name: str, properties: dict[str, str]) -> None:
+        self.properties.append((collection_name, properties))
+        self.calls.append(f"alter:{collection_name}:{','.join(properties)}")
+
+    def drop_collection_properties(self, collection_name: str, property_keys: list[str]) -> None:
+        self.dropped_properties.append((collection_name, property_keys))
+        self.calls.append(f"drop_props:{collection_name}:{','.join(property_keys)}")
+
+    def rename_collection(self, old_name: str, new_name: str) -> None:
+        self.calls.append(f"rename:{old_name}->{new_name}")
+        if old_name in self.rename_failures:
+            raise RuntimeError(f"rename of {old_name} refused")
+        self.renames.append((old_name, new_name))
+        self._existing.discard(old_name)
+        self._existing.add(new_name)
+
+
+# ---------------------------------------------------------------------------
+# Skip paths — the collection is left alone, only the stamp moves
+# ---------------------------------------------------------------------------
+
+
+def test_already_at_target_version_does_nothing(migration) -> None:
+    client = _FakeClient(_desc(version="2"))
+
+    migration.upgrade(client, "openrag")
+
+    assert client.created == []
+    assert client.properties == []
+
+
+def test_dense_only_collection_is_only_restamped(migration) -> None:
+    # No `sparse` field means no BM25 leg, so the analyzer is never consulted.
+    client = _FakeClient(_desc(hybrid=False))
+
+    migration.upgrade(client, "openrag")
+
+    assert client.created == []
+    assert client.properties == [("openrag", {"openrag.schema_version": "2"})]
+
+
+def test_collection_already_in_v2_shape_is_only_restamped(migration) -> None:
+    client = _FakeClient(_desc(analyzer=_V2_ANALYZER, enable_match=None))
+
+    migration.upgrade(client, "openrag")
+
+    assert client.created == []
+    assert client.properties == [("openrag", {"openrag.schema_version": "2"})]
+
+
+def test_text_match_alone_still_forces_a_rebuild(migration) -> None:
+    # The analyzer is already right, but `enable_match` cannot be turned off in
+    # place — and while it is set, no later analyzer change is possible either.
+    client = _FakeClient(_desc(analyzer=_V2_ANALYZER, enable_match="true"))
+
+    migration.upgrade(client, "openrag")
+
+    assert client.created == ["openrag_v2_rebuild"]
+
+
+def test_dry_run_changes_nothing(migration) -> None:
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag", dry_run=True)
+
+    assert client.created == []
+    assert client.properties == []
+    assert client.renames == []
+
+
+# ---------------------------------------------------------------------------
+# The rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_rebuilt_text_field_drops_text_match_and_lowercases(migration) -> None:
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag")
+
+    text = next(f for f in client.schema.fields if f["field_name"] == "text")
+    assert "enable_match" not in text
+    assert text["analyzer_params"]["filter"][0] == "lowercase"
+
+
+def test_successful_rebuild_swaps_the_names(migration) -> None:
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag")
+
+    assert client.renames == [("openrag", "openrag_v1_backup"), ("openrag_v2_rebuild", "openrag")]
+    assert ("openrag_v2_rebuild", {"openrag.schema_version": "2"}) in client.properties
+
+
+def test_an_interrupted_previous_run_refuses_to_start(migration) -> None:
+    client = _FakeClient(_desc(), existing=("openrag", "openrag_v2_rebuild"))
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        migration.upgrade(client, "openrag")
+
+
+def test_row_count_mismatch_aborts_before_any_rename(migration) -> None:
+    client = _FakeClient(_desc(), target_count=0)
+
+    with pytest.raises(RuntimeError, match="Row-count mismatch"):
+        migration.upgrade(client, "openrag")
+
+    assert client.renames == []
+
+
+def test_a_failed_swap_puts_the_original_collection_back(migration) -> None:
+    # If the second rename fails the collection name resolves to nothing, so the
+    # backup has to be renamed back rather than left aside.
+    client = _FakeClient(_desc())
+    client.rename_failures = {"openrag_v2_rebuild"}
+
+    with pytest.raises(RuntimeError, match="rename of openrag_v2_rebuild refused"):
+        migration.upgrade(client, "openrag")
+
+    assert client.renames == [("openrag", "openrag_v1_backup"), ("openrag_v1_backup", "openrag")]
+    assert client.has_collection("openrag")
+
+
+# ---------------------------------------------------------------------------
+# Copy paging
+# ---------------------------------------------------------------------------
+
+
+def test_copy_batch_size_shrinks_as_the_declared_text_length_grows(migration) -> None:
+    small = migration._copy_batch_size(_desc(dim=1024, text_max_length=1_024))
+    large = migration._copy_batch_size(_desc(dim=1024, text_max_length=65_535))
+    assert small > large
+
+
+def test_copy_batch_size_counts_every_declared_varchar(migration) -> None:
+    # `partition` and `file_id` are declared as wide as `text`; a budget that
+    # only charged for `text` would page three times too optimistically.
+    narrow = _desc(dim=8)
+    narrow["fields"] = [
+        f if f["name"] not in ("partition", "file_id") else {**f, "params": {"max_length": 256}}
+        for f in narrow["fields"]
+    ]
+    assert migration._copy_batch_size(narrow) > migration._copy_batch_size(_desc(dim=8))
+
+
+def test_copy_batch_size_charges_for_the_sparse_column(migration) -> None:
+    # `output_fields=["*"]` brings `sparse` back over the wire even though the
+    # copy strips it before inserting, so the page has to have room for it.
+    assert migration._copy_batch_size(_desc(hybrid=False)) > migration._copy_batch_size(_desc(hybrid=True))
+
+
+def test_copy_batch_size_stays_positive_for_an_absurd_row(migration) -> None:
+    assert migration._copy_batch_size(_desc(dim=4096, text_max_length=10 * 1024 * 1024)) >= 1
+
+
+def test_copy_batch_size_is_capped(migration) -> None:
+    tiny = _desc(dim=1, text_max_length=1, hybrid=False)
+    tiny["fields"] = [
+        f if f["name"] not in ("partition", "file_id") else {**f, "params": {"max_length": 1}} for f in tiny["fields"]
+    ]
+    assert migration._copy_batch_size(tiny) == migration.MAX_COPY_BATCH
+
+
+def test_the_copy_pages_on_the_declared_schema(migration) -> None:
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag")
+
+    assert client.batch_size == migration._copy_batch_size(_desc())
+
+
+def test_the_copy_keeps_chunk_ids_and_drops_the_function_column(migration) -> None:
+    # `sparse` is regenerated server-side and is rejected from a caller; `_id`
+    # has to survive or every chunk id handed out earlier stops resolving.
+    client = _FakeClient(
+        _desc(),
+        rows=[{"_id": 7, "sparse": {1: 0.5}, "text": "Rapport", "vector": [0.1] * 8, "file_id": "f"}],
+    )
+
+    migration.upgrade(client, "openrag")
+
+    assert client.inserted == [{"_id": 7, "text": "Rapport", "vector": [0.1] * 8, "file_id": "f"}]
+
+
+# ---------------------------------------------------------------------------
+# auto_id override and concurrent-write detection
+# ---------------------------------------------------------------------------
+
+
+def test_auto_id_override_is_set_for_the_copy_and_dropped_before_the_swap(migration) -> None:
+    # An `auto_id` primary key rejects caller-supplied values unless the
+    # collection carries `allow_insert_auto_id`; it must not outlive the copy.
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag")
+
+    assert ("openrag_v2_rebuild", {"allow_insert_auto_id": "true"}) in client.properties
+    assert client.dropped_properties == [("openrag_v2_rebuild", ["allow_insert_auto_id"])]
+
+    order = [
+        c for c in client.calls if c.startswith(("alter:openrag_v2_rebuild:allow", "insert", "drop_props", "rename"))
+    ]
+    assert order[0].startswith("alter:openrag_v2_rebuild:allow")
+    assert order[1].startswith("insert:")
+    assert order[2].startswith("drop_props:")
+    assert order[3].startswith("rename:")
+
+
+def test_a_source_that_changes_during_the_copy_aborts_the_swap(migration) -> None:
+    # OpenRAG is supposed to be stopped; if it was not, the copy is a stale
+    # snapshot and swapping it in would lose the newer rows.
+    client = _FakeClient(_desc(), source_count_after_copy=99)
+
+    with pytest.raises(RuntimeError, match="changed during the copy"):
+        migration.upgrade(client, "openrag")
+
+    assert client.renames == []
+
+
+# ---------------------------------------------------------------------------
+# Memory: the collection moved aside must not stay resident
+# ---------------------------------------------------------------------------
+
+
+def test_the_backup_is_released_after_the_swap(migration) -> None:
+    # Counting rows loads both collections and a rename does not unload them,
+    # so without this the deployment carries two full copies in query-node
+    # memory until Milvus restarts.
+    client = _FakeClient(_desc())
+
+    migration.upgrade(client, "openrag")
+
+    assert client.released == ["openrag_v1_backup"]
+    order = [c for c in client.calls if c.startswith(("rename:", "release:"))]
+    assert order[-1] == "release:openrag_v1_backup"
+
+
+def test_a_release_that_fails_does_not_fail_the_migration(migration) -> None:
+    client = _FakeClient(_desc())
+    client.release_collection = lambda name: (_ for _ in ()).throw(RuntimeError("release refused"))
+
+    migration.upgrade(client, "openrag")
+
+    assert client.renames == [("openrag", "openrag_v1_backup"), ("openrag_v2_rebuild", "openrag")]
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_swaps_the_backup_back_and_restamps(migration) -> None:
+    client = _FakeClient(_desc(version="2"), existing=("openrag", "openrag_v1_backup"))
+
+    migration.downgrade(client, "openrag")
+
+    assert client.renames == [("openrag", "openrag_v2_rolled_back"), ("openrag_v1_backup", "openrag")]
+    assert client.properties == [("openrag", {"openrag.schema_version": "1"})]
+    assert client.released == ["openrag_v2_rolled_back"]
+
+
+def test_a_failed_rollback_rename_puts_the_v2_collection_back(migration) -> None:
+    # Same hazard as the upgrade swap: if the second rename fails the
+    # configured collection name resolves to nothing and OpenRAG cannot start.
+    client = _FakeClient(_desc(version="2"), existing=("openrag", "openrag_v1_backup"))
+    client.rename_failures = {"openrag_v1_backup"}
+
+    with pytest.raises(RuntimeError, match="rename of openrag_v1_backup refused"):
+        migration.downgrade(client, "openrag")
+
+    assert client.renames == [("openrag", "openrag_v2_rolled_back"), ("openrag_v2_rolled_back", "openrag")]
+    assert client.has_collection("openrag")
+
+
+def test_rollback_of_a_dense_only_collection_moves_the_stamp_back(migration) -> None:
+    # The upgrade only re-stamped it — there was no analyzer to fix — so it
+    # correctly has no backup, and the rollback is the stamp going back. The
+    # old code returned here, leaving version 2 stamped on a v1 deployment.
+    client = _FakeClient(_desc(version="2", hybrid=False), existing=("openrag",))
+
+    migration.downgrade(client, "openrag")
+
+    assert client.properties == [("openrag", {"openrag.schema_version": "1"})]
+    assert client.renames == []
+
+
+def test_dry_run_rollback_of_a_dense_only_collection_changes_nothing(migration) -> None:
+    client = _FakeClient(_desc(version="2", hybrid=False), existing=("openrag",))
+
+    migration.downgrade(client, "openrag", dry_run=True)
+
+    assert client.properties == []
+
+
+def test_rollback_of_a_rebuilt_collection_without_its_backup_fails_loudly(migration) -> None:
+    # A hybrid collection at version 2 was rebuilt, so a missing backup means
+    # the backup was lost — not that the upgrade skipped the rebuild.
+    client = _FakeClient(_desc(version="2", analyzer=_V2_ANALYZER, enable_match=None), existing=("openrag",))
+
+    with pytest.raises(RuntimeError, match="No backup collection"):
+        migration.downgrade(client, "openrag")
+
+    assert client.properties == []

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -20,8 +20,8 @@ from pymilvus import MilvusException
 
 from openrag.core.config.infrastructure import VectorDBConfig
 from openrag.core.models.chunk import Chunk, ChunkType
-from openrag.core.utils.exceptions import VDBSearchError
-from openrag.services.storage.milvus_store import MilvusVectorStore
+from openrag.core.utils.exceptions import VDBSchemaMigrationRequiredError, VDBSearchError
+from openrag.services.storage.milvus_store import MilvusVectorStore, analyzer_params
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -61,7 +61,11 @@ def store(vdb_config: VectorDBConfig, monkeypatch: pytest.MonkeyPatch) -> Milvus
 
     monkeypatch.setattr(_store_mod, "MilvusClient", MagicMock())
     monkeypatch.setattr(_store_mod, "AsyncMilvusClient", MagicMock())
-    return MilvusVectorStore(vdb_config)
+    built = MilvusVectorStore(vdb_config)
+    # Construction probes the schema version for the startup warning; that is
+    # setup noise, not something a test asserting on client calls should see.
+    built._client.reset_mock()
+    return built
 
 
 # ---------------------------------------------------------------------------
@@ -727,3 +731,160 @@ class TestParseSearchResponse:
 
     def test_empty_response_is_empty_list(self, store: MilvusVectorStore) -> None:
         assert store._parse_search_response([]) == []
+
+
+# ---------------------------------------------------------------------------
+# BM25 text analyzer
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzerParams:
+    """A missing filter here silently skews BM25 rather than raising."""
+
+    def test_declares_a_lowercase_filter(self) -> None:
+        # A custom analyzer inherits nothing; without this, `Rapport` and
+        # `rapport` are distinct BM25 terms.
+        assert "lowercase" in analyzer_params["filter"]
+
+    def test_lowercase_precedes_the_stop_filter(self) -> None:
+        # The `_english_` / `_french_` lists are lowercase, so they only match
+        # folded tokens.
+        filters = analyzer_params["filter"]
+        stop_index = next(i for i, f in enumerate(filters) if isinstance(f, dict) and f.get("type") == "stop")
+        assert filters.index("lowercase") < stop_index
+
+    def test_wired_onto_the_text_field(self, store: MilvusVectorStore) -> None:
+        store._embedding_dimension = 8
+        store._create_schema()
+
+        add_field = store._client.create_schema.return_value.add_field
+        text_calls = [c for c in add_field.call_args_list if c.kwargs.get("field_name") == "text"]
+        assert len(text_calls) == 1
+        assert text_calls[0].kwargs["analyzer_params"] is analyzer_params
+
+    def test_text_match_is_not_enabled(self, store: MilvusVectorStore) -> None:
+        # Nothing queries TEXT_MATCH, and while `enable_match` is set Milvus
+        # refuses to alter the analyzer — which is what forced the v2 rebuild.
+        store._embedding_dimension = 8
+        store._create_schema()
+
+        add_field = store._client.create_schema.return_value.add_field
+        text_call = next(c for c in add_field.call_args_list if c.kwargs.get("field_name") == "text")
+        assert "enable_match" not in text_call.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Schema-version reporting
+# ---------------------------------------------------------------------------
+
+
+class _LogRecorder:
+    """Stands in for the module logger so warnings can be asserted."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+        self.infos: list[str] = []
+
+    def warning(self, message: str, **kwargs) -> None:
+        self.warnings.append(message)
+
+    def info(self, message: str, **kwargs) -> None:
+        self.infos.append(message)
+
+
+@pytest.fixture
+def logs(monkeypatch: pytest.MonkeyPatch) -> _LogRecorder:
+    import openrag.services.storage.milvus_store as _store_mod
+
+    recorder = _LogRecorder()
+    monkeypatch.setattr(_store_mod, "logger", recorder)
+    return recorder
+
+
+def _describes(store: MilvusVectorStore, version: str | None) -> None:
+    properties = {} if version is None else {"openrag.schema_version": version}
+    store._client.has_collection.return_value = True
+    store._client.describe_collection.return_value = {"properties": properties}
+
+
+class TestWarnIfMigrationPending:
+    """A mismatch has to be visible in the logs, not just at the first upload."""
+
+    def test_matching_version_does_not_warn(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        _describes(store, "1")
+
+        store.warn_if_migration_pending()
+
+        assert logs.warnings == []
+
+    def test_stale_collection_warns_with_the_runner_command(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        _describes(store, None)  # unstamped reads as version 0
+
+        store.warn_if_migration_pending()
+
+        (warning,) = logs.warnings
+        assert "schema version 0" in warning
+        assert "expects 1" in warning
+        assert "migrate.py" in warning
+
+    def test_collection_ahead_of_the_build_warns(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        # Rolling an image back is the usual cause; the fix is the opposite one.
+        _describes(store, "3")
+
+        store.warn_if_migration_pending()
+
+        (warning,) = logs.warnings
+        assert "ahead of the 1" in warning
+
+    def test_absent_collection_is_not_a_mismatch(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        store._client.has_collection.return_value = False
+
+        store.warn_if_migration_pending()
+
+        assert logs.warnings == []
+
+    def test_the_probe_cannot_block_construction(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        # A slow metadata RPC must not hold up building the store, so the probe
+        # carries its own short timeout rather than the client's (120s default).
+        import openrag.services.storage.milvus_store as _store_mod
+
+        _describes(store, "1")
+
+        store.warn_if_migration_pending()
+
+        assert store._client.has_collection.call_args.kwargs["timeout"] == _store_mod._SCHEMA_PROBE_TIMEOUT
+        assert store._client.describe_collection.call_args.kwargs["timeout"] == _store_mod._SCHEMA_PROBE_TIMEOUT
+
+    def test_the_indexing_path_keeps_the_configured_timeout(self, store: MilvusVectorStore) -> None:
+        # _check_schema_version is not a probe: it must use the client default.
+        _describes(store, "1")
+
+        store._check_schema_version()
+
+        assert store._client.describe_collection.call_args.kwargs["timeout"] is None
+
+    def test_an_unreachable_milvus_is_logged_not_raised(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        # A warning must never be the thing that stops the caller.
+        store._client.has_collection.side_effect = MilvusException(message="no route to host")
+
+        store.warn_if_migration_pending()
+
+        assert "Could not read the schema version" in logs.warnings[0]
+
+
+class TestCheckSchemaVersion:
+    def test_logs_the_mismatch_before_raising(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        # The exception reaches the API caller; the log line carries the fix.
+        _describes(store, None)
+
+        with pytest.raises(VDBSchemaMigrationRequiredError):
+            store._check_schema_version()
+
+        assert "migrate.py" in logs.warnings[0]
+
+    def test_matching_version_passes_quietly(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
+        _describes(store, "1")
+
+        store._check_schema_version()
+
+        assert logs.warnings == []


### PR DESCRIPTION
BM25 lexical search is case-sensitive: a query for `rapport` scores zero against text that says `Rapport`. Closes #870.

## Why it happened

The `text` field declares a **custom** analyzer — `"tokenizer": "standard"` plus an explicit filter chain — not the built-in `standard` analyzer, which is `{"type": "standard"}`. A custom analyzer inherits nothing, so this silently opted out of the `lowercase` filter the built-in one bundles. Milvus runs the same analyzer over the query text at search time, so a case mismatch on either side scores zero on the lexical leg of hybrid search. The dense leg still returns something, which is why this looked like mediocre recall rather than a bug.

Order matters, so `lowercase` goes first: the `_english_` / `_french_` stop lists are lowercase and previously only matched tokens that happened to already be folded — `the` was stripped, `The` was not, which also skewed IDF.

## Why `enable_match` goes too

Nothing in the codebase issues a `TEXT_MATCH` query; it is reachable only through the raw `expr` escape hatch. It is not free, though: Milvus refuses to alter `analyzer_params` while text match is enabled, **and** refuses to turn `enable_match` off (`enable_match does not allow update in collection field param`). While it is set, the analyzer is frozen forever.

So both changes ride one rebuild — and it is the last one. With `enable_match` gone, a future analyzer change is `drop_function_field` → `alter_collection_field` → `add_function_field` on the live collection, with the sparse column backfilled by compaction.

## The migration

`2.rebuild_text_analyzer.py`, schema version 1 → 2. Copies the rows into `<collection>_v2_rebuild`, verifies the counts, swaps the names, keeps the old collection as `<collection>_v1_backup` (never dropped automatically).

Nothing is re-embedded — dense vectors are copied verbatim and the sparse ones are regenerated server-side on insert, which is what applies the new analyzer. Per-deployment values (vector dim, VARCHAR lengths, hybrid or not) are read off the live collection rather than assumed, and a declared field the migration does not know about aborts the run rather than being silently dropped.

Chunk IDs survive. `_id` is `auto_id`, which normally refuses caller-supplied keys, so the rebuild collection carries `allow_insert_auto_id` for the duration of the copy and drops it again before the swap — the collection ends up with the same semantics as a freshly created one, and an ID handed out earlier by MCP still resolves.

The copy reads a snapshot, so the migration re-counts the source afterwards and aborts, original untouched, if the count moved — i.e. if something was still writing when the runbook said to stop OpenRAG.

It reuses the copy/swap logic from #871 (closed) with both of that PR's open review findings fixed: the swap now renames the backup back into place if the second rename fails — the one moment the collection name resolves to nothing — and the copy pages on the collection's *declared* `text` length instead of a guessed fixed allowance, so a page of maximally long chunks cannot exceed the RPC cap.

## Making the mismatch visible

`_check_schema_version` raises, but only on the indexing path, so an un-migrated deployment boots, answers searches against the old schema, and only learns about it at the first upload. The store now probes the collection when it is **constructed** — which is where the API process first reaches Milvus, since it never calls `initialize` — and logs a warning naming the runner command:

```
WARNING | Collection `openrag` is at schema version 1, but this build expects 2.
          Indexing fails until the pending migration(s) are applied. Run, with
          OpenRAG stopped: uv run python .../migrate.py --dry-run (then without).
```

It never raises: a collection that does not exist yet is not a mismatch, and an unreadable one is logged and swallowed. A collection *ahead* of the build gets the opposite advice. Construction already connected (`MilvusClient` does an eager `_wait_for_channel_ready`, and `__init__` already converted that failure into `VDBConnectionError`), so this adds one RPC to a connection that was being made anyway.

**This does not need Storage V3** (#876). It was verified on a Storage V2 server precisely to keep the two independent; V3 is what makes the *next* such change cheap, not this one.

## Verification

End to end against a throwaway Milvus 3.0.0 on **Storage V2**, seeded with a v1-shaped collection (old analyzer, `enable_match`, 20 rows across 3 partitions):

| | before | after |
|---|---|---|
| `bm25("rapport")` | 10 / 20 rows | **20 / 20** |
| `bm25("RAPPORT")` | 0 | **20** |
| `enable_match` on `text` | `"true"` | absent |

Also: all 20 `_id` values came back identical; `allow_insert_auto_id` was not left on the collection and a subsequent normal insert still auto-generated; `--dry-run` created nothing and left the stamp at 1; a second `upgrade` is a no-op; the partition key survived the copy; `downgrade` put the v1 collection back with all 20 rows and kept the v2 one aside.

In-repo:

- `uv run pytest tests/unit/` — 2571 passed. 17 new tests drive the migration against a fake client (skip paths, the interrupted-previous-run guard, the row-count mismatch abort, the failed-swap restore, copy paging, the `auto_id` property lifecycle, the concurrent-write abort), 4 pin the analyzer shape and assert `enable_match` is no longer wired onto the field, and 7 cover the startup warning (stale, ahead, current, absent, unreachable, and log-before-raise).
- `uv run pytest tests/integration/repos/test_milvus_store_integration.py -m integration` — 19 passed against a live Milvus, including two new ones: `run_analyzer` folds case (`le` / `de` are now stripped, which only happens because the fold precedes the `_french_` list), and a lowercase query matches capitalised text with the dense leg range-filtered out, so only BM25 can be answering.
- ruff clean; `scripts/check_layer_imports.py` OK.

## Operator impact

- **A migration is required.** `vectordb.schema_version` goes to 2, so an un-migrated collection is stale. The version check runs on the indexing path only: the deployment still boots and still answers searches — with the old analyzer — and fails the first upload with `Collection ... is at schema version 1 but the application requires version 2`. Run `migrate.py` before restarting, with OpenRAG stopped — the copy reads a snapshot, and the migration aborts if the source changes underneath it. Allow roughly twice the collection size while both copies exist. Chunk IDs are preserved. `hybrid_search: false` deployments have no BM25 leg and are only re-stamped.

Documented under `## Schema Migrations` → "Version 2" in `milvus_migration.mdx`, along with what the v2 → v1 rollback can and cannot recover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BM25 text search is now case-insensitive, improving matches regardless of capitalization.
  * Added a Milvus schema migration that rebuilds collections while preserving data and supporting rollback.
  * Migration previews include consistency checks, backups, and safeguards before collections are replaced.
  * Startup checks warn when a collection requires migration.

* **Documentation**
  * Added upgrade, dry-run, rollback, naming, and operational guidance.

* **Bug Fixes**
  * Improved consistency between indexed text and search queries through case normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->