### PR TITLE
fix(retrieval): keep multi-partition search alive when one partition fails

### DIFF
--- a/openrag/services/orchestrators/retrieval_service.py
+++ b/openrag/services/orchestrators/retrieval_service.py
@@ -25,7 +25,7 @@ built ``searcher`` / ``reranker`` / ``llm`` plus ``config``.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from core.prompts import load_template_by_key
@@ -375,8 +375,11 @@ class RetrievalService:
     # Pipeline retrieval (powers QueryService — 8C.2)
     # ------------------------------------------------------------------
 
-    async def _gather_partition_groups(self, coros: list) -> list:
+    async def _gather_partition_groups(self, legs: list[tuple[list[str], Awaitable[list]]]) -> list:
         """Await one coroutine per partition group, bounding concurrency.
+
+        Each leg is ``(partition_names, coroutine)``; the names are carried so a
+        dropped leg can be named in the log.
 
         Small fan-outs (the common case: a handful of partitions) run fully
         parallel via a plain gather — no added overhead, byte-identical to the
@@ -390,18 +393,44 @@ class RetrievalService:
         the ``retrieve_per_query`` → ``retrieve`` nesting (each inner call bounds
         its own leaves; the coroutines being awaited hold no permit while
         waiting for one, so there is no cross-level deadlock).
+
+        One unhealthy partition must not empty the whole result set (#736), so
+        legs are gathered with ``return_exceptions=True`` and a failed one is
+        dropped with a warning naming it. Two cases are deliberately not
+        degraded: ``CancelledError`` is re-raised so a client disconnect or a
+        timeout still unwinds, and if *every* leg failed the first error is
+        re-raised — an empty list is indistinguishable from "no match" and would
+        answer from no context instead of surfacing the outage.
         """
         limit = self._config.retriever.max_partition_concurrency
-        if len(coros) <= limit:
-            return await asyncio.gather(*coros)
+        coros = [coro for _, coro in legs]
+        if len(coros) > limit:
+            semaphore = asyncio.Semaphore(limit)
 
-        semaphore = asyncio.Semaphore(limit)
+            async def _bounded(coro):
+                async with semaphore:
+                    return await coro
 
-        async def _bounded(coro):
-            async with semaphore:
-                return await coro
+            coros = [_bounded(c) for c in coros]
+        results = await asyncio.gather(*coros, return_exceptions=True)
 
-        return await asyncio.gather(*(_bounded(c) for c in coros))
+        ranked_lists = []
+        first_error: BaseException | None = None
+        for (partition_names, _), result in zip(legs, results, strict=True):
+            if not isinstance(result, BaseException):
+                ranked_lists.append(result)
+                continue
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if first_error is None:
+                first_error = result
+            logger.bind(partitions=partition_names).warning(
+                f"Retrieval degraded: dropping partition(s) {partition_names} — {type(result).__name__}: {result}"
+            )
+
+        if first_error is not None and not ranked_lists:
+            raise first_error
+        return ranked_lists
 
     async def retrieve(
         self,
@@ -415,11 +444,14 @@ class RetrievalService:
         groups = await self._pipeline_groups_for_partitions(partitions)
         ranked_lists = await self._gather_partition_groups(
             [
-                pipeline.retrieve_docs(
-                    partition=partition_group,
-                    query=query,
-                    top_k=top_k if top_k is not None else default_top_k,
-                    filter_params=filter_params,
+                (
+                    partition_group,
+                    pipeline.retrieve_docs(
+                        partition=partition_group,
+                        query=query,
+                        top_k=top_k if top_k is not None else default_top_k,
+                        filter_params=filter_params,
+                    ),
                 )
                 for partition_group, pipeline, default_top_k in groups
             ]
@@ -438,11 +470,14 @@ class RetrievalService:
         groups = await self._pipeline_groups_for_partitions(partitions)
         ranked_lists = await self._gather_partition_groups(
             [
-                pipeline.get_relevant_docs(
-                    partition=partition_group,
-                    search_queries=search_queries,
-                    top_k=top_k if top_k is not None else default_top_k,
-                    filter_params=filter_params,
+                (
+                    partition_group,
+                    pipeline.get_relevant_docs(
+                        partition=partition_group,
+                        search_queries=search_queries,
+                        top_k=top_k if top_k is not None else default_top_k,
+                        filter_params=filter_params,
+                    ),
                 )
                 for partition_group, pipeline, default_top_k in groups
             ]

--- a/tests/unit/services/orchestrators/test_retrieval_service.py
+++ b/tests/unit/services/orchestrators/test_retrieval_service.py
@@ -565,3 +565,192 @@ async def test_single_strategy_resolves_no_prompt():
     svc = RetrievalService(searcher=FakeSearcher(), reranker=None, llm=None, config=cfg, prompt_service=rec)
     await svc._pipeline_for_partition("tenant-a")
     assert rec.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Partition fan-out resilience (#736)
+# --------------------------------------------------------------------------- #
+
+
+class ExplodingSearcher(FakeSearcher):
+    """A searcher whose partition is unreachable — e.g. its embedder endpoint is
+    down, which is the realistic per-leg failure now that every partition shares
+    one Milvus collection."""
+
+    async def search(self, **kwargs):
+        raise RuntimeError("embedder endpoint unreachable")
+
+
+def _mixed_factory(failing: set[str]):
+    """Searcher factory where the named embedders raise and the rest answer."""
+    made: dict[str, FakeSearcher] = {}
+
+    def factory(name: str) -> FakeSearcher:
+        if name not in made:
+            s = ExplodingSearcher() if name in failing else FakeSearcher()
+            s.search_result = [_chunk(f"{name}-hit")]
+            made[name] = s
+        return made[name]
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_retrieve_survives_one_failing_partition():
+    """One unhealthy partition must not wipe out the healthy ones (#736).
+
+    The fan-out gathers one leg per partition group. Without
+    ``return_exceptions`` a single raising leg aborts the whole gather, so a
+    user with several memberships — or a super-admin on ``all`` — gets nothing
+    back instead of the partitions that answered fine.
+    """
+    cfg = _config()
+    cfg.partitions = {
+        "good": _partition(name="good", embedder="embed-good"),
+        "bad": _partition(name="bad", embedder="embed-bad"),
+    }
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_mixed_factory({"embed-bad"}),
+    )
+
+    out = await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+    assert [c.id for c in out] == ["embed-good-hit"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_multi_survives_one_failing_partition():
+    """The multi-query fan-out shares the same choke point, so it degrades too."""
+    cfg = _config()
+    cfg.partitions = {
+        "good": _partition(name="good", embedder="embed-good"),
+        "bad": _partition(name="bad", embedder="embed-bad"),
+    }
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_mixed_factory({"embed-bad"}),
+    )
+
+    out = await svc.retrieve_multi(partitions=["all"], search_queries=SearchQueries(query_list=[Query(query="hello")]))
+
+    assert [c.id for c in out] == ["embed-good-hit"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_when_every_partition_fails():
+    """Fail-open stops at total failure.
+
+    With no leg left there is nothing to degrade to, and an empty list reads as
+    "the corpus has no match" — the caller would answer from no context instead
+    of surfacing the outage. The original error type is preserved so the API
+    keeps mapping it as before.
+    """
+    cfg = _config()
+    cfg.partitions = {
+        "a": _partition(name="a", embedder="embed-a"),
+        "b": _partition(name="b", embedder="embed-b"),
+    }
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_mixed_factory({"embed-a", "embed-b"}),
+    )
+
+    with pytest.raises(RuntimeError, match="embedder endpoint unreachable"):
+        await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+
+@pytest.mark.asyncio
+async def test_retrieve_propagates_cancellation_rather_than_degrading():
+    """A cancelled request is not a degraded partition.
+
+    ``return_exceptions=True`` captures ``CancelledError`` like any other
+    exception, which would silently turn a client disconnect or a timeout into
+    a partial result. It must unwind instead.
+    """
+
+    class CancellingSearcher(FakeSearcher):
+        async def search(self, **kwargs):
+            raise asyncio.CancelledError()
+
+    def factory(name: str) -> FakeSearcher:
+        if name == "embed-cancel":
+            return CancellingSearcher()
+        s = FakeSearcher()
+        s.search_result = [_chunk(f"{name}-hit")]
+        return s
+
+    cfg = _config()
+    cfg.partitions = {
+        "good": _partition(name="good", embedder="embed-good"),
+        "gone": _partition(name="gone", embedder="embed-cancel"),
+    }
+    svc = RetrievalService(searcher=FakeSearcher(), reranker=None, llm=None, config=cfg, searcher_factory=factory)
+
+    with pytest.raises(asyncio.CancelledError):
+        await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+
+
+@pytest.mark.asyncio
+async def test_bounded_fanout_also_degrades_per_partition():
+    """Resilience must hold on the throttled path too, not just the fast one.
+
+    Above ``max_partition_concurrency`` the legs run through a semaphore
+    wrapper, which is a separate gather call — the earlier fix would have been
+    easy to apply to only one of them.
+    """
+    cfg = _config()
+    cfg.retriever.max_partition_concurrency = 2
+    cfg.partitions = {f"p{i}": _partition(name=f"p{i}", embedder=f"e{i}") for i in range(5)}
+    svc = RetrievalService(
+        searcher=FakeSearcher(),
+        reranker=None,
+        llm=None,
+        config=cfg,
+        searcher_factory=_mixed_factory({"e1", "e3"}),
+    )
+
+    out = await svc.retrieve(partitions=["all"], query=Query(query="hi"))
+
+    assert sorted(c.id for c in out) == ["e0-hit", "e2-hit", "e4-hit"]
+
+
+@pytest.mark.asyncio
+async def test_dropped_partition_is_named_in_the_log():
+    """Degrading silently would hide a broken partition indefinitely: results
+    still come back, so nobody notices until someone asks why a tenant's
+    documents stopped being cited. The warning names the partitions (#736)."""
+    from loguru import logger as _logger
+
+    messages: list[str] = []
+    sink_id = _logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        cfg = _config()
+        cfg.partitions = {
+            "healthy": _partition(name="healthy", embedder="embed-good"),
+            "broken": _partition(name="broken", embedder="embed-bad"),
+        }
+        svc = RetrievalService(
+            searcher=FakeSearcher(),
+            reranker=None,
+            llm=None,
+            config=cfg,
+            searcher_factory=_mixed_factory({"embed-bad"}),
+        )
+        await svc.retrieve(partitions=["all"], query=Query(query="hello"))
+    finally:
+        _logger.remove(sink_id)
+
+    dropped = [m for m in messages if "broken" in m]
+    assert dropped, f"the dropped partition was not logged: {messages}"
+    assert "RuntimeError" in dropped[0]
+    assert "healthy" not in dropped[0], "only the failed partition should be named"


### PR DESCRIPTION
The per-partition fan-out gathered without `return_exceptions`, so one raising leg aborted the whole gather — a user with several memberships, or a super-admin on `all`, got nothing instead of the partitions that answered fine. Legs now carry their partition names, are gathered with `return_exceptions`, and a failed leg is dropped with a warning naming it.

Two cases are deliberately *not* degraded, both tested:

- `CancelledError` is re-raised. `return_exceptions=True` captures it like any other exception, which would silently turn a client disconnect or a timeout into a partial result.
- If every leg failed, the first error is re-raised. An empty list is indistinguishable from "the corpus has no match", so the caller would answer from no context instead of surfacing the outage. The original exception type is preserved so the API maps it as before.

**The issue's stated trigger does not exist.** It assumed a partition's Milvus collection could be dropped. Verified otherwise: partitions share one collection and are selected by filter, so an unknown partition returns `[]` (benign) and only an absent *collection* raises — which is global, not per-partition. The realistic per-leg failure is a partition whose configured embedder endpoint is unreachable, which is what the tests model.

**Tradeoff worth deciding in the open:** fail-open is silent to the API caller. A client gets 200 with results from a subset of its partitions and no way to tell. That is the point of fail-open for most callers, but not for anyone measuring retrieval quality — recall is computed against a corpus that quietly shrank. Surfacing it (a `degraded_partitions` entry in `extra`) is a contract change and deliberately not in this PR.

Two notes for review:

- Legs are partition *groups*, not single partitions — grouping by embedder config came in with #708 — so one dropped leg drops everything sharing that embedder. Finer granularity is #735's territory.
- The issue also names `retrieve_per_query`. It has no production caller: the web-search path moved to `retrieve_multi` in #707 and a test asserts the old path is not taken. Left untouched rather than adding untested resilience to dead code.

Closes #736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retrieval now continues returning results when one partition fails during multi-partition searches.
  * Failed partitions are identified in warning logs.
  * Complete retrieval failures still surface the underlying error.
  * Cancellation requests continue to propagate correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->