### PR TITLE
ci: run the UI vitest suite on pull requests

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -1,0 +1,39 @@
+name: UI tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+jobs:
+  ui-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: ui
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest
+        # vite.config.ts sets passWithNoTests: true for local runs; in CI an empty
+        # test discovery means something broke, so make it a failure.
+        run: npm test -- --passWithNoTests=false


### PR DESCRIPTION
## Context

`ui/` has a full vitest suite (`ui/package.json`'s `test` script, 34 files / 286 tests as of this PR) but no workflow ever runs it. `build.yml`/`build_rc.yml` only build the admin-ui Docker image (`tsc -b && vite build`) when publishing release images — that's a type-check + bundle, not a test run. Every other PR-triggered check (`api-tests`, `lint`, `tests`, `milvus-integration`, `layer-import-guard`) only covers the Python package.

Net effect: a broken frontend test currently merges silently — CI has nothing to say about it.

## Change

Adds `ui_tests.yml`, mirroring this repo's existing workflow conventions (`unit_tests.yml`, `api_tests.yml`): runs on `pull_request` and on `push` to `main`/`develop`, checks out, sets up Node with npm caching keyed on `ui/package-lock.json`, `npm ci`, then `vitest run` from the `ui/` working directory.

Notable details:

- **Least-privilege token** — job declares `permissions: contents: read`, matching `build.yml`/`build_rc.yml`.
- **`persist-credentials: false`** — the job runs PR-authored code (`npm ci` executes lifecycle scripts, `npm test` runs the suite), so the `GITHUB_TOKEN` is kept out of the runner's git config. Same as `build.yml`/`build_rc.yml` already do.
- **Node 22** — matches `infra/docker/ui.Dockerfile` (`node:22-alpine`), so CI and the shipped image agree. Node 20 is EOL.
- **`--passWithNoTests=false`** — `ui/vite.config.ts` sets `passWithNoTests: true`, which is convenient locally but would let a broken discovery glob report a green CI run with zero tests executed. Overridden at the CI invocation rather than changing local dev behavior. Verified the override actually takes effect: `vitest run <no-match>` exits 0, `vitest run --passWithNoTests=false <no-match>` exits 1.

## Test plan

- [x] Ran `npm ci && npm test -- --passWithNoTests=false` locally in `ui/` — 34 files / 286 tests pass
- [x] Verified `--passWithNoTests=false` overrides the config value (exit 1 on empty discovery)
- [ ] CI on this PR runs the new `ui-tests` job and it passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated UI test execution for changes submitted to the main development branches and pull requests.
  * UI tests now run consistently with a clean dependency installation and validation that test cases are discovered and executed.
  * Test failures are reported automatically to help identify regressions before changes are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->