### PR TITLE
docs(releasing): add step 9 — verify the GitHub Release object

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -397,7 +397,10 @@ git show "$VER:infra/charts/openrag-stack/Chart.yaml" | grep -E '^version:'
 Steps 1-8 verify what was *built*. Nothing so far looks at the Release object
 users actually land on. A release whose `name` is empty renders with the tagged
 commit's subject as its title — so a perfectly good release displays as
-`Merge pull request #NNN from linagora/release/vX.Y.Z`. That happened on v2.2.0.
+`Merge pull request #NNN from linagora/release/vX.Y.Z`. v2.2.0 published with
+the commit subject as its title and was corrected by hand minutes later — which
+is the point: nothing catches it, so the title is only right when someone
+happens to notice.
 
 `gh release create` leaves `name` empty unless `--title` is passed, so this is a
 recurring trap rather than a one-off slip: **always pass `--title "$VER"`.**
@@ -431,6 +434,9 @@ name=$(printf '%s' "$rel" | jq -r '.name')
 [ "$(printf '%s' "$rel" | jq -r '.isPrerelease')" = "false" ] \
   && echo "OK    not flagged prerelease" || { echo "FAIL  GA release flagged as prerelease"; fail=1; }
 
+# 200, not 0: a body of "." passes a >0 check while telling a user nothing.
+# Real releases run 2-5k chars (v2.1.1 2306, v2.1.0 4226, v2.2.0 4688), so this
+# only trips a release that genuinely shipped without notes.
 n=$(printf '%s' "$rel" | jq -r '.body|length')
 [ "$n" -gt 200 ] \
   && echo "OK    release notes present ($n chars)" \

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -392,6 +392,61 @@ git show "$VER:infra/charts/openrag-stack/Chart.yaml" | grep -E '^version:'
 
 **PASS**: `step 8 PASS`, and chart `version` moved.
 
+## 9. The GitHub Release itself is correctly formed
+
+Steps 1-8 verify what was *built*. Nothing so far looks at the Release object
+users actually land on. A release whose `name` is empty renders with the tagged
+commit's subject as its title — so a perfectly good release displays as
+`Merge pull request #NNN from linagora/release/vX.Y.Z`. That happened on v2.2.0.
+
+`gh release create` leaves `name` empty unless `--title` is passed, so this is a
+recurring trap rather than a one-off slip: **always pass `--title "$VER"`.**
+
+```bash
+gh release view "$VER" --json name,tagName,isDraft,isPrerelease,body \
+  --jq '{name, tag: .tagName, draft: .isDraft, prerelease: .isPrerelease, notes: (.body|length)}'
+```
+
+A hard gate:
+
+```bash
+fail=0
+rel=$(gh release view "$VER" --json name,tagName,isDraft,isPrerelease,body) || {
+  echo "FAIL  no GitHub Release for $VER" >&2; exit 1; }
+
+# The title must be the tag. Empty renders as the commit subject; anything else
+# breaks the convention every prior GA release follows.
+name=$(printf '%s' "$rel" | jq -r '.name')
+[ "$name" = "$VER" ] \
+  && echo "OK    title=$name" \
+  || { echo "FAIL  title=${name:-<empty — will render as the commit subject>} (want $VER)"; fail=1; }
+
+[ "$(printf '%s' "$rel" | jq -r '.tagName')" = "$VER" ] \
+  && echo "OK    tag=$VER" || { echo "FAIL  tag mismatch"; fail=1; }
+
+[ "$(printf '%s' "$rel" | jq -r '.isDraft')" = "false" ] \
+  && echo "OK    published (not a draft)" || { echo "FAIL  still a draft"; fail=1; }
+
+# A GA release marked prerelease is excluded from "latest" and from most tooling.
+[ "$(printf '%s' "$rel" | jq -r '.isPrerelease')" = "false" ] \
+  && echo "OK    not flagged prerelease" || { echo "FAIL  GA release flagged as prerelease"; fail=1; }
+
+n=$(printf '%s' "$rel" | jq -r '.body|length')
+[ "$n" -gt 200 ] \
+  && echo "OK    release notes present ($n chars)" \
+  || { echo "FAIL  release notes empty or near-empty ($n chars)"; fail=1; }
+
+[ "$fail" -eq 0 ] && echo "step 9 PASS" || { echo "step 9 FAIL" >&2; exit 1; }
+```
+
+**PASS**: `step 9 PASS`.
+
+Fixing a bad title needs no rebuild and no retag — it is metadata only:
+
+```bash
+gh release edit "$VER" --title "$VER"
+```
+
 ---
 
 ## What v2.0.1 actually did, and the rules that follow


### PR DESCRIPTION
v2.2.0 shipped with an empty release `name`, so GitHub rendered the tagged commit's subject as the title: "Merge pull request #895 from linagora/release/v2.2.0". Steps 1-8 verify what was built; nothing checked the Release object itself.

Step 9 gates on title, tag, draft, prerelease and non-empty notes. Verified against v2.2.0 and v2.1.1 (PASS) and five synthetic broken states (all FAIL).

The v2.2.0 title is already corrected — metadata only, no retag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the release-title failure example by noting that it was manually corrected after version 2.2.0.
  * Added context explaining why release notes must exceed 200 characters.
  * Documented historical release-note lengths for additional reference.
  * Expanded release guidance to make validation requirements and prior examples easier to understand during future release preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->