### PR TITLE
fix(inference): strip falsy logprobs from Ollama request payloads

### DIFF
--- a/openrag/services/inference/ollama_client.py
+++ b/openrag/services/inference/ollama_client.py
@@ -25,11 +25,11 @@ from core.utils.exceptions import (
     InferenceTimeoutError,
 )
 from core.utils.logging import get_logger
+from services.inference.vllm_client import _parse_response, _strip_falsy_logprobs
 
 from ._call_log import log_llm_call
 from ._circuit_breaker import with_circuit_breaker
 from ._retry import with_retry
-from .vllm_client import _parse_response
 
 logger = get_logger()
 _ERROR_SNIPPET_LIMIT = 500
@@ -84,6 +84,7 @@ class OllamaClient(LLM):
     async def generate(self, prompt: str, **kwargs) -> dict:
         payload = {**self._defaults, **kwargs, "model": self._model, "prompt": prompt}
         payload.pop("metadata", None)
+        _strip_falsy_logprobs(payload)
         log_llm_call(caller="OllamaClient.generate", model=self._model, endpoint=self._endpoint, prompt=prompt)
         try:
             resp = await self._client.post(f"{self._endpoint}/completions", json=payload)
@@ -104,6 +105,7 @@ class OllamaClient(LLM):
     async def chat(self, messages: list[dict[str, str]], **kwargs) -> dict:
         payload = {**self._defaults, **kwargs, "model": self._model, "messages": messages, "stream": False}
         payload.pop("metadata", None)
+        _strip_falsy_logprobs(payload)
         log_llm_call(caller="OllamaClient.chat", model=self._model, endpoint=self._endpoint, messages=messages)
         try:
             resp = await self._client.post(f"{self._endpoint}/chat/completions", json=payload)
@@ -122,6 +124,7 @@ class OllamaClient(LLM):
     async def stream_chat(self, messages: list[dict[str, str]], **kwargs) -> AsyncIterator[str]:
         payload = {**self._defaults, **kwargs, "model": self._model, "messages": messages, "stream": True}
         payload.pop("metadata", None)
+        _strip_falsy_logprobs(payload)
         log_llm_call(
             caller="OllamaClient.stream_chat",
             model=self._model,

--- a/tests/unit/services/inference/test_ollama_client.py
+++ b/tests/unit/services/inference/test_ollama_client.py
@@ -208,6 +208,78 @@ class TestOllamaClient:
         lines = [line async for line in client.stream_chat([{"role": "user", "content": "hi"}])]
         assert lines == ["data: [DONE]"]
 
+    @pytest.mark.asyncio
+    async def test_falsy_logprobs_default_stripped_from_chat_payload(self):
+        """``llm.logprobs`` defaults to False in config and lands in ``_defaults``,
+        so without stripping it is sent on every request -- and Ollama's
+        OpenAI-compatible API does not support the field."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "logprobs" not in body
+            assert "top_logprobs" not in body
+            return _chat_response()
+
+        await self._make_client(handler, logprobs=False).chat([{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_falsy_logprobs_default_stripped_from_stream_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "logprobs" not in body
+            return httpx.Response(200, text="data: [DONE]\n")
+
+        client = self._make_client(handler, logprobs=False)
+        lines = [line async for line in client.stream_chat([{"role": "user", "content": "hi"}])]
+        assert lines == ["data: [DONE]"]
+
+    @pytest.mark.asyncio
+    async def test_falsy_logprobs_default_stripped_from_generate_payload(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "logprobs" not in body
+            return _completions_response()
+
+        await self._make_client(handler, logprobs=False).generate("hi")
+
+    @pytest.mark.asyncio
+    async def test_request_supplied_falsy_logprobs_stripped(self):
+        """A client sending an explicit ``logprobs: false`` is asking for nothing,
+        so it must not reach the provider either."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert "logprobs" not in body
+            return _chat_response()
+
+        await self._make_client(handler).chat([{"role": "user", "content": "hi"}], logprobs=False)
+
+    @pytest.mark.asyncio
+    async def test_truthy_logprobs_forwarded(self):
+        """A truthy logprobs is a deliberate opt-in and is passed through with its
+        dependent top_logprobs."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["logprobs"] is True
+            assert body["top_logprobs"] == 3
+            return _chat_response()
+
+        await self._make_client(handler).chat([{"role": "user", "content": "hi"}], logprobs=True, top_logprobs=3)
+
+    @pytest.mark.asyncio
+    async def test_zero_logprobs_forwarded_on_generate(self):
+        """On /v1/completions logprobs is an *integer* count, where 0 is a
+        meaningful request ("the sampled token's own logprob, no alternates")
+        rather than an off state -- so it must survive the strip."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            assert body["logprobs"] == 0
+            return _completions_response()
+
+        await self._make_client(handler).generate("hi", logprobs=0)
+
     def test_endpoint_v1_appended_when_missing(self):
         client = OllamaClient(endpoint="http://ollama:11434", model_name="llama3")
         assert client._endpoint == "http://ollama:11434/v1"


### PR DESCRIPTION
## Problem

`OllamaClient` builds every request body by merging two sources:

```python
payload = {**self._defaults, **kwargs, "model": ..., "messages": ..., "stream": False}
```

`self._defaults` carries the endpoint config, and `LLMParamsConfig.logprobs` defaults to `False` (`conf/config.yaml`, `core/config/endpoints.py`). So `logprobs: false` is merged into **every** chat, stream and completion request — even when the client sent nothing.

Ollama's OpenAI-compatible `/v1` API does not support `logprobs`; it is only implemented on the native `/api/chat` and `/api/generate` endpoints.

Reproduced with a mock transport, with no client-supplied `logprobs` at all:

```
{"logprobs": false, "temperature": 0.1, "model": "m", "messages": [...], "stream": false}
```

## Fix

`VLLMClient` already guards against exactly this — `_strip_falsy_logprobs()` exists and its docstring names this scenario: *"the config default (`LLMParamsConfig.logprobs = False`) lands in `self._defaults` and is sent on every request."* The helper was simply never wired into `OllamaClient`.

Reuse it in `chat`, `stream_chat` and `generate`. `ollama_client` already imports `_parse_response` from `vllm_client`, so this needs no new module — 1 import line and 3 calls.

## Semantics preserved

Only `None` and `False` are stripped, via `is` comparisons:

- a truthy `logprobs` is a deliberate opt-in and is forwarded with its `top_logprobs`
- `/v1/completions` takes `logprobs` as an **integer** count, where `0` means "the sampled token's own logprob, no alternates" — a real request, not an off state. It survives.

## Testing

6 new tests in `TestOllamaClient`. Verified they are not vacuous: disabling the three strip calls fails the 4 stripping tests, while the 2 pass-through tests stay green (they guard the opposite direction — over-stripping).

`uv run pytest tests/unit/services/inference` → 294 passed.

## Note

Found by CodeRabbit on #897. That PR does not cause this — it was already happening on `develop` from the config default alone — so the fix is split out here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference request handling by filtering empty or false `logprobs` values before sending requests.
  * Preserved valid `logprobs` configurations, including values used to request response details.

* **Tests**
  * Added coverage for chat, streaming, and generation requests with empty, false, zero, and configured `logprobs` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->