### PR TITLE
fix(migrations): quarantine workspace_files orphans instead of deleting them

### DIFF
--- a/openrag/services/persistence/migrations/alembic/versions/f1a2b3c4d5e6_add_workspace_files_file_id_fk.py
+++ b/openrag/services/persistence/migrations/alembic/versions/f1a2b3c4d5e6_add_workspace_files_file_id_fk.py
@@ -6,6 +6,7 @@ Create Date: 2026-03-12 10:00:00.000000
 
 """
 
+import logging
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -15,6 +16,7 @@ from schema_helpers import (
     column_type_is,
     fk_exists,
     index_exists,
+    table_exists,
     unique_constraint_exists,
 )
 
@@ -23,6 +25,31 @@ revision: str = "f1a2b3c4d5e6"
 down_revision: str | Sequence[str] | None = "e7f8a9b0c1d2"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+#: Rows this migration removes are copied here instead of being dropped outright.
+#: A follow-up migration can drop the table once operators have reviewed it.
+ORPHAN_TABLE = "workspace_files_orphans_f1a2b3c4d5e6"
+
+
+def _quarantine_delete(condition: str, reason: str) -> None:
+    """Delete the workspace_files rows matching `condition`, keeping a copy.
+
+    The delete and the copy are a single statement, so they share the
+    migration's transaction: either both happen or neither does.
+    """
+    result = op.get_bind().execute(
+        sa.text(
+            f"WITH removed AS ("
+            f"  DELETE FROM workspace_files wf WHERE {condition}"
+            f"  RETURNING wf.workspace_id, wf.file_id"
+            f") INSERT INTO {ORPHAN_TABLE} (workspace_id, file_id, reason) "
+            f"SELECT workspace_id, file_id, :reason FROM removed"
+        ),
+        {"reason": reason},
+    )
+    logger.info("workspace_files: quarantined %s row(s) in %s (%s)", result.rowcount, ORPHAN_TABLE, reason)
 
 
 def upgrade() -> None:
@@ -34,8 +61,15 @@ def upgrade() -> None:
     if column_type_is("workspace_files", "file_id", sa.Integer):
         return
 
+    op.execute(
+        f"CREATE TABLE IF NOT EXISTS {ORPHAN_TABLE} ("
+        "workspace_id VARCHAR NOT NULL, file_id VARCHAR NOT NULL, reason VARCHAR NOT NULL)"
+    )
+
     # 1. Purge rows that have no matching file (no valid files.file_id to JOIN against).
-    op.execute("DELETE FROM workspace_files WHERE file_id NOT IN (SELECT file_id FROM files)")
+    #    NOT EXISTS rather than NOT IN: a NULL in the subquery would make NOT IN
+    #    match nothing and turn the purge into a silent no-op.
+    _quarantine_delete("NOT EXISTS (SELECT 1 FROM files f WHERE f.file_id = wf.file_id)", "no_matching_file")
 
     # 2. Add a temporary integer column to hold the resolved files.id value.
     if not column_exists("workspace_files", "file_fk"):
@@ -55,7 +89,7 @@ def upgrade() -> None:
     )
 
     # 3b. Drop any rows that couldn't be resolved (file_fk still NULL).
-    op.execute("DELETE FROM workspace_files WHERE file_fk IS NULL")
+    _quarantine_delete("wf.file_fk IS NULL", "unresolved_partition")
 
     # 4. Drop the old string column and its index.
     if index_exists("workspace_files", "ix_workspace_files_file_id"):
@@ -100,3 +134,14 @@ def downgrade() -> None:
         op.create_index("ix_workspace_files_file_id", "workspace_files", ["file_id"])
     if not unique_constraint_exists("workspace_files", "uix_workspace_file"):
         op.create_unique_constraint("uix_workspace_file", "workspace_files", ["workspace_id", "file_id"])
+
+    # Put back the rows upgrade() quarantined, now that file_id is a string again.
+    # Workspaces deleted since the upgrade are skipped: their FK no longer resolves.
+    if table_exists(ORPHAN_TABLE):
+        op.execute(
+            f"INSERT INTO workspace_files (workspace_id, file_id) "
+            f"SELECT o.workspace_id, o.file_id FROM {ORPHAN_TABLE} o "
+            f"WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.workspace_id = o.workspace_id) "
+            f"ON CONFLICT ON CONSTRAINT uix_workspace_file DO NOTHING"
+        )
+        op.execute(f"DROP TABLE {ORPHAN_TABLE}")

--- a/tests/unit/services/persistence/test_workspace_files_fk_migration.py
+++ b/tests/unit/services/persistence/test_workspace_files_fk_migration.py
@@ -1,0 +1,110 @@
+"""Tests for the workspace_files.file_id FK migration.
+
+The migration removes rows it cannot resolve. It must never do so silently:
+every removed row is copied into a quarantine table, the count is logged, and
+downgrade() puts the rows back.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def migration(monkeypatch):
+    alembic_dir = (
+        Path(__file__).resolve().parents[4] / "openrag" / "services" / "persistence" / "migrations" / "alembic"
+    )
+    monkeypatch.syspath_prepend(str(alembic_dir))
+    return importlib.import_module(
+        "services.persistence.migrations.alembic.versions.f1a2b3c4d5e6_add_workspace_files_file_id_fk",
+    )
+
+
+class _FakeResult:
+    rowcount = 7
+
+
+class _FakeBind:
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+
+    def execute(self, statement, params=None):
+        self.calls.append(str(statement))
+        return _FakeResult()
+
+
+class _FakeOp:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_bind(self):
+        return _FakeBind(self.calls)
+
+    def execute(self, statement) -> None:
+        self.calls.append(str(statement))
+
+    def __getattr__(self, name):
+        def _record(*args, **kwargs):
+            self.calls.append(f"{name}{args}")
+
+        return _record
+
+
+def _run(monkeypatch, migration, func, **helpers):
+    fake_op = _FakeOp()
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration, "column_type_is", lambda *_: False)
+    for helper in ("column_exists", "index_exists", "fk_exists", "unique_constraint_exists", "table_exists"):
+        monkeypatch.setattr(migration, helper, helpers.get(helper, lambda *_: True))
+    func()
+    return "\n".join(fake_op.calls)
+
+
+def test_upgrade_quarantines_instead_of_deleting(monkeypatch, migration) -> None:
+    statements = _run(monkeypatch, migration, migration.upgrade)
+
+    assert f"CREATE TABLE IF NOT EXISTS {migration.ORPHAN_TABLE}" in statements
+    # Both purges copy the rows out before dropping them, in one statement.
+    assert statements.count(f"INSERT INTO {migration.ORPHAN_TABLE}") == 2
+    assert "NOT EXISTS (SELECT 1 FROM files f WHERE f.file_id = wf.file_id)" in statements
+    assert "wf.file_fk IS NULL" in statements
+    # No bare delete survives.
+    assert "DELETE FROM workspace_files WHERE" not in statements
+
+
+def test_upgrade_logs_the_removed_row_count(monkeypatch, migration, caplog) -> None:
+    with caplog.at_level("INFO", logger="alembic.runtime.migration"):
+        _run(monkeypatch, migration, migration.upgrade)
+
+    assert [r.getMessage() for r in caplog.records] == [
+        f"workspace_files: quarantined 7 row(s) in {migration.ORPHAN_TABLE} (no_matching_file)",
+        f"workspace_files: quarantined 7 row(s) in {migration.ORPHAN_TABLE} (unresolved_partition)",
+    ]
+
+
+def test_upgrade_is_a_no_op_when_already_migrated(monkeypatch, migration) -> None:
+    fake_op = _FakeOp()
+    monkeypatch.setattr(migration, "op", fake_op)
+    monkeypatch.setattr(migration, "column_type_is", lambda *_: True)
+
+    migration.upgrade()
+
+    assert fake_op.calls == []
+
+
+def test_downgrade_restores_the_quarantined_rows(monkeypatch, migration) -> None:
+    statements = _run(monkeypatch, migration, migration.downgrade)
+
+    assert f"SELECT o.workspace_id, o.file_id FROM {migration.ORPHAN_TABLE} o" in statements
+    assert "ON CONFLICT ON CONSTRAINT uix_workspace_file DO NOTHING" in statements
+    assert f"DROP TABLE {migration.ORPHAN_TABLE}" in statements
+
+
+def test_downgrade_skips_the_restore_when_nothing_was_quarantined(monkeypatch, migration) -> None:
+    statements = _run(monkeypatch, migration, migration.downgrade, table_exists=lambda *_: False)
+
+    assert migration.ORPHAN_TABLE not in statements


### PR DESCRIPTION
Fixes #357

The workspace_files FK migration deleted rows it could not resolve. It never said
how many, and downgrade could not bring them back.

Now each delete copies the rows into a `workspace_files_orphans_f1a2b3c4d5e6`
table in the same statement, logs the count, and `downgrade()` puts them back.
Also swapped `NOT IN` for `NOT EXISTS`.

Checked with an upgrade/downgrade round trip on a real Postgres, plus 5 new unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Integrity**
  * Workspace file references are now validated against existing files.
  * Orphaned records are preserved during cleanup and can be restored when safely possible.
* **Reliability**
  * Migration handling is safer for already-migrated databases and avoids duplicate restorations.
* **Tests**
  * Added coverage for orphan preservation, cleanup reporting, restoration, and repeatable migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->