### PR TITLE
feat(jobs): persist indexing job state to Postgres

### DIFF
--- a/openrag/core/models/__init__.py
+++ b/openrag/core/models/__init__.py
@@ -1,6 +1,6 @@
 """Domain models — pure Pydantic, no infrastructure imports."""
 
-from .catalog import TERMINAL_TASK_STATES, DocumentRecord, DocumentStatus, IndexationJob, JobStatus
+from .catalog import TERMINAL_TASK_STATES, DocumentRecord, DocumentStatus, IndexationJob
 from .chunk import Chunk, ChunkType
 from .contextualization import ContextualizedQuery
 from .conversation import Conversation, Message
@@ -25,7 +25,6 @@ __all__ = [
     "DocumentType",
     "ImageBlock",
     "IndexationJob",
-    "JobStatus",
     "Message",
     "OIDCSession",
     "PartitionRole",

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -58,9 +58,14 @@ class DocumentRecord(BaseModel):
 class IndexationJob(BaseModel):
     """The durable record of one indexing task.
 
-    Mirrors a ``TaskStateManager`` entry into Postgres so job state survives a
-    restart and stays visible to operators. ``status`` reuses
-    :class:`DocumentStatus`, the state machine the indexing path already writes.
+    The Postgres row is what remains of a task after the ``TaskStateManager``
+    actor evicts it, so job state survives a restart and stays visible to
+    operators. ``status`` reuses :class:`DocumentStatus`, the state machine the
+    indexing path already writes.
+
+    ``started_at`` is stamped when the task leaves the queue and ``completed_at``
+    when it settles, so queue wait and service time are separable rather than
+    collapsed into one settle timestamp.
     """
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -71,4 +76,5 @@ class IndexationJob(BaseModel):
     error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime | None = None
-    finished_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None

--- a/openrag/core/models/catalog.py
+++ b/openrag/core/models/catalog.py
@@ -37,14 +37,6 @@ INDEXING_CONTENT_CLAIM_TOKEN_PREFIX = "task:"
 COPY_CONTENT_CLAIM_TOKEN_PREFIX = "copy:"
 
 
-class JobStatus(str, Enum):
-    QUEUED = "QUEUED"
-    RUNNING = "RUNNING"
-    SUCCESS = "SUCCESS"
-    FAILED = "FAILED"
-    PARTIAL = "PARTIAL"
-
-
 class DocumentRecord(BaseModel):
     """A document entry in the catalog (PostgreSQL)."""
 
@@ -64,12 +56,19 @@ class DocumentRecord(BaseModel):
 
 
 class IndexationJob(BaseModel):
-    """An indexation job tracking batch document processing."""
+    """The durable record of one indexing task.
+
+    Mirrors a ``TaskStateManager`` entry into Postgres so job state survives a
+    restart and stays visible to operators. ``status`` reuses
+    :class:`DocumentStatus`, the state machine the indexing path already writes.
+    """
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    status: JobStatus = JobStatus.QUEUED
-    total_documents: int = 0
+    status: DocumentStatus = DocumentStatus.QUEUED
     partition: str = "default"
+    file_id: str | None = None
+    user_id: int | None = None
+    error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    updated_at: datetime | None = None
+    finished_at: datetime | None = None

--- a/openrag/core/ports/job_repo.py
+++ b/openrag/core/ports/job_repo.py
@@ -22,7 +22,7 @@ class JobRepository(ABC):
     async def list_jobs(
         self,
         *,
-        status: str | None = None,
+        statuses: list[str] | None = None,
         user_id: int | None = None,
         offset: int = 0,
         limit: int = 50,

--- a/openrag/core/ports/job_repo.py
+++ b/openrag/core/ports/job_repo.py
@@ -3,22 +3,35 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from datetime import datetime
 
 from openrag.core.models.catalog import IndexationJob
 
 
 class JobRepository(ABC):
-    """CRUD operations for indexation jobs."""
+    """Durable records for indexing tasks."""
 
     @abstractmethod
-    async def create_job(self, job: IndexationJob) -> IndexationJob: ...
+    async def upsert_job(self, job: IndexationJob) -> IndexationJob:
+        """Create the record, or advance it. Terminal states never regress."""
 
     @abstractmethod
     async def get_job(self, job_id: str) -> IndexationJob | None: ...
 
     @abstractmethod
-    async def list_jobs(self, status: str | None = None, offset: int = 0, limit: int = 50) -> list[IndexationJob]: ...
+    async def list_jobs(
+        self,
+        *,
+        status: str | None = None,
+        user_id: int | None = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> list[IndexationJob]: ...
 
     @abstractmethod
-    async def update_job(self, job_id: str, **fields: Any) -> IndexationJob | None: ...
+    async def fail_orphaned_jobs(self, *, active_ids: list[str], error: str, before: datetime) -> int:
+        """Fail unfinished records no live task owns, e.g. after a restart."""
+
+    @abstractmethod
+    async def purge_terminal_jobs(self, *, older_than: datetime) -> int:
+        """Drop finished records past retention so the table stays bounded."""

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -617,6 +617,7 @@ class ServiceContainer:
                     document_repo=self.document_repo,
                     workspace_repo=self.workspace_repo,
                     collection=settings.vectordb.collection_name,
+                    job_repo=self.job_repo,
                 ),
                 config=settings,
                 partition_service=self.partition_service,
@@ -636,7 +637,7 @@ class ServiceContainer:
             from services.orchestrators.job_service import JobService
             from services.workers.bootstrap import get_task_state_manager
 
-            self._job_service = JobService(task_state_manager=get_task_state_manager())
+            self._job_service = JobService(task_state_manager=get_task_state_manager(), job_repo=self.job_repo)
         return self._job_service
 
     @property

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -197,7 +197,7 @@ class JobService:
 def _job_to_info(job: Any) -> dict[str, Any]:
     """Render a durable row in the same shape the actor returns."""
     created_at = job.created_at.isoformat() if job.created_at else None
-    finished_at = job.finished_at.isoformat() if job.finished_at else None
+    completed_at = job.completed_at.isoformat() if job.completed_at else None
     state = job.status.value
     return {
         "state": state,
@@ -209,7 +209,7 @@ def _job_to_info(job: Any) -> dict[str, Any]:
             "user_id": job.user_id,
         },
         "created_at": created_at,
-        "duration_ms": _duration_ms(created_at, finished_at, state=state, now=datetime.now(UTC)),
+        "duration_ms": _duration_ms(created_at, completed_at, state=state, now=datetime.now(UTC)),
     }
 
 

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -107,7 +107,10 @@ class JobService:
 
         # The actor only remembers live and recent tasks. Durable rows fill in
         # history it has evicted, and everything dispatched before a restart.
-        all_info = {**await self._durable_task_info(is_admin=is_admin, user_id=user_id), **all_info}
+        all_info = {
+            **await self._durable_task_info(is_admin=is_admin, user_id=user_id, task_status=task_status),
+            **all_info,
+        }
 
         if task_status is None:
             filtered = list(all_info.items())
@@ -180,11 +183,18 @@ class JobService:
             logger.warning("Failed to read durable job", task_id=task_id, error=str(exc))
             return None
 
-    async def _durable_task_info(self, *, is_admin: bool, user_id: int | None) -> dict[str, dict]:
+    async def _durable_task_info(
+        self,
+        *,
+        is_admin: bool,
+        user_id: int | None,
+        task_status: str | None,
+    ) -> dict[str, dict]:
         if self._job_repo is None:
             return {}
         try:
             jobs = await self._job_repo.list_jobs(
+                statuses=_durable_statuses(task_status),
                 user_id=None if is_admin else user_id,
                 limit=_DURABLE_TASK_LIMIT,
             )
@@ -192,6 +202,19 @@ class JobService:
             logger.warning("Failed to list durable jobs", error=str(exc))
             return {}
         return {job.id: _job_to_info(job) for job in jobs}
+
+
+def _durable_statuses(task_status: str | None) -> list[str] | None:
+    """The statuses the durable query should return, or ``None`` for all.
+
+    The row limit applies to what the query returns, so an unfiltered read
+    would hide older matches behind newer rows of every other status.
+    """
+    if task_status is None:
+        return None
+    if task_status.lower() == "active":
+        return list(_ACTIVE_STATES)
+    return [task_status.upper()]
 
 
 def _job_to_info(job: Any) -> dict[str, Any]:

--- a/openrag/services/orchestrators/job_service.py
+++ b/openrag/services/orchestrators/job_service.py
@@ -23,17 +23,22 @@ from core.models.catalog import (
     TASK_FINISHED_AT_METADATA_KEY,
     TERMINAL_TASK_STATES,
 )
+from core.utils.logging import get_logger
+
+logger = get_logger()
 
 _ACTIVE_STATES = ("QUEUED", "SERIALIZING")
+_DURABLE_TASK_LIMIT = 500
 _TERMINAL_STATES = frozenset(state.value for state in TERMINAL_TASK_STATES)
 
 
 class JobService:
     """Queue/worker introspection over the TaskStateManager actor."""
 
-    def __init__(self, task_state_manager: Any, timeout: float = 60.0) -> None:
+    def __init__(self, task_state_manager: Any, timeout: float = 60.0, *, job_repo: Any = None) -> None:
         self._tsm = task_state_manager
         self._timeout = timeout
+        self._job_repo = job_repo
 
     async def _call(self, submit: Any, task_description: str) -> Any:
         """Route TaskStateManager calls through the centralized Ray helper.
@@ -100,6 +105,10 @@ class JobService:
                 f"get_all_user_info({user_id})",
             )
 
+        # The actor only remembers live and recent tasks. Durable rows fill in
+        # history it has evicted, and everything dispatched before a restart.
+        all_info = {**await self._durable_task_info(is_admin=is_admin, user_id=user_id), **all_info}
+
         if task_status is None:
             filtered = list(all_info.items())
         elif task_status.lower() == "active":
@@ -155,9 +164,53 @@ class JobService:
             f"get_details({task_id})",
         )
         if details is None:
+            job = await self._durable_job(task_id)
+            details = _job_to_info(job)["details"] if job is not None else None
+        if details is None:
             return None
         public_details, _, _ = _task_details(details)
         return public_details
+
+    async def _durable_job(self, task_id: str) -> Any:
+        if self._job_repo is None:
+            return None
+        try:
+            return await self._job_repo.get_job(task_id)
+        except Exception as exc:
+            logger.warning("Failed to read durable job", task_id=task_id, error=str(exc))
+            return None
+
+    async def _durable_task_info(self, *, is_admin: bool, user_id: int | None) -> dict[str, dict]:
+        if self._job_repo is None:
+            return {}
+        try:
+            jobs = await self._job_repo.list_jobs(
+                user_id=None if is_admin else user_id,
+                limit=_DURABLE_TASK_LIMIT,
+            )
+        except Exception as exc:
+            logger.warning("Failed to list durable jobs", error=str(exc))
+            return {}
+        return {job.id: _job_to_info(job) for job in jobs}
+
+
+def _job_to_info(job: Any) -> dict[str, Any]:
+    """Render a durable row in the same shape the actor returns."""
+    created_at = job.created_at.isoformat() if job.created_at else None
+    finished_at = job.finished_at.isoformat() if job.finished_at else None
+    state = job.status.value
+    return {
+        "state": state,
+        "error": job.error,
+        "details": {
+            "file_id": job.file_id,
+            "partition": job.partition,
+            "metadata": {},
+            "user_id": job.user_id,
+        },
+        "created_at": created_at,
+        "duration_ms": _duration_ms(created_at, finished_at, state=state, now=datetime.now(UTC)),
+    }
 
 
 def _duration_ms(

--- a/openrag/services/persistence/job_repo.py
+++ b/openrag/services/persistence/job_repo.py
@@ -97,20 +97,22 @@ class PgJobRepository(JobRepository):
     async def list_jobs(
         self,
         *,
-        status: str | None = None,
+        statuses: list[str] | None = None,
         user_id: int | None = None,
         offset: int = 0,
         limit: int = 50,
     ) -> list[IndexationJob]:
+        """List the newest matching rows. Filtering happens here, before the
+        limit, so a status query cannot be crowded out by newer rows."""
         rows = await self.pool.fetch(
             f"""
             SELECT {_COLUMNS} FROM jobs
-            WHERE ($1::text IS NULL OR status = $1)
+            WHERE ($1::text[] IS NULL OR status = ANY($1::text[]))
               AND ($2::int IS NULL OR user_id = $2)
             ORDER BY created_at DESC
             OFFSET $3 LIMIT $4
             """,
-            status,
+            statuses,
             user_id,
             max(0, offset),
             max(1, limit),

--- a/openrag/services/persistence/job_repo.py
+++ b/openrag/services/persistence/job_repo.py
@@ -1,41 +1,129 @@
-"""Stub :class:`JobRepository` — see ``_stubs.py`` for the rationale.
+"""asyncpg-backed :class:`JobRepository`.
 
-Job state is currently tracked in-memory by the
-:class:`components.indexer.indexer.TaskStateManager` Ray actor. The
-post-refactoring P0 feature is to persist jobs to Postgres so they
-survive restarts and become visible to operators. When that lands,
-swap the body of each method for an asyncpg implementation against a
-new ``jobs`` table — the port shape is already pinned by Phase 4.
+Durable mirror of the in-memory ``TaskStateManager``. The actor stays the hot
+path while it is alive; these rows are what remains after a restart, so job
+history stays observable and orphaned work is recoverable.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from datetime import datetime
+from typing import TYPE_CHECKING
 
-from core.models.catalog import IndexationJob
+from core.models.catalog import TERMINAL_TASK_STATES, IndexationJob
 from core.ports.job_repo import JobRepository
-from services.persistence._stubs import _StubRepositoryBase, stub_not_implemented
+
+if TYPE_CHECKING:
+    import asyncpg
+
+_COLUMNS = "id, partition, file_id, user_id, status, error, created_at, updated_at, finished_at"
+_TERMINAL_STATUSES = sorted(state.value for state in TERMINAL_TASK_STATES)
+_MAX_ERROR_CHARS = 8_000
 
 
-class PgJobRepository(_StubRepositoryBase, JobRepository):
-    """TODO: real impl once the ``jobs`` table is added. See REFACTORING P0 plan."""
+class PgJobRepository(JobRepository):
+    """Store one row per indexing task, keyed by task id."""
 
-    async def create_job(self, job: IndexationJob) -> IndexationJob:
-        raise stub_not_implemented("DB-backed job tracking")
+    def __init__(self, pool_getter: Callable[[], asyncpg.Pool]) -> None:
+        self._pool_getter = pool_getter
+
+    @property
+    def pool(self) -> asyncpg.Pool:
+        return self._pool_getter()
+
+    @staticmethod
+    def _row_to_job(row: asyncpg.Record) -> IndexationJob:
+        return IndexationJob(**dict(row))
+
+    async def upsert_job(self, job: IndexationJob) -> IndexationJob:
+        row = await self.pool.fetchrow(
+            f"""
+            INSERT INTO jobs (id, partition, file_id, user_id, status, error, finished_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (id) DO UPDATE SET
+                -- A settled job never reopens, mirroring TaskStateManager.
+                status = CASE
+                    WHEN jobs.status = ANY($8::text[]) THEN jobs.status
+                    ELSE EXCLUDED.status
+                END,
+                file_id = COALESCE(EXCLUDED.file_id, jobs.file_id),
+                user_id = COALESCE(EXCLUDED.user_id, jobs.user_id),
+                error = COALESCE(EXCLUDED.error, jobs.error),
+                finished_at = COALESCE(jobs.finished_at, EXCLUDED.finished_at),
+                updated_at = now()
+            RETURNING {_COLUMNS}
+            """,
+            job.id,
+            job.partition,
+            job.file_id,
+            job.user_id,
+            job.status.value,
+            job.error[:_MAX_ERROR_CHARS] if job.error else None,
+            job.finished_at,
+            _TERMINAL_STATUSES,
+        )
+        return self._row_to_job(row)
 
     async def get_job(self, job_id: str) -> IndexationJob | None:
-        raise stub_not_implemented("DB-backed job tracking")
+        row = await self.pool.fetchrow(f"SELECT {_COLUMNS} FROM jobs WHERE id = $1", job_id)
+        return self._row_to_job(row) if row is not None else None
 
     async def list_jobs(
         self,
+        *,
         status: str | None = None,
+        user_id: int | None = None,
         offset: int = 0,
         limit: int = 50,
     ) -> list[IndexationJob]:
-        raise stub_not_implemented("DB-backed job tracking")
+        rows = await self.pool.fetch(
+            f"""
+            SELECT {_COLUMNS} FROM jobs
+            WHERE ($1::text IS NULL OR status = $1)
+              AND ($2::bigint IS NULL OR user_id = $2)
+            ORDER BY created_at DESC
+            OFFSET $3 LIMIT $4
+            """,
+            status,
+            user_id,
+            max(0, offset),
+            max(1, limit),
+        )
+        return [self._row_to_job(row) for row in rows]
 
-    async def update_job(self, job_id: str, **fields: Any) -> IndexationJob | None:
-        raise stub_not_implemented("DB-backed job tracking")
+    async def fail_orphaned_jobs(self, *, active_ids: list[str], error: str, before: datetime) -> int:
+        return await self.pool.fetchval(
+            """
+            WITH failed AS (
+                UPDATE jobs
+                SET status = 'FAILED', error = $1, finished_at = now(), updated_at = now()
+                WHERE status <> ALL($2::text[])
+                  AND id <> ALL($3::text[])
+                  AND updated_at < $4
+                RETURNING 1
+            )
+            SELECT COUNT(*)::int FROM failed
+            """,
+            error[:_MAX_ERROR_CHARS],
+            _TERMINAL_STATUSES,
+            list(active_ids),
+            before,
+        )
+
+    async def purge_terminal_jobs(self, *, older_than: datetime) -> int:
+        return await self.pool.fetchval(
+            """
+            WITH purged AS (
+                DELETE FROM jobs
+                WHERE status = ANY($1::text[]) AND COALESCE(finished_at, updated_at) < $2
+                RETURNING 1
+            )
+            SELECT COUNT(*)::int FROM purged
+            """,
+            _TERMINAL_STATUSES,
+            older_than,
+        )
 
 
 __all__ = ["PgJobRepository"]

--- a/openrag/services/persistence/job_repo.py
+++ b/openrag/services/persistence/job_repo.py
@@ -1,8 +1,12 @@
 """asyncpg-backed :class:`JobRepository`.
 
-Durable mirror of the in-memory ``TaskStateManager``. The actor stays the hot
-path while it is alive; these rows are what remains after a restart, so job
-history stays observable and orphaned work is recoverable.
+The durable record of indexing job state. The actor bounds its own retention,
+so it stops being able to answer for a task once it evicts it; these rows are
+what job history is read from, with the actor as the fallback for the window
+where a write has not landed yet.
+
+Writes stay best-effort by design: a Postgres blip degrades history, it does
+not fail indexing.
 """
 
 from __future__ import annotations
@@ -17,7 +21,7 @@ from core.ports.job_repo import JobRepository
 if TYPE_CHECKING:
     import asyncpg
 
-_COLUMNS = "id, partition, file_id, user_id, status, error, created_at, updated_at, finished_at"
+_COLUMNS = "id, partition, file_id, user_id, status, error, created_at, updated_at, started_at, completed_at"
 _TERMINAL_STATUSES = sorted(state.value for state in TERMINAL_TASK_STATES)
 _MAX_ERROR_CHARS = 8_000
 
@@ -39,18 +43,31 @@ class PgJobRepository(JobRepository):
     async def upsert_job(self, job: IndexationJob) -> IndexationJob:
         row = await self.pool.fetchrow(
             f"""
-            INSERT INTO jobs (id, partition, file_id, user_id, status, error, finished_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO jobs (id, partition, file_id, user_id, status, error, started_at, completed_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT (id) DO UPDATE SET
                 -- A settled job never reopens, mirroring TaskStateManager.
                 status = CASE
-                    WHEN jobs.status = ANY($8::text[]) THEN jobs.status
+                    WHEN jobs.status = ANY($9::text[]) THEN jobs.status
                     ELSE EXCLUDED.status
                 END,
+                -- The outcome is decided by whichever write settled the row, and
+                -- the three fields that describe it move together. Freezing the
+                -- status alone lets a FAILED write that lost the cancel race
+                -- staple its traceback onto a row reading CANCELLED.
+                error = CASE
+                    WHEN jobs.status = ANY($9::text[]) THEN jobs.error
+                    ELSE COALESCE(EXCLUDED.error, jobs.error)
+                END,
+                completed_at = CASE
+                    WHEN jobs.status = ANY($9::text[]) THEN jobs.completed_at
+                    ELSE COALESCE(jobs.completed_at, EXCLUDED.completed_at)
+                END,
+                -- First stamp wins: a retried transition must not restart the
+                -- clock queue wait is measured against.
+                started_at = COALESCE(jobs.started_at, EXCLUDED.started_at),
                 file_id = COALESCE(EXCLUDED.file_id, jobs.file_id),
                 user_id = COALESCE(EXCLUDED.user_id, jobs.user_id),
-                error = COALESCE(EXCLUDED.error, jobs.error),
-                finished_at = COALESCE(jobs.finished_at, EXCLUDED.finished_at),
                 updated_at = now()
             RETURNING {_COLUMNS}
             """,
@@ -60,7 +77,8 @@ class PgJobRepository(JobRepository):
             job.user_id,
             job.status.value,
             job.error[:_MAX_ERROR_CHARS] if job.error else None,
-            job.finished_at,
+            job.started_at,
+            job.completed_at,
             _TERMINAL_STATUSES,
         )
         return self._row_to_job(row)
@@ -81,7 +99,7 @@ class PgJobRepository(JobRepository):
             f"""
             SELECT {_COLUMNS} FROM jobs
             WHERE ($1::text IS NULL OR status = $1)
-              AND ($2::bigint IS NULL OR user_id = $2)
+              AND ($2::int IS NULL OR user_id = $2)
             ORDER BY created_at DESC
             OFFSET $3 LIMIT $4
             """,
@@ -97,7 +115,7 @@ class PgJobRepository(JobRepository):
             """
             WITH failed AS (
                 UPDATE jobs
-                SET status = 'FAILED', error = $1, finished_at = now(), updated_at = now()
+                SET status = 'FAILED', error = $1, completed_at = now(), updated_at = now()
                 WHERE status <> ALL($2::text[])
                   AND id <> ALL($3::text[])
                   AND updated_at < $4
@@ -116,7 +134,9 @@ class PgJobRepository(JobRepository):
             """
             WITH purged AS (
                 DELETE FROM jobs
-                WHERE status = ANY($1::text[]) AND COALESCE(finished_at, updated_at) < $2
+                -- Matches ix_jobs_settled_at. A row whose terminal write
+                -- raced a failure has no completed_at and ages out on created_at.
+                WHERE status = ANY($1::text[]) AND COALESCE(completed_at, created_at) < $2
                 RETURNING 1
             )
             SELECT COUNT(*)::int FROM purged

--- a/openrag/services/persistence/job_repo.py
+++ b/openrag/services/persistence/job_repo.py
@@ -68,7 +68,13 @@ class PgJobRepository(JobRepository):
                 -- clock queue wait is measured against.
                 started_at = COALESCE(jobs.started_at, EXCLUDED.started_at),
                 file_id = COALESCE(EXCLUDED.file_id, jobs.file_id),
-                user_id = COALESCE(EXCLUDED.user_id, jobs.user_id),
+                -- user_id is set once, at insert, and the foreign key owns it
+                -- from then on. Deleting a user nulls it via ON DELETE SET NULL,
+                -- and a later worker write still carries the old id, so taking
+                -- EXCLUDED.user_id here would re-point the row at a user that no
+                -- longer exists. Postgres rejects the whole upsert for that, the
+                -- caller swallows it as a best-effort history write, and the
+                -- terminal status is silently lost.
                 updated_at = now()
             RETURNING {_COLUMNS}
             """,

--- a/openrag/services/persistence/job_repo.py
+++ b/openrag/services/persistence/job_repo.py
@@ -1,9 +1,10 @@
 """asyncpg-backed :class:`JobRepository`.
 
 The durable record of indexing job state. The actor bounds its own retention,
-so it stops being able to answer for a task once it evicts it; these rows are
-what job history is read from, with the actor as the fallback for the window
-where a write has not landed yet.
+so it stops being able to answer for a task once it evicts it, and a restart
+takes the rest with it. These rows are what survives both, and the queue views
+union them with whatever the actor still holds: history comes from here, live
+sub-state from the actor that is writing it.
 
 Writes stay best-effort by design: a Postgres blip degrades history, it does
 not fail indexing.

--- a/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
+++ b/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
@@ -59,8 +59,11 @@ def upgrade() -> None:
             ),
             sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            # Frozen copy of DocumentStatus as of this revision. A new state has
+            # to arrive with its own migration, which is what the parity test in
+            # tests/unit/services/persistence/test_jobs_migration.py enforces.
             sa.CheckConstraint(
-                "status IN ('QUEUED','SERIALIZING','CHUNKING','INSERTING','COMPLETED','FAILED','CANCELLED')",
+                "status IN ('QUEUED','SERIALIZING','COMPLETED','FAILED','CANCELLED')",
                 name="ck_jobs_status",
             ),
             # Left unnamed so this CREATE TABLE and the startup

--- a/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
+++ b/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
@@ -1,0 +1,63 @@
+"""add jobs table
+
+Revision ID: c7d8e9f0a1b2
+Revises: b9c0d1e2f3a4
+Create Date: 2026-09-07 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from schema_helpers import index_exists, table_exists
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d8e9f0a1b2"
+down_revision: str | Sequence[str] | None = "b9c0d1e2f3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not table_exists("jobs"):
+        op.create_table(
+            "jobs",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("partition", sa.String(), nullable=False),
+            sa.Column("file_id", sa.String(), nullable=True),
+            sa.Column("user_id", sa.BigInteger(), nullable=True),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("error", sa.String(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+    if not index_exists("jobs", "ix_jobs_status"):
+        op.create_index("ix_jobs_status", "jobs", ["status"])
+    if not index_exists("jobs", "ix_jobs_user_id"):
+        op.create_index("ix_jobs_user_id", "jobs", ["user_id"])
+    if not index_exists("jobs", "ix_jobs_partition_file_id"):
+        op.create_index("ix_jobs_partition_file_id", "jobs", ["partition", "file_id"])
+
+
+def downgrade() -> None:
+    if index_exists("jobs", "ix_jobs_partition_file_id"):
+        op.drop_index("ix_jobs_partition_file_id", table_name="jobs")
+    if index_exists("jobs", "ix_jobs_user_id"):
+        op.drop_index("ix_jobs_user_id", table_name="jobs")
+    if index_exists("jobs", "ix_jobs_status"):
+        op.drop_index("ix_jobs_status", table_name="jobs")
+    if table_exists("jobs"):
+        op.drop_table("jobs")

--- a/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
+++ b/openrag/services/persistence/migrations/alembic/versions/c7d8e9f0a1b2_add_jobs.py
@@ -19,14 +19,30 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+_INDEXES: tuple[tuple[str, list], ...] = (
+    ("ix_jobs_status_created_at", ["status", "created_at"]),
+    ("ix_jobs_user_status", ["user_id", "status"]),
+    # Expression index: the retention sweep filters and orders on
+    # ``COALESCE(completed_at, created_at)``, not on ``completed_at`` alone.
+    ("ix_jobs_settled_at", [sa.text("COALESCE(completed_at, created_at)")]),
+    ("ix_jobs_partition_file_id", ["partition", "file_id"]),
+)
+
+
 def upgrade() -> None:
+    """Create the durable indexing-job table.
+
+    Idempotent: ``Base.metadata.create_all()`` runs at startup, so a freshly
+    bootstrapped database already has ``jobs`` before alembic reaches this
+    revision, and an unguarded CREATE TABLE would raise ``DuplicateTable``.
+    """
     if not table_exists("jobs"):
         op.create_table(
             "jobs",
             sa.Column("id", sa.String(), primary_key=True),
             sa.Column("partition", sa.String(), nullable=False),
             sa.Column("file_id", sa.String(), nullable=True),
-            sa.Column("user_id", sa.BigInteger(), nullable=True),
+            sa.Column("user_id", sa.Integer(), nullable=True),
             sa.Column("status", sa.String(), nullable=False),
             sa.Column("error", sa.String(), nullable=True),
             sa.Column(
@@ -41,23 +57,26 @@ def upgrade() -> None:
                 server_default=sa.text("now()"),
                 nullable=False,
             ),
-            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('QUEUED','SERIALIZING','CHUNKING','INSERTING','COMPLETED','FAILED','CANCELLED')",
+                name="ck_jobs_status",
+            ),
+            # Left unnamed so this CREATE TABLE and the startup
+            # ``metadata.create_all()`` converge on the same Postgres-default
+            # name (``jobs_user_id_fkey``).
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
         )
 
-    if not index_exists("jobs", "ix_jobs_status"):
-        op.create_index("ix_jobs_status", "jobs", ["status"])
-    if not index_exists("jobs", "ix_jobs_user_id"):
-        op.create_index("ix_jobs_user_id", "jobs", ["user_id"])
-    if not index_exists("jobs", "ix_jobs_partition_file_id"):
-        op.create_index("ix_jobs_partition_file_id", "jobs", ["partition", "file_id"])
+    for name, columns in _INDEXES:
+        if not index_exists("jobs", name):
+            op.create_index(name, "jobs", columns)
 
 
 def downgrade() -> None:
-    if index_exists("jobs", "ix_jobs_partition_file_id"):
-        op.drop_index("ix_jobs_partition_file_id", table_name="jobs")
-    if index_exists("jobs", "ix_jobs_user_id"):
-        op.drop_index("ix_jobs_user_id", table_name="jobs")
-    if index_exists("jobs", "ix_jobs_status"):
-        op.drop_index("ix_jobs_status", table_name="jobs")
+    for name, _ in _INDEXES:
+        if index_exists("jobs", name):
+            op.drop_index(name, table_name="jobs")
     if table_exists("jobs"):
         op.drop_table("jobs")

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -264,20 +264,51 @@ file_content_claims = Table(
 )
 
 
+# One row per dispatched indexing task, keyed by the dispatcher's ``task_id``.
+#
+# ``partition`` deliberately carries no FK to ``partitions.partition``: a job row
+# is a historical record and must outlive the partition it targeted, and a
+# terminal job must not block a partition delete. ``user_id`` does carry one, so
+# deleting a user cannot leave a row pointing at an id that no longer resolves;
+# it is nulled rather than cascaded for the same must-outlive reason.
+#
+# Rows are bounded by retention, not by the table: see
+# ``PgJobRepository.purge_terminal_jobs``.
 jobs = Table(
     "jobs",
     metadata,
     Column("id", String, primary_key=True),
     Column("partition", String, nullable=False),
     Column("file_id", String, nullable=True),
-    Column("user_id", BigInteger, nullable=True),
+    # ``users.id`` is Integer, so the FK target fixes this type.
+    Column("user_id", Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
     Column("status", String, nullable=False),
     Column("error", String, nullable=True),
     Column("created_at", DateTime(timezone=True), server_default=text("now()"), nullable=False),
     Column("updated_at", DateTime(timezone=True), server_default=text("now()"), nullable=False),
-    Column("finished_at", DateTime(timezone=True), nullable=True),
-    Index("ix_jobs_status", "status"),
-    Index("ix_jobs_user_id", "user_id"),
+    # Queue wait is ``started_at - created_at`` and service time is
+    # ``completed_at - started_at``; a single settle timestamp cannot separate
+    # the two, and the queue-wait series is what tells a slow parser apart from
+    # a starved pool.
+    Column("started_at", DateTime(timezone=True), nullable=True),
+    Column("completed_at", DateTime(timezone=True), nullable=True),
+    # The state machine is DocumentStatus. Pinning it in the database keeps a
+    # typo or a future rename from silently writing a status nothing queries.
+    CheckConstraint(
+        "status IN ('QUEUED','SERIALIZING','CHUNKING','INSERTING','COMPLETED','FAILED','CANCELLED')",
+        name="ck_jobs_status",
+    ),
+    # Queue views filter by status and order by recency.
+    Index("ix_jobs_status_created_at", "status", "created_at"),
+    # Per-user task listing, which filters on user_id and often on status too.
+    Index("ix_jobs_user_status", "user_id", "status"),
+    # Retention sweeps terminal rows by settle time, which is
+    # ``COALESCE(completed_at, created_at)``: a row whose terminal write raced a
+    # failure has no completed_at and ages out on created_at instead. The index
+    # has to match that expression, because a plain b-tree on bare completed_at
+    # serves neither the filter nor the ordering the sweep uses.
+    Index("ix_jobs_settled_at", text("COALESCE(completed_at, created_at)")),
+    # Incident lookups start from a file, not a task id.
     Index("ix_jobs_partition_file_id", "partition", "file_id"),
 )
 

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -13,6 +13,7 @@ divergence as a pending schema change.
 
 from datetime import datetime
 
+from core.models.catalog import DocumentStatus
 from sqlalchemy import (
     JSON,
     BigInteger,
@@ -264,6 +265,9 @@ file_content_claims = Table(
 )
 
 
+_JOB_STATUS_CHECK = "status IN ({})".format(",".join(f"'{status.value}'" for status in DocumentStatus))
+
+
 # One row per dispatched indexing task, keyed by the dispatcher's ``task_id``.
 #
 # ``partition`` deliberately carries no FK to ``partitions.partition``: a job row
@@ -292,12 +296,13 @@ jobs = Table(
     # a starved pool.
     Column("started_at", DateTime(timezone=True), nullable=True),
     Column("completed_at", DateTime(timezone=True), nullable=True),
-    # The state machine is DocumentStatus. Pinning it in the database keeps a
-    # typo or a future rename from silently writing a status nothing queries.
-    CheckConstraint(
-        "status IN ('QUEUED','SERIALIZING','CHUNKING','INSERTING','COMPLETED','FAILED','CANCELLED')",
-        name="ck_jobs_status",
-    ),
+    # The state machine is DocumentStatus, and the constraint is generated from
+    # it so the two cannot drift. It is what makes hydration total: a status the
+    # enum does not know would raise in ``PgJobRepository._row_to_job``, so the
+    # database has to refuse it on the way in. Note that this deliberately
+    # excludes the legacy CHUNKING/INSERTING states, which #721 removed from the
+    # public state machine and which no write path can produce.
+    CheckConstraint(_JOB_STATUS_CHECK, name="ck_jobs_status"),
     # Queue views filter by status and order by recency.
     Index("ix_jobs_status_created_at", "status", "created_at"),
     # Per-user task listing, which filters on user_id and often on status too.

--- a/openrag/services/persistence/schema.py
+++ b/openrag/services/persistence/schema.py
@@ -264,6 +264,24 @@ file_content_claims = Table(
 )
 
 
+jobs = Table(
+    "jobs",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column("partition", String, nullable=False),
+    Column("file_id", String, nullable=True),
+    Column("user_id", BigInteger, nullable=True),
+    Column("status", String, nullable=False),
+    Column("error", String, nullable=True),
+    Column("created_at", DateTime(timezone=True), server_default=text("now()"), nullable=False),
+    Column("updated_at", DateTime(timezone=True), server_default=text("now()"), nullable=False),
+    Column("finished_at", DateTime(timezone=True), nullable=True),
+    Index("ix_jobs_status", "status"),
+    Index("ix_jobs_user_id", "user_id"),
+    Index("ix_jobs_partition_file_id", "partition", "file_id"),
+)
+
+
 topic_tags = Table(
     "topic_tags",
     metadata,

--- a/openrag/services/storage/postgres_store.py
+++ b/openrag/services/storage/postgres_store.py
@@ -22,7 +22,7 @@ repository call should never touch it.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from core.ports.catalog_store import CatalogStore
 from services.persistence.audit_log_repo import PgAuditLogRepository
@@ -64,6 +64,15 @@ if TYPE_CHECKING:
     from core.ports.workspace_repo import WorkspaceRepository
 
 
+def catalog_rdb_config(settings: Any) -> Any:
+    """Resolve the catalog database for a process that has only the settings."""
+    if settings.rdb.database is not None:
+        return settings.rdb
+    return settings.rdb.model_copy(
+        update={"database": f"partitions_for_collection_{settings.vectordb.collection_name}"}
+    )
+
+
 class PostgresStore(CatalogStore):
     """asyncpg-backed :class:`CatalogStore` composing all repository ports."""
 
@@ -84,9 +93,10 @@ class PostgresStore(CatalogStore):
         self._oidc_session_repo = PgOIDCSessionRepository(pool_getter)
         self._workspace_repo = PgWorkspaceRepository(pool_getter)
 
+        self._job_repo = PgJobRepository(pool_getter)
+
         # Stubs — every method raises StubRepositoryError until the matching
         # table exists. Listed in the post-refactoring roadmap.
-        self._job_repo = PgJobRepository(pool_getter)
         self._chunk_repo = PgChunkRepository(pool_getter)
         self._prompt_repo = PgPromptRepository(pool_getter)
         self._conversation_repo = PgConversationRepository(pool_getter)
@@ -169,14 +179,14 @@ class PostgresStore(CatalogStore):
     def workspace_repo(self) -> WorkspaceRepository:
         return self._workspace_repo
 
+    @property
+    def job_repo(self) -> JobRepository:
+        return self._job_repo
+
     # ------------------------------------------------------------------
     # Stub repos — methods raise StubRepositoryError until the matching
     # tables and orchestrators are added in the post-refactoring roadmap.
     # ------------------------------------------------------------------
-
-    @property
-    def job_repo(self) -> JobRepository:
-        return self._job_repo
 
     @property
     def chunk_repo(self) -> ChunkRepository:

--- a/openrag/services/workers/bootstrap.py
+++ b/openrag/services/workers/bootstrap.py
@@ -152,7 +152,12 @@ def get_task_completion_tracker(namespace: str = "openrag"):
 
 def _supports_task_completion_recovery(actor) -> bool:
     method_names = getattr(actor, "_ray_actor_method_names", None)
-    if isinstance(method_names, (frozenset, list, set, tuple)) and "supports_cancellation_recovery" not in method_names:
+    # ``reconcile_jobs`` came with durable history: a tracker that predates it
+    # would never write a settled row or recover one a restart orphaned.
+    required = ("supports_cancellation_recovery", "reconcile_jobs")
+    if isinstance(method_names, (frozenset, list, set, tuple)) and not set(required) <= set(method_names):
+        return False
+    if getattr(actor, "reconcile_jobs", None) is None:
         return False
     method = getattr(actor, "supports_cancellation_recovery", None)
     remote = getattr(method, "remote", None)

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -372,7 +372,21 @@ class WorkerDispatcher(IndexingDispatcher):
                 if not submission_outcome_unknown:
                     await self._record_finished_at(task_id, task_details)
                     if mark_submit_failed:
-                        await self._mark_submit_failed(task_id, traceback.format_exc())
+                        tb = traceback.format_exc()
+                        await self._mark_submit_failed(task_id, tb)
+                        # The completion tracker never saw this task, so nothing
+                        # else settles its row: it would stay QUEUED until a
+                        # restart reconciled it, long after the actor forgot the
+                        # failure.
+                        await self._record_job(
+                            task_id,
+                            status=DocumentStatus.FAILED,
+                            partition=partition,
+                            file_id=file_id,
+                            user_id=task_details["user_id"],
+                            error=tb,
+                            finished_at=datetime.now(UTC),
+                        )
             finally:
                 if claimed_content and not submission_outcome_unknown and (task is None or mark_submit_failed):
                     await self._document_repo.release_content_sha256_claim(
@@ -681,6 +695,8 @@ class WorkerDispatcher(IndexingDispatcher):
         partition: str,
         file_id: str | None = None,
         user_id: int | None = None,
+        error: str | None = None,
+        finished_at: datetime | None = None,
     ) -> None:
         """Mirror a task transition to Postgres. History must never fail indexing."""
         if self._job_repo is None:
@@ -693,6 +709,8 @@ class WorkerDispatcher(IndexingDispatcher):
                     partition=partition,
                     file_id=file_id,
                     user_id=user_id,
+                    error=error,
+                    finished_at=finished_at,
                 )
             )
         except Exception as exc:

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -718,15 +718,31 @@ class WorkerDispatcher(IndexingDispatcher):
         except Exception as exc:
             logger.warning("Failed to record indexing job", task_id=task_id, error=str(exc))
 
+    async def _durable_job(self, task_id: str) -> IndexationJob | None:
+        """Read the durable row, or ``None`` if it cannot be read.
+
+        Reads are best-effort for the same reason writes are: this is a
+        fallback for tasks the actor has already forgotten, and a status route
+        that 500s during a Postgres outage is worse than one that reports what
+        the actor still knows.
+        """
+        if self._job_repo is None:
+            return None
+        try:
+            return await self._job_repo.get_job(task_id)
+        except Exception as exc:
+            logger.warning("Failed to read durable job", task_id=task_id, error=str(exc))
+            return None
+
     async def get_task_state(self, task_id: str) -> str | None:
         state = await self._call_method(
             lambda: self._tsm.get_state.remote(task_id),
             task_description=f"get_state({task_id})",
         )
-        if state is not None or self._job_repo is None:
+        if state is not None:
             return state
         # The actor forgets settled tasks; the durable record outlives it.
-        job = await self._job_repo.get_job(task_id)
+        job = await self._durable_job(task_id)
         return job.status.value if job is not None else None
 
     async def get_task_error(self, task_id: str) -> str | None:
@@ -734,9 +750,9 @@ class WorkerDispatcher(IndexingDispatcher):
             lambda: self._tsm.get_error.remote(task_id),
             task_description=f"get_error({task_id})",
         )
-        if error is not None or self._job_repo is None:
+        if error is not None:
             return error
-        job = await self._job_repo.get_job(task_id)
+        job = await self._durable_job(task_id)
         return job.error if job is not None else None
 
     async def cancel_task(self, task_id: str) -> bool:

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -13,6 +13,8 @@ from core.models.catalog import (
     INDEXING_CONTENT_CLAIM_TOKEN_PREFIX,
     TASK_CREATED_AT_METADATA_KEY,
     TASK_FINISHED_AT_METADATA_KEY,
+    DocumentStatus,
+    IndexationJob,
 )
 from core.utils.consts import is_internal_metadata_key, strip_internal_metadata
 from core.utils.exceptions import ConflictError, mark_indexing_worker_may_be_running
@@ -59,6 +61,7 @@ class WorkerDispatcher(IndexingDispatcher):
         document_repo: Any,
         workspace_repo: Any,
         collection: str,
+        job_repo: Any = None,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         self._pool = pool
@@ -67,6 +70,7 @@ class WorkerDispatcher(IndexingDispatcher):
         self._vector_store = vector_store
         self._document_repo = document_repo
         self._workspace_repo = workspace_repo
+        self._job_repo = job_repo
         self._collection = collection
         self._timeout = timeout
 
@@ -306,6 +310,14 @@ class WorkerDispatcher(IndexingDispatcher):
             raise RuntimeError(
                 f"Task {task_id} was rejected because file {file_id!r} in partition {partition!r} is being deleted"
             )
+
+        await self._record_job(
+            task_id,
+            status=DocumentStatus.QUEUED,
+            partition=partition,
+            file_id=file_id,
+            user_id=task_details["user_id"],
+        )
 
         task: Any | None = None
         submission_started = False
@@ -661,17 +673,51 @@ class WorkerDispatcher(IndexingDispatcher):
             if k not in self._FILE_METADATA_EXCLUDED_KEYS and not is_internal_metadata_key(k)
         }
 
+    async def _record_job(
+        self,
+        task_id: str,
+        *,
+        status: DocumentStatus,
+        partition: str,
+        file_id: str | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        """Mirror a task transition to Postgres. History must never fail indexing."""
+        if self._job_repo is None:
+            return
+        try:
+            await self._job_repo.upsert_job(
+                IndexationJob(
+                    id=task_id,
+                    status=status,
+                    partition=partition,
+                    file_id=file_id,
+                    user_id=user_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to record indexing job", task_id=task_id, error=str(exc))
+
     async def get_task_state(self, task_id: str) -> str | None:
-        return await self._call_method(
+        state = await self._call_method(
             lambda: self._tsm.get_state.remote(task_id),
             task_description=f"get_state({task_id})",
         )
+        if state is not None or self._job_repo is None:
+            return state
+        # The actor forgets settled tasks; the durable record outlives it.
+        job = await self._job_repo.get_job(task_id)
+        return job.status.value if job is not None else None
 
     async def get_task_error(self, task_id: str) -> str | None:
-        return await self._call_method(
+        error = await self._call_method(
             lambda: self._tsm.get_error.remote(task_id),
             task_description=f"get_error({task_id})",
         )
+        if error is not None or self._job_repo is None:
+            return error
+        job = await self._job_repo.get_job(task_id)
+        return job.error if job is not None else None
 
     async def cancel_task(self, task_id: str) -> bool:
         import ray
@@ -709,6 +755,7 @@ def from_ray_namespace(
     document_repo: Any,
     workspace_repo: Any,
     collection: str,
+    job_repo: Any = None,
 ) -> WorkerDispatcher:
     import ray
     from services.workers.indexer_pool import build_indexer_pool
@@ -721,6 +768,7 @@ def from_ray_namespace(
         document_repo=document_repo,
         workspace_repo=workspace_repo,
         collection=collection,
+        job_repo=job_repo,
         timeout=timeout,
     )
 

--- a/openrag/services/workers/dispatcher.py
+++ b/openrag/services/workers/dispatcher.py
@@ -385,7 +385,7 @@ class WorkerDispatcher(IndexingDispatcher):
                             file_id=file_id,
                             user_id=task_details["user_id"],
                             error=tb,
-                            finished_at=datetime.now(UTC),
+                            completed_at=datetime.now(UTC),
                         )
             finally:
                 if claimed_content and not submission_outcome_unknown and (task is None or mark_submit_failed):
@@ -696,7 +696,8 @@ class WorkerDispatcher(IndexingDispatcher):
         file_id: str | None = None,
         user_id: int | None = None,
         error: str | None = None,
-        finished_at: datetime | None = None,
+        started_at: datetime | None = None,
+        completed_at: datetime | None = None,
     ) -> None:
         """Mirror a task transition to Postgres. History must never fail indexing."""
         if self._job_repo is None:
@@ -710,7 +711,8 @@ class WorkerDispatcher(IndexingDispatcher):
                     file_id=file_id,
                     user_id=user_id,
                     error=error,
-                    finished_at=finished_at,
+                    started_at=started_at,
+                    completed_at=completed_at,
                 )
             )
         except Exception as exc:

--- a/openrag/services/workers/indexer_actor.py
+++ b/openrag/services/workers/indexer_actor.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import traceback
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from core.models.catalog import DocumentStatus, IndexationJob
 from core.models.document import Document
 from core.utils.logging import get_logger
 from services.workers.indexing_callback import send_indexing_callback
@@ -54,6 +55,7 @@ class IndexerWorker:
         topic_tag_repo: Any = None,
         vector_store: Any = None,
         collection: str = "default",
+        job_repo: Any = None,
     ) -> None:
         self._pipeline = pipeline
         self._tsm = task_state_manager
@@ -61,6 +63,38 @@ class IndexerWorker:
         self._topic_tag_repo = topic_tag_repo
         self._vector_store = vector_store
         self._collection = collection
+        self._job_repo = job_repo
+
+    async def _record_started(
+        self,
+        task_id: str,
+        *,
+        partition: str,
+        metadata: dict[str, Any],
+        user: dict[str, Any] | None,
+    ) -> None:
+        """Stamp the durable row with the moment the task left the queue.
+
+        Best-effort like every other job write: history must never fail
+        indexing. Written here because this is the only place that observes the
+        queued-to-running transition, and ``started_at`` is what makes queue
+        wait separable from service time.
+        """
+        if self._job_repo is None:
+            return
+        try:
+            await self._job_repo.upsert_job(
+                IndexationJob(
+                    id=task_id,
+                    status=DocumentStatus.SERIALIZING,
+                    partition=partition,
+                    file_id=metadata.get("file_id"),
+                    user_id=(user or {}).get("id"),
+                    started_at=datetime.now(UTC),
+                )
+            )
+        except Exception as exc:
+            logger.warning("Failed to record indexing job start", task_id=task_id, error=str(exc))
 
     async def process_file(
         self,
@@ -102,6 +136,7 @@ class IndexerWorker:
             )
             if accepted is False:
                 raise _TaskCancelledBeforeStart
+            await self._record_started(task_id, partition=partition, metadata=metadata, user=user)
             document = await _load_document(path, metadata, partition)
             # One indexation timestamp for this file, shared by the Milvus chunks
             # (via the store stage) and the Postgres catalog row, so they agree.

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -70,11 +70,9 @@ def _indexer_worker_actor_name(index: int) -> str:
 
 
 def _catalog_rdb_config(settings: Settings) -> Any:
-    if settings.rdb.database is not None:
-        return settings.rdb
-    return settings.rdb.model_copy(
-        update={"database": f"partitions_for_collection_{settings.vectordb.collection_name}"}
-    )
+    from services.storage.postgres_store import catalog_rdb_config
+
+    return catalog_rdb_config(settings)
 
 
 @ray.remote

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -202,6 +202,7 @@ class IndexerWorkerActor:
             task_state_manager=task_state_manager,
             document_repo=self._catalog_store.document_repo,
             topic_tag_repo=self._catalog_store.topic_tag_repo,
+            job_repo=self._catalog_store.job_repo,
             vector_store=self._vector_store,
             collection=cfg.vectordb.collection_name,
         )

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -18,6 +19,8 @@ _REFLESS_RECOVERY_POLL_SECONDS = 5.0
 _TASK_STATE_CALL_TIMEOUT_SECONDS = 30.0
 _JOB_RETENTION_DAYS = 30
 _ORPHAN_GRACE_SECONDS = 300
+_SETTLEMENT_RETRY_SECONDS = 30.0
+_MAX_PENDING_SETTLEMENTS = 1_000
 _ORPHANED_JOB_ERROR = "Indexing task was interrupted by a restart and no longer has a live worker."
 
 
@@ -33,6 +36,9 @@ class TaskCompletionTracker:
         self._recovery_lock = asyncio.Lock()
         self._catalog_store: Any = None
         self._catalog_lock = asyncio.Lock()
+        # Outcomes Postgres has not taken yet, oldest first.
+        self._pending_settlements: OrderedDict[str, IndexationJob] = OrderedDict()
+        self._settlement_retry: asyncio.Future | None = None
 
     def supports_cancellation_recovery(self) -> bool:
         """Identify trackers that preserve unsettled cancellation fences."""
@@ -171,16 +177,13 @@ class TaskCompletionTracker:
             self._tracked_task_ids.discard(task_id)
 
     async def _record_finished_at(self, task_id: str) -> None:
-        task_state_manager = self._task_state_manager()
         details = await self._call_task_state(
-            lambda: task_state_manager.get_details.remote(task_id),
+            lambda: self._task_state_manager().get_details.remote(task_id),
             f"get_details({task_id}) for completion timestamp",
         )
         if not isinstance(details, dict) or _has_finished_at(details):
             return
 
-        metadata = details.get("metadata")
-        metadata = dict(metadata) if isinstance(metadata, dict) else {}
         # Persist before stamping the actor: the stamp is what stops this method
         # running again, so a failed write must leave the task unstamped for
         # ``recover`` to pick up. Stamping regardless would strand the row at
@@ -188,6 +191,25 @@ class TaskCompletionTracker:
         # marked a completed job FAILED after a restart.
         if not await self._record_settled_job(task_id, details):
             return
+        await self._stamp_finished_at(task_id, details)
+
+    async def _stamp_finished_at(self, task_id: str, details: dict[str, Any] | None = None) -> None:
+        """Mark the task settled in the actor, if it still knows the task.
+
+        The retry path arrives here long after the fact, so it re-reads rather
+        than replaying stale details: ``set_details`` on a task the actor has
+        already evicted would put the record back.
+        """
+        task_state_manager = self._task_state_manager()
+        if details is None:
+            details = await self._call_task_state(
+                lambda: task_state_manager.get_details.remote(task_id),
+                f"get_details({task_id}) for completion timestamp",
+            )
+            if not isinstance(details, dict) or _has_finished_at(details):
+                return
+        metadata = details.get("metadata")
+        metadata = dict(metadata) if isinstance(metadata, dict) else {}
         metadata[TASK_FINISHED_AT_METADATA_KEY] = _utc_now_iso()
         await self._call_task_state(
             lambda: task_state_manager.set_details.remote(
@@ -261,22 +283,62 @@ class TaskCompletionTracker:
                 lambda: task_state_manager.get_error.remote(task_id),
                 f"get_error({task_id}) for job history",
             )
-            repo = await self._job_repo()
-            await repo.upsert_job(
-                IndexationJob(
-                    id=task_id,
-                    status=DocumentStatus(state),
-                    partition=details.get("partition") or "default",
-                    file_id=details.get("file_id"),
-                    user_id=details.get("user_id"),
-                    error=error,
-                    completed_at=datetime.now(UTC),
-                )
+            job = IndexationJob(
+                id=task_id,
+                status=DocumentStatus(state),
+                partition=details.get("partition") or "default",
+                file_id=details.get("file_id"),
+                user_id=details.get("user_id"),
+                error=error,
+                completed_at=datetime.now(UTC),
             )
         except Exception as exc:
-            self._logger.warning("Failed to record settled indexing job", task_id=task_id, error=str(exc))
+            self._logger.warning("Failed to read settled indexing job", task_id=task_id, error=str(exc))
+            return False
+        if await self._write_job(job):
+            return True
+        self._queue_settlement_retry(job)
+        return False
+
+    async def _write_job(self, job: IndexationJob) -> bool:
+        try:
+            repo = await self._job_repo()
+            await repo.upsert_job(job)
+        except Exception as exc:
+            self._logger.warning("Failed to record settled indexing job", task_id=job.id, error=str(exc))
             return False
         return True
+
+    def _queue_settlement_retry(self, job: IndexationJob) -> None:
+        """Hold a decided outcome until Postgres takes it.
+
+        Nothing re-reads it later: ``track`` is about to forget the task and the
+        actor evicts its record soon after, so a dropped outcome leaves the row
+        non-terminal for orphan reconciliation to report as a failed job.
+        """
+        if job.id not in self._pending_settlements and len(self._pending_settlements) >= _MAX_PENDING_SETTLEMENTS:
+            dropped, _ = self._pending_settlements.popitem(last=False)
+            self._logger.warning("Dropped a pending indexing job settlement", task_id=dropped)
+        self._pending_settlements[job.id] = job
+        if self._settlement_retry is None or self._settlement_retry.done():
+            self._settlement_retry = asyncio.ensure_future(self._retry_pending_settlements())
+
+    async def _retry_pending_settlements(self, delay: float = _SETTLEMENT_RETRY_SECONDS) -> None:
+        """Re-offer held outcomes until Postgres accepts them."""
+        while self._pending_settlements:
+            await asyncio.sleep(delay)
+            for task_id, job in list(self._pending_settlements.items()):
+                if not await self._write_job(job):
+                    continue
+                self._pending_settlements.pop(task_id, None)
+                try:
+                    await self._stamp_finished_at(task_id)
+                except Exception as exc:
+                    self._logger.warning(
+                        "Failed to record indexing task completion time",
+                        task_id=task_id,
+                        error=str(exc),
+                    )
 
     async def reconcile_jobs(self, active_ids: list[str]) -> None:
         """Settle records a restart orphaned and drop history past retention."""
@@ -284,7 +346,9 @@ class TaskCompletionTracker:
             repo = await self._job_repo()
             now = datetime.now(UTC)
             orphaned = await repo.fail_orphaned_jobs(
-                active_ids=active_ids,
+                # A settlement waiting on Postgres has an outcome already; it is
+                # not an orphan, and failing it here would freeze the wrong one.
+                active_ids=[*active_ids, *self._pending_settlements],
                 error=_ORPHANED_JOB_ERROR,
                 # A row written moments ago may belong to a dispatch that has
                 # not reached the actor yet, so leave the recent ones alone.

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -260,7 +260,7 @@ class TaskCompletionTracker:
                     file_id=details.get("file_id"),
                     user_id=details.get("user_id"),
                     error=error,
-                    finished_at=datetime.now(UTC),
+                    completed_at=datetime.now(UTC),
                 )
             )
         except Exception as exc:

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import ray
-from core.models.catalog import TASK_FINISHED_AT_METADATA_KEY, TERMINAL_TASK_STATES
+from core.models.catalog import (
+    TASK_FINISHED_AT_METADATA_KEY,
+    TERMINAL_TASK_STATES,
+    DocumentStatus,
+    IndexationJob,
+)
 from services.workers.ray_utils import call_ray_actor_method_with_timeout
 
 _TERMINAL_STATES = frozenset(state.value for state in TERMINAL_TASK_STATES)
 _REFLESS_RECOVERY_POLL_SECONDS = 5.0
 _TASK_STATE_CALL_TIMEOUT_SECONDS = 30.0
+_JOB_RETENTION_DAYS = 30
+_ORPHAN_GRACE_SECONDS = 300
+_ORPHANED_JOB_ERROR = "Indexing task was interrupted by a restart and no longer has a live worker."
 
 
 class TaskCompletionTracker:
@@ -23,6 +31,8 @@ class TaskCompletionTracker:
         self._logger = get_logger()
         self._tracked_task_ids: set[str] = set()
         self._recovery_lock = asyncio.Lock()
+        self._catalog_store: Any = None
+        self._catalog_lock = asyncio.Lock()
 
     def supports_cancellation_recovery(self) -> bool:
         """Identify trackers that preserve unsettled cancellation fences."""
@@ -58,6 +68,7 @@ class TaskCompletionTracker:
                     task_state_manager.get_all_info.remote,
                     "get_all_info_for_completion_recovery",
                 )
+                await self.reconcile_jobs(list(all_info))
                 for task_id, info in all_info.items():
                     state = info.get("state")
                     if state == "CANCELLED":
@@ -170,6 +181,9 @@ class TaskCompletionTracker:
 
         metadata = details.get("metadata")
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        # Persist before stamping the actor: the stamp is what stops this method
+        # running again, so a failed write would otherwise never be retried.
+        await self._record_settled_job(task_id, details)
         metadata[TASK_FINISHED_AT_METADATA_KEY] = _utc_now_iso()
         await self._call_task_state(
             lambda: task_state_manager.set_details.remote(
@@ -209,6 +223,66 @@ class TaskCompletionTracker:
                 f"has_unsettled_cancelled_worker({task_id})",
             )
         )
+
+    async def _job_repo(self) -> Any:
+        """Build the catalog store lazily: this actor outlives any API process."""
+        if self._catalog_store is None:
+            async with self._catalog_lock:
+                if self._catalog_store is None:
+                    from core.config import load_config
+                    from services.storage.postgres_store import PostgresStore, catalog_rdb_config
+
+                    store = PostgresStore(catalog_rdb_config(load_config()), run_migrations=False)
+                    await store.initialize()
+                    self._catalog_store = store
+        return self._catalog_store.job_repo
+
+    async def _record_settled_job(self, task_id: str, details: dict[str, Any]) -> None:
+        """Persist the final state of a settled task. History must never fail indexing."""
+        try:
+            task_state_manager = self._task_state_manager()
+            state = await self._call_task_state(
+                lambda: task_state_manager.get_state.remote(task_id),
+                f"get_state({task_id}) for job history",
+            )
+            if state not in _TERMINAL_STATES:
+                return
+            error = await self._call_task_state(
+                lambda: task_state_manager.get_error.remote(task_id),
+                f"get_error({task_id}) for job history",
+            )
+            repo = await self._job_repo()
+            await repo.upsert_job(
+                IndexationJob(
+                    id=task_id,
+                    status=DocumentStatus(state),
+                    partition=details.get("partition") or "default",
+                    file_id=details.get("file_id"),
+                    user_id=details.get("user_id"),
+                    error=error,
+                    finished_at=datetime.now(UTC),
+                )
+            )
+        except Exception as exc:
+            self._logger.warning("Failed to record settled indexing job", task_id=task_id, error=str(exc))
+
+    async def reconcile_jobs(self, active_ids: list[str]) -> None:
+        """Settle records a restart orphaned and drop history past retention."""
+        try:
+            repo = await self._job_repo()
+            now = datetime.now(UTC)
+            orphaned = await repo.fail_orphaned_jobs(
+                active_ids=active_ids,
+                error=_ORPHANED_JOB_ERROR,
+                # A row written moments ago may belong to a dispatch that has
+                # not reached the actor yet, so leave the recent ones alone.
+                before=now - timedelta(seconds=_ORPHAN_GRACE_SECONDS),
+            )
+            purged = await repo.purge_terminal_jobs(older_than=now - timedelta(days=_JOB_RETENTION_DAYS))
+            if orphaned or purged:
+                self._logger.info("Reconciled indexing job history", orphaned=orphaned, purged=purged)
+        except Exception as exc:
+            self._logger.warning("Failed to reconcile indexing job history", error=str(exc))
 
     def _task_state_manager(self) -> Any:
         return ray.get_actor("TaskStateManager", namespace=self._namespace)

--- a/openrag/services/workers/task_completion.py
+++ b/openrag/services/workers/task_completion.py
@@ -182,8 +182,12 @@ class TaskCompletionTracker:
         metadata = details.get("metadata")
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
         # Persist before stamping the actor: the stamp is what stops this method
-        # running again, so a failed write would otherwise never be retried.
-        await self._record_settled_job(task_id, details)
+        # running again, so a failed write must leave the task unstamped for
+        # ``recover`` to pick up. Stamping regardless would strand the row at
+        # whatever non-terminal status it last held, until orphan reconciliation
+        # marked a completed job FAILED after a restart.
+        if not await self._record_settled_job(task_id, details):
+            return
         metadata[TASK_FINISHED_AT_METADATA_KEY] = _utc_now_iso()
         await self._call_task_state(
             lambda: task_state_manager.set_details.remote(
@@ -237,8 +241,14 @@ class TaskCompletionTracker:
                     self._catalog_store = store
         return self._catalog_store.job_repo
 
-    async def _record_settled_job(self, task_id: str, details: dict[str, Any]) -> None:
-        """Persist the final state of a settled task. History must never fail indexing."""
+    async def _record_settled_job(self, task_id: str, details: dict[str, Any]) -> bool:
+        """Persist the final state of a settled task. History must never fail indexing.
+
+        Returns whether the caller may stamp the actor. ``True`` covers both a
+        successful write and a task with nothing to persist yet; only a genuine
+        failure returns ``False``, because the stamp is what stops recovery
+        retrying this task.
+        """
         try:
             task_state_manager = self._task_state_manager()
             state = await self._call_task_state(
@@ -246,7 +256,7 @@ class TaskCompletionTracker:
                 f"get_state({task_id}) for job history",
             )
             if state not in _TERMINAL_STATES:
-                return
+                return True
             error = await self._call_task_state(
                 lambda: task_state_manager.get_error.remote(task_id),
                 f"get_error({task_id}) for job history",
@@ -265,6 +275,8 @@ class TaskCompletionTracker:
             )
         except Exception as exc:
             self._logger.warning("Failed to record settled indexing job", task_id=task_id, error=str(exc))
+            return False
+        return True
 
     async def reconcile_jobs(self, active_ids: list[str]) -> None:
         """Settle records a restart orphaned and drop history past retention."""

--- a/tests/unit/services/orchestrators/test_job_service.py
+++ b/tests/unit/services/orchestrators/test_job_service.py
@@ -227,11 +227,17 @@ class FakeJobRepo:
     def __init__(self, jobs=None, *, broken: bool = False):
         self._jobs = {job.id: job for job in (jobs or [])}
         self._broken = broken
+        self.listed_statuses = []
 
-    async def list_jobs(self, *, status=None, user_id=None, offset=0, limit=50):
+    async def list_jobs(self, *, statuses=None, user_id=None, offset=0, limit=50):
         if self._broken:
             raise RuntimeError("jobs table is missing")
-        return [job for job in self._jobs.values() if user_id is None or job.user_id == user_id]
+        self.listed_statuses.append(statuses)
+        return [
+            job
+            for job in self._jobs.values()
+            if (user_id is None or job.user_id == user_id) and (statuses is None or job.status.value in statuses)
+        ]
 
     async def get_job(self, job_id):
         if self._broken:
@@ -266,6 +272,25 @@ async def test_list_tasks_includes_jobs_the_actor_has_forgotten():
     assert set(by_id) == {"t-live", "t-old"}
     assert by_id["t-old"]["state"] == "COMPLETED"
     assert by_id["t-old"]["duration_ms"] == 30_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task_status", "expected"),
+    [("failed", ["FAILED"]), ("active", ["QUEUED", "SERIALIZING"]), (None, None)],
+    ids=["exact", "active", "unfiltered"],
+)
+async def test_a_status_query_is_filtered_before_the_row_limit(task_status, expected):
+    # The durable read is capped, so filtering it afterwards would drop matches
+    # that sit behind newer rows of another status.
+    from core.models.catalog import DocumentStatus
+
+    repo = FakeJobRepo([_job(id="t-failed", status=DocumentStatus.FAILED)])
+    service = JobService(FakeTSM(info={}), job_repo=repo)
+
+    await service.list_tasks(is_admin=True, user_id=7, task_status=task_status)
+
+    assert repo.listed_statuses == [expected]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/orchestrators/test_job_service.py
+++ b/tests/unit/services/orchestrators/test_job_service.py
@@ -219,3 +219,80 @@ async def test_get_user_pending_task_count_uses_task_state_manager():
     pending = await JobService(FakeTSM(info=info)).get_user_pending_task_count(7)
 
     assert pending == 2
+
+
+class FakeJobRepo:
+    """Durable job rows, as the actor would never return them."""
+
+    def __init__(self, jobs=None, *, broken: bool = False):
+        self._jobs = {job.id: job for job in (jobs or [])}
+        self._broken = broken
+
+    async def list_jobs(self, *, status=None, user_id=None, offset=0, limit=50):
+        if self._broken:
+            raise RuntimeError("jobs table is missing")
+        return [job for job in self._jobs.values() if user_id is None or job.user_id == user_id]
+
+    async def get_job(self, job_id):
+        if self._broken:
+            raise RuntimeError("jobs table is missing")
+        return self._jobs.get(job_id)
+
+
+def _job(**kwargs):
+    from core.models.catalog import DocumentStatus, IndexationJob
+
+    base = {
+        "id": "t-old",
+        "status": DocumentStatus.COMPLETED,
+        "partition": "tenant-a",
+        "file_id": "file-1",
+        "user_id": 7,
+        "created_at": datetime(2026, 9, 1, 10, 0, tzinfo=UTC),
+        "finished_at": datetime(2026, 9, 1, 10, 0, 30, tzinfo=UTC),
+    }
+    base.update(kwargs)
+    return IndexationJob(**base)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_includes_jobs_the_actor_has_forgotten():
+    info = {"t-live": {"state": "QUEUED", "details": {}, "user": 7}}
+    service = JobService(FakeTSM(info=info), job_repo=FakeJobRepo([_job()]))
+
+    rows = await service.list_tasks(is_admin=True, user_id=7)
+
+    by_id = {row["task_id"]: row for row in rows}
+    assert set(by_id) == {"t-live", "t-old"}
+    assert by_id["t-old"]["state"] == "COMPLETED"
+    assert by_id["t-old"]["duration_ms"] == 30_000
+
+
+@pytest.mark.asyncio
+async def test_live_actor_state_wins_over_the_durable_row():
+    info = {"t1": {"state": "SERIALIZING", "details": {}, "user": 7}}
+    service = JobService(FakeTSM(info=info), job_repo=FakeJobRepo([_job(id="t1")]))
+
+    rows = await service.list_tasks(is_admin=True, user_id=7)
+
+    assert [row["state"] for row in rows] == ["SERIALIZING"]
+
+
+@pytest.mark.asyncio
+async def test_get_task_details_falls_back_to_the_durable_row():
+    service = JobService(FakeTSM(info={}), job_repo=FakeJobRepo([_job()]))
+
+    details = await service.get_task_details("t-old")
+
+    assert details == {"file_id": "file-1", "partition": "tenant-a", "metadata": {}, "user_id": 7}
+
+
+@pytest.mark.asyncio
+async def test_queue_views_survive_an_unavailable_jobs_table():
+    info = {"t-live": {"state": "QUEUED", "details": {}, "user": 7}}
+    service = JobService(FakeTSM(info=info), job_repo=FakeJobRepo(broken=True))
+
+    rows = await service.list_tasks(is_admin=True, user_id=7)
+
+    assert [row["task_id"] for row in rows] == ["t-live"]
+    assert await service.get_task_details("t-live") == {}

--- a/tests/unit/services/orchestrators/test_job_service.py
+++ b/tests/unit/services/orchestrators/test_job_service.py
@@ -249,7 +249,7 @@ def _job(**kwargs):
         "file_id": "file-1",
         "user_id": 7,
         "created_at": datetime(2026, 9, 1, 10, 0, tzinfo=UTC),
-        "finished_at": datetime(2026, 9, 1, 10, 0, 30, tzinfo=UTC),
+        "completed_at": datetime(2026, 9, 1, 10, 0, 30, tzinfo=UTC),
     }
     base.update(kwargs)
     return IndexationJob(**base)

--- a/tests/unit/services/persistence/test_job_repo.py
+++ b/tests/unit/services/persistence/test_job_repo.py
@@ -21,7 +21,8 @@ def _row(**kwargs):
         "error": None,
         "created_at": _NOW,
         "updated_at": _NOW,
-        "finished_at": None,
+        "started_at": None,
+        "completed_at": None,
     }
     base.update(kwargs)
     return base
@@ -83,9 +84,57 @@ async def test_upsert_job_keeps_settled_states_and_bounds_the_error():
 
     query, params = pool.calls[0]
     # A settled row never reopens, mirroring the TaskStateManager guard.
-    assert "WHEN jobs.status = ANY($8::text[]) THEN jobs.status" in query
-    assert sorted(params[7]) == ["CANCELLED", "COMPLETED", "FAILED"]
+    assert "WHEN jobs.status = ANY($9::text[]) THEN jobs.status" in query
+    assert sorted(params[8]) == ["CANCELLED", "COMPLETED", "FAILED"]
     assert len(params[5]) == 8_000
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_freezes_the_outcome_fields_together_on_a_settled_row():
+    """A FAILED write that lost the cancel race must not mark a CANCELLED row.
+
+    Freezing ``status`` alone leaves ``error`` and ``completed_at`` writable, so
+    the row reads CANCELLED while carrying the loser's traceback.
+    """
+    pool = _FakePool(fetchrow=_row(status="CANCELLED"))
+    repo = _repo(pool)
+
+    await repo.upsert_job(
+        IndexationJob(
+            id="task-1",
+            status=DocumentStatus.FAILED,
+            partition="tenant-a",
+            error="late traceback",
+            completed_at=_NOW,
+        )
+    )
+
+    query, _params = pool.calls[0]
+    compact = " ".join(query.split())
+    settled = "jobs.status = ANY($9::text[])"
+    for field, frozen in (("status", "jobs.status"), ("error", "jobs.error"), ("completed_at", "jobs.completed_at")):
+        assert f"{field} = CASE WHEN {settled} THEN {frozen}" in compact, field
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_keeps_the_first_started_at():
+    """Queue wait is measured against the first stamp, so a retry cannot move it."""
+    pool = _FakePool(fetchrow=_row(status="SERIALIZING", started_at=_NOW))
+    repo = _repo(pool)
+
+    job = await repo.upsert_job(
+        IndexationJob(
+            id="task-1",
+            status=DocumentStatus.SERIALIZING,
+            partition="tenant-a",
+            started_at=_NOW,
+        )
+    )
+
+    query, params = pool.calls[0]
+    assert "started_at = COALESCE(jobs.started_at, EXCLUDED.started_at)" in query
+    assert params[6] == _NOW
+    assert job.started_at == _NOW
 
 
 @pytest.mark.asyncio
@@ -118,6 +167,7 @@ async def test_fail_orphaned_jobs_skips_settled_rows_and_live_tasks():
     assert "id <> ALL($3::text[])" in query
     # A row written moments ago belongs to a dispatch still in flight.
     assert "updated_at < $4" in query
+    assert "completed_at = now()" in query
     assert params[2] == ["task-9"]
     assert params[3] == cutoff
 
@@ -132,4 +182,6 @@ async def test_purge_terminal_jobs_only_removes_settled_rows():
 
     query, params = pool.calls[0]
     assert "status = ANY($1::text[])" in query
+    # Must match ix_jobs_settled_at, or the sweep cannot use it.
+    assert "COALESCE(completed_at, created_at) < $2" in query
     assert params[1] == cutoff

--- a/tests/unit/services/persistence/test_job_repo.py
+++ b/tests/unit/services/persistence/test_job_repo.py
@@ -167,10 +167,13 @@ async def test_list_jobs_filters_by_status_and_user():
     pool = _FakePool(fetch=[_row(), _row(id="task-2")])
     repo = _repo(pool)
 
-    jobs = await repo.list_jobs(status="FAILED", user_id=7, offset=-5, limit=0)
+    jobs = await repo.list_jobs(statuses=["QUEUED", "SERIALIZING"], user_id=7, offset=-5, limit=0)
 
-    _query, params = pool.calls[0]
-    assert params == ("FAILED", 7, 0, 1)
+    query, params = pool.calls[0]
+    # The filter belongs in the query: applying it after LIMIT would hide older
+    # matches behind newer rows of another status.
+    assert "status = ANY($1::text[])" in query
+    assert params == (["QUEUED", "SERIALIZING"], 7, 0, 1)
     assert [job.id for job in jobs] == ["task-1", "task-2"]
 
 

--- a/tests/unit/services/persistence/test_job_repo.py
+++ b/tests/unit/services/persistence/test_job_repo.py
@@ -1,0 +1,135 @@
+"""Unit tests for :class:`PgJobRepository`."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from core.models.catalog import DocumentStatus, IndexationJob
+from services.persistence.job_repo import PgJobRepository
+
+_NOW = datetime(2026, 9, 1, tzinfo=UTC)
+
+
+def _row(**kwargs):
+    base = {
+        "id": "task-1",
+        "partition": "tenant-a",
+        "file_id": "file-1",
+        "user_id": 7,
+        "status": "QUEUED",
+        "error": None,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "finished_at": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+class _FakePool:
+    def __init__(self, *, fetchrow=None, fetch=None, fetchval=None):
+        self.calls: list[tuple[str, tuple]] = []
+        self._fetchrow = fetchrow
+        self._fetch = fetch or []
+        self._fetchval = fetchval
+
+    async def fetchrow(self, query, *params):
+        self.calls.append((query, params))
+        return self._fetchrow
+
+    async def fetch(self, query, *params):
+        self.calls.append((query, params))
+        return self._fetch
+
+    async def fetchval(self, query, *params):
+        self.calls.append((query, params))
+        return self._fetchval
+
+
+def _repo(pool):
+    return PgJobRepository(lambda: pool)
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_writes_the_task_row_and_maps_it_back():
+    pool = _FakePool(fetchrow=_row(status="SERIALIZING"))
+    repo = _repo(pool)
+
+    job = await repo.upsert_job(
+        IndexationJob(
+            id="task-1",
+            status=DocumentStatus.SERIALIZING,
+            partition="tenant-a",
+            file_id="file-1",
+            user_id=7,
+        )
+    )
+
+    query, params = pool.calls[0]
+    assert params[:6] == ("task-1", "tenant-a", "file-1", 7, "SERIALIZING", None)
+    assert job.status is DocumentStatus.SERIALIZING
+    assert job.file_id == "file-1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_job_keeps_settled_states_and_bounds_the_error():
+    pool = _FakePool(fetchrow=_row(status="FAILED", error="boom"))
+    repo = _repo(pool)
+
+    await repo.upsert_job(
+        IndexationJob(id="task-1", status=DocumentStatus.FAILED, partition="tenant-a", error="x" * 20_000)
+    )
+
+    query, params = pool.calls[0]
+    # A settled row never reopens, mirroring the TaskStateManager guard.
+    assert "WHEN jobs.status = ANY($8::text[]) THEN jobs.status" in query
+    assert sorted(params[7]) == ["CANCELLED", "COMPLETED", "FAILED"]
+    assert len(params[5]) == 8_000
+
+
+@pytest.mark.asyncio
+async def test_get_job_returns_none_when_absent():
+    assert await _repo(_FakePool(fetchrow=None)).get_job("nope") is None
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_filters_by_status_and_user():
+    pool = _FakePool(fetch=[_row(), _row(id="task-2")])
+    repo = _repo(pool)
+
+    jobs = await repo.list_jobs(status="FAILED", user_id=7, offset=-5, limit=0)
+
+    _query, params = pool.calls[0]
+    assert params == ("FAILED", 7, 0, 1)
+    assert [job.id for job in jobs] == ["task-1", "task-2"]
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_jobs_skips_settled_rows_and_live_tasks():
+    pool = _FakePool(fetchval=3)
+    repo = _repo(pool)
+
+    cutoff = _NOW - timedelta(minutes=5)
+    assert await repo.fail_orphaned_jobs(active_ids=["task-9"], error="restart", before=cutoff) == 3
+
+    query, params = pool.calls[0]
+    assert "status <> ALL($2::text[])" in query
+    assert "id <> ALL($3::text[])" in query
+    # A row written moments ago belongs to a dispatch still in flight.
+    assert "updated_at < $4" in query
+    assert params[2] == ["task-9"]
+    assert params[3] == cutoff
+
+
+@pytest.mark.asyncio
+async def test_purge_terminal_jobs_only_removes_settled_rows():
+    pool = _FakePool(fetchval=12)
+    repo = _repo(pool)
+    cutoff = _NOW - timedelta(days=30)
+
+    assert await repo.purge_terminal_jobs(older_than=cutoff) == 12
+
+    query, params = pool.calls[0]
+    assert "status = ANY($1::text[])" in query
+    assert params[1] == cutoff

--- a/tests/unit/services/persistence/test_job_repo.py
+++ b/tests/unit/services/persistence/test_job_repo.py
@@ -138,6 +138,26 @@ async def test_upsert_job_keeps_the_first_started_at():
 
 
 @pytest.mark.asyncio
+async def test_upsert_job_never_rewrites_user_id_on_conflict():
+    """ON DELETE SET NULL owns the column once the row exists.
+
+    A terminal worker write still carries the id of a user who has since been
+    deleted. Taking it here re-points the row at a missing user, Postgres
+    rejects the whole upsert, the caller swallows it as best-effort history,
+    and the terminal status is lost.
+    """
+    pool = _FakePool(fetchrow=_row(user_id=None))
+    repo = _repo(pool)
+
+    await repo.upsert_job(IndexationJob(id="task-1", status=DocumentStatus.COMPLETED, partition="tenant-a", user_id=7))
+
+    query, _params = pool.calls[0]
+    update_clause = query.split("DO UPDATE SET", 1)[1].split("RETURNING", 1)[0]
+    statements = [line for line in update_clause.splitlines() if not line.strip().startswith("--")]
+    assert "user_id" not in "\n".join(statements)
+
+
+@pytest.mark.asyncio
 async def test_get_job_returns_none_when_absent():
     assert await _repo(_FakePool(fetchrow=None)).get_job("nope") is None
 

--- a/tests/unit/services/persistence/test_jobs_migration.py
+++ b/tests/unit/services/persistence/test_jobs_migration.py
@@ -6,6 +6,8 @@ import importlib
 from pathlib import Path
 
 import pytest
+import sqlalchemy as sa
+from core.models.catalog import DocumentStatus
 
 
 @pytest.fixture
@@ -23,9 +25,11 @@ class _FakeOp:
     def __init__(self) -> None:
         self.created_tables: list[str] = []
         self.created_indexes: list[str] = []
+        self.constraints: list = []
 
-    def create_table(self, name, *_columns) -> None:
+    def create_table(self, name, *columns) -> None:
         self.created_tables.append(name)
+        self.constraints.extend(c for c in columns if isinstance(c, sa.CheckConstraint | sa.ForeignKeyConstraint))
 
     def create_index(self, name, table, columns) -> None:
         self.created_indexes.append(name)
@@ -65,3 +69,29 @@ def test_upgrade_is_a_no_op_when_the_table_is_already_there(monkeypatch, migrati
 
     assert op.created_tables == []
     assert op.created_indexes == []
+
+
+def test_the_status_check_still_matches_the_state_machine(monkeypatch, migration):
+    """The constraint is a frozen copy, so a new state needs its own migration.
+
+    A row carrying a status DocumentStatus does not know raises in
+    ``PgJobRepository._row_to_job``, so widening the enum without widening the
+    database turns a write into an unreadable row.
+    """
+    op = _install(monkeypatch, migration, exists=False)
+
+    migration.upgrade()
+
+    (check,) = [c for c in op.constraints if isinstance(c, sa.CheckConstraint)]
+    pinned = {value.strip().strip("'") for value in str(check.sqltext).split("(", 1)[1].rstrip(")").split(",")}
+    assert pinned == {status.value for status in DocumentStatus}
+
+
+def test_user_id_is_nulled_rather_than_cascaded(monkeypatch, migration):
+    """A job row is a historical record: deleting a user must not delete history."""
+    op = _install(monkeypatch, migration, exists=False)
+
+    migration.upgrade()
+
+    (fk,) = [c for c in op.constraints if isinstance(c, sa.ForeignKeyConstraint)]
+    assert fk.ondelete == "SET NULL"

--- a/tests/unit/services/persistence/test_jobs_migration.py
+++ b/tests/unit/services/persistence/test_jobs_migration.py
@@ -1,0 +1,66 @@
+"""The jobs migration must be re-runnable on a database that already has it."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def migration(monkeypatch):
+    alembic_dir = (
+        Path(__file__).resolve().parents[4] / "openrag" / "services" / "persistence" / "migrations" / "alembic"
+    )
+    monkeypatch.syspath_prepend(str(alembic_dir))
+    return importlib.import_module(
+        "services.persistence.migrations.alembic.versions.c7d8e9f0a1b2_add_jobs",
+    )
+
+
+class _FakeOp:
+    def __init__(self) -> None:
+        self.created_tables: list[str] = []
+        self.created_indexes: list[str] = []
+
+    def create_table(self, name, *_columns) -> None:
+        self.created_tables.append(name)
+
+    def create_index(self, name, table, columns) -> None:
+        self.created_indexes.append(name)
+
+
+def _install(monkeypatch, migration, *, exists: bool):
+    op = _FakeOp()
+    monkeypatch.setattr(migration, "op", op)
+    monkeypatch.setattr(migration, "table_exists", lambda _table: exists)
+    monkeypatch.setattr(migration, "index_exists", lambda _table, _index: exists)
+    return op
+
+
+def test_migration_follows_the_previous_head(migration):
+    assert migration.revision == "c7d8e9f0a1b2"
+    assert migration.down_revision == "b9c0d1e2f3a4"
+
+
+def test_upgrade_creates_the_table_and_its_indexes(monkeypatch, migration):
+    op = _install(monkeypatch, migration, exists=False)
+
+    migration.upgrade()
+
+    assert op.created_tables == ["jobs"]
+    assert op.created_indexes == [
+        "ix_jobs_status",
+        "ix_jobs_user_id",
+        "ix_jobs_partition_file_id",
+    ]
+
+
+def test_upgrade_is_a_no_op_when_the_table_is_already_there(monkeypatch, migration):
+    op = _install(monkeypatch, migration, exists=True)
+
+    migration.upgrade()
+
+    assert op.created_tables == []
+    assert op.created_indexes == []

--- a/tests/unit/services/persistence/test_jobs_migration.py
+++ b/tests/unit/services/persistence/test_jobs_migration.py
@@ -51,8 +51,9 @@ def test_upgrade_creates_the_table_and_its_indexes(monkeypatch, migration):
 
     assert op.created_tables == ["jobs"]
     assert op.created_indexes == [
-        "ix_jobs_status",
-        "ix_jobs_user_id",
+        "ix_jobs_status_created_at",
+        "ix_jobs_user_status",
+        "ix_jobs_settled_at",
         "ix_jobs_partition_file_id",
     ]
 

--- a/tests/unit/services/workers/test_bootstrap.py
+++ b/tests/unit/services/workers/test_bootstrap.py
@@ -152,6 +152,7 @@ def test_legacy_task_completion_tracker_is_replaced_before_recovery(monkeypatch)
     legacy = SimpleNamespace(recover=SimpleNamespace(remote=Mock()))
     replacement = SimpleNamespace(
         supports_cancellation_recovery=SimpleNamespace(remote=Mock(return_value="capability-ref")),
+        reconcile_jobs=SimpleNamespace(remote=Mock()),
         recover=SimpleNamespace(remote=Mock()),
     )
     get_or_create = Mock(side_effect=[legacy, replacement])
@@ -168,6 +169,32 @@ def test_legacy_task_completion_tracker_is_replaced_before_recovery(monkeypatch)
     kill.assert_called_once_with(legacy, no_restart=True)
     replacement.recover.remote.assert_called_once_with()
     assert get_or_create.call_count == 2
+
+
+def test_task_completion_tracker_without_durable_history_is_replaced(monkeypatch):
+    # A tracker left detached by an earlier deployment answers the cancellation
+    # check but never records a settled job or reconciles an orphaned one.
+    legacy = SimpleNamespace(
+        supports_cancellation_recovery=SimpleNamespace(remote=Mock(return_value="capability-ref")),
+        recover=SimpleNamespace(remote=Mock()),
+    )
+    replacement = SimpleNamespace(
+        supports_cancellation_recovery=SimpleNamespace(remote=Mock(return_value="capability-ref")),
+        reconcile_jobs=SimpleNamespace(remote=Mock()),
+        recover=SimpleNamespace(remote=Mock()),
+    )
+    get_or_create = Mock(side_effect=[legacy, replacement])
+    kill = Mock()
+
+    monkeypatch.setattr(bootstrap, "actor_creation_map", {})
+    monkeypatch.setattr(bootstrap, "get_or_create_actor", get_or_create)
+    monkeypatch.setattr(ray, "kill", kill)
+    monkeypatch.setattr(ray, "get", Mock(return_value=True))
+    monkeypatch.setattr(ray, "get_actor", Mock(side_effect=ValueError("actor removed")))
+
+    assert bootstrap.get_task_completion_tracker() is replacement
+
+    kill.assert_called_once_with(legacy, no_restart=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -2253,7 +2253,7 @@ async def test_dispatch_failure_settles_the_durable_job() -> None:
     assert [job.status for job in repo.saved] == [DocumentStatus.QUEUED, DocumentStatus.FAILED]
     settled = repo.saved[-1]
     assert (settled.partition, settled.file_id, settled.user_id) == ("tenant-a", "file-1", 42)
-    assert settled.finished_at is not None
+    assert settled.completed_at is not None
     assert "rejected before worker submission" in settled.error
 
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -2192,6 +2192,23 @@ async def test_unknown_task_stays_unknown_without_a_durable_job() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_durable_read_failure_does_not_break_the_status_routes() -> None:
+    """A history-store outage must degrade the answer, not turn it into a 500.
+
+    The status routes are exactly what gets looked at while Postgres is down.
+    """
+    tsm = _task_state_manager()
+    tsm.get_state = _remote_mock(None)
+    tsm.get_error = _remote_mock(None)
+    repo = _JobRepoSpy()
+    repo.get_job = AsyncMock(side_effect=RuntimeError("postgres is unreachable"))
+    dispatcher = _dispatcher_with_job_repo(tsm, repo)
+
+    assert await dispatcher.get_task_state("task-1") is None
+    assert await dispatcher.get_task_error("task-1") is None
+
+
+@pytest.mark.asyncio
 async def test_recording_a_job_never_breaks_dispatch() -> None:
     from core.models.catalog import DocumentStatus
 

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -2126,3 +2126,105 @@ async def test_dispatch_indexing_does_not_mark_failure_before_worker_submission(
             )
 
     assert indexing_worker_may_be_running(excinfo.value) is False
+
+
+class _JobRepoSpy:
+    def __init__(self, job=None):
+        self.saved: list[Any] = []
+        self._job = job
+
+    async def upsert_job(self, job):
+        self.saved.append(job)
+        return job
+
+    async def get_job(self, job_id):
+        return self._job
+
+
+def _dispatcher_with_job_repo(tsm, job_repo):
+    from services.workers.dispatcher import WorkerDispatcher
+
+    return WorkerDispatcher(
+        pool=_pool_with_ref(object()),
+        task_state_manager=tsm,
+        completion_tracker=_completion_tracker(),
+        vector_store=_vector_store(),
+        document_repo=_document_repo(),
+        workspace_repo=_workspace_repo(),
+        collection="default",
+        job_repo=job_repo,
+        timeout=0.01,
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_state_falls_back_to_the_durable_job() -> None:
+    from core.models.catalog import DocumentStatus, IndexationJob
+
+    tsm = _task_state_manager()
+    tsm.get_state = _remote_mock(None)
+    tsm.get_error = _remote_mock(None)
+    job = IndexationJob(id="task-1", status=DocumentStatus.FAILED, partition="tenant-a", error="boom")
+    dispatcher = _dispatcher_with_job_repo(tsm, _JobRepoSpy(job))
+
+    assert await dispatcher.get_task_state("task-1") == "FAILED"
+    assert await dispatcher.get_task_error("task-1") == "boom"
+
+
+@pytest.mark.asyncio
+async def test_live_actor_state_is_not_overridden_by_the_durable_job() -> None:
+    from core.models.catalog import DocumentStatus, IndexationJob
+
+    tsm = _task_state_manager()
+    job = IndexationJob(id="task-1", status=DocumentStatus.COMPLETED, partition="tenant-a")
+    dispatcher = _dispatcher_with_job_repo(tsm, _JobRepoSpy(job))
+
+    assert await dispatcher.get_task_state("task-1") == "SERIALIZING"
+
+
+@pytest.mark.asyncio
+async def test_unknown_task_stays_unknown_without_a_durable_job() -> None:
+    tsm = _task_state_manager()
+    tsm.get_state = _remote_mock(None)
+    dispatcher = _dispatcher_with_job_repo(tsm, _JobRepoSpy(None))
+
+    assert await dispatcher.get_task_state("task-1") is None
+
+
+@pytest.mark.asyncio
+async def test_recording_a_job_never_breaks_dispatch() -> None:
+    from core.models.catalog import DocumentStatus
+
+    repo = _JobRepoSpy()
+    repo.upsert_job = AsyncMock(side_effect=RuntimeError("jobs table is missing"))
+    dispatcher = _dispatcher_with_job_repo(_task_state_manager(), repo)
+
+    await dispatcher._record_job("task-1", status=DocumentStatus.QUEUED, partition="tenant-a")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_the_job_before_the_worker_runs() -> None:
+    from core.models.catalog import DocumentStatus
+
+    repo = _JobRepoSpy()
+    tsm = _task_state_manager()
+    tsm.set_queued_details = _remote_mock(True)
+    dispatcher = _dispatcher_with_job_repo(tsm, repo)
+
+    await dispatcher.dispatch_indexing(
+        path="/data/report.txt",
+        metadata={"file_id": "file-1", "filename": "report.txt"},
+        partition="tenant-a",
+        user={"id": 42},
+        workspace_ids=None,
+        replace=False,
+    )
+
+    assert len(repo.saved) == 1
+    job = repo.saved[0]
+    assert (job.status, job.partition, job.file_id, job.user_id) == (
+        DocumentStatus.QUEUED,
+        "tenant-a",
+        "file-1",
+        42,
+    )

--- a/tests/unit/services/workers/test_dispatcher.py
+++ b/tests/unit/services/workers/test_dispatcher.py
@@ -2228,3 +2228,52 @@ async def test_dispatch_records_the_job_before_the_worker_runs() -> None:
         "file-1",
         42,
     )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_settles_the_durable_job() -> None:
+    """Nothing else settles this row: the completion tracker never saw the task."""
+    from core.models.catalog import DocumentStatus
+
+    repo = _JobRepoSpy()
+    tsm = _task_state_manager()
+    tsm.begin_worker_submission.remote = AsyncMock(return_value=False)
+    dispatcher = _dispatcher_with_job_repo(tsm, repo)
+
+    with pytest.raises(RuntimeError, match="rejected before worker submission"):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert [job.status for job in repo.saved] == [DocumentStatus.QUEUED, DocumentStatus.FAILED]
+    settled = repo.saved[-1]
+    assert (settled.partition, settled.file_id, settled.user_id) == ("tenant-a", "file-1", 42)
+    assert settled.finished_at is not None
+    assert "rejected before worker submission" in settled.error
+
+
+@pytest.mark.asyncio
+async def test_uncertain_submission_leaves_the_durable_job_queued() -> None:
+    """The worker may be running, so the row must not be settled as failed."""
+    from core.models.catalog import DocumentStatus
+
+    repo = _JobRepoSpy()
+    dispatcher = _dispatcher_with_job_repo(_task_state_manager(), repo)
+    dispatcher._pool.submit.remote = AsyncMock(side_effect=RuntimeError("pool is gone"))
+
+    with pytest.raises(RuntimeError, match="pool is gone"):
+        await dispatcher.dispatch_indexing(
+            path="/data/report.txt",
+            metadata={"file_id": "file-1"},
+            partition="tenant-a",
+            user={"id": 42},
+            workspace_ids=None,
+            replace=False,
+        )
+
+    assert [job.status for job in repo.saved] == [DocumentStatus.QUEUED]

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -1521,6 +1521,7 @@ def test_indexer_pool_wires_contextualizer_factory_and_worker_namespace(monkeypa
     class Store:
         document_repo = object()
         topic_tag_repo = object()
+        job_repo = object()
 
     class Worker:
         def __init__(self, **kwargs):
@@ -1609,6 +1610,7 @@ def test_indexer_pool_loads_caption_prompt_without_global_vlm_default(monkeypatc
     class Store:
         document_repo = object()
         topic_tag_repo = object()
+        job_repo = object()
 
     class Worker:
         def __init__(self, **kwargs):

--- a/tests/unit/services/workers/test_indexer_worker.py
+++ b/tests/unit/services/workers/test_indexer_worker.py
@@ -1123,3 +1123,99 @@ async def test_serializing_state_failure_still_sends_the_error_callback(
     callback_mock.assert_awaited_once_with(
         "https://cozy.example.com/ai/index/status", "p", "f1", "error", metadata, callback_token="jwt"
     )
+
+
+# ---------------------------------------------------------------------------
+# Durable job start (issue #660)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingJobRepo:
+    """Captures ``upsert_job`` calls; optionally raises to prove writes are best-effort."""
+
+    def __init__(self, *, raises: bool = False) -> None:
+        self.saved: list[Any] = []
+        self._raises = raises
+
+    async def upsert_job(self, job: Any) -> Any:
+        if self._raises:
+            raise RuntimeError("postgres is down")
+        self.saved.append(job)
+        return job
+
+
+@pytest.mark.asyncio
+async def test_process_file_stamps_started_at_when_the_task_leaves_the_queue(tmp_path: Path) -> None:
+    """``started_at`` is what makes queue wait separable from service time."""
+    from core.models.catalog import DocumentStatus
+
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    processed = ProcessedDocument(document_id="d1", text_blocks=[TextBlock(text="content")])
+    chunks = [Chunk(id="c1", text="content", partition="p")]
+    repo = _RecordingJobRepo()
+
+    worker = IndexerWorker(
+        pipeline=_make_pipeline(processed, chunks),
+        task_state_manager=_fake_tsm(),
+        job_repo=repo,
+    )
+    await worker.process_file(
+        task_id="t1",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="p",
+        user={"id": 42},
+    )
+
+    assert len(repo.saved) == 1
+    job = repo.saved[0]
+    assert (job.id, job.status, job.partition, job.file_id, job.user_id) == (
+        "t1",
+        DocumentStatus.SERIALIZING,
+        "p",
+        "f1",
+        42,
+    )
+    assert job.started_at is not None
+    assert job.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_process_file_does_not_stamp_a_task_cancelled_before_start(tmp_path: Path) -> None:
+    """A task fenced before it ran never left the queue, so it has no start."""
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    tsm = _fake_tsm()
+    tsm.set_state.remote.return_value = False
+    repo = _RecordingJobRepo()
+
+    worker = IndexerWorker(pipeline=AsyncMock(), task_state_manager=tsm, job_repo=repo)
+
+    with pytest.raises(RuntimeError, match="cancelled before indexing started"):
+        await worker.process_file(task_id="t1", path=str(path), metadata={"file_id": "f1"}, partition="p")
+
+    assert repo.saved == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_job_write_does_not_fail_indexing(tmp_path: Path) -> None:
+    """History is best-effort: a Postgres outage must not lose the document."""
+    path = tmp_path / "doc.txt"
+    path.write_bytes(b"content")
+    processed = ProcessedDocument(document_id="d1", text_blocks=[TextBlock(text="content")])
+    chunks = [Chunk(id="c1", text="content", partition="p")]
+
+    worker = IndexerWorker(
+        pipeline=_make_pipeline(processed, chunks),
+        task_state_manager=_fake_tsm(),
+        job_repo=_RecordingJobRepo(raises=True),
+    )
+    result = await worker.process_file(
+        task_id="t1",
+        path=str(path),
+        metadata={"file_id": "f1"},
+        partition="p",
+    )
+
+    assert result["stored_count"] == 1

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -191,8 +191,6 @@ async def test_tracker_retries_active_task_without_stored_ref_after_restart() ->
 
 @pytest.mark.asyncio
 async def test_tracker_records_recovered_refless_task_when_it_reaches_terminal_state() -> None:
-    from services.workers.task_completion import TaskCompletionTracker
-
     details = {
         "file_id": "file-1",
         "partition": "tenant-a",
@@ -201,14 +199,18 @@ async def test_tracker_records_recovered_refless_task_when_it_reaches_terminal_s
     }
     tsm = _task_state_manager(object_ref=None)
     tsm.get_details.remote.return_value = details
-    tsm.get_state.remote.side_effect = ["SERIALIZING", "COMPLETED"]
+    # Three reads: two by the poll loop, one by the history write that now has to
+    # succeed before the actor is stamped.
+    tsm.get_state.remote.side_effect = ["SERIALIZING", "COMPLETED", "COMPLETED"]
 
     with (
         patch("services.workers.task_completion.ray.get_actor", return_value=tsm),
         patch("services.workers.task_completion._utc_now_iso", return_value="2026-07-20T08:01:05+00:00"),
         patch("services.workers.task_completion.asyncio.sleep", AsyncMock()),
     ):
-        tracker = TaskCompletionTracker()
+        # A settled task now only stamps the actor once its history row is
+        # written, so the tracker needs a repository that answers.
+        tracker = _tracker_with_repo(_FakeJobRepo())
         await tracker.recover_refless("task-1", poll_interval=0)
 
     tsm.set_details.remote.assert_awaited_once_with(
@@ -225,8 +227,6 @@ async def test_tracker_records_recovered_refless_task_when_it_reaches_terminal_s
 
 @pytest.mark.asyncio
 async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
-    from services.workers.task_completion import TaskCompletionTracker
-
     ref = asyncio.get_running_loop().create_future()
     ref.set_result(None)
     details = {
@@ -245,7 +245,9 @@ async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
         patch("services.workers.task_completion._utc_now_iso", return_value="2026-07-20T08:01:05+00:00"),
         patch("services.workers.task_completion.asyncio.sleep", AsyncMock()),
     ):
-        tracker = TaskCompletionTracker()
+        # A settled task now only stamps the actor once its history row is
+        # written, so the tracker needs a repository that answers.
+        tracker = _tracker_with_repo(_FakeJobRepo())
         await tracker.recover_refless(
             "task-1",
             poll_interval=0,
@@ -259,8 +261,6 @@ async def test_tracker_waits_for_submitted_cancelled_worker_ref() -> None:
 
 @pytest.mark.asyncio
 async def test_tracker_finishes_cancelled_submission_after_pool_clears_fence() -> None:
-    from services.workers.task_completion import TaskCompletionTracker
-
     details = {
         "file_id": "file-1",
         "partition": "tenant-a",
@@ -276,7 +276,9 @@ async def test_tracker_finishes_cancelled_submission_after_pool_clears_fence() -
         patch("services.workers.task_completion._utc_now_iso", return_value="2026-07-20T08:01:05+00:00"),
         patch("services.workers.task_completion.asyncio.sleep", AsyncMock()),
     ):
-        tracker = TaskCompletionTracker()
+        # A settled task now only stamps the actor once its history row is
+        # written, so the tracker needs a repository that answers.
+        tracker = _tracker_with_repo(_FakeJobRepo())
         await tracker.recover_refless(
             "task-1",
             poll_interval=0,
@@ -466,6 +468,29 @@ async def test_settled_task_is_written_to_the_job_history() -> None:
         42,
     )
     assert job.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_history_write_leaves_the_task_unstamped() -> None:
+    """The stamp is what stops recovery retrying, so it must follow the write.
+
+    Stamping regardless strands the row at its last non-terminal status until
+    orphan reconciliation marks a completed job FAILED after a restart.
+    """
+    repo = _FakeJobRepo()
+    repo.upsert_job = AsyncMock(side_effect=RuntimeError("postgres is unreachable"))
+    tsm = _task_state_manager(state="COMPLETED")
+    tsm.get_details.remote.return_value = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {},
+        "user_id": 42,
+    }
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        await _tracker_with_repo(repo)._record_finished_at("task-1")
+
+    tsm.set_details.remote.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -465,7 +465,7 @@ async def test_settled_task_is_written_to_the_job_history() -> None:
         "file-1",
         42,
     )
-    assert job.finished_at is not None
+    assert job.completed_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -488,9 +488,12 @@ async def test_a_failed_history_write_leaves_the_task_unstamped() -> None:
     }
 
     with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
-        await _tracker_with_repo(repo)._record_finished_at("task-1")
+        tracker = _tracker_with_repo(repo)
+        await tracker._record_finished_at("task-1")
 
     tsm.set_details.remote.assert_not_awaited()
+    assert list(tracker._pending_settlements) == ["task-1"]
+    tracker._settlement_retry.cancel()
 
 
 @pytest.mark.asyncio
@@ -514,6 +517,53 @@ async def test_job_history_failure_never_breaks_completion_tracking() -> None:
     with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
         tracker = _tracker_with_repo(repo)
         await tracker._record_settled_job("task-1", {"partition": "tenant-a"})
+
+    tracker._settlement_retry.cancel()
+
+
+@pytest.mark.asyncio
+async def test_a_held_settlement_is_retried_until_postgres_takes_it() -> None:
+    # Nothing re-reads a settled task later: track() forgets it and the actor
+    # evicts its record, so a dropped write leaves the row non-terminal and
+    # orphan reconciliation reports a finished job as failed.
+    repo = _FakeJobRepo()
+    repo.upsert_job = AsyncMock(side_effect=[RuntimeError("postgres is unreachable"), None])
+    tsm = _task_state_manager(state="COMPLETED")
+    tsm.get_details.remote.return_value = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {},
+        "user_id": 42,
+    }
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = _tracker_with_repo(repo)
+        await tracker._record_finished_at("task-1")
+
+        assert list(tracker._pending_settlements) == ["task-1"]
+
+        tracker._settlement_retry.cancel()
+        await tracker._retry_pending_settlements(delay=0)
+
+    assert tracker._pending_settlements == {}
+    assert repo.upsert_job.await_count == 2
+    assert repo.upsert_job.await_args_list[1].args[0].status.value == "COMPLETED"
+    tsm.set_details.remote.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_held_settlement_is_not_reconciled_as_an_orphan() -> None:
+    from core.models.catalog import DocumentStatus, IndexationJob
+
+    repo = _FakeJobRepo()
+    tracker = _tracker_with_repo(repo)
+    tracker._pending_settlements["task-1"] = IndexationJob(
+        id="task-1", status=DocumentStatus.COMPLETED, partition="tenant-a"
+    )
+
+    await tracker.reconcile_jobs([])
+
+    assert repo.failed_calls[0]["active_ids"] == ["task-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_task_completion.py
+++ b/tests/unit/services/workers/test_task_completion.py
@@ -23,6 +23,7 @@ def _task_state_manager(
     tsm.get_all_info = _remote_mock(all_info or {})
     tsm.get_object_ref = _remote_mock(object_ref)
     tsm.get_state = _remote_mock(state)
+    tsm.get_error = _remote_mock()
     tsm.get_details = _remote_mock()
     tsm.set_details = _remote_mock()
     tsm.finish_cancellation = _remote_mock()
@@ -409,3 +410,98 @@ async def test_tracker_does_not_replace_existing_completion_time() -> None:
 
     tsm.get_details.remote.assert_not_called()
     tsm.set_details.remote.assert_not_called()
+
+
+class _FakeJobRepo:
+    def __init__(self) -> None:
+        self.saved: list[Any] = []
+        self.failed_calls: list[dict] = []
+        self.purged_before: list[Any] = []
+
+    async def upsert_job(self, job):
+        self.saved.append(job)
+        return job
+
+    async def fail_orphaned_jobs(self, *, active_ids, error, before):
+        self.failed_calls.append({"active_ids": list(active_ids), "error": error, "before": before})
+        return len(self.failed_calls)
+
+    async def purge_terminal_jobs(self, *, older_than):
+        self.purged_before.append(older_than)
+        return 0
+
+
+def _tracker_with_repo(repo):
+    from services.workers.task_completion import TaskCompletionTracker
+
+    tracker = TaskCompletionTracker()
+    tracker._job_repo = AsyncMock(return_value=repo)
+    return tracker
+
+
+@pytest.mark.asyncio
+async def test_settled_task_is_written_to_the_job_history() -> None:
+    from core.models.catalog import DocumentStatus
+
+    repo = _FakeJobRepo()
+    tsm = _task_state_manager(state="COMPLETED")
+    tsm.get_details.remote.return_value = {
+        "file_id": "file-1",
+        "partition": "tenant-a",
+        "metadata": {},
+        "user_id": 42,
+    }
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = _tracker_with_repo(repo)
+        await tracker._record_finished_at("task-1")
+
+    assert len(repo.saved) == 1
+    job = repo.saved[0]
+    assert (job.id, job.status, job.partition, job.file_id, job.user_id) == (
+        "task-1",
+        DocumentStatus.COMPLETED,
+        "tenant-a",
+        "file-1",
+        42,
+    )
+    assert job.finished_at is not None
+
+
+@pytest.mark.asyncio
+async def test_active_task_is_not_written_as_settled() -> None:
+    repo = _FakeJobRepo()
+    tsm = _task_state_manager(state="SERIALIZING")
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = _tracker_with_repo(repo)
+        await tracker._record_settled_job("task-1", {"partition": "tenant-a"})
+
+    assert repo.saved == []
+
+
+@pytest.mark.asyncio
+async def test_job_history_failure_never_breaks_completion_tracking() -> None:
+    repo = _FakeJobRepo()
+    repo.upsert_job = AsyncMock(side_effect=RuntimeError("jobs table is missing"))
+    tsm = _task_state_manager(state="FAILED")
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = _tracker_with_repo(repo)
+        await tracker._record_settled_job("task-1", {"partition": "tenant-a"})
+
+
+@pytest.mark.asyncio
+async def test_recover_settles_jobs_a_restart_orphaned() -> None:
+    repo = _FakeJobRepo()
+    tsm = _task_state_manager(all_info={"task-live": {"state": "QUEUED", "details": {}}})
+    tsm.get_object_ref.remote.return_value = {"ref": object()}
+
+    with patch("services.workers.task_completion.ray.get_actor", return_value=tsm):
+        tracker = _tracker_with_repo(repo)
+        await tracker.recover()
+
+    assert repo.failed_calls[0]["active_ids"] == ["task-live"]
+    assert "restart" in repo.failed_calls[0]["error"]
+    assert repo.failed_calls[0]["before"] is not None  # recent rows are spared
+    assert repo.purged_before  # retention runs in the same pass


### PR DESCRIPTION
Second half of #660. The memory leak half is #903.

Indexing job state lived only in memory, so a restart erased all job history
and left in-flight work invisible with nothing to clean it up.

Each indexing task now gets a row in a new jobs table. It is written when the
task is admitted, updated when it settles, and read back when the actor no
longer knows the task, so status and the task list survive a restart. On
startup, records left in flight by a restart are marked failed, and history
older than 30 days is deleted. A failed history write never blocks indexing.

The schema is the one from #677, which cannot merge on its own. user_id has a
foreign key to users.id with ON DELETE SET NULL, and a CHECK pins status to the
DocumentStatus values (five, not #677's seven: #721 removed CHUNKING and
INSERTING after that PR was written). finished_at is replaced by started_at and
completed_at, so queue wait and service time are separable instead of collapsed
into one settle timestamp; started_at is stamped by the indexer worker when the
task leaves the queue. Indexes are (status, created_at) and (user_id, status),
plus an expression index on COALESCE(completed_at, created_at) that the
retention sweep now filters on.

A settled row freezes status, error and completed_at together. Freezing the
status alone let a FAILED write that lost the cancel race staple its traceback
onto a row reading CANCELLED.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable indexing job history with statuses, errors, timestamps, and optional user/file details.
  * Job lists and task details remain available after live task state is no longer retained.
  * Added user filtering, automatic recovery, retry handling, and cleanup of old completed jobs.

* **Bug Fixes**
  * Indexing continues when history persistence is temporarily unavailable.
  * Workspace ownership is transferred only after all attachments succeed.

* **Tests**
  * Added coverage for persistence, recovery, cleanup, migrations, and worker integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
