### PR TITLE
feat(compression): pluggable context compression with a Headroom backend

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -371,7 +371,8 @@ mcp:
 # Shrinks retrieved text (and optionally chat history) before it reaches the
 # LLM. Deployment-wide kill switch; whether a request compresses is decided by
 # its partition's retrieval preset. Backends: noop, headroom.
-# headroom needs the headroom-ai package and runs on CPU.
+# headroom needs the headroom-ai package (not installed by default, see
+# docs/content/docs/documentation/context_compression.md) and runs on CPU.
 compression:
   enabled: false
   backend: noop

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -371,12 +371,13 @@ mcp:
 # Shrinks retrieved text (and optionally chat history) before it reaches the
 # LLM. Deployment-wide kill switch; whether a request compresses is decided by
 # its partition's retrieval preset. Backends: noop, headroom.
-# headroom needs the headroom-ai package (not installed by default, see
-# docs/content/docs/documentation/context_compression.md) and runs on CPU.
+# headroom needs the compression extra (uv sync --extra compression) and runs
+# on CPU. See docs/content/docs/documentation/context_compression.md for the
+# measured savings and latency before enabling it.
 compression:
   enabled: false
   backend: noop
   target_ratio: null    # fraction of each source to keep; null = backend decides
   min_chars: 1000       # texts shorter than this are passed through
-  timeout_s: 5.0
+  timeout_s: 15.0       # ~0.5s per 400-word chunk on CPU with the headroom backend
   extra: {}             # backend kwargs, e.g. {model: gpt-4o}

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -366,3 +366,16 @@ mcp:
   similarity_threshold: 0.8
   download_timeout: 30.0
   max_download_bytes: 104857600  # 100 MiB
+
+# --- Context compression ---
+# Shrinks retrieved text (and optionally chat history) before it reaches the
+# LLM. Deployment-wide kill switch; whether a request compresses is decided by
+# its partition's retrieval preset. Backends: noop, headroom.
+# headroom needs the headroom-ai package and runs on CPU.
+compression:
+  enabled: false
+  backend: noop
+  target_ratio: null    # fraction of each source to keep; null = backend decides
+  min_chars: 1000       # texts shorter than this are passed through
+  timeout_s: 5.0
+  extra: {}             # backend kwargs, e.g. {model: gpt-4o}

--- a/docs/content/docs/documentation/context_compression.md
+++ b/docs/content/docs/documentation/context_compression.md
@@ -30,7 +30,7 @@ compression:
   backend: noop        # noop | headroom
   target_ratio: null   # fraction of each source to keep; null = backend decides
   min_chars: 1000      # texts shorter than this are passed through
-  timeout_s: 5.0
+  timeout_s: 15.0
   extra: {}            # backend kwargs, e.g. {model: gpt-4o}
 ```
 
@@ -53,14 +53,52 @@ Compression needs a single owning partition. Multi-partition requests and the
 
 `headroom` uses [Headroom](https://github.com/headroomlabs-ai/headroom), which
 routes content to a per-type compressor: statistical folding for JSON and
-logs, a small ModernBERT model for prose. It runs on CPU and needs no GPU.
+logs, a small ModernBERT model for prose. Retrieved chunks are prose, so the
+model path is the one that matters here. It runs on CPU and needs no GPU.
 
-> **Not installable alongside the Infinity reranker client today.**
-> `headroom-ai` depends on `litellm`, which requires `httpx>=0.28`, while
-> `infinity-client` pins `httpx<0.28`. The package is therefore not declared
-> in `pyproject.toml`. A deployment that wants it must either not use
-> `infinity-client`, or override the `httpx` pin deliberately. Until then the
-> backend degrades to passthrough, which is safe but does nothing.
+### Installing it
+
+`headroom-ai` is declared as an optional extra:
+
+```bash
+uv sync --extra compression
+```
+
+It also declares `litellm`, which requires `httpx>=0.28` and so collides with
+`infinity-client`'s `httpx<0.28` pin. Headroom uses litellm only for its model
+registry and non-core providers, all lazily imported and ImportError-guarded;
+the compression path never touches it, and upstream itself ships without it on
+Python 3.14. A uv override in `pyproject.toml` therefore drops it. Everything
+else the prose compressor needs (transformers, onnxruntime, huggingface-hub)
+is already in the dependency set.
+
+The model is fetched from HuggingFace on first use. Construction kicks off a
+background load so the download never blocks startup, which means the first
+few requests in a fresh process pass through uncompressed. Set
+`extra: {warmup: false}` to skip it, and pre-seed the HuggingFace cache in the
+image if you need compression active from the first request.
+
+### What it costs
+
+Measured on a 10-core CPU, 400-word chunks:
+
+| target_ratio | Tokens saved | Latency |
+| --- | --- | --- |
+| null (model decides) | ~13% | ~490 ms per chunk |
+| 0.7 | ~19% | ~490 ms per chunk |
+| 0.5 | ~43% | ~490 ms per chunk |
+| 0.3 | ~57% | ~490 ms per chunk |
+
+Latency is linear in the number of chunks and independent of the ratio, so a
+partition retrieving `top_n: 10` pays roughly five seconds per query. Size
+`timeout_s` above that or the compressor will spend the time and then pass the
+originals through anyway. This is why compression is off by default and why it
+is worth enabling mainly where the retrieval set would otherwise be truncated,
+or on partitions where answer latency is not interactive.
+
+Compression is lossy. At aggressive ratios it strips function words, so
+sources read as clipped notes rather than prose. Check answer quality on your
+own corpus before turning it on widely.
 
 ## Adding a backend
 

--- a/docs/content/docs/documentation/context_compression.md
+++ b/docs/content/docs/documentation/context_compression.md
@@ -1,0 +1,84 @@
+---
+title: Context compression
+description: Shrink retrieved chunks and chat history before they reach the LLM.
+---
+
+# Context compression
+
+Retrieved chunks are fitted to a context-token budget before the prompt is
+assembled. Anything past the budget is dropped, so a relevant source can be
+lost for lack of room. Compression shrinks each source instead, letting more
+of the retrieval set reach the model.
+
+Compression is off by default. On prose the gain is modest and it costs
+latency on the query path, so it is opt-in per partition.
+
+## What the model sees, and what the user sees
+
+Only the text sent to the LLM is compressed. The sources returned to the
+client keep their original content, so a citation always resolves to the real
+document.
+
+## Configuration
+
+Two levels. The deployment-wide switch in `conf/config.yaml` decides whether
+compression is available at all and which backend runs it:
+
+```yaml
+compression:
+  enabled: false
+  backend: noop        # noop | headroom
+  target_ratio: null   # fraction of each source to keep; null = backend decides
+  min_chars: 1000      # texts shorter than this are passed through
+  timeout_s: 5.0
+  extra: {}            # backend kwargs, e.g. {model: gpt-4o}
+```
+
+Per-partition settings live on the retrieval preset and are editable from
+**Admin → Presets → Retrieval → Context compression**:
+
+| Field | Meaning |
+| --- | --- |
+| `compression_enabled` | Compress this partition's retrieved chunks |
+| `compression_target_ratio` | Overrides the deployment default |
+| `compress_history` | Also compress older chat turns |
+| `compress_history_keep_recent` | Turns left untouched at the end of the history |
+
+Compression needs a single owning partition. Multi-partition requests and the
+`openrag-all` sentinel skip it, because there is no one preset to obey.
+
+## Backends
+
+`noop` is the default and returns every text unchanged.
+
+`headroom` uses [Headroom](https://github.com/headroomlabs-ai/headroom), which
+routes content to a per-type compressor: statistical folding for JSON and
+logs, a small ModernBERT model for prose. It runs on CPU and needs no GPU.
+
+> **Not installable alongside the Infinity reranker client today.**
+> `headroom-ai` depends on `litellm`, which requires `httpx>=0.28`, while
+> `infinity-client` pins `httpx<0.28`. The package is therefore not declared
+> in `pyproject.toml`. A deployment that wants it must either not use
+> `infinity-client`, or override the `httpx` pin deliberately. Until then the
+> backend degrades to passthrough, which is safe but does nothing.
+
+## Adding a backend
+
+Subclass `Compressor`, register it, and import the module from
+`di/compressors.register_compressors`:
+
+```python
+from core.compression import Compressor, compressor_registry
+
+@compressor_registry.register("mine")
+class MyCompressor(Compressor):
+    name = "mine"
+
+    async def _compress(self, texts, *, options):
+        return [shorten(t) for t in texts]
+```
+
+Return one string per input, in the same order. The base class handles the
+rest: it enforces the count, reverts any text that came back longer, bounds
+the call with `timeout_s`, and returns the originals if the backend raises. A
+compression fault never fails a query.

--- a/openrag/api/routers/admin/presets.py
+++ b/openrag/api/routers/admin/presets.py
@@ -12,7 +12,7 @@ from core.chunking import chunking_registry
 from core.config.indexation_pipeline import PARSING_STRATEGIES
 from core.rerankers.registry import reranker_registry
 from core.retrieval import retriever_registry
-from di.providers import get_preset_service
+from di.providers import get_config, get_preset_service
 from fastapi import APIRouter, Depends, Response, status
 
 router = APIRouter(dependencies=[Depends(require_admin)])
@@ -32,9 +32,11 @@ def _registered_or_default(registered: list[str], defaults: list[str]) -> list[s
 
 
 @router.get("/options", response_model=PresetOptionsResponse)
-async def get_preset_options():
+async def get_preset_options(config=Depends(get_config)):
     """Return available preset strategy choices."""
     return PresetOptionsResponse(
+        compression_available=config.compression.enabled,
+        compression_backend=config.compression.backend,
         chunking_strategies=chunking_registry.list_registered(),
         parsing_strategies=_PARSING_STRATEGIES,
         retrieval_types=retriever_registry.list_registered(),

--- a/openrag/api/schemas/admin/preset_schemas.py
+++ b/openrag/api/schemas/admin/preset_schemas.py
@@ -90,6 +90,8 @@ class PresetOptionsResponse(BaseModel):
     parsing_strategies: list[str]
     retrieval_types: list[str]
     reranker_providers: list[str]
+    compression_available: bool = False
+    compression_backend: str = "noop"
 
 
 __all__ = [

--- a/openrag/core/compression/__init__.py
+++ b/openrag/core/compression/__init__.py
@@ -1,0 +1,15 @@
+"""Compressor ABC + registry."""
+
+from core.models.compression import CompressionOptions, CompressionResult
+
+from .compressor import Compressor
+from .noop import NoopCompressor
+from .registry import compressor_registry
+
+__all__ = [
+    "CompressionOptions",
+    "CompressionResult",
+    "Compressor",
+    "NoopCompressor",
+    "compressor_registry",
+]

--- a/openrag/core/compression/compressor.py
+++ b/openrag/core/compression/compressor.py
@@ -1,0 +1,69 @@
+"""Abstract context compressor interface."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from core.models.compression import CompressionOptions, CompressionResult
+from core.utils.logging import get_logger
+
+logger = get_logger()
+
+
+class Compressor(ABC):
+    """Shrinks text before it reaches an LLM.
+
+    Subclasses implement :meth:`_compress` and return one string per input.
+    :meth:`compress` wraps it with the guarantees callers rely on: order and
+    count are preserved, a text is never replaced by a longer one, work is
+    bounded by ``options.timeout_s``, and any failure returns the originals
+    rather than raising. A compression fault must not fail a RAG query.
+    """
+
+    name: str = "compressor"
+
+    async def compress(self, texts: Sequence[str], *, options: CompressionOptions) -> CompressionResult:
+        originals = list(texts)
+        if not originals:
+            return CompressionResult(texts=[], backend=self.name)
+
+        try:
+            async with asyncio.timeout(options.timeout_s):
+                compressed = await self._compress(originals, options=options)
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError:
+            return self._passthrough(originals, "timeout")
+        except Exception as exc:
+            logger.warning(f"Compressor '{self.name}' failed, passing content through: {exc}")
+            return self._passthrough(originals, str(exc))
+
+        if len(compressed) != len(originals):
+            logger.error(f"Compressor '{self.name}' returned {len(compressed)} texts for {len(originals)} inputs")
+            return self._passthrough(originals, "cardinality mismatch")
+
+        kept = [c if len(c) < len(o) else o for o, c in zip(originals, compressed, strict=True)]
+        return CompressionResult(
+            texts=kept,
+            backend=self.name,
+            chars_before=sum(len(t) for t in originals),
+            chars_after=sum(len(t) for t in kept),
+        )
+
+    @abstractmethod
+    async def _compress(self, texts: list[str], *, options: CompressionOptions) -> list[str]:
+        """Compress ``texts``, returning one entry per input in the same order."""
+
+    async def aclose(self) -> None:
+        """Release backend resources. Overridden when a backend holds any."""
+
+    def _passthrough(self, texts: list[str], detail: str) -> CompressionResult:
+        total = sum(len(t) for t in texts)
+        return CompressionResult(
+            texts=texts, backend=self.name, chars_before=total, chars_after=total, degraded=True, detail=detail
+        )
+
+
+__all__ = ["Compressor"]

--- a/openrag/core/compression/noop.py
+++ b/openrag/core/compression/noop.py
@@ -1,0 +1,21 @@
+"""Passthrough compressor — the default backend."""
+
+from __future__ import annotations
+
+from core.models.compression import CompressionOptions
+
+from .compressor import Compressor
+from .registry import compressor_registry
+
+
+@compressor_registry.register("noop")
+class NoopCompressor(Compressor):
+    """Returns every text unchanged."""
+
+    name = "noop"
+
+    async def _compress(self, texts: list[str], *, options: CompressionOptions) -> list[str]:
+        return texts
+
+
+__all__ = ["NoopCompressor"]

--- a/openrag/core/compression/registry.py
+++ b/openrag/core/compression/registry.py
@@ -1,0 +1,7 @@
+"""Compressor registry."""
+
+from core.utils.registry import Registry
+
+from .compressor import Compressor
+
+compressor_registry: Registry[Compressor] = Registry("compressor")

--- a/openrag/core/config/compression.py
+++ b/openrag/core/config/compression.py
@@ -1,0 +1,28 @@
+"""Context compression configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .base import ConfigMixin
+
+
+class CompressionConfig(ConfigMixin):
+    """Deployment-wide compression settings.
+
+    ``enabled`` is the global kill switch; whether a given request compresses
+    is decided per partition by its retrieval preset. Off by default: on prose
+    the gain is modest and it costs latency on the query path.
+    """
+
+    enabled: bool = False
+    backend: str = "noop"
+    target_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
+    min_chars: int = Field(default=1000, ge=0)
+    timeout_s: float = Field(default=5.0, gt=0.0)
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = ["CompressionConfig"]

--- a/openrag/core/config/compression.py
+++ b/openrag/core/config/compression.py
@@ -21,7 +21,7 @@ class CompressionConfig(ConfigMixin):
     backend: str = "noop"
     target_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
     min_chars: int = Field(default=1000, ge=0)
-    timeout_s: float = Field(default=5.0, gt=0.0)
+    timeout_s: float = Field(default=15.0, gt=0.0)
     extra: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/openrag/core/config/retrieval_pipeline.py
+++ b/openrag/core/config/retrieval_pipeline.py
@@ -29,6 +29,14 @@ class RetrievalPipelineConfig(BaseModel):
     include_ancestors: bool = True
     rrf_k: int = Field(default=60, gt=0, le=1000)  # Reciprocal Rank Fusion constant
 
+    # Context compression. Applied to retrieved chunk text (and optionally the
+    # chat history) before the prompt is assembled. Requires the deployment to
+    # have compression enabled; the backend is deployment-wide.
+    compression_enabled: bool = False
+    compression_target_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
+    compress_history: bool = False
+    compress_history_keep_recent: int = Field(default=2, ge=0, le=50)
+
     # Prompt selection: name a library prompt for this preset's query-side
     # prompts (None = the type's global default, then the disk seed). hyde /
     # multi_query drive the query-expansion strategies (resolved per request in

--- a/openrag/core/config/root.py
+++ b/openrag/core/config/root.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 from .base import ConfigMixin
 from .chunking import ChunkerConfig
+from .compression import CompressionConfig
 from .endpoints import (
     EmbedderConfig,
     LLMConfig,
@@ -62,6 +63,7 @@ class Settings(ConfigMixin):
     loader: LoaderConfig = Field(default_factory=LoaderConfig)
     ray: RayConfig = Field(default_factory=RayConfig)
     chunker: ChunkerConfig = Field(default_factory=ChunkerConfig)
+    compression: CompressionConfig = Field(default_factory=CompressionConfig)
     retriever: RetrieverConfig = Field(default_factory=SingleRetrieverConfig)
     rag: RAGConfig = Field(default_factory=RAGConfig)
     websearch: WebSearchConfig = Field(default_factory=StaanWebSearchConfig)

--- a/openrag/core/models/compression.py
+++ b/openrag/core/models/compression.py
@@ -1,0 +1,42 @@
+"""Compression domain models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CompressionOptions(BaseModel):
+    """Per-call compression knobs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    target_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
+    min_chars: int = Field(default=1000, ge=0)
+    timeout_s: float = Field(default=5.0, gt=0.0)
+
+
+class CompressionResult(BaseModel):
+    """Outcome of one compression call.
+
+    ``texts`` always has the same length and order as the input: callers map
+    results back to their sources by position.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    texts: list[str]
+    backend: str
+    chars_before: int = 0
+    chars_after: int = 0
+    degraded: bool = False
+    detail: str | None = None
+
+    @property
+    def ratio(self) -> float:
+        """Fraction of characters removed, 0.0 when nothing was compressed."""
+        if self.chars_before <= 0:
+            return 0.0
+        return max(0, self.chars_before - self.chars_after) / self.chars_before
+
+
+__all__ = ["CompressionOptions", "CompressionResult"]

--- a/openrag/core/models/compression.py
+++ b/openrag/core/models/compression.py
@@ -12,7 +12,7 @@ class CompressionOptions(BaseModel):
 
     target_ratio: float | None = Field(default=None, gt=0.0, le=1.0)
     min_chars: int = Field(default=1000, ge=0)
-    timeout_s: float = Field(default=5.0, gt=0.0)
+    timeout_s: float = Field(default=15.0, gt=0.0)
 
 
 class CompressionResult(BaseModel):

--- a/openrag/di/compressors.py
+++ b/openrag/di/compressors.py
@@ -1,0 +1,40 @@
+"""Registration and construction of the context compressor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from core.compression import Compressor, compressor_registry
+from core.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from core.config.root import Settings
+
+logger = get_logger()
+
+
+def register_compressors() -> None:
+    import core.compression.noop  # noqa: F401
+    import services.compression.headroom_compressor  # noqa: F401
+
+
+def create_compressor(settings: Settings) -> Compressor:
+    """Build the configured compressor, falling back to noop on any failure.
+
+    A misconfigured or uninstalled backend must not stop the app from booting,
+    so this degrades to passthrough and logs rather than raising.
+    """
+    from core.compression.noop import NoopCompressor
+
+    cfg = settings.compression
+    if not cfg.enabled or cfg.backend == "noop":
+        return NoopCompressor()
+
+    try:
+        return compressor_registry.create(cfg.backend, **cfg.extra)
+    except Exception as exc:
+        logger.error(f"Compressor backend '{cfg.backend}' unavailable, falling back to noop: {exc}")
+        return NoopCompressor()
+
+
+__all__ = ["create_compressor", "register_compressors"]

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -24,11 +24,13 @@ import os
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from core.compression import Compressor
 from core.embeddings import embedder_registry
 from core.llm import llm_registry
 from core.rerankers import reranker_registry
 from core.utils.logging import get_logger
 from core.vlm import vlm_registry
+from di.compressors import create_compressor, register_compressors
 from di.embedders import register_embedders
 from di.factories import make_component_factory
 from di.llms import register_llms
@@ -88,6 +90,7 @@ class ServiceContainer:
         register_llms()
         register_rerankers()
         register_vlms()
+        register_compressors()
 
         # Validate + freeze the OIDC env config now so misconfiguration
         # (AUTH_MODE=oidc with missing OIDC_*, invalid claim_source,
@@ -112,6 +115,7 @@ class ServiceContainer:
         self.vlm_factory = self._missing_named_factory("vlm")
         self._catalog_store: CatalogStore | None = create_catalog_store(settings) if settings is not None else None
         self._vector_store: VectorStore | None = create_vector_store(settings) if settings is not None else None
+        self._compressor: Compressor | None = create_compressor(settings) if settings is not None else None
         self._auth_service: AuthService | None = None
         self._user_service: UserService | None = None
         self._partition_service: PartitionService | None = None
@@ -243,6 +247,8 @@ class ServiceContainer:
                 for client in list(cache.values()):
                     await self._close_inference_client(client, seen_client_ids)
                 cache.clear()
+            if self._compressor is not None:
+                await self._close_inference_client(self._compressor, seen_client_ids)
             if self._catalog_store is not None:
                 await self._catalog_store.shutdown()
         finally:
@@ -276,6 +282,13 @@ class ServiceContainer:
     # ------------------------------------------------------------------
     # Storage adapters
     # ------------------------------------------------------------------
+
+    @property
+    def compressor(self) -> Compressor:
+        """The configured context compressor, or a passthrough when disabled."""
+        if self._compressor is None:
+            raise RuntimeError(_NO_SETTINGS_MESSAGE)
+        return self._compressor
 
     @property
     def catalog_store(self) -> CatalogStore:
@@ -585,6 +598,7 @@ class ServiceContainer:
                 **{k: v for k, v in llm_cfg.items() if k not in ("base_url", "model", "api_key")},
             )
             self._query_service = QueryService(
+                compressor=self.compressor,
                 retrieval_service=self.retrieval_service,
                 llm=llm,
                 config=settings,

--- a/openrag/services/compression/__init__.py
+++ b/openrag/services/compression/__init__.py
@@ -1,0 +1,1 @@
+"""Compressor adapters."""

--- a/openrag/services/compression/headroom_compressor.py
+++ b/openrag/services/compression/headroom_compressor.py
@@ -8,6 +8,11 @@ does the work here. It runs on CPU by default.
 ``headroom.compress`` is synchronous and CPU-bound, so it is called in a worker
 thread. Each text is sent as its own user message in one batched call, which
 keeps us on the public API instead of reaching into Headroom's router.
+
+``headroom-ai`` is not an OpenRAG dependency: it requires litellm, which
+requires httpx>=0.28, while infinity-client pins httpx<0.28. Import is
+therefore deferred to construction, and ``di.compressors.create_compressor``
+falls back to the noop backend when it fails.
 """
 
 from __future__ import annotations

--- a/openrag/services/compression/headroom_compressor.py
+++ b/openrag/services/compression/headroom_compressor.py
@@ -3,16 +3,25 @@
 Headroom (https://github.com/headroomlabs-ai/headroom) routes content to a
 per-type compressor: statistical folding for JSON and logs, a small ModernBERT
 model for prose. Retrieved chunks are prose, so the model path is the one that
-does the work here. It runs on CPU by default.
+does the work here. It runs on CPU and needs no GPU.
 
 ``headroom.compress`` is synchronous and CPU-bound, so it is called in a worker
 thread. Each text is sent as its own user message in one batched call, which
 keeps us on the public API instead of reaching into Headroom's router.
 
-``headroom-ai`` is not an OpenRAG dependency: it requires litellm, which
-requires httpx>=0.28, while infinity-client pins httpx<0.28. Import is
-therefore deferred to construction, and ``di.compressors.create_compressor``
-falls back to the noop backend when it fails.
+Two behaviours of the upstream package this adapter has to account for:
+
+* Compression is gated on an in-process model cache, not the on-disk one, so a
+  fresh worker silently compresses nothing until the model is loaded.
+  ``ensure_background_load`` primes it without blocking construction.
+* Prose compression costs roughly 500 ms per 400-word chunk on CPU, so a
+  ``top_n`` of 10 adds several seconds. Size ``compression.timeout_s``
+  accordingly; the base class passes content through when it is exceeded.
+
+``headroom-ai`` also declares ``litellm``, which collides with the httpx pin of
+``infinity-client``; the dependency is dropped via a uv override (see
+``pyproject.toml``). Import is deferred to construction regardless, and
+``di.compressors.create_compressor`` falls back to noop when it fails.
 """
 
 from __future__ import annotations
@@ -35,7 +44,7 @@ class HeadroomCompressor(Compressor):
 
     name = "headroom"
 
-    def __init__(self, *, model: str = DEFAULT_MODEL, **extra: Any) -> None:
+    def __init__(self, *, model: str = DEFAULT_MODEL, warmup: bool = True, **extra: Any) -> None:
         try:
             from headroom import CompressConfig, compress
         except ImportError as exc:
@@ -45,6 +54,22 @@ class HeadroomCompressor(Compressor):
         self._config_cls = CompressConfig
         self._model = model
         self._extra = extra
+        if warmup:
+            self._warmup()
+
+    def _warmup(self) -> None:
+        """Prime the prose model off the calling thread.
+
+        Without this the first requests in every process route to a no-op: the
+        readiness gate reads an in-process cache that only a load populates.
+        Downloading is someone else's thread, so construction stays I/O-free.
+        """
+        try:
+            from headroom.transforms.kompress_compressor import KompressCompressor
+
+            KompressCompressor().ensure_background_load()
+        except Exception as exc:
+            logger.warning(f"Headroom model warmup failed; compression stays inactive until it loads: {exc}")
 
     async def _compress(self, texts: list[str], *, options: CompressionOptions) -> list[str]:
         indices = [i for i, t in enumerate(texts) if len(t) >= options.min_chars]

--- a/openrag/services/compression/headroom_compressor.py
+++ b/openrag/services/compression/headroom_compressor.py
@@ -1,0 +1,81 @@
+"""Headroom-backed compressor.
+
+Headroom (https://github.com/headroomlabs-ai/headroom) routes content to a
+per-type compressor: statistical folding for JSON and logs, a small ModernBERT
+model for prose. Retrieved chunks are prose, so the model path is the one that
+does the work here. It runs on CPU by default.
+
+``headroom.compress`` is synchronous and CPU-bound, so it is called in a worker
+thread. Each text is sent as its own user message in one batched call, which
+keeps us on the public API instead of reaching into Headroom's router.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from core.compression import Compressor, compressor_registry
+from core.models.compression import CompressionOptions
+from core.utils.logging import get_logger
+
+logger = get_logger()
+
+DEFAULT_MODEL = "gpt-4o"
+
+
+@compressor_registry.register("headroom")
+class HeadroomCompressor(Compressor):
+    """Compresses text with Headroom's content-aware pipeline."""
+
+    name = "headroom"
+
+    def __init__(self, *, model: str = DEFAULT_MODEL, **extra: Any) -> None:
+        try:
+            from headroom import CompressConfig, compress
+        except ImportError as exc:
+            raise RuntimeError("headroom backend selected but headroom-ai is not installed") from exc
+
+        self._compress_fn = compress
+        self._config_cls = CompressConfig
+        self._model = model
+        self._extra = extra
+
+    async def _compress(self, texts: list[str], *, options: CompressionOptions) -> list[str]:
+        indices = [i for i, t in enumerate(texts) if len(t) >= options.min_chars]
+        if not indices:
+            return texts
+
+        compressed = await asyncio.to_thread(self._run, [texts[i] for i in indices], options)
+        if compressed is None:
+            return texts
+
+        out = list(texts)
+        for i, text in zip(indices, compressed, strict=True):
+            out[i] = text
+        return out
+
+    def _run(self, texts: list[str], options: CompressionOptions) -> list[str] | None:
+        config = self._config_cls(
+            compress_user_messages=True,
+            protect_recent=0,
+            protect_analysis_context=False,
+            target_ratio=options.target_ratio,
+            **self._extra,
+        )
+        result = self._compress_fn(
+            [{"role": "user", "content": t} for t in texts],
+            model=self._model,
+            config=config,
+        )
+        messages = result.messages
+        if len(messages) != len(texts):
+            logger.error(f"headroom returned {len(messages)} messages for {len(texts)} texts")
+            return None
+        return [
+            m["content"] if isinstance(m.get("content"), str) else original
+            for m, original in zip(messages, texts, strict=True)
+        ]
+
+
+__all__ = ["HeadroomCompressor"]

--- a/openrag/services/orchestrators/query_service.py
+++ b/openrag/services/orchestrators/query_service.py
@@ -41,6 +41,8 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from core.compression import Compressor, NoopCompressor
+from core.models.compression import CompressionOptions
 from core.models.preset import resolve_partition_chat_llm
 from core.models.query import Query, SearchQueries
 from core.prompts import (
@@ -61,6 +63,7 @@ from core.utils.web_url import normalize_web_url
 from services.inference.runtime import detect_language, get_llm_semaphore
 
 if TYPE_CHECKING:
+    from core.config.retrieval_pipeline import RetrievalPipelineConfig
     from core.config.root import Settings
     from core.llm.llm import LLM
     from services.orchestrators.prompt_service import PromptService
@@ -133,8 +136,10 @@ class QueryService:
         workspace_service: WorkspaceService,
         prompt_service: PromptService,
         llm_factory: Callable[[str], LLM] | None = None,
+        compressor: Compressor | None = None,
     ) -> None:
         self._retrieval = retrieval_service
+        self._compressor = compressor or NoopCompressor()
         self._llm = llm
         self._llm_factory = llm_factory
         self._web = web_search_service
@@ -200,6 +205,45 @@ class QueryService:
             if explicit:
                 return max(explicit)
         return self._default_chat_history_depth
+
+    def _compression_settings(self, partition: list[str] | None) -> RetrievalPipelineConfig | None:
+        """Retrieval preset driving compression, or ``None`` when it is off.
+
+        Compression needs a single owning partition: the ``"all"`` sentinel and
+        multi-partition requests have no one preset to obey, so they skip it.
+        """
+        if not self._config.compression.enabled or not partition or len(partition) != 1 or "all" in partition:
+            return None
+        cfg = self._config.partitions.get(partition[0])
+        if cfg is None or not cfg.retrieval.compression_enabled:
+            return None
+        return cfg.retrieval
+
+    def _compression_options(self, preset: RetrievalPipelineConfig) -> CompressionOptions:
+        globals_ = self._config.compression
+        return CompressionOptions(
+            target_ratio=preset.compression_target_ratio or globals_.target_ratio,
+            min_chars=globals_.min_chars,
+            timeout_s=globals_.timeout_s,
+        )
+
+    async def _compress_texts(self, texts: list[str], preset: RetrievalPipelineConfig) -> list[str]:
+        result = await self._compressor.compress(texts, options=self._compression_options(preset))
+        if result.ratio:
+            logger.debug(f"Compressed context by {result.ratio:.0%} via '{result.backend}'")
+        return result.texts
+
+    async def _compress_history(self, messages: list[dict], preset: RetrievalPipelineConfig) -> list[dict]:
+        """Compress the content of turns older than the keep-recent window."""
+        older = len(messages) - preset.compress_history_keep_recent
+        indices = [i for i in range(max(0, older)) if isinstance(messages[i].get("content"), str)]
+        if not indices:
+            return messages
+        compressed = await self._compress_texts([messages[i]["content"] for i in indices], preset)
+        out = list(messages)
+        for i, content in zip(indices, compressed, strict=True):
+            out[i] = {**out[i], "content": content}
+        return out
 
     def _resolve_llm(self, partition: list[str] | None) -> LLM:
         """Effective LLM for this request — query generation and answering.
@@ -455,6 +499,7 @@ class QueryService:
         custom_prompt, messages = _split_leading_system_prompt(payload["messages"], messages)
         if not messages:
             raise ValidationError("Request must contain at least one non-system message")
+        compression = self._compression_settings(partition)
         queries = await self.generate_query(messages, llm=llm, partition=partition)
 
         metadata = payload.get("metadata") or {}
@@ -545,8 +590,11 @@ class QueryService:
                 start_index=web_start_index,
                 max_tokens=self._web.max_tokens,
             )
+        texts = [doc.page_content for doc in docs]
+        if compression is not None and texts:
+            texts = await self._compress_texts(texts, compression)
         context, included = format_context(
-            [doc.page_content for doc in docs],
+            texts,
             max_context_tokens=self._max_context_tokens - web_tokens,
             length_function=get_num_tokens(),
         )
@@ -570,6 +618,8 @@ class QueryService:
         tmpl = await self._prompt_service.resolve_prompt(
             prompt_type, names=[self._generation_prompt_name(prompt_type, partition)]
         )
+        if compression is not None and compression.compress_history:
+            messages = await self._compress_history(messages, compression)
         new_messages = prepend_system_prompt(
             messages,
             tmpl,
@@ -627,8 +677,12 @@ class QueryService:
             # Full retrieval set before the token-budget selection below, kept
             # separately for `all_retrieved_sources` (#847).
             retrieved_docs = docs
+            texts = [doc.page_content for doc in docs]
+            compression = self._compression_settings(partition)
+            if compression is not None and texts:
+                texts = await self._compress_texts(texts, compression)
             context, included = format_context(
-                [doc.page_content for doc in docs],
+                texts,
                 max_context_tokens=self._max_context_tokens,
                 length_function=get_num_tokens(),
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,6 @@ dependencies = [
     "pymilvus>=3.0.1,<3.1",
     "protobuf>=5.27,<6.0",
     "faster-whisper>=1.1.0",
-    # Context compression backend (core.compression "headroom"). CPU-only by
-    # default; the module degrades to passthrough when it is unavailable.
-    "headroom-ai>=0.37",
     "authlib>=1.3",
     "itsdangerous>=2.2",
     "cryptography>=42",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,17 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["openrag"]
 
+[project.optional-dependencies]
+compression = ["headroom-ai>=0.37"]
+
+[tool.uv]
+# headroom-ai declares litellm, which requires httpx>=0.28 and so collides with
+# infinity-client's httpx<0.28 pin. Headroom only uses litellm for its model
+# registry and non-core providers, all lazily imported and ImportError-guarded;
+# the compression path we call never touches it (upstream ships without it on
+# Python 3.14 for the same reason). The always-false marker drops it.
+override-dependencies = ["litellm ; python_full_version < '0'"]
+
 [tool.uv.workspace]
 exclude = ["tests/load/prompt_eval"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     "pymilvus>=3.0.1,<3.1",
     "protobuf>=5.27,<6.0",
     "faster-whisper>=1.1.0",
+    # Context compression backend (core.compression "headroom"). CPU-only by
+    # default; the module degrades to passthrough when it is unavailable.
+    "headroom-ai>=0.37",
     "authlib>=1.3",
     "itsdangerous>=2.2",
     "cryptography>=42",

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from api.dependencies.auth import require_admin
 from api.routers.admin import model_endpoints, presets
-from di.providers import get_model_endpoint_service, get_preset_service
+from core.config.compression import CompressionConfig
+from di.providers import get_config, get_model_endpoint_service, get_preset_service
 from fastapi import FastAPI
 
 
@@ -152,12 +154,18 @@ def _build_app(
     *,
     model_service: FakeModelEndpointService | None = None,
     preset_service: FakePresetService | None = None,
+    compression: CompressionConfig | None = None,
 ) -> FastAPI:
     """Build a small app with Phase 14 routers and fake dependencies."""
     app = FastAPI()
     app.include_router(model_endpoints.router, prefix="/model-endpoints")
     app.include_router(presets.router, prefix="/presets")
     app.dependency_overrides[require_admin] = lambda: {"id": "admin", "is_admin": True}
+    # ``/presets/options`` reads the deployment compression switch off the root
+    # settings. These routers are mounted without a DI container, so the real
+    # provider would 503; stand in the one section the route actually reads.
+    config = SimpleNamespace(compression=compression or CompressionConfig())
+    app.dependency_overrides[get_config] = lambda: config
     if model_service is not None:
         app.dependency_overrides[get_model_endpoint_service] = lambda: model_service
     if preset_service is not None:
@@ -697,6 +705,33 @@ async def test_preset_options_return_registered_choices(async_client_factory):
     assert body["chunking_strategies"] == ["recursive_splitter", "structured_section"]
     assert set(body["retrieval_types"]) == {"single", "multiQuery", "hyde"}
     assert body["reranker_providers"] == ["infinity", "openai", "tei"]
+
+
+@pytest.mark.parametrize(
+    ("compression", "expected_available", "expected_backend"),
+    [
+        (None, False, "noop"),
+        (CompressionConfig(enabled=True, backend="headroom"), True, "headroom"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_preset_options_report_the_deployment_compression_switch(
+    async_client_factory, compression, expected_available, expected_backend
+):
+    """Preset options should mirror the deployment-wide compression settings.
+
+    The admin UI hides the per-preset compression fields unless the deployment
+    has the feature switched on, so the switch has to reach the client here.
+    """
+    app = _build_app(compression=compression)
+
+    async with async_client_factory(app) as client:
+        response = await client.get("/presets/options")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["compression_available"] is expected_available
+    assert body["compression_backend"] == expected_backend
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/compression/test_compressor.py
+++ b/tests/unit/core/compression/test_compressor.py
@@ -1,0 +1,94 @@
+"""Contract tests for the Compressor base guarantees."""
+
+import asyncio
+
+import pytest
+from core.compression import Compressor, NoopCompressor, compressor_registry
+from core.models.compression import CompressionOptions
+
+OPTIONS = CompressionOptions(min_chars=0, timeout_s=1.0)
+
+
+class _Fake(Compressor):
+    name = "fake"
+
+    def __init__(self, behaviour):
+        self._behaviour = behaviour
+
+    async def _compress(self, texts, *, options):
+        return await self._behaviour(texts)
+
+
+def _fake(fn):
+    async def behaviour(texts):
+        return fn(texts)
+
+    return _Fake(behaviour)
+
+
+async def test_noop_returns_input_unchanged():
+    result = await NoopCompressor().compress(["a", "b"], options=OPTIONS)
+    assert result.texts == ["a", "b"]
+    assert result.degraded is False
+
+
+async def test_empty_input_short_circuits():
+    result = await NoopCompressor().compress([], options=OPTIONS)
+    assert result.texts == []
+
+
+async def test_order_and_count_are_preserved():
+    compressor = _fake(lambda texts: [t[:2] for t in texts])
+    result = await compressor.compress(["aaaa", "bbbb", "cccc"], options=OPTIONS)
+    assert result.texts == ["aa", "bb", "cc"]
+
+
+async def test_cardinality_mismatch_falls_back_to_originals():
+    compressor = _fake(lambda texts: texts[:1])
+    result = await compressor.compress(["aaaa", "bbbb"], options=OPTIONS)
+    assert result.texts == ["aaaa", "bbbb"]
+    assert result.degraded is True
+    assert result.detail == "cardinality mismatch"
+
+
+async def test_inflated_text_is_reverted_per_entry():
+    compressor = _fake(lambda texts: ["x" * 100, "yy"])
+    result = await compressor.compress(["short", "original"], options=OPTIONS)
+    assert result.texts == ["short", "yy"]
+
+
+async def test_backend_failure_returns_originals():
+    def boom(texts):
+        raise RuntimeError("backend down")
+
+    result = await _fake(boom).compress(["a"], options=OPTIONS)
+    assert result.texts == ["a"]
+    assert result.degraded is True
+    assert "backend down" in result.detail
+
+
+async def test_timeout_returns_originals():
+    async def slow(texts):
+        await asyncio.sleep(1)
+        return texts
+
+    result = await _Fake(slow).compress(["a"], options=CompressionOptions(min_chars=0, timeout_s=0.01))
+    assert result.texts == ["a"]
+    assert result.detail == "timeout"
+
+
+async def test_cancellation_propagates():
+    async def hang(texts):
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await _Fake(hang).compress(["a"], options=OPTIONS)
+
+
+async def test_ratio_reports_characters_removed():
+    result = await _fake(lambda texts: ["ab"]).compress(["abcdefgh"], options=OPTIONS)
+    assert result.ratio == pytest.approx(0.75)
+
+
+def test_noop_is_registered():
+    assert "noop" in compressor_registry.list_registered()

--- a/tests/unit/di/test_compressors.py
+++ b/tests/unit/di/test_compressors.py
@@ -1,0 +1,34 @@
+"""Compressor construction falls back to passthrough rather than failing boot."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.compression import compressor_registry
+from di.compressors import create_compressor, register_compressors
+
+
+def _settings(**kwargs):
+    defaults = {"enabled": True, "backend": "headroom", "target_ratio": None, "min_chars": 0, "timeout_s": 5.0}
+    return SimpleNamespace(compression=SimpleNamespace(**{**defaults, **kwargs}, extra={}))
+
+
+def test_registration_exposes_both_backends():
+    register_compressors()
+    assert {"noop", "headroom"} <= set(compressor_registry.list_registered())
+
+
+def test_disabled_config_returns_noop():
+    assert create_compressor(_settings(enabled=False)).name == "noop"
+
+
+def test_unknown_backend_falls_back_to_noop():
+    register_compressors()
+    assert create_compressor(_settings(backend="does-not-exist")).name == "noop"
+
+
+def test_unavailable_backend_falls_back_to_noop(monkeypatch):
+    """headroom-ai is not a test dependency, so constructing it must degrade."""
+    register_compressors()
+    monkeypatch.setitem(__import__("sys").modules, "headroom", None)
+    assert create_compressor(_settings(backend="headroom")).name == "noop"

--- a/tests/unit/services/compression/test_headroom_compressor.py
+++ b/tests/unit/services/compression/test_headroom_compressor.py
@@ -1,0 +1,101 @@
+"""Tests for the Headroom adapter, driven by a stub headroom module."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+
+import pytest
+from core.models.compression import CompressionOptions
+
+OPTIONS = CompressionOptions(min_chars=0, timeout_s=5.0)
+
+
+@dataclass
+class _StubResult:
+    messages: list[dict]
+
+
+@dataclass
+class _StubHeadroom:
+    """Records calls and returns whatever ``responder`` produces."""
+
+    responder: object = None
+    calls: list[dict] = field(default_factory=list)
+
+    def compress(self, messages, model, config):
+        self.calls.append({"messages": messages, "model": model, "config": config})
+        if self.responder is None:
+            return _StubResult([{"role": "user", "content": m["content"][:2]} for m in messages])
+        return self.responder(messages)
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    stub = _StubHeadroom()
+
+    class CompressConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module = types.ModuleType("headroom")
+    module.compress = stub.compress
+    module.CompressConfig = CompressConfig
+    monkeypatch.setitem(sys.modules, "headroom", module)
+    return stub
+
+
+def _compressor():
+    from services.compression.headroom_compressor import HeadroomCompressor
+
+    return HeadroomCompressor()
+
+
+async def test_compresses_each_text(stub):
+    result = await _compressor().compress(["aaaa", "bbbb"], options=OPTIONS)
+    assert result.texts == ["aa", "bb"]
+    assert result.backend == "headroom"
+
+
+async def test_texts_below_min_chars_are_skipped(stub):
+    options = CompressionOptions(min_chars=10, timeout_s=5.0)
+    result = await _compressor().compress(["short", "a longer piece of text"], options=options)
+    assert result.texts[0] == "short"
+    assert [m["content"] for m in stub.calls[0]["messages"]] == ["a longer piece of text"]
+
+
+async def test_all_texts_below_min_chars_skips_the_backend(stub):
+    result = await _compressor().compress(["a", "b"], options=CompressionOptions(min_chars=100, timeout_s=5.0))
+    assert result.texts == ["a", "b"]
+    assert stub.calls == []
+
+
+async def test_message_count_mismatch_returns_originals(stub):
+    stub.responder = lambda messages: _StubResult(messages[:1])
+    result = await _compressor().compress(["aaaa", "bbbb"], options=OPTIONS)
+    assert result.texts == ["aaaa", "bbbb"]
+
+
+async def test_non_string_content_keeps_the_original(stub):
+    stub.responder = lambda messages: _StubResult([{"role": "user", "content": [{"type": "text"}]}])
+    result = await _compressor().compress(["aaaa"], options=OPTIONS)
+    assert result.texts == ["aaaa"]
+
+
+async def test_backend_exception_is_contained(stub):
+    def boom(messages):
+        raise RuntimeError("model missing")
+
+    stub.responder = boom
+    result = await _compressor().compress(["aaaa"], options=OPTIONS)
+    assert result.texts == ["aaaa"]
+    assert result.degraded is True
+
+
+async def test_missing_dependency_raises_at_construction(monkeypatch):
+    monkeypatch.setitem(sys.modules, "headroom", None)
+    from services.compression.headroom_compressor import HeadroomCompressor
+
+    with pytest.raises(RuntimeError, match="headroom-ai is not installed"):
+        HeadroomCompressor()

--- a/tests/unit/services/compression/test_headroom_compressor.py
+++ b/tests/unit/services/compression/test_headroom_compressor.py
@@ -46,10 +46,10 @@ def stub(monkeypatch):
     return stub
 
 
-def _compressor():
+def _compressor(**kwargs):
     from services.compression.headroom_compressor import HeadroomCompressor
 
-    return HeadroomCompressor()
+    return HeadroomCompressor(warmup=False, **kwargs)
 
 
 async def test_compresses_each_text(stub):
@@ -99,3 +99,13 @@ async def test_missing_dependency_raises_at_construction(monkeypatch):
 
     with pytest.raises(RuntimeError, match="headroom-ai is not installed"):
         HeadroomCompressor()
+
+
+async def test_warmup_failure_does_not_break_construction(stub, monkeypatch):
+    """A model that cannot load must leave a working passthrough, not an error."""
+    from services.compression.headroom_compressor import HeadroomCompressor
+
+    monkeypatch.setitem(sys.modules, "headroom.transforms.kompress_compressor", None)
+    compressor = HeadroomCompressor()
+    result = await compressor.compress(["aaaa"], options=OPTIONS)
+    assert result.texts == ["aa"]

--- a/tests/unit/services/orchestrators/test_query_service.py
+++ b/tests/unit/services/orchestrators/test_query_service.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 import services.orchestrators.query_service as qs
+from core.compression import Compressor
 from core.config import load_config
 from core.models.chunk import Chunk
 from core.models.workspace import WorkspaceScope
@@ -145,11 +146,15 @@ def _config(mode="SimpleRag"):
         prompts=_PROMPT_CFG.prompts,
         partitions={},
         models=SimpleNamespace(llm={}),
+        compression=SimpleNamespace(enabled=False, target_ratio=None, min_chars=1000, timeout_s=5.0),
     )
 
 
-def _svc(*, llm=None, retrieval=None, web=None, mode="SimpleRag", llm_factory=None, workspace=None) -> QueryService:
+def _svc(
+    *, llm=None, retrieval=None, web=None, mode="SimpleRag", llm_factory=None, workspace=None, compressor=None
+) -> QueryService:
     return QueryService(
+        compressor=compressor,
         retrieval_service=retrieval or FakeRetrieval(),
         llm=llm or FakeLLM(),
         config=_config(mode),
@@ -1734,3 +1739,113 @@ def test_split_leading_system_prompt_returns_none_when_every_system_turn_is_empt
 
     assert pinned is None
     assert rest == [{"role": "user", "content": "hi"}]
+
+
+# --------------------------------------------------------------------------- #
+# context compression
+# --------------------------------------------------------------------------- #
+
+
+class RecordingCompressor(Compressor):
+    """Replaces every text with a marker, recording what it was given."""
+
+    name = "recording"
+
+    def __init__(self):
+        self.batches: list[list[str]] = []
+
+    async def _compress(self, texts, *, options):
+        self.batches.append(list(texts))
+        return [f"<{i}>" for i in range(len(texts))]
+
+
+def _compression_config(*, enabled=True, **preset):
+    defaults = {
+        "compression_enabled": True,
+        "compression_target_ratio": None,
+        "compress_history": False,
+        "compress_history_keep_recent": 2,
+    }
+    return (
+        SimpleNamespace(enabled=enabled, target_ratio=None, min_chars=0, timeout_s=5.0),
+        SimpleNamespace(retrieval=SimpleNamespace(**{**defaults, **preset}), chat_history_depth=10),
+    )
+
+
+def _compressing_svc(*, enabled=True, chunks=None, **preset):
+    compressor = RecordingCompressor()
+    global_cfg, partition_cfg = _compression_config(enabled=enabled, **preset)
+    svc = _svc(
+        llm=FakeLLM(chat_responses=["answer"]),
+        retrieval=FakeRetrieval(chunks),
+        compressor=compressor,
+    )
+    svc._config.compression = global_cfg
+    svc._config.partitions = {"p": partition_cfg}
+    return svc, compressor
+
+
+async def test_compression_is_skipped_when_globally_disabled():
+    svc, compressor = _compressing_svc(enabled=False)
+    await svc._prepare_chat(["p"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    assert compressor.batches == []
+
+
+async def test_compression_is_skipped_when_the_preset_disables_it():
+    svc, compressor = _compressing_svc(compression_enabled=False)
+    await svc._prepare_chat(["p"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    assert compressor.batches == []
+
+
+async def test_compression_is_skipped_for_multi_partition_requests():
+    svc, compressor = _compressing_svc()
+    await svc._prepare_chat(["p", "other"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    assert compressor.batches == []
+
+
+async def test_compression_is_skipped_for_the_all_sentinel():
+    svc, compressor = _compressing_svc()
+    await svc._prepare_chat(["all"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    assert compressor.batches == []
+
+
+async def test_retrieved_text_is_compressed_into_the_prompt():
+    chunks = [Chunk(id="c1", text="a long original chunk", metadata={"_id": "c1"})]
+    svc, compressor = _compressing_svc(chunks=chunks)
+    result = await svc._prepare_chat(["p"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    payload = result.payload
+    assert compressor.batches == [["a long original chunk"]]
+    system = payload["messages"][0]["content"]
+    assert "<0>" in system
+    assert "a long original chunk" not in system
+
+
+async def test_sources_keep_their_original_text():
+    """The model reads the compressed text; the user is shown the real source."""
+    chunks = [Chunk(id="c1", text="a long original chunk", metadata={"_id": "c1"})]
+    svc, _ = _compressing_svc(chunks=chunks)
+    result = await svc._prepare_chat(["p"], {"messages": [{"role": "user", "content": "q"}], "metadata": {}})
+    assert [d.page_content for d in result.docs] == ["a long original chunk"]
+
+
+async def test_history_is_untouched_unless_enabled():
+    svc, compressor = _compressing_svc()
+    messages = [{"role": "user", "content": f"turn {i}"} for i in range(4)]
+    await svc._prepare_chat(["p"], {"messages": messages, "metadata": {}})
+    assert all("turn" not in "".join(batch) for batch in compressor.batches)
+
+
+async def test_history_older_than_the_window_is_compressed():
+    svc, compressor = _compressing_svc(compress_history=True, compress_history_keep_recent=2)
+    messages = [{"role": "user", "content": f"turn {i}"} for i in range(4)]
+    payload = (await svc._prepare_chat(["p"], {"messages": messages, "metadata": {}})).payload
+    assert ["turn 0", "turn 1"] in compressor.batches
+    # messages[0] is the prepended system prompt; the user turns follow.
+    assert [m["content"] for m in payload["messages"][1:]] == ["<0>", "<1>", "turn 2", "turn 3"]
+
+
+async def test_history_shorter_than_the_window_is_untouched():
+    svc, compressor = _compressing_svc(compress_history=True, compress_history_keep_recent=5)
+    messages = [{"role": "user", "content": f"turn {i}"} for i in range(3)]
+    payload = (await svc._prepare_chat(["p"], {"messages": messages, "metadata": {}})).payload
+    assert [m["content"] for m in payload["messages"][1:]] == ["turn 0", "turn 1", "turn 2"]

--- a/ui/src/lib/api/presets.ts
+++ b/ui/src/lib/api/presets.ts
@@ -39,6 +39,9 @@ export interface PresetOptionsResponse {
   parsing_strategies?: string[];
   retrieval_types: string[];
   reranker_providers: string[];
+  // Optional: older backends predate context compression.
+  compression_available?: boolean;
+  compression_backend?: string;
 }
 
 const BASE = "/presets";

--- a/ui/src/pages/admin/presets.tsx
+++ b/ui/src/pages/admin/presets.tsx
@@ -50,6 +50,7 @@ import {
   type Config,
   configGet,
   configSet,
+  configUnset,
   applyParsingStrategyChange,
   PARSING_STRATEGY_INHERIT,
 } from "./preset-config";
@@ -669,6 +670,8 @@ function RetrievalPresetForm({
   rerankers,
   llms,
   prompts,
+  compressionAvailable,
+  compressionBackend,
 }: {
   config: Config;
   onChange: (c: Config) => void;
@@ -676,6 +679,8 @@ function RetrievalPresetForm({
   rerankers: string[];
   llms: string[];
   prompts: PromptResponse[];
+  compressionAvailable: boolean;
+  compressionBackend: string;
 }) {
   const set = (key: string, value: unknown) => onChange(configSet(config, key, value));
   const pipelineType: string = configGet(config, "type", "single");
@@ -836,6 +841,65 @@ function RetrievalPresetForm({
 
       <Separator />
 
+      {/* Context compression */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium">Context compression</h4>
+          <Switch
+            checked={configGet(config, "compression_enabled", false) as boolean}
+            onCheckedChange={(on) => set("compression_enabled", on)}
+            disabled={!compressionAvailable}
+            size="sm"
+          />
+        </div>
+        <p className="text-[0.7rem] text-muted-foreground">
+          {compressionAvailable
+            ? `Shrink retrieved text before it reaches the LLM (backend: ${compressionBackend}). More sources fit the context budget, at the cost of some latency per query.`
+            : "Disabled for this deployment. Set compression.enabled in the server config to turn it on."}
+        </p>
+        <div className="space-y-1.5 max-w-xs">
+          <Label className="text-xs">Target ratio</Label>
+          <p className="text-[0.7rem] text-muted-foreground">
+            Fraction of each source to keep (0–1). Empty = let the backend decide.
+          </p>
+          <Input
+            type="number"
+            min={0.05}
+            max={1}
+            step={0.05}
+            value={configGet(config, "compression_target_ratio", "") as string | number}
+            onChange={(e) =>
+              e.target.value === ""
+                ? onChange(configUnset(config, "compression_target_ratio"))
+                : set("compression_target_ratio", numOr(e.target.value, 0.5))
+            }
+            disabled={!compressionAvailable || !configGet(config, "compression_enabled", false)}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Label className="text-xs">Also compress chat history</Label>
+          <Switch
+            checked={configGet(config, "compress_history", false) as boolean}
+            onCheckedChange={(on) => set("compress_history", on)}
+            disabled={!compressionAvailable || !configGet(config, "compression_enabled", false)}
+            size="sm"
+          />
+        </div>
+        <div className="space-y-1.5 max-w-xs">
+          <Label className="text-xs">Keep recent turns uncompressed</Label>
+          <Input
+            type="number"
+            min={0}
+            max={50}
+            value={configGet(config, "compress_history_keep_recent", 2)}
+            onChange={(e) => set("compress_history_keep_recent", intOr(e.target.value, 2))}
+            disabled={!compressionAvailable || !configGet(config, "compress_history", false)}
+          />
+        </div>
+      </section>
+
+      <Separator />
+
       {/* Advanced Pipeline Settings */}
       <section className="space-y-3">
         <button
@@ -989,6 +1053,8 @@ function PresetDialog({
               rerankers={rerankers}
               llms={llms}
               prompts={allPrompts}
+              compressionAvailable={options?.compression_available ?? false}
+              compressionBackend={options?.compression_backend ?? "noop"}
             />
           )}
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+overrides = [{ name = "litellm", marker = "python_full_version < '0'" }]
+
 [[package]]
 name = "aiobreaker"
 version = "1.2.0"
@@ -188,6 +191,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "ast-grep-cli"
+version = "0.45.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/46/35e89cbf27fe8a866796f9cb6ae711b88e0ff67e14e2580ced649b3d6a19/ast_grep_cli-0.45.3.tar.gz", hash = "sha256:d8b527b71655eede16637311bc3ca49624b8198c48bffeb5dcf06a78332bf917", size = 283689, upload-time = "2026-08-31T02:27:07.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/8d/fded0d3cf2138b56454101e061ba8525bd47c9d022d924fd92320fad4d98/ast_grep_cli-0.45.3-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ebc1510a6775f65a8681345dd422590fb257fe48036a7c599a5ca9f54dea8801", size = 15743557, upload-time = "2026-08-31T01:50:19.053Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f8/d9b41ae197bf9a41034a03d742d9bb2ca05bf4f7da741c00242019b44d3e/ast_grep_cli-0.45.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7afbe49870d8a34c0b224ac940da1fbf736617fcc81aa846884e377eddf8c1a0", size = 7870417, upload-time = "2026-08-31T01:50:21.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d5/584cc4cf46a751f35fc086e9dca9962c05de2b37f95056f3653dc4736e19/ast_grep_cli-0.45.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ced023ae9fbc7c779570cd8bcc0fa7626d9561afd60369d3c335bfce2ca565b3", size = 7752458, upload-time = "2026-08-31T01:50:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/1445bff6593d492c31904fe309c157cb16bcb73cfd30b4a55718acef5cb1/ast_grep_cli-0.45.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2d151b89c6d45c2640338fe5d24b2ee0810224902d603cb271803bf7418054ea", size = 8027608, upload-time = "2026-08-31T01:50:25.179Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/da/03562d9c4994d756d7fa7b751f7e92f4218d96fd86bdd27a5fe7be63e4d8/ast_grep_cli-0.45.3-py3-none-win32.whl", hash = "sha256:b96c897dc44052c7b1d08ba6086d0c270fe89d37645e38f08e2d4fa15948ea3c", size = 14970295, upload-time = "2026-08-31T01:50:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cc/a8d5a4039470b58a4b0a5ce9826975796ff091539849984f04a0ac98582f/ast_grep_cli-0.45.3-py3-none-win_amd64.whl", hash = "sha256:13dfb43b2028bb585f41b2f399e8b30bf0310e9bbeff2369d60a2e36accbb2e6", size = 15914271, upload-time = "2026-08-31T01:50:30.211Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/8e/bb893d035ee6349a07287f83b471fc54b067c2c61b34dd6c9e2072a7064f/ast_grep_cli-0.45.3-py3-none-win_arm64.whl", hash = "sha256:6c4222e17ac7a9e23c839b6eefb3a7858349e7a37a704acd451c266beadf75b4", size = 15293472, upload-time = "2026-08-31T02:27:05.122Z" },
 ]
 
 [[package]]
@@ -622,14 +640,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -1332,7 +1347,7 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
 wheels = [
@@ -1406,6 +1421,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/0f/97a315772abf99b3c230e3d57f3fa426d163ce4d6070241d68a3f0241ea9/hdbscan-0.8.40-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:991e745aa51abfb8abfb0e1525b9309df03a2f67fdd8df96e18f91fe7fe06806", size = 4362227, upload-time = "2025-10-11T11:53:16.452Z" },
     { url = "https://files.pythonhosted.org/packages/c0/cb/6b4254f8a33e075118512e55acf3485c155ea52c6c35d69a985bdc59297c/hdbscan-0.8.40-cp312-cp312-win_amd64.whl", hash = "sha256:1b55a935ed7b329adac52072e1c4028979dfc54312ca08de2deece9c97d6ebb1", size = 726198, upload-time = "2024-11-18T16:18:09.99Z" },
     { url = "https://files.pythonhosted.org/packages/80/2d/ca4d81a5aa5b8ccde1d41b892a2f480c2df238c58f113eee4df50473a3b0/hdbscan-0.8.40-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:32ea7bc4ce8854b5549d341edc841a29766feb62f8c399520e6e0940a41c5e39", size = 4336968, upload-time = "2025-10-11T11:53:10.417Z" },
+]
+
+[[package]]
+name = "headroom-ai"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-grep-cli" },
+    { name = "click" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tiktoken" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/17/10c3eb35dddb30055d84116444b7158d435758c4cfc161d7c206fb871782/headroom_ai-0.37.0.tar.gz", hash = "sha256:7ffdecba91ce44dd02f1601499f6c935c47374b7cb6ec61e569b816a4bb78a26", size = 2842752, upload-time = "2026-08-27T21:51:09.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/cc/385712352911b7a482514902745cba802e03947850689a784b2d40764e06/headroom_ai-0.37.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d89fd5858e701ada53d01849f73039d891fad84d9eb370f952d56581962d9cf8", size = 13799033, upload-time = "2026-08-27T21:50:58.97Z" },
+    { url = "https://files.pythonhosted.org/packages/47/21/8a87b66e83498da89404cdba4ced6397e84331047df9e11a9ea6f3510b29/headroom_ai-0.37.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b4392f68a8d02d74c62c1734cf5bf327511dcc72678f01669f44f0612944d59c", size = 13780628, upload-time = "2026-08-27T21:51:01.723Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2e/8d1c60683c74ae2871270789e0af1acc93727a51189799e74529679d795c/headroom_ai-0.37.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bc30d31a6b9336155d62bbdd99f3c2f6c5a1ed3882a8730ea0cd8ede4c40fa19", size = 13816313, upload-time = "2026-08-27T21:51:03.725Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b8/16878cf4fe6fc390a0d22025b671468619db690ff14c1b103ace4b5e35f9/headroom_ai-0.37.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2efc5cdf681a10c5fc7a2a271a471179c409074537045f682b10e4d724976f46", size = 13961835, upload-time = "2026-08-27T21:51:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/84/6803f3cc069dc8a6843c7ed8b155d1cf0c603a7467f58ffa24c5c399b8c9/headroom_ai-0.37.0-cp310-abi3-win_amd64.whl", hash = "sha256:e961f892786f7577e75f2c26229f11e2609fc007083dae24d336e76fc4c72e58", size = 13903214, upload-time = "2026-08-27T21:51:07.941Z" },
 ]
 
 [[package]]
@@ -2823,6 +2861,11 @@ dependencies = [
     { name = "umap-learn" },
 ]
 
+[package.optional-dependencies]
+compression = [
+    { name = "headroom-ai" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -2852,6 +2895,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.1,<0.117" },
     { name = "faster-whisper", specifier = ">=1.1.0" },
     { name = "hdbscan", specifier = ">=0.8.40" },
+    { name = "headroom-ai", marker = "extra == 'compression'", specifier = ">=0.37" },
     { name = "html-to-markdown", specifier = ">=2.4.0" },
     { name = "infinity-client", specifier = ">=0.0.76" },
     { name = "itsdangerous", specifier = ">=2.2" },
@@ -2892,6 +2936,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.4.1" },
     { name = "umap-learn", specifier = ">=0.5.9.post2" },
 ]
+provides-extras = ["compression"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5211,6 +5256,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a swappable context-compression module and wires it into the RAG query path.

Retrieved chunks are currently truncated at the context-token budget, so sources past the cut are dropped. Compressing them instead lets more of the retrieval set reach the model.

**Structure** (follows the co-located-ABC pattern)

- `core/compression`: `Compressor` ABC, registry, `noop` default
- `services/compression`: Headroom backend
- `di/compressors`: registration, and construction that degrades to `noop`

The base class enforces what callers depend on: order and count are preserved so citation indices stay aligned, a text is never replaced by a longer one, work is bounded by a timeout, and any failure returns the originals. A compression fault cannot fail a query. Sources returned to the client keep their original text.

**Configuration**

Off by default. A deployment-wide switch in `conf/config.yaml` plus per-partition fields on the retrieval preset, editable under Admin > Presets > Retrieval.

**Worth knowing before enabling**

Prose compression costs roughly 490ms per 400-word chunk on CPU, so `top_n: 10` adds about five seconds per query, for ~43% fewer context tokens at `target_ratio: 0.5`. It earns that mainly where the retrieval set would otherwise be truncated. `headroom-ai` is an optional extra; it declares `litellm`, which collides with `infinity-client`'s httpx pin, so a uv override drops it (it is never imported on the compression path). Details and measurements in `docs/content/docs/documentation/context_compression.md`.

31 unit tests, plus an end-to-end run against the real Headroom package: config resolution through the DI factory, the adapter's invariants, timeout fail-open, and the prompt built by `QueryService` (compressed context in, `[Source 1]` intact, returned sources still carrying their original text).

Layer guard, ruff and tsc are clean, and the `src/pages/admin` UI tests this touches pass. Note the full `ui` vitest suite has 43 pre-existing failures in `auth.test.tsx` and `api/client.test.ts`; identical on `develop`, unrelated to this branch.
