### PR TITLE
fix(api): preserve Milvus error status and details

### DIFF
--- a/openrag/core/chunking/chunking_strategy.py
+++ b/openrag/core/chunking/chunking_strategy.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from openrag.core.models.chunk import Chunk
-from openrag.core.models.document import ProcessedDocument
+from core.models.chunk import Chunk
+from core.models.document import ProcessedDocument
 
 
 class ChunkingStrategy(ABC):

--- a/openrag/core/chunking/registry.py
+++ b/openrag/core/chunking/registry.py
@@ -1,6 +1,6 @@
 """Chunking strategy registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .chunking_strategy import ChunkingStrategy
 

--- a/openrag/core/embeddings/registry.py
+++ b/openrag/core/embeddings/registry.py
@@ -1,6 +1,6 @@
 """Embedder registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .embedder import Embedder
 

--- a/openrag/core/indexing/parsers/registry.py
+++ b/openrag/core/indexing/parsers/registry.py
@@ -1,6 +1,6 @@
 """Document parser registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .document_parser import DocumentParser
 

--- a/openrag/core/llm/registry.py
+++ b/openrag/core/llm/registry.py
@@ -1,6 +1,6 @@
 """LLM registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .llm import LLM
 

--- a/openrag/core/ports/conversation_repo.py
+++ b/openrag/core/ports/conversation_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from openrag.core.models.conversation import Conversation, Message
+from core.models.conversation import Conversation, Message
 
 
 class ConversationRepository(ABC):

--- a/openrag/core/ports/document_repo.py
+++ b/openrag/core/ports/document_repo.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from openrag.core.models.catalog import DocumentRecord
+from core.models.catalog import DocumentRecord
 
 
 @dataclass(frozen=True, slots=True)

--- a/openrag/core/ports/job_repo.py
+++ b/openrag/core/ports/job_repo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from openrag.core.models.catalog import IndexationJob
+from core.models.catalog import IndexationJob
 
 
 class JobRepository(ABC):

--- a/openrag/core/ports/oidc_session_repo.py
+++ b/openrag/core/ports/oidc_session_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from openrag.core.models.user import OIDCSession
+from core.models.user import OIDCSession
 
 
 class OIDCSessionRepository(ABC):

--- a/openrag/core/ports/partition_membership_repo.py
+++ b/openrag/core/ports/partition_membership_repo.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from openrag.core.models.user import PartitionRole, UserPartition
+from core.models.user import PartitionRole, UserPartition
 
 
 class PartitionMembershipRepository(ABC):

--- a/openrag/core/ports/user_repo.py
+++ b/openrag/core/ports/user_repo.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from openrag.core.models.user import ApiKey, User
+from core.models.user import ApiKey, User
 
 
 class UserRepository(ABC):

--- a/openrag/core/ports/workspace_repo.py
+++ b/openrag/core/ports/workspace_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from openrag.core.models.workspace import Workspace
+from core.models.workspace import Workspace
 
 
 class WorkspaceRepository(ABC):

--- a/openrag/core/rerankers/registry.py
+++ b/openrag/core/rerankers/registry.py
@@ -1,6 +1,6 @@
 """Reranker registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .reranker import Reranker
 

--- a/openrag/core/vector_stores/vector_store.py
+++ b/openrag/core/vector_stores/vector_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from openrag.core.models.chunk import Chunk
+from core.models.chunk import Chunk
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/openrag/core/vlm/registry.py
+++ b/openrag/core/vlm/registry.py
@@ -1,6 +1,6 @@
 """VLM registry."""
 
-from openrag.core.utils.registry import Registry
+from core.utils.registry import Registry
 
 from .vlm import VLM
 

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -282,10 +282,17 @@ class MilvusVectorStore(VectorStore):
                 operation="wait_for_indexes",
             )
 
-        description = self._client.describe_collection(
-            self._collection_name,
-            timeout=remaining,
-        )
+        try:
+            description = self._client.describe_collection(
+                self._collection_name,
+                timeout=remaining,
+            )
+        except MilvusException as e:
+            raise VDBCreateOrLoadCollectionError(
+                f"Failed to inspect collection `{self._collection_name}`: {e!s}",
+                collection_name=self._collection_name,
+                operation="describe_collection",
+            ) from e
         fields = {field.get("name") for field in description.get("fields", [])}
 
         if self._hybrid and "sparse" not in fields:

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -40,7 +40,19 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from core.config.infrastructure import VectorDBConfig
+from core.models.chunk import Chunk
+from core.utils.exceptions import (
+    UnexpectedVDBError,
+    VDBConnectionError,
+    VDBCreateOrLoadCollectionError,
+    VDBDeleteError,
+    VDBInsertError,
+    VDBSchemaMigrationRequiredError,
+    VDBSearchError,
+)
 from core.utils.logging import get_logger
+from core.vector_stores import VectorStore
 from pymilvus import (
     AnnSearchRequest,
     AsyncMilvusClient,
@@ -51,19 +63,6 @@ from pymilvus import (
     MilvusException,
     RRFRanker,
 )
-
-from openrag.core.config.infrastructure import VectorDBConfig
-from openrag.core.models.chunk import Chunk
-from openrag.core.utils.exceptions import (
-    UnexpectedVDBError,
-    VDBConnectionError,
-    VDBCreateOrLoadCollectionError,
-    VDBDeleteError,
-    VDBInsertError,
-    VDBSchemaMigrationRequiredError,
-    VDBSearchError,
-)
-from openrag.core.vector_stores import VectorStore
 
 logger = get_logger()
 

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -473,7 +473,14 @@ class MilvusVectorStore(VectorStore):
         ``timeout`` overrides the client default for callers that must not
         block, such as the construction-time probe.
         """
-        desc = self._client.describe_collection(self._collection_name, timeout=timeout)
+        try:
+            desc = self._client.describe_collection(self._collection_name, timeout=timeout)
+        except MilvusException as e:
+            raise VDBCreateOrLoadCollectionError(
+                f"Failed to inspect collection `{self._collection_name}`: {e!s}",
+                collection_name=self._collection_name,
+                operation="describe_collection",
+            ) from e
         raw = desc.get("properties", {}).get(SCHEMA_VERSION_PROPERTY_KEY)
         try:
             return int(raw) if raw is not None else 0

--- a/openrag/services/workers/indexer_pool.py
+++ b/openrag/services/workers/indexer_pool.py
@@ -10,13 +10,12 @@ from typing import Any
 
 import ray
 from core.config.model_endpoints import CONTROL_EXTRA_KEYS
+from core.config.root import Settings
 from core.models.catalog import CONTENT_CLAIM_TOKEN_METADATA_KEY
 from core.utils.exceptions import NotFoundError
 from services.workers.indexer_actor import IndexerWorker, _display_filename, delete_uploaded_file
 from services.workers.indexing_callback import send_indexing_callback
 from services.workers.ray_utils import retry_idempotent_ray_actor_method
-
-from openrag.core.config.root import Settings
 
 # The indexer reloads the DB-backed model-endpoint registry at most once per
 # this window (and on a miss), bounding both staleness and DB load regardless

--- a/scripts/check_layer_imports.py
+++ b/scripts/check_layer_imports.py
@@ -12,6 +12,9 @@ Only files inside openrag/{core,services,api,di}/ are checked. Legacy
 paths (openrag/components/, openrag/routers/, openrag/models/, ...) are
 ignored until they are migrated.
 
+Absolute application imports must use the bare layer root, not ``openrag.``:
+mixing the two loads distinct copies of classes such as exception types.
+
 Usage:
     python scripts/check_layer_imports.py
 
@@ -103,6 +106,10 @@ def check_file(path: Path) -> list[str]:
             dotted = resolve_relative(path, level, module)
         else:
             dotted = entry
+            if dotted == "openrag" or dotted.startswith("openrag."):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{lineno}  use the bare import root, not {dotted} (#885)")
+                continue
         tgt_layer = layer_of(dotted)
         if tgt_layer is None or tgt_layer == src_layer:
             continue

--- a/tests/integration/repos/test_milvus_store_integration.py
+++ b/tests/integration/repos/test_milvus_store_integration.py
@@ -26,10 +26,9 @@ import uuid
 from collections.abc import Iterator
 
 import pytest
-
-from openrag.core.config.infrastructure import VectorDBConfig
-from openrag.core.models.chunk import Chunk, ChunkType
-from openrag.services.storage.milvus_store import MilvusVectorStore, analyzer_params
+from core.config.infrastructure import VectorDBConfig
+from core.models.chunk import Chunk, ChunkType
+from services.storage.milvus_store import MilvusVectorStore, analyzer_params
 
 pytestmark = pytest.mark.integration
 
@@ -236,7 +235,7 @@ class TestEndToEnd:
     async def test_upsert_without_embedding_raises(self, hybrid_store: MilvusVectorStore) -> None:
         await hybrid_store.initialize(_EMBEDDING_DIM)
         bad = Chunk(text="missing", partition="p1", embedding=None)
-        from openrag.core.utils.exceptions import VDBInsertError
+        from core.utils.exceptions import VDBInsertError
 
         with pytest.raises(VDBInsertError, match="no embedding"):
             await hybrid_store.upsert([bad])

--- a/tests/unit/core/prompts/test_chat_prompt_builder.py
+++ b/tests/unit/core/prompts/test_chat_prompt_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from openrag.core.prompts.chat_prompt_builder import (
+from core.prompts.chat_prompt_builder import (
     EMPTY_CONTEXT_MESSAGE,
     SOURCE_SEPARATOR,
     format_context,

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -16,16 +16,37 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from api.error_handlers import register_error_handlers
+from core.config.infrastructure import VectorDBConfig
+from core.models.chunk import Chunk, ChunkType
+from core.utils.exceptions import VDBSchemaMigrationRequiredError, VDBSearchError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pymilvus import MilvusException
-
-from openrag.core.config.infrastructure import VectorDBConfig
-from openrag.core.models.chunk import Chunk, ChunkType
-from openrag.core.utils.exceptions import VDBSchemaMigrationRequiredError, VDBSearchError
-from openrag.services.storage.milvus_store import MilvusVectorStore, analyzer_params
+from services.storage.milvus_store import MilvusVectorStore, analyzer_params
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+def test_milvus_search_error_keeps_its_http_status_and_details(store: MilvusVectorStore) -> None:
+    """Mixed import roots must not turn a storage error into UNEXPECTED_ERROR (#885)."""
+    store._async_client.hybrid_search = AsyncMock(side_effect=MilvusException(1, "search unavailable"))
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/search")
+    async def search():
+        return await store.search([0.1, 0.2], query_text="test")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/search")
+
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("[VDB_SEARCH_ERROR]: Milvus hybrid search failed:")
+    assert "search unavailable" in response.json()["detail"]
+    assert response.json()["extra"] == {"collection_name": "test_collection"}
 
 
 @pytest.fixture
@@ -50,14 +71,9 @@ def store(vdb_config: VectorDBConfig, monkeypatch: pytest.MonkeyPatch) -> Milvus
     Use this for pure-logic tests. Methods that drive the client (``upsert``,
     ``search``, ...) will hit the mocks; assert on mock calls if you must.
 
-    We monkeypatch the symbols directly inside the loaded module rather than
-    using ``unittest.mock.patch`` because the project's pythonpath setup
-    (``pythonpath = ./openrag`` plus the ``openrag`` package itself on
-    sys.path) lets the same source file get registered under two different
-    module names depending on the import form, which makes string-based
-    patch paths fragile.
+    Patch the clients in the same module used by production callers.
     """
-    import openrag.services.storage.milvus_store as _store_mod
+    import services.storage.milvus_store as _store_mod
 
     monkeypatch.setattr(_store_mod, "MilvusClient", MagicMock())
     monkeypatch.setattr(_store_mod, "AsyncMilvusClient", MagicMock())
@@ -543,7 +559,7 @@ class TestHybridDispatch:
         the dense path — the collection has no ``sparse`` field, so the BM25
         leg must never be reached.
         """
-        import openrag.services.storage.milvus_store as _store_mod
+        import services.storage.milvus_store as _store_mod
 
         monkeypatch.setattr(_store_mod, "MilvusClient", MagicMock())
         monkeypatch.setattr(_store_mod, "AsyncMilvusClient", MagicMock())
@@ -572,7 +588,7 @@ class TestHybridDispatch:
         self, store: MilvusVectorStore, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         logger = MagicMock()
-        monkeypatch.setattr("openrag.services.storage.milvus_store.logger", logger)
+        monkeypatch.setattr("services.storage.milvus_store.logger", logger)
         store._async_client.hybrid_search = AsyncMock(  # type: ignore[attr-defined]
             side_effect=MilvusException(5, "service internal error: unsupported ID type")
         )
@@ -599,7 +615,7 @@ class TestHybridDispatch:
         self, store: MilvusVectorStore, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         logger = MagicMock()
-        monkeypatch.setattr("openrag.services.storage.milvus_store.logger", logger)
+        monkeypatch.setattr("services.storage.milvus_store.logger", logger)
         store._async_client.hybrid_search = AsyncMock(  # type: ignore[attr-defined]
             side_effect=MilvusException(100, "collection not found[database=default][collection=test_collection]")
         )
@@ -794,7 +810,7 @@ class _LogRecorder:
 
 @pytest.fixture
 def logs(monkeypatch: pytest.MonkeyPatch) -> _LogRecorder:
-    import openrag.services.storage.milvus_store as _store_mod
+    import services.storage.milvus_store as _store_mod
 
     recorder = _LogRecorder()
     monkeypatch.setattr(_store_mod, "logger", recorder)
@@ -846,7 +862,7 @@ class TestWarnIfMigrationPending:
     def test_the_probe_cannot_block_construction(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
         # A slow metadata RPC must not hold up building the store, so the probe
         # carries its own short timeout rather than the client's (120s default).
-        import openrag.services.storage.milvus_store as _store_mod
+        import services.storage.milvus_store as _store_mod
 
         _describes(store, "1")
 

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -893,6 +893,17 @@ class TestWarnIfMigrationPending:
 
 
 class TestCheckSchemaVersion:
+    def test_describe_failure_preserves_lifecycle_error(self, store: MilvusVectorStore) -> None:
+        inspection_error = MilvusException(message="schema inspection unavailable")
+        store._client.describe_collection.side_effect = inspection_error
+
+        with pytest.raises(VDBCreateOrLoadCollectionError, match="schema inspection unavailable") as error:
+            store._check_schema_version()
+
+        assert error.value.__cause__ is inspection_error
+        assert error.value.extra["operation"] == "describe_collection"
+        assert error.value.extra["collection_name"] == store._collection_name
+
     def test_logs_the_mismatch_before_raising(self, store: MilvusVectorStore, logs: _LogRecorder) -> None:
         # The exception reaches the API caller; the log line carries the fix.
         _describes(store, None)

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -911,6 +911,25 @@ class TestCheckSchemaVersion:
 
 
 class TestEnsureLoadedConcurrentCreation:
+    @pytest.mark.parametrize("collection_exists", [False, True])
+    def test_schema_inspection_failure_preserves_lifecycle_error(
+        self, store: MilvusVectorStore, collection_exists: bool
+    ) -> None:
+        store._embedding_dimension = 8
+        store._client.has_collection.return_value = collection_exists
+        inspection_error = MilvusException(message="schema inspection unavailable")
+        responses = [{"properties": {SCHEMA_VERSION_PROPERTY_KEY: "1"}}] if collection_exists else []
+        store._client.describe_collection.side_effect = [*responses, inspection_error]
+
+        with pytest.raises(VDBCreateOrLoadCollectionError, match="schema inspection unavailable") as error:
+            store._ensure_loaded()
+
+        assert error.value.__cause__ is inspection_error
+        assert error.value.extra["operation"] == "describe_collection"
+        assert error.value.extra["collection_name"] == store._collection_name
+        store._client.list_indexes.assert_not_called()
+        store._client.load_collection.assert_not_called()
+
     def test_hybrid_collection_without_sparse_field_fails_immediately(
         self,
         store: MilvusVectorStore,

--- a/tests/unit/services/storage/test_vector_store_searcher.py
+++ b/tests/unit/services/storage/test_vector_store_searcher.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-from openrag.services.storage.vector_store_searcher import VectorStoreSearcher, _dict_to_chunk
+from services.storage.vector_store_searcher import VectorStoreSearcher, _dict_to_chunk
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_layer_imports.py
+++ b/tests/unit/test_layer_imports.py
@@ -1,0 +1,25 @@
+"""Keep application modules from loading under two import roots."""
+
+import pytest
+
+from scripts import check_layer_imports as guard
+
+
+@pytest.mark.parametrize(
+    ("source", "rejected"),
+    [
+        ("from openrag.core.utils.exceptions import OpenRAGError", True),
+        ("import openrag.core.utils.exceptions", True),
+        ("from openrag import core", True),
+        ("from core.utils.exceptions import OpenRAGError", False),
+        ("from .exceptions import OpenRAGError", False),
+    ],
+)
+def test_canonical_import_root(tmp_path, monkeypatch, source, rejected):
+    monkeypatch.setattr(guard, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(guard, "OPENRAG", tmp_path / "openrag")
+    path = tmp_path / "openrag/core/utils/example.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(source)
+
+    assert bool(guard.check_file(path)) is rejected

--- a/tests/unit/test_layer_imports.py
+++ b/tests/unit/test_layer_imports.py
@@ -1,8 +1,15 @@
 """Keep application modules from loading under two import roots."""
 
+import importlib.util
+from pathlib import Path
+
 import pytest
 
-from scripts import check_layer_imports as guard
+spec = importlib.util.spec_from_file_location(
+    "check_layer_imports", Path(__file__).resolve().parents[2] / "scripts/check_layer_imports.py"
+)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Milvus search errors were reaching clients as generic 500 responses because mixed import roots loaded separate copies of the exception classes. This uses the existing import convention consistently so the API preserves the intended status and error details, and extends the import guard to prevent a recurrence.

The regression test reproduced the 500 before the fix and now receives 422 with the original error details. All 2,930 unit tests pass, along with lint, formatting, and the import guard.

Closes #885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized internal module references across application services, storage integrations, workers, and tests.
  - Broadened import validation to cover project utilities and test areas.

- **Bug Fixes**
  - Improved handling of collection-inspection failures, including clearer error details and consistent error reporting.

- **Tests**
  - Expanded coverage for import rules, layer boundaries, storage errors, and collection-loading scenarios.

- **User Impact**
  - No intentional changes to core functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->