### PR TITLE
fix(indexing): release the failed PDF before reopening it cleaned; restart indexer actors

### DIFF
--- a/openrag/core/indexing/parsers/pdf/pymupdf.py
+++ b/openrag/core/indexing/parsers/pdf/pymupdf.py
@@ -67,6 +67,8 @@ def _extract_markdown(raw: bytes, filename: str) -> tuple[list[str], list[ImageB
     with pymupdf.open(stream=raw, filetype="pdf") as doc:
         try:
             chunks = _to_markdown(doc)
+            pages = [(chunk.get("text") or "").strip() for chunk in chunks]
+            return pages, []
         except RuntimeError as exc:
             # MuPDF hard-errors on some legal-but-unusual object graphs — e.g.
             # Type3 fonts with no embedded font file trip "code=4: no font file
@@ -79,8 +81,12 @@ def _extract_markdown(raw: bytes, filename: str) -> tuple[list[str], list[ImageB
                 "pymupdf4llm.to_markdown failed; retrying against a garbage-collected/cleaned copy"
             )
             cleaned = doc.tobytes(garbage=4, clean=True)
-            with pymupdf.open(stream=cleaned, filetype="pdf") as clean_doc:
-                chunks = _to_markdown(clean_doc)
+    # Outside the `with`: the failed document is closed before the cleaned copy
+    # is opened, so MuPDF's parsed structures for the first are released rather
+    # than held alongside the second. ``raw`` itself belongs to the caller's
+    # Document and stays live either way (#846).
+    with pymupdf.open(stream=cleaned, filetype="pdf") as clean_doc:
+        chunks = _to_markdown(clean_doc)
     pages = [(chunk.get("text") or "").strip() for chunk in chunks]
     return pages, []
 

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -38,7 +38,11 @@ _MISSING_WORKER_REF_ERROR = "Indexer worker did not receive a registered task re
 # _active_indexation_config contextvar — a different contract that happened
 # to reuse the same version string on its own branch.
 # v7: merge of both v6 lineages — neither alone is compatible with this one.
-_INDEXER_ACTOR_PROTOCOL_VERSION = "v7"
+# v8: max_restarts on the dispatcher and the workers. Ray applies actor options
+# only when it creates the actor, and get_if_exists=True reuses a detached actor
+# left by the previous release — so without a new name the restart policy would
+# silently not apply to exactly the long-running deployments that need it (#846).
+_INDEXER_ACTOR_PROTOCOL_VERSION = "v8"
 _INDEXER_POOL_DISPATCHER_ACTOR_NAME = f"IndexerPoolDispatcher-{_INDEXER_ACTOR_PROTOCOL_VERSION}"
 
 # Detached actors default to max_restarts=0, so one that dies — an OOM on a

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -41,6 +41,12 @@ _MISSING_WORKER_REF_ERROR = "Indexer worker did not receive a registered task re
 _INDEXER_ACTOR_PROTOCOL_VERSION = "v7"
 _INDEXER_POOL_DISPATCHER_ACTOR_NAME = f"IndexerPoolDispatcher-{_INDEXER_ACTOR_PROTOCOL_VERSION}"
 
+# Detached actors default to max_restarts=0, so one that dies — an OOM on a
+# large document, a node fault — stays dead and its pool slot is lost until the
+# next deploy. Marker and Docling already set 5 on both their pool and their
+# workers; the indexer tier had nothing (#846).
+_ACTOR_MAX_RESTARTS = 5
+
 
 def _explicit_indexation_selection(config: dict[str, Any] | None, key: str) -> str | None:
     """Return a nonblank named resource selected by an indexation preset."""
@@ -576,6 +582,7 @@ class IndexerPool:
                 get_if_exists=True,
                 lifetime="detached",
                 max_concurrency=max_tasks_per_worker,
+                max_restarts=_ACTOR_MAX_RESTARTS,
             ).remote(namespace)
             for i in range(pool_size)
         ]
@@ -834,6 +841,7 @@ def build_indexer_pool(namespace: str = "openrag") -> Any:
         get_if_exists=True,
         lifetime="detached",
         max_concurrency=max(1, pool_size * max_tasks_per_worker),
+        max_restarts=_ACTOR_MAX_RESTARTS,
     ).remote(
         pool_size=pool_size,
         max_tasks_per_worker=max_tasks_per_worker,

--- a/tests/unit/core/indexing/parsers/pdf/test_pymupdf.py
+++ b/tests/unit/core/indexing/parsers/pdf/test_pymupdf.py
@@ -66,3 +66,35 @@ class TestPyMuPDFParserRecovery:
 
         assert [block.text for block in result.text_blocks] == ["hello world"]
         assert result.page_count == 1
+
+
+class TestRecoveryPathResidency:
+    def test_failed_document_is_closed_before_the_cleaned_copy_is_opened(self):
+        """Peak memory on the #640 recovery path (#846).
+
+        The failed document and the cleaned copy used to be open at the same
+        time, so MuPDF held parsed structures for both. Closing the first before
+        opening the second releases one of them. ``raw`` itself belongs to the
+        caller's Document and stays live either way — this is the part the
+        parser can actually control.
+        """
+        raw = _minimal_pdf_bytes()
+        opened: list[pymupdf.Document] = []
+        real_open = pymupdf.open
+        closed_when_second_opened: list[bool] = []
+
+        def tracking_open(*args, **kwargs):
+            if opened:
+                closed_when_second_opened.append(opened[0].is_closed)
+            doc = real_open(*args, **kwargs)
+            opened.append(doc)
+            return doc
+
+        with (
+            patch("core.indexing.parsers.pdf.pymupdf.pymupdf.open", side_effect=tracking_open),
+            patch(_TO_MARKDOWN, side_effect=[RuntimeError("code=4"), [{"text": "ok"}]]),
+        ):
+            pages, _ = _extract_markdown(raw, "broken.pdf")
+
+        assert pages == ["ok"]
+        assert closed_when_second_opened == [True], "the failed document was still open"

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -157,7 +157,7 @@ def test_build_indexer_pool_uses_current_protocol_dispatcher_name(
     opts = options_calls[0]
     # A protocol-specific name prevents a rolling deployment from attaching to
     # a detached actor that still runs the previous claim implementation.
-    assert opts["name"] == "IndexerPoolDispatcher-v7"
+    assert opts["name"] == "IndexerPoolDispatcher-v8"
     assert opts["namespace"] == "openrag"
     assert opts["get_if_exists"] is True
     assert opts["lifetime"] == "detached"
@@ -198,9 +198,9 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
     # One detached worker actor per pool_size slot, each capped at max_tasks_per_worker.
     assert len(pool._workers) == 3
     assert {c["name"] for c in calls} == {
-        "IndexerWorker-v7-0",
-        "IndexerWorker-v7-1",
-        "IndexerWorker-v7-2",
+        "IndexerWorker-v8-0",
+        "IndexerWorker-v8-1",
+        "IndexerWorker-v8-2",
     }
     for c in calls:
         assert c["lifetime"] == "detached"
@@ -1196,7 +1196,7 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work(monkeypatch
     await pool.submit(task_id="accepted-before-drain")
 
     assert await pool.begin_drain() == {
-        "protocol_version": "v7",
+        "protocol_version": "v8",
         "accepting_tasks": False,
         "inflight_jobs": 1,
         "worker_names": ["test-worker-0"],
@@ -1229,7 +1229,7 @@ async def test_pool_drain_rejects_new_work_and_reports_accepted_work(monkeypatch
 
     await _settle_pool_release_tasks(pool, worker.futures[0])
     assert await pool.status() == {
-        "protocol_version": "v7",
+        "protocol_version": "v8",
         "accepting_tasks": False,
         "inflight_jobs": 0,
         "worker_names": ["test-worker-0"],
@@ -1264,7 +1264,7 @@ async def test_pool_abort_drain_restores_acceptance() -> None:
         await pool.submit(task_id="rejected-while-draining")
 
     assert await pool.abort_drain() == {
-        "protocol_version": "v7",
+        "protocol_version": "v8",
         "accepting_tasks": True,
         "inflight_jobs": 0,
         "worker_names": ["test-worker-0"],
@@ -1279,7 +1279,7 @@ async def test_pool_abort_drain_restores_acceptance() -> None:
 async def test_pool_reports_current_protocol_version() -> None:
     pool = _bare_pool([_FakeWorker()])
 
-    assert await pool.protocol_version() == "v7"
+    assert await pool.protocol_version() == "v8"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/workers/test_indexer_pool.py
+++ b/tests/unit/services/workers/test_indexer_pool.py
@@ -163,6 +163,9 @@ def test_build_indexer_pool_uses_current_protocol_dispatcher_name(
     assert opts["lifetime"] == "detached"
     # max_concurrency bounds concurrent submit() calls → whole-fleet capacity.
     assert opts["max_concurrency"] == 12
+    # Detached actors default to max_restarts=0: without this the dispatcher
+    # stays dead after a crash until the next deploy (#846).
+    assert opts["max_restarts"] == 5
     # pool_size / max_tasks_per_worker are passed to the actor constructor.
     assert remote_calls == [{"pool_size": 3, "max_tasks_per_worker": 4, "namespace": "openrag"}]
 
@@ -202,6 +205,7 @@ def test_indexer_pool_actor_spawns_pool_size_detached_workers(
     for c in calls:
         assert c["lifetime"] == "detached"
         assert c["max_concurrency"] == 4
+        assert c["max_restarts"] == 5  # a worker that OOMs must come back (#846)
         assert c["get_if_exists"] is True
         assert c["namespace"] == "tenant-ray"
     assert remote_calls == ["tenant-ray", "tenant-ray", "tenant-ray"]


### PR DESCRIPTION
Two of the three parts of #846. The third is not what the issue thought, so this is `Refs`, not `Closes`.

**The #640 recovery path held two documents open.** The cleaned copy was opened while the failed one was still open, so MuPDF kept parsed structures for both. The failed document is now closed first.

The obvious one-line version of this — `doc.close()` inside the `except` — does not work: PyMuPDF's `close()` is not idempotent, so the enclosing `with` then raises `ValueError: document closed` on exit, turning a rare parse failure into a guaranteed one. Hence the early return. The cost is a duplicated two-line tail; a helper or a sentinel flag would remove it and both read worse.

**Detached actors default to `max_restarts=0`.** An indexer worker or the dispatcher that died — an OOM on a large document, a node fault — stayed dead and its pool slot was lost until the next deploy. Marker and Docling already set 5 on both tiers. `IndexerWorkerActor.__init__` is safe to re-run: it builds an embedder and looks up `TaskStateManager`, with catalog init deferred, so no registration or claim side effects repeat.

### Not fixed, deliberately

**The issue's headline — "the default PDF parser holds the whole document in memory" — is misattributed.** `indexer_actor.py` reads every file with `read_bytes` before any parser runs and hands the parser `document.raw_bytes` directly. The bytes are already resident; opening PyMuPDF from a path would not lower peak memory while that stands, and freeing `raw` inside the parser is impossible because the `Document` owns it. Making parsers path-based is an architectural change across the whole stack and belongs in its own issue, next to #663.

Routing large PDFs to Marker/Docling by size threshold would add a config surface and a GPU dependency to solve a memory problem. `doc_parser.py`'s `read_bytes` of the converted `.docx` is the same class, but its contract returns bytes to its caller, so changing it is a contract change rather than a one-liner.

Two further corrections for anyone reading the issue against the code: its line numbers are from v2.1.0 and have all moved, and it states Marker/Docling set `max_restarts` on their workers via decorators — they set it on the pools via decorators and on the workers via `.options()`.

### Known limitation

`max_restarts` restores the actor, not the work. A file being indexed when a worker dies is still lost; the restart means the pool slot returns instead of staying dead until redeploy.

### Verification

2907 unit tests, `ruff check`, `ruff format --check` and `check_layer_imports.py` clean. The residency test is mutation-checked — it fails against the previous code and passes against this one — and the four existing #640 fallback tests are untouched and still pass.

Refs #846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF processing recovery by releasing failed document resources before retrying, reducing memory pressure during fallback processing.
  - Indexing workers and the dispatcher now automatically restart after crashes or out-of-memory failures, helping prevent interrupted indexing jobs.
  - Improved indexing service resilience during worker and dispatcher failures, allowing processing to resume more reliably without manual intervention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->