### PR TITLE
fix(health): check dependencies before marking the API ready

### DIFF
--- a/docs/content/docs/documentation/kubernetes.md
+++ b/docs/content/docs/documentation/kubernetes.md
@@ -73,6 +73,14 @@ one before upgrading:
 
 ## Notes
 
+Startup and readiness probes use `/ready`; liveness uses `/health_check`.
+Readiness returns 503 when startup is incomplete or PostgreSQL, Milvus, Ray,
+the default chat or embedding model, or the enabled default reranker is unavailable.
+Checks use short timeouts and results are cached for two seconds. Optional VLM/STT
+and partition-specific model endpoints do not gate the whole API. Model probes
+check availability without running inference; they do not guarantee every request
+will succeed. Use an application image that includes `/ready` with these probes.
+
 - If using a public IP instead of a hostname, you can leave `ingress.host` empty in your `values.yaml`.  
   The ingress will then match all hosts.
 

--- a/docs/content/docs/documentation/kubernetes.md
+++ b/docs/content/docs/documentation/kubernetes.md
@@ -73,13 +73,20 @@ one before upgrading:
 
 ## Notes
 
-Startup and readiness probes use `/ready`; liveness uses `/health_check`.
+For the default direct-API deployment, startup and readiness probes use `/ready`;
+liveness uses `/health_check`. When `ENABLE_RAY_SERVE=true`, override the HTTP
+probes with exec probes as noted in the chart values: the Ray Serve HTTP proxy
+runs on the Ray head, not on the API pod.
 Readiness returns 503 when startup is incomplete or PostgreSQL, Milvus, Ray,
 the default chat or embedding model, or the enabled default reranker is unavailable.
 Checks use short timeouts and results are cached for two seconds. Optional VLM/STT
 and partition-specific model endpoints do not gate the whole API. Model probes
 check availability without running inference; they do not guarantee every request
 will succeed. Use an application image that includes `/ready` with these probes.
+
+Readiness uses the configured model endpoints and API keys, just like inference.
+HTTP endpoints do not encrypt those credentials; configure HTTPS when transport
+encryption is required.
 
 - If using a public IP instead of a hostname, you can leave `ingress.host` empty in your `values.yaml`.  
   The ingress will then match all hosts.

--- a/docs/content/docs/documentation/kubernetes.md
+++ b/docs/content/docs/documentation/kubernetes.md
@@ -73,16 +73,18 @@ one before upgrading:
 
 ## Notes
 
-For the default direct-API deployment, startup and readiness probes use `/ready`;
-liveness uses `/health_check`. When `ENABLE_RAY_SERVE=true`, override the HTTP
+For the default direct-API deployment, startup and liveness probes use
+`/health_check`, while the readiness probe uses `/ready`. When
+`ENABLE_RAY_SERVE=true`, override the HTTP
 probes with exec probes as noted in the chart values: the Ray Serve HTTP proxy
 runs on the Ray head, not on the API pod.
-Readiness returns 503 when startup is incomplete or PostgreSQL, Milvus, Ray,
-the default chat or embedding model, or the enabled default reranker is unavailable.
-Checks use short timeouts and results are cached for two seconds. Optional VLM/STT
-and partition-specific model endpoints do not gate the whole API. Model probes
-check availability without running inference; they do not guarantee every request
-will succeed. Use an application image that includes `/ready` with these probes.
+Readiness returns 503 when startup is incomplete or PostgreSQL, Milvus, or Ray is
+unavailable. Model checks are reported in the response but do not gate the whole
+API, so optional VLM/STT and partition-specific model endpoints do not remove
+healthy replicas from service. Checks use short timeouts and results are cached
+for two seconds. Model probes check availability without running inference; they
+do not guarantee every request will succeed. Use an application image that
+includes `/ready` with these probes.
 
 Readiness uses the configured model endpoints and API keys, just like inference.
 HTTP endpoints do not encrypt those credentials; configure HTTPS when transport

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -529,7 +529,7 @@ openrag:
   probes:
     startup:
       httpGet:
-        path: /ready
+        path: /health_check
         port: openrag
       timeoutSeconds: 5
       failureThreshold: 30

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -529,14 +529,16 @@ openrag:
   probes:
     startup:
       httpGet:
-        path: /health_check
+        path: /ready
         port: openrag
+      timeoutSeconds: 5
       failureThreshold: 30
       periodSeconds: 10
     readiness:
       httpGet:
-        path: /health_check
+        path: /ready
         port: openrag
+      timeoutSeconds: 5
       initialDelaySeconds: 10
       periodSeconds: 10
       failureThreshold: 3

--- a/openrag/api/middleware/instrumentation.py
+++ b/openrag/api/middleware/instrumentation.py
@@ -16,7 +16,7 @@ from starlette.routing import Match, Mount
 
 # Paths to exclude from metric recording — avoids self-referential noise
 # and inflated counters on probe traffic.
-_EXCLUDED_PREFIXES = ("/metrics", "/health_check", "/docs", "/openapi.json", "/redoc")
+_EXCLUDED_PREFIXES = ("/metrics", "/health_check", "/ready", "/docs", "/openapi.json", "/redoc")
 
 # Label for a URL no route in the app can serve. A *fixed* string is the whole
 # point: the endpoint label must stay bounded, or a scanner walking 10k random

--- a/openrag/api/middleware/rate_limit.py
+++ b/openrag/api/middleware/rate_limit.py
@@ -134,6 +134,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         path = request.url.path
 
+        if path in {"/health_check", "/ready"}:
+            return await call_next(request)
+
         # Exempt prefixes are checked before the admin bypass on purpose: these
         # paths never run through AuthMiddleware, so request.state.user is unset
         # and _is_admin() is False even for an admin's browser session.

--- a/openrag/api/routers/admin/model_endpoints.py
+++ b/openrag/api/routers/admin/model_endpoints.py
@@ -252,7 +252,7 @@ async def validate_endpoint_draft(
         model_name=body.model_name,
         api_key=api_key,
         timeout=body.timeout,
-        extra=body.extra if body.model_type == "stt" else None,
+        extra=body.extra or None,
     )
 
 
@@ -264,11 +264,16 @@ async def validate_model_endpoint(
 ):
     """Probe a registered endpoint for reachability and model capabilities."""
     endpoint = await service.get_model_endpoint(name=name, model_type=model_type)
+    validation_extra = (
+        endpoint.extra
+        if model_type == "stt"
+        else {key: value for key, value in endpoint.extra.items() if key != "api_key"}
+    )
     return await service.validate_endpoint(
         url=endpoint.endpoint,
         model_type=model_type,
         model_name=endpoint.model_name,
         api_key=endpoint.extra.get("api_key"),
         timeout=endpoint.timeout,
-        extra=endpoint.extra if model_type == "stt" else None,
+        extra=validation_extra or None,
     )

--- a/openrag/api/routers/user/health.py
+++ b/openrag/api/routers/user/health.py
@@ -1,28 +1,29 @@
-"""Health / version endpoints (Phase 10F move).
-
-Lifts the inline ``/health_check`` and ``/version`` routes out of
-``openrag/api/main.py`` per the Phase 10A plan ("Inline health endpoint
-(3 lines) -> Dedicated api/routers/user/health.py"). Both routes are
-unauthenticated (``AuthMiddleware`` bypasses them via the bypass list)
-so they can be hit by load balancers, kubernetes probes, and ``curl``
-without a token.
-
-The actual ``app.version`` value is set in ``api/main.py`` and read off
-``request.app.version`` at call time so this router does not need its
-own access to ``importlib.metadata``.
-"""
+"""Public liveness, dependency readiness, and version endpoints."""
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
 
 router = APIRouter()
 
 
 @router.get("/health_check", summary="Health check endpoint for API", dependencies=[])
 async def health_check(request: Request) -> str:
-    # TODO: Error reporting about llm and vlm.
     return "RAG API is up."
+
+
+@router.get("/ready", summary="Dependency readiness", dependencies=[])
+async def ready(request: Request) -> JSONResponse:
+    container = getattr(request.app.state, "container", None)
+    if container is None or not container.is_initialized:
+        return JSONResponse({"status": "not_ready", "checks": {"startup": "unavailable"}}, status_code=503)
+    checks = await container.readiness_service.check()
+    is_ready = all(value == "ok" for value in checks.values())
+    return JSONResponse(
+        {"status": "ready" if is_ready else "not_ready", "checks": checks},
+        status_code=200 if is_ready else 503,
+    )
 
 
 @router.get("/version", summary="Get openRAG version", dependencies=[])

--- a/openrag/api/routers/user/health.py
+++ b/openrag/api/routers/user/health.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+_CORE_READINESS_CHECKS = frozenset({"postgres", "milvus", "ray"})
 
 
 @router.get("/health_check", summary="Health check endpoint for API", dependencies=[])
@@ -19,7 +20,8 @@ async def ready(request: Request) -> JSONResponse:
     if container is None or not container.is_initialized:
         return JSONResponse({"status": "not_ready", "checks": {"startup": "unavailable"}}, status_code=503)
     checks = await container.readiness_service.check()
-    is_ready = all(value == "ok" for value in checks.values())
+    required_checks = _CORE_READINESS_CHECKS.intersection(checks)
+    is_ready = bool(required_checks) and all(checks[name] == "ok" for name in required_checks)
     return JSONResponse(
         {"status": "ready" if is_ready else "not_ready", "checks": checks},
         status_code=200 if is_ready else 503,

--- a/openrag/core/config/auth.py
+++ b/openrag/core/config/auth.py
@@ -244,6 +244,7 @@ DEFAULT_BYPASS_PATHS: tuple[str, ...] = (
     "/openapi.json",
     "/redoc",
     "/health_check",
+    "/ready",
     "/version",
     "/auth/login",
     "/auth/callback",

--- a/openrag/core/config/model_endpoints.py
+++ b/openrag/core/config/model_endpoints.py
@@ -9,6 +9,13 @@ from core.config.base import ConfigMixin
 from pydantic import BaseModel, Field
 
 ModelEndpointType = Literal["embedder", "reranker", "llm", "vlm", "stt"]
+DEFAULT_MODEL_IMPLEMENTATIONS = {
+    "embedder": "vllm",
+    "llm": "vllm",
+    "vlm": "vllm",
+    "reranker": "infinity",
+    "stt": "vllm",
+}
 
 
 class ModelEndpointConfig(BaseModel):

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -25,6 +25,7 @@ from collections.abc import Awaitable, Callable
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from core.config.model_endpoints import DEFAULT_MODEL_IMPLEMENTATIONS
 from core.embeddings import embedder_registry
 from core.llm import llm_registry
 from core.rerankers import reranker_registry
@@ -180,26 +181,26 @@ class ServiceContainer:
         self.embedder_factory, self._embedder_cache = make_component_factory(
             registry=embedder_registry,
             config_section=models.embedder,
-            default_impl="vllm",
+            default_impl=DEFAULT_MODEL_IMPLEMENTATIONS["embedder"],
             client_caches=self._client_caches,
             extra_kwargs_fn=_embedder_extra_kwargs,
         )
         self.reranker_factory, self._reranker_cache = make_component_factory(
             registry=reranker_registry,
             config_section=models.reranker,
-            default_impl="infinity",
+            default_impl=DEFAULT_MODEL_IMPLEMENTATIONS["reranker"],
             client_caches=self._client_caches,
         )
         self.llm_factory, self._llm_cache = make_component_factory(
             registry=llm_registry,
             config_section=models.llm,
-            default_impl="vllm",
+            default_impl=DEFAULT_MODEL_IMPLEMENTATIONS["llm"],
             client_caches=self._client_caches,
         )
         self.vlm_factory, self._vlm_cache = make_component_factory(
             registry=vlm_registry,
             config_section=models.vlm,
-            default_impl="vllm",
+            default_impl=DEFAULT_MODEL_IMPLEMENTATIONS["vlm"],
             client_caches=self._client_caches,
         )
 

--- a/openrag/di/container.py
+++ b/openrag/di/container.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Awaitable, Callable
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from core.embeddings import embedder_registry
@@ -82,6 +83,12 @@ _NO_SETTINGS_MESSAGE = (
 
 class ServiceContainer:
     """Populates registries and provides typed factory access."""
+
+    @cached_property
+    def readiness_service(self):
+        from di.readiness import create_readiness_service
+
+        return create_readiness_service(self)
 
     def __init__(self, settings: Settings | None = None) -> None:
         register_embedders()

--- a/openrag/di/readiness.py
+++ b/openrag/di/readiness.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from typing import TYPE_CHECKING, cast
 
@@ -13,19 +15,46 @@ from services.storage.postgres_store import PostgresStore
 from services.workers.ray_utils import call_ray_actor_method_with_timeout
 
 _ray_actor = None
+_ray_actor_lookup: Future | None = None
+_ray_actor_lookup_lock = threading.Lock()
+_ray_actor_lookup_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="readiness-ray-lookup")
 
 if TYPE_CHECKING:
     from di.container import ServiceContainer
 
 
+async def _lookup_ray_actor():
+    global _ray_actor_lookup
+    with _ray_actor_lookup_lock:
+        lookup = _ray_actor_lookup
+        if lookup is None:
+            lookup = _ray_actor_lookup_executor.submit(ray.get_actor, "TaskStateManager", namespace="openrag")
+            _ray_actor_lookup = lookup
+    try:
+        actor = await asyncio.shield(asyncio.wrap_future(lookup))
+    except asyncio.CancelledError:
+        raise
+    except BaseException:
+        with _ray_actor_lookup_lock:
+            if _ray_actor_lookup is lookup:
+                _ray_actor_lookup = None
+        raise
+    with _ray_actor_lookup_lock:
+        if _ray_actor_lookup is lookup:
+            _ray_actor_lookup = None
+    return actor
+
+
 async def _check_ray() -> None:
-    global _ray_actor
+    global _ray_actor, _ray_actor_lookup
     if not ray.is_initialized():
         _ray_actor = None
+        with _ray_actor_lookup_lock:
+            _ray_actor_lookup = None
         raise RuntimeError("Ray is not initialized")
+    if _ray_actor is None:
+        _ray_actor = await _lookup_ray_actor()
     try:
-        if _ray_actor is None:
-            _ray_actor = await asyncio.to_thread(ray.get_actor, "TaskStateManager", namespace="openrag")
         await call_ray_actor_method_with_timeout(
             _ray_actor.get_pool_info.remote, timeout=1.0, task_description="readiness"
         )

--- a/openrag/di/readiness.py
+++ b/openrag/di/readiness.py
@@ -12,15 +12,26 @@ from services.storage.milvus_store import MilvusVectorStore
 from services.storage.postgres_store import PostgresStore
 from services.workers.ray_utils import call_ray_actor_method_with_timeout
 
+_ray_actor = None
+
 if TYPE_CHECKING:
     from di.container import ServiceContainer
 
 
 async def _check_ray() -> None:
+    global _ray_actor
     if not ray.is_initialized():
+        _ray_actor = None
         raise RuntimeError("Ray is not initialized")
-    actor = await asyncio.to_thread(ray.get_actor, "TaskStateManager", namespace="openrag")
-    await call_ray_actor_method_with_timeout(actor.get_pool_info.remote, timeout=1.0, task_description="readiness")
+    try:
+        if _ray_actor is None:
+            _ray_actor = await asyncio.to_thread(ray.get_actor, "TaskStateManager", namespace="openrag")
+        await call_ray_actor_method_with_timeout(
+            _ray_actor.get_pool_info.remote, timeout=1.0, task_description="readiness"
+        )
+    except BaseException:
+        _ray_actor = None
+        raise
 
 
 def create_readiness_service(container: ServiceContainer) -> ReadinessService:
@@ -31,7 +42,7 @@ def create_readiness_service(container: ServiceContainer) -> ReadinessService:
         config = getattr(settings.models, kind).get("default")
         if config is None:
             raise RuntimeError("Default model endpoint is not configured")
-        await check_model_endpoint(config)
+        await check_model_endpoint(config, model_type=kind)
 
     checks = {
         "postgres": cast(PostgresStore, container.catalog_store).check_health,

--- a/openrag/di/readiness.py
+++ b/openrag/di/readiness.py
@@ -1,0 +1,45 @@
+"""Wire readiness to the same stores and model configuration as API requests."""
+
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+from typing import TYPE_CHECKING, cast
+
+import ray
+from services.orchestrators.readiness_service import ReadinessService, check_model_endpoint
+from services.storage.milvus_store import MilvusVectorStore
+from services.storage.postgres_store import PostgresStore
+from services.workers.ray_utils import call_ray_actor_method_with_timeout
+
+if TYPE_CHECKING:
+    from di.container import ServiceContainer
+
+
+async def _check_ray() -> None:
+    if not ray.is_initialized():
+        raise RuntimeError("Ray is not initialized")
+    actor = await asyncio.to_thread(ray.get_actor, "TaskStateManager", namespace="openrag")
+    await call_ray_actor_method_with_timeout(actor.get_pool_info.remote, timeout=1.0, task_description="readiness")
+
+
+def create_readiness_service(container: ServiceContainer) -> ReadinessService:
+    settings = container._require_settings()
+
+    async def check_model(kind: str) -> None:
+        # Resolve on every refresh so admin changes do not leave a stale target.
+        config = getattr(settings.models, kind).get("default")
+        if config is None:
+            raise RuntimeError("Default model endpoint is not configured")
+        await check_model_endpoint(config)
+
+    checks = {
+        "postgres": cast(PostgresStore, container.catalog_store).check_health,
+        "milvus": cast(MilvusVectorStore, container.vector_store).check_health,
+        "ray": _check_ray,
+        "embedder": partial(check_model, "embedder"),
+        "llm": partial(check_model, "llm"),
+    }
+    if settings.reranker.enabled:
+        checks["reranker"] = partial(check_model, "reranker")
+    return ReadinessService(checks)

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -721,6 +721,46 @@ class ModelEndpointService:
         if parsed.username or parsed.password:
             result["detail"] = "Endpoint URL must not include credentials."
             return result
+        if model_type != "stt":
+            from services.orchestrators.readiness_service import (
+                ModelEndpointProbeError,
+                ModelNotFoundError,
+                check_model_endpoint,
+            )
+
+            config = ModelEndpointConfig(
+                endpoint=url,
+                model_name=normalized_model_name,
+                timeout=timeout or 5.0,
+                extra={
+                    **(extra or {}),
+                    **({"api_key": api_key} if api_key else {}),
+                },
+            )
+            try:
+                model_ids = await check_model_endpoint(config, model_type=model_type, timeout=timeout or 5.0)
+            except httpx.TimeoutException:
+                result["detail"] = "Model list request timed out."
+            except ModelEndpointProbeError as exc:
+                result["reachable"] = True
+                result["detail"] = f"Model list returned HTTP {exc.status_code}."
+            except ModelNotFoundError as exc:
+                result["reachable"] = True
+                result["models_served"] = exc.model_ids
+                result["model_found"] = False
+            except Exception as exc:
+                result["detail"] = str(exc)
+            else:
+                result["reachable"] = True
+                result["models_served"] = model_ids
+                result["model_found"] = (
+                    None
+                    if model_ids is None
+                    else True
+                    if normalized_model_name is None
+                    else normalized_model_name in model_ids
+                )
+            return result
         base_url = url.rstrip("/")
         models_url = base_url + "/models"
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}

--- a/openrag/services/orchestrators/model_endpoint_service.py
+++ b/openrag/services/orchestrators/model_endpoint_service.py
@@ -724,6 +724,7 @@ class ModelEndpointService:
         if model_type != "stt":
             from services.orchestrators.readiness_service import (
                 ModelEndpointProbeError,
+                ModelListUnavailableError,
                 ModelNotFoundError,
                 check_model_endpoint,
             )
@@ -744,6 +745,9 @@ class ModelEndpointService:
             except ModelEndpointProbeError as exc:
                 result["reachable"] = True
                 result["detail"] = f"Model list returned HTTP {exc.status_code}."
+            except ModelListUnavailableError as exc:
+                result["reachable"] = True
+                result["detail"] = str(exc)
             except ModelNotFoundError as exc:
                 result["reachable"] = True
                 result["models_served"] = exc.model_ids

--- a/openrag/services/orchestrators/readiness_service.py
+++ b/openrag/services/orchestrators/readiness_service.py
@@ -26,6 +26,13 @@ class ModelNotFoundError(ValueError):
         self.model_ids = model_ids
 
 
+class ModelListUnavailableError(ValueError):
+    """A reachable endpoint did not return a usable model list."""
+
+    def __init__(self) -> None:
+        super().__init__("Endpoint returned an invalid model list.")
+
+
 class ReadinessService:
     def __init__(
         self, checks: dict[str, Callable[[], Awaitable[None]]], *, timeout: float = 2.0, cache_ttl: float = 2.0
@@ -89,7 +96,10 @@ async def check_model_endpoint(
         elif response.status_code >= 400:
             raise ModelEndpointProbeError(response.status_code)
     if not health_only:
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ModelListUnavailableError from exc
         models = payload.get("data") if isinstance(payload, dict) else None
         model_ids = (
             [item["id"] for item in models if isinstance(item, dict) and isinstance(item.get("id"), str)]
@@ -98,7 +108,7 @@ async def check_model_endpoint(
         )
         if not isinstance(models, list) or (config.model_name and config.model_name not in model_ids):
             if not isinstance(models, list):
-                raise ValueError("Configured model is unavailable")
+                raise ModelListUnavailableError
             raise ModelNotFoundError(model_ids)
         return model_ids
     return None

--- a/openrag/services/orchestrators/readiness_service.py
+++ b/openrag/services/orchestrators/readiness_service.py
@@ -1,0 +1,59 @@
+"""Short, cached dependency probes for traffic readiness."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+
+import httpx
+from core.config.model_endpoints import ModelEndpointConfig
+
+
+class ReadinessService:
+    def __init__(
+        self, checks: dict[str, Callable[[], Awaitable[None]]], *, timeout: float = 2.0, cache_ttl: float = 2.0
+    ) -> None:
+        self._checks = checks
+        self._timeout = timeout
+        self._cache_ttl = cache_ttl
+        self._expires_at = 0.0
+        self._result: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+
+    async def check(self) -> dict[str, str]:
+        async with self._lock:
+            if time.monotonic() >= self._expires_at:
+                results = await asyncio.gather(*(self._probe(check) for check in self._checks.values()))
+                self._result = dict(zip(self._checks, results, strict=True))
+                self._expires_at = time.monotonic() + self._cache_ttl
+            return dict(self._result)
+
+    async def _probe(self, check: Callable[[], Awaitable[None]]) -> str:
+        try:
+            await asyncio.wait_for(check(), timeout=self._timeout)
+            return "ok"
+        except TimeoutError:
+            return "timeout"
+        except Exception:
+            # This endpoint is public: never return connection strings or keys.
+            return "unavailable"
+
+
+async def check_model_endpoint(config: ModelEndpointConfig) -> None:
+    """Check availability without generating tokens or running embeddings."""
+    base = config.endpoint.rstrip("/")
+    implementation = config.extra.get("implementation", "vllm")
+    if implementation == "ollama" and not base.endswith("/v1"):
+        base += "/v1"
+    health_only = implementation in {"infinity", "tei"}
+    url = base + ("/health" if health_only else "/models")
+    api_key = config.extra.get("api_key")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    async with httpx.AsyncClient(timeout=2.0, headers=headers) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+    if not health_only:
+        models = response.json()["data"]
+        if not isinstance(models, list) or (config.model_name and config.model_name not in [m["id"] for m in models]):
+            raise ValueError("Configured model is unavailable")

--- a/openrag/services/orchestrators/readiness_service.py
+++ b/openrag/services/orchestrators/readiness_service.py
@@ -7,7 +7,23 @@ import time
 from collections.abc import Awaitable, Callable
 
 import httpx
-from core.config.model_endpoints import ModelEndpointConfig
+from core.config.model_endpoints import DEFAULT_MODEL_IMPLEMENTATIONS, ModelEndpointConfig
+
+
+class ModelEndpointProbeError(RuntimeError):
+    """A model endpoint answered with an unsuccessful HTTP status."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"Model endpoint returned HTTP {status_code}")
+        self.status_code = status_code
+
+
+class ModelNotFoundError(ValueError):
+    """A reachable endpoint does not serve the configured model."""
+
+    def __init__(self, model_ids: list[str]) -> None:
+        super().__init__("Configured model is unavailable")
+        self.model_ids = model_ids
 
 
 class ReadinessService:
@@ -33,27 +49,56 @@ class ReadinessService:
         try:
             await asyncio.wait_for(check(), timeout=self._timeout)
             return "ok"
-        except TimeoutError:
+        except (TimeoutError, httpx.TimeoutException):
             return "timeout"
         except Exception:
             # This endpoint is public: never return connection strings or keys.
             return "unavailable"
 
 
-async def check_model_endpoint(config: ModelEndpointConfig) -> None:
+def model_implementation(config: ModelEndpointConfig, model_type: str | None = None) -> str:
+    """Resolve the configured provider, matching the DI factory defaults."""
+    configured = config.extra.get("implementation")
+    if isinstance(configured, str) and configured:
+        return configured
+    return DEFAULT_MODEL_IMPLEMENTATIONS.get(model_type or "", "vllm")
+
+
+async def check_model_endpoint(
+    config: ModelEndpointConfig,
+    *,
+    model_type: str | None = None,
+    timeout: float = 2.0,
+) -> list[str] | None:
     """Check availability without generating tokens or running embeddings."""
     base = config.endpoint.rstrip("/")
-    implementation = config.extra.get("implementation", "vllm")
+    implementation = model_implementation(config, model_type)
     if implementation == "ollama" and not base.endswith("/v1"):
         base += "/v1"
     health_only = implementation in {"infinity", "tei"}
     url = base + ("/health" if health_only else "/models")
     api_key = config.extra.get("api_key")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    async with httpx.AsyncClient(timeout=2.0, headers=headers) as client:
+    async with httpx.AsyncClient(timeout=timeout, headers=headers, follow_redirects=False) as client:
         response = await client.get(url)
-        response.raise_for_status()
+        if hasattr(response, "raise_for_status"):
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise ModelEndpointProbeError(exc.response.status_code) from exc
+        elif response.status_code >= 400:
+            raise ModelEndpointProbeError(response.status_code)
     if not health_only:
-        models = response.json()["data"]
-        if not isinstance(models, list) or (config.model_name and config.model_name not in [m["id"] for m in models]):
-            raise ValueError("Configured model is unavailable")
+        payload = response.json()
+        models = payload.get("data") if isinstance(payload, dict) else None
+        model_ids = (
+            [item["id"] for item in models if isinstance(item, dict) and isinstance(item.get("id"), str)]
+            if isinstance(models, list)
+            else []
+        )
+        if not isinstance(models, list) or (config.model_name and config.model_name not in model_ids):
+            if not isinstance(models, list):
+                raise ValueError("Configured model is unavailable")
+            raise ModelNotFoundError(model_ids)
+        return model_ids
+    return None

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -1326,6 +1326,11 @@ class MilvusVectorStore(VectorStore):
 
         return int(result.get("delete_count", 0)) if isinstance(result, dict) else 0
 
+    async def check_health(self) -> None:
+        # A missing collection is normal before the first upload. A failed RPC
+        # is not. Bound the SDK call too: cancelling to_thread cannot stop it.
+        await asyncio.to_thread(self._client.has_collection, self._collection_name, timeout=2.0)
+
     async def collection_exists(self, name: str) -> bool:
         """Report whether the Milvus collection exists on the server.
 

--- a/openrag/services/storage/milvus_store.py
+++ b/openrag/services/storage/milvus_store.py
@@ -1328,8 +1328,8 @@ class MilvusVectorStore(VectorStore):
 
     async def check_health(self) -> None:
         # A missing collection is normal before the first upload. A failed RPC
-        # is not. Bound the SDK call too: cancelling to_thread cannot stop it.
-        await asyncio.to_thread(self._client.has_collection, self._collection_name, timeout=2.0)
+        # is not. Use the async data-plane client so cancellation stops the RPC.
+        await self._async_client.has_collection(self._collection_name, timeout=2.0)
 
     async def collection_exists(self, name: str) -> bool:
         """Report whether the Milvus collection exists on the server.

--- a/openrag/services/storage/postgres_store.py
+++ b/openrag/services/storage/postgres_store.py
@@ -126,6 +126,10 @@ class PostgresStore(CatalogStore):
         await self._conn.shutdown()
         self._initialized = False
 
+    async def check_health(self) -> None:
+        async with self.pool.acquire(timeout=2.0) as conn:
+            await conn.fetchval("SELECT 1", timeout=2.0)
+
     # ------------------------------------------------------------------
     # Connection access (escape hatch for Phase 8 orchestrators)
     # ------------------------------------------------------------------

--- a/tests/unit/api/middleware/test_bypass_config.py
+++ b/tests/unit/api/middleware/test_bypass_config.py
@@ -41,6 +41,7 @@ def test_default_bypass_paths_match_legacy_set() -> None:
         "/openapi.json",
         "/redoc",
         "/health_check",
+        "/ready",
         "/version",
         "/auth/login",
         "/auth/callback",

--- a/tests/unit/api/middleware/test_instrumentation.py
+++ b/tests/unit/api/middleware/test_instrumentation.py
@@ -70,6 +70,7 @@ def test_skips_excluded_paths(monkeypatch) -> None:
     client = TestClient(app)
     client.get("/metrics")
     client.get("/health_check")
+    client.get("/ready")
     client.get("/docs")
     client.get("/openapi.json")
 

--- a/tests/unit/api/middleware/test_oidc_docs_gating.py
+++ b/tests/unit/api/middleware/test_oidc_docs_gating.py
@@ -93,7 +93,7 @@ async def test_oidc_authenticated_session_reaches_docs() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("path", ["/health_check", "/version", "/auth/login"])
+@pytest.mark.parametrize("path", ["/health_check", "/ready", "/version", "/auth/login"])
 async def test_oidc_non_docs_bypass_paths_stay_public(path) -> None:
     """Only the docs are gated — health/version/auth callbacks still bypass."""
     mw = _middleware(_anon_service())

--- a/tests/unit/api/middleware/test_rate_limit.py
+++ b/tests/unit/api/middleware/test_rate_limit.py
@@ -45,6 +45,8 @@ def _build_app(monkeypatch, **env):
             Route("/v1/chat", ok),
             Route("/auth/login", ok),
             Route("/other", ok),
+            Route("/health_check", ok),
+            Route("/ready", ok),
             Route("/chainlit/ws/socket.io/", ok),
             Route("/chainlithack", ok),
             Route("/assets/pdf.worker.mjs", ok),
@@ -59,6 +61,14 @@ def test_allows_under_limit(monkeypatch):
     client = TestClient(app)
     for _ in range(5):
         assert client.get("/v1/chat").status_code == 200
+
+
+@pytest.mark.parametrize("path", ["/health_check", "/ready"])
+def test_probes_are_not_blocked_by_exhausted_request_budget(monkeypatch, path):
+    client = TestClient(_build_app(monkeypatch, RATE_LIMIT_DEFAULT="1/minute"))
+    assert client.get("/other").status_code == 200
+    assert client.get("/other").status_code == 429
+    assert client.get(path).status_code == 200
 
 
 def test_blocks_over_limit_with_retry_after(monkeypatch):

--- a/tests/unit/api/routers/admin/test_phase14_admin_routers.py
+++ b/tests/unit/api/routers/admin/test_phase14_admin_routers.py
@@ -356,6 +356,33 @@ async def test_validate_model_endpoint_uses_stored_api_key(async_client_factory)
 
 
 @pytest.mark.asyncio
+async def test_validate_stored_reranker_forwards_implementation(async_client_factory):
+    model_service = FakeModelEndpointService()
+    model_service.endpoint_model_name = "jina-reranker-v2"
+    model_service.endpoint_extra = {"implementation": "openai"}
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post("/model-endpoints/reranker/jina/validate")
+
+    assert response.status_code == 200
+    assert model_service.calls == [
+        ("get", {"name": "jina", "model_type": "reranker"}),
+        (
+            "validate",
+            {
+                "url": "http://llm:8000/v1",
+                "model_type": "reranker",
+                "model_name": "jina-reranker-v2",
+                "api_key": None,
+                "timeout": 30.0,
+                "extra": {"implementation": "openai"},
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_validate_stored_stt_endpoint_forwards_request_options(async_client_factory):
     model_service = FakeModelEndpointService()
     model_service.endpoint_model_name = "moss-transcribe-diarize"
@@ -422,6 +449,37 @@ async def test_validate_endpoint_draft_forwards_body_without_lookup(async_client
                 "api_key": "draft-key",
                 "timeout": 900.0,
                 "extra": {"language": "fr", "response_format": "json"},
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_reranker_draft_forwards_implementation(async_client_factory):
+    model_service = FakeModelEndpointService()
+    app = _build_app(model_service=model_service)
+
+    async with async_client_factory(app) as client:
+        response = await client.post(
+            "/model-endpoints/validate",
+            json={
+                "endpoint": "http://reranker:8000/v1",
+                "model_type": "reranker",
+                "model_name": "jina-reranker-v2",
+                "extra": {"implementation": "openai"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert model_service.calls == [
+        (
+            "validate",
+            {
+                "url": "http://reranker:8000/v1",
+                "model_type": "reranker",
+                "model_name": "jina-reranker-v2",
+                "api_key": None,
+                "extra": {"implementation": "openai"},
             },
         ),
     ]

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from api.routers.user.health import router
+from fastapi import FastAPI
+
+
+@pytest.mark.parametrize("initialized", [False, True])
+async def test_liveness_does_not_depend_on_container(async_client_factory, initialized):
+    app = FastAPI()
+    app.include_router(router)
+    app.state.container = SimpleNamespace(is_initialized=initialized)
+    async with async_client_factory(app) as client:
+        response = await client.get("/health_check")
+    assert response.status_code == 200
+    assert response.json() == "RAG API is up."
+
+
+@pytest.mark.parametrize("container", [None, SimpleNamespace(is_initialized=False)])
+async def test_readiness_rejects_incomplete_startup(async_client_factory, container):
+    app = FastAPI()
+    app.include_router(router)
+    app.state.container = container
+    async with async_client_factory(app) as client:
+        response = await client.get("/ready")
+    assert response.status_code == 503
+
+
+@pytest.mark.parametrize("dependency_status,expected_status", [("ok", 200), ("unavailable", 503), ("timeout", 503)])
+async def test_readiness_reports_dependency_status(async_client_factory, dependency_status, expected_status):
+    checks = {"postgres": "ok", "milvus": dependency_status}
+    app = FastAPI()
+    app.include_router(router)
+    app.state.container = SimpleNamespace(
+        is_initialized=True, readiness_service=SimpleNamespace(check=AsyncMock(return_value=checks))
+    )
+    async with async_client_factory(app) as client:
+        response = await client.get("/ready")
+    assert response.status_code == expected_status
+    assert response.json() == {"status": "ready" if expected_status == 200 else "not_ready", "checks": checks}

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -39,3 +39,16 @@ async def test_readiness_reports_dependency_status(async_client_factory, depende
         response = await client.get("/ready")
     assert response.status_code == expected_status
     assert response.json() == {"status": "ready" if expected_status == 200 else "not_ready", "checks": checks}
+
+
+async def test_model_failure_is_reported_without_gating_core_readiness(async_client_factory):
+    checks = {"postgres": "ok", "milvus": "ok", "ray": "ok", "llm": "unavailable"}
+    app = FastAPI()
+    app.include_router(router)
+    app.state.container = SimpleNamespace(
+        is_initialized=True, readiness_service=SimpleNamespace(check=AsyncMock(return_value=checks))
+    )
+    async with async_client_factory(app) as client:
+        response = await client.get("/ready")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready", "checks": checks}

--- a/tests/unit/di/test_readiness.py
+++ b/tests/unit/di/test_readiness.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -5,6 +7,7 @@ import pytest
 from core.config.model_endpoints import ModelEndpointConfig
 from core.config.root import Settings
 from di.readiness import _check_ray, create_readiness_service
+from services.orchestrators.readiness_service import ReadinessService
 
 
 @pytest.mark.parametrize("reranker_enabled", [False, True])
@@ -69,3 +72,31 @@ async def test_ray_probe_reuses_actor_handle_until_it_fails(monkeypatch):
     await _check_ray()
     lookup.assert_called_once_with("TaskStateManager", namespace="openrag")
     assert method.await_count == 2
+
+
+async def test_timed_out_ray_probe_reuses_the_in_flight_actor_lookup(monkeypatch):
+    monkeypatch.setattr("di.readiness._ray_actor", None)
+    monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: True)
+    release_lookup = threading.Event()
+    lookup_started = threading.Event()
+    method = AsyncMock(return_value={"pool_size": 1})
+    actor = SimpleNamespace(get_pool_info=SimpleNamespace(remote=method))
+
+    def blocked_lookup(*args, **kwargs):
+        lookup_started.set()
+        release_lookup.wait(timeout=1)
+        return actor
+
+    lookup = MagicMock(side_effect=blocked_lookup)
+    monkeypatch.setattr("di.readiness.ray.get_actor", lookup)
+    service = ReadinessService({"ray": _check_ray}, timeout=0.01, cache_ttl=0)
+
+    try:
+        assert await service.check() == {"ray": "timeout"}
+        assert lookup_started.wait(timeout=1)
+        assert await service.check() == {"ray": "timeout"}
+        assert await service.check() == {"ray": "timeout"}
+        assert lookup.call_count == 1
+        assert await asyncio.wait_for(asyncio.to_thread(lambda: "available"), timeout=0.1) == "available"
+    finally:
+        release_lookup.set()

--- a/tests/unit/di/test_readiness.py
+++ b/tests/unit/di/test_readiness.py
@@ -40,6 +40,7 @@ async def test_wiring_checks_core_dependencies_and_current_default_models(monkey
 
 
 async def test_ray_probe_requires_a_successful_actor_call(monkeypatch):
+    monkeypatch.setattr("di.readiness._ray_actor", None)
     monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: True)
     method = AsyncMock(return_value={"pool_size": 1})
     actor = SimpleNamespace(get_pool_info=SimpleNamespace(remote=method))
@@ -51,6 +52,20 @@ async def test_ray_probe_requires_a_successful_actor_call(monkeypatch):
 
 
 async def test_ray_probe_rejects_uninitialized_ray(monkeypatch):
+    monkeypatch.setattr("di.readiness._ray_actor", None)
     monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: False)
     with pytest.raises(RuntimeError, match="not initialized"):
         await _check_ray()
+
+
+async def test_ray_probe_reuses_actor_handle_until_it_fails(monkeypatch):
+    monkeypatch.setattr("di.readiness._ray_actor", None)
+    monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: True)
+    method = AsyncMock(return_value={"pool_size": 1})
+    actor = SimpleNamespace(get_pool_info=SimpleNamespace(remote=method))
+    lookup = MagicMock(return_value=actor)
+    monkeypatch.setattr("di.readiness.ray.get_actor", lookup)
+    await _check_ray()
+    await _check_ray()
+    lookup.assert_called_once_with("TaskStateManager", namespace="openrag")
+    assert method.await_count == 2

--- a/tests/unit/di/test_readiness.py
+++ b/tests/unit/di/test_readiness.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from core.config.model_endpoints import ModelEndpointConfig
+from core.config.root import Settings
+from di.readiness import _check_ray, create_readiness_service
+
+
+@pytest.mark.parametrize("reranker_enabled", [False, True])
+async def test_wiring_checks_core_dependencies_and_current_default_models(monkeypatch, reranker_enabled):
+    settings = Settings(rdb={"password": "test"}, reranker={"provider": "infinity", "enabled": reranker_enabled})
+    config = ModelEndpointConfig(endpoint="https://model.test/v1", model_name="model")
+    settings.models.llm["default"] = config
+    settings.models.embedder["default"] = config
+    postgres = AsyncMock(side_effect=RuntimeError("database down"))
+    milvus = AsyncMock(side_effect=RuntimeError("Milvus down"))
+    monkeypatch.setattr("di.readiness._check_ray", AsyncMock(side_effect=RuntimeError("Ray down")))
+    model_probe = AsyncMock()
+    monkeypatch.setattr("di.readiness.check_model_endpoint", model_probe)
+    container = SimpleNamespace(
+        _require_settings=lambda: settings,
+        catalog_store=SimpleNamespace(check_health=postgres),
+        vector_store=SimpleNamespace(check_health=milvus),
+    )
+    service = create_readiness_service(container)
+    expected = {
+        "postgres": "unavailable",
+        "milvus": "unavailable",
+        "ray": "unavailable",
+        "embedder": "ok",
+        "llm": "ok",
+    }
+    if reranker_enabled:
+        expected["reranker"] = "unavailable"
+    assert await service.check() == expected
+    # A missing default must not silently report ready. Optional models are not checked.
+    settings.models.llm.clear()
+    assert (await create_readiness_service(container).check())["llm"] == "unavailable"
+
+
+async def test_ray_probe_requires_a_successful_actor_call(monkeypatch):
+    monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: True)
+    method = AsyncMock(return_value={"pool_size": 1})
+    actor = SimpleNamespace(get_pool_info=SimpleNamespace(remote=method))
+    lookup = MagicMock(return_value=actor)
+    monkeypatch.setattr("di.readiness.ray.get_actor", lookup)
+    await _check_ray()
+    lookup.assert_called_once_with("TaskStateManager", namespace="openrag")
+    method.assert_awaited_once()
+
+
+async def test_ray_probe_rejects_uninitialized_ray(monkeypatch):
+    monkeypatch.setattr("di.readiness.ray.is_initialized", lambda: False)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await _check_ray()

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -1533,6 +1533,47 @@ async def test_validate_endpoint_reports_missing_model_on_reachable_endpoint(mon
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [{"models": [{"id": "other-model"}]}, None])
+async def test_validate_endpoint_keeps_reachable_when_model_list_is_invalid(monkeypatch, payload):
+    import httpx
+
+    svc = _make_service()
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            if payload is None:
+                raise ValueError("not JSON")
+            return payload
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, _url):
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    result = await svc.validate_endpoint("http://llm:8000/v1", "mistral-small")
+
+    assert result == {
+        "reachable": True,
+        "model_found": None,
+        "models_served": None,
+        "transcription_supported": None,
+        "detail": "Endpoint returned an invalid model list.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_validate_health_only_endpoint_keeps_model_presence_unknown(monkeypatch):
     import httpx
 

--- a/tests/unit/services/orchestrators/test_model_endpoint_service.py
+++ b/tests/unit/services/orchestrators/test_model_endpoint_service.py
@@ -1495,6 +1495,84 @@ async def test_validate_endpoint_probes_url_and_model_name(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_validate_endpoint_reports_missing_model_on_reachable_endpoint(monkeypatch):
+    import httpx
+
+    svc = _make_service()
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"id": "other-model"}]}
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, _url):
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    result = await svc.validate_endpoint("http://llm:8000/v1", "missing-model")
+
+    assert result == {
+        "reachable": True,
+        "model_found": False,
+        "models_served": ["other-model"],
+        "transcription_supported": None,
+        "detail": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_health_only_endpoint_keeps_model_presence_unknown(monkeypatch):
+    import httpx
+
+    svc = _make_service()
+
+    class FakeResponse:
+        status_code = 200
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, _url):
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    result = await svc.validate_endpoint(
+        "http://reranker:8000",
+        "reranker-model",
+        model_type="reranker",
+        extra={"implementation": "infinity"},
+    )
+
+    assert result == {
+        "reachable": True,
+        "model_found": None,
+        "models_served": None,
+        "transcription_supported": None,
+        "detail": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_validate_stt_endpoint_probes_transcription_capability_with_redirects_enabled(monkeypatch):
     import httpx
 

--- a/tests/unit/services/orchestrators/test_readiness_service.py
+++ b/tests/unit/services/orchestrators/test_readiness_service.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 from core.config.model_endpoints import ModelEndpointConfig
 from services.orchestrators.readiness_service import ReadinessService, check_model_endpoint
@@ -65,9 +66,24 @@ async def test_model_probe_uses_provider_path_and_credentials(respx_mock, implem
     assert probe.calls[0].request.headers["Authorization"] == "Bearer test-key"
 
 
+async def test_reranker_defaults_to_infinity_health_probe(respx_mock):
+    probe = respx_mock.get("https://model.test/health").respond(200)
+    config = ModelEndpointConfig(endpoint="https://model.test", model_name="reranker")
+    await check_model_endpoint(config, model_type="reranker")
+    assert probe.called
+
+
 @pytest.mark.parametrize("status,payload", [(401, {}), (503, {}), (200, {"data": []}), (200, {})])
 async def test_model_probe_rejects_unavailable_or_missing_model(respx_mock, status, payload):
     respx_mock.get("https://model.test/v1/models").respond(status, json=payload)
     config = ModelEndpointConfig(endpoint="https://model.test/v1", model_name="model")
     service = ReadinessService({"llm": lambda: check_model_endpoint(config)})
     assert await service.check() == {"llm": "unavailable"}
+
+
+async def test_httpx_timeout_is_reported_as_timeout(monkeypatch):
+    async def timed_out():
+        raise httpx.ReadTimeout("model timed out")
+
+    service = ReadinessService({"llm": timed_out})
+    assert await service.check() == {"llm": "timeout"}

--- a/tests/unit/services/orchestrators/test_readiness_service.py
+++ b/tests/unit/services/orchestrators/test_readiness_service.py
@@ -1,0 +1,73 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from core.config.model_endpoints import ModelEndpointConfig
+from services.orchestrators.readiness_service import ReadinessService, check_model_endpoint
+
+
+async def test_checks_run_concurrently_and_share_cached_result():
+    entered = 0
+    all_entered = asyncio.Event()
+
+    async def check():
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            all_entered.set()
+        await all_entered.wait()
+
+    service = ReadinessService({"postgres": check, "milvus": check})
+    results = await asyncio.gather(*(service.check() for _ in range(3)))
+    assert results == [{"postgres": "ok", "milvus": "ok"}] * 3
+    assert entered == 2
+
+
+async def test_outage_recovers_after_cache_expiry():
+    check = AsyncMock(side_effect=[RuntimeError("secret connection string"), None])
+    service = ReadinessService({"postgres": check}, cache_ttl=0)
+    assert await service.check() == {"postgres": "unavailable"}
+    assert await service.check() == {"postgres": "ok"}
+
+
+async def test_hung_check_times_out_without_losing_healthy_results():
+    async def hung():
+        await asyncio.Event().wait()
+
+    service = ReadinessService({"ray": hung, "postgres": AsyncMock()}, timeout=0.01)
+    assert await service.check() == {"ray": "timeout", "postgres": "ok"}
+
+
+async def test_cancellation_is_not_cached_as_an_outage():
+    service = ReadinessService({"ray": AsyncMock(side_effect=asyncio.CancelledError)})
+    with pytest.raises(asyncio.CancelledError):
+        await service.check()
+
+
+@pytest.mark.parametrize(
+    "implementation,base,path",
+    [
+        ("vllm", "/v1/", "/v1/models"),
+        ("ollama", "", "/v1/models"),
+        ("ollama", "/v1", "/v1/models"),
+        ("infinity", "", "/health"),
+        ("tei", "", "/health"),
+    ],
+)
+async def test_model_probe_uses_provider_path_and_credentials(respx_mock, implementation, base, path):
+    probe = respx_mock.get("https://model.test" + path).respond(200, json={"data": [{"id": "model"}]})
+    config = ModelEndpointConfig(
+        endpoint="https://model.test" + base,
+        model_name="model",
+        extra={"implementation": implementation, "api_key": "test-key"},
+    )
+    await check_model_endpoint(config)
+    assert probe.calls[0].request.headers["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.parametrize("status,payload", [(401, {}), (503, {}), (200, {"data": []}), (200, {})])
+async def test_model_probe_rejects_unavailable_or_missing_model(respx_mock, status, payload):
+    respx_mock.get("https://model.test/v1/models").respond(status, json=payload)
+    config = ModelEndpointConfig(endpoint="https://model.test/v1", model_name="model")
+    service = ReadinessService({"llm": lambda: check_model_endpoint(config)})
+    assert await service.check() == {"llm": "unavailable"}

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -74,10 +74,10 @@ def store(vdb_config: VectorDBConfig, monkeypatch: pytest.MonkeyPatch) -> Milvus
 
 
 async def test_health_accepts_a_fresh_collection_and_bounds_the_rpc(store):
-    store._client.has_collection.return_value = False
+    store._async_client.has_collection = AsyncMock(return_value=False)
     await store.check_health()
-    store._client.has_collection.assert_called_once_with("test_collection", timeout=2.0)
-    store._client.has_collection.side_effect = MilvusException(1, "unavailable")
+    store._async_client.has_collection.assert_awaited_once_with("test_collection", timeout=2.0)
+    store._async_client.has_collection.side_effect = MilvusException(1, "unavailable")
     with pytest.raises(MilvusException):
         await store.check_health()
 

--- a/tests/unit/services/storage/test_milvus_store.py
+++ b/tests/unit/services/storage/test_milvus_store.py
@@ -73,6 +73,15 @@ def store(vdb_config: VectorDBConfig, monkeypatch: pytest.MonkeyPatch) -> Milvus
 # ---------------------------------------------------------------------------
 
 
+async def test_health_accepts_a_fresh_collection_and_bounds_the_rpc(store):
+    store._client.has_collection.return_value = False
+    await store.check_health()
+    store._client.has_collection.assert_called_once_with("test_collection", timeout=2.0)
+    store._client.has_collection.side_effect = MilvusException(1, "unavailable")
+    with pytest.raises(MilvusException):
+        await store.check_health()
+
+
 class TestFormatValue:
     def test_int_renders_unquoted(self) -> None:
         assert MilvusVectorStore._format_value(42) == "42"

--- a/tests/unit/services/storage/test_postgres_health.py
+++ b/tests/unit/services/storage/test_postgres_health.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from services.storage.postgres_store import PostgresStore
+
+
+async def test_health_uses_the_live_pool_and_propagates_query_failure():
+    connection = SimpleNamespace(fetchval=AsyncMock(return_value=1))
+    pool = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=connection)
+    store = object.__new__(PostgresStore)
+    store._conn = SimpleNamespace(pool=pool)
+
+    await store.check_health()
+    pool.acquire.assert_called_once_with(timeout=2.0)
+    connection.fetchval.assert_awaited_once_with("SELECT 1", timeout=2.0)
+
+    connection.fetchval.side_effect = RuntimeError("database unavailable")
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await store.check_health()

--- a/ui/src/pages/admin/models.test.tsx
+++ b/ui/src/pages/admin/models.test.tsx
@@ -36,6 +36,12 @@ beforeAll(() => {
       disconnect() {}
     },
   );
+  Object.defineProperties(HTMLElement.prototype, {
+    hasPointerCapture: { configurable: true, value: () => false },
+    setPointerCapture: { configurable: true, value: () => undefined },
+    releasePointerCapture: { configurable: true, value: () => undefined },
+    scrollIntoView: { configurable: true, value: () => undefined },
+  });
 });
 
 function renderPage() {
@@ -82,6 +88,62 @@ describe("ModelsPage validation", () => {
         }),
       ),
     );
+  });
+
+  it("requires revalidation after changing the provider", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("No embedder endpoints configured.");
+    await user.click(screen.getByRole("tab", { name: "reranker" }));
+    await user.click(screen.getByRole("button", { name: /add endpoint/i }));
+
+    const dialog = screen.getByRole("dialog");
+    const textboxes = within(dialog).getAllByRole("textbox");
+    await user.type(textboxes[0], "reranker");
+    await user.type(textboxes[1], "http://reranker:8000");
+    await user.type(textboxes[2], "jina-reranker-v2");
+    await user.click(within(dialog).getByRole("button", { name: "Validate" }));
+
+    const createButton = within(dialog).getByRole("button", { name: "Create" }) as HTMLButtonElement;
+    await waitFor(() => expect(createButton.disabled).toBe(false));
+    await user.click(within(dialog).getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /openai/i }));
+
+    await waitFor(() => expect(createButton.disabled).toBe(true));
+  });
+
+  it("does not restore validation for an edited endpoint after its provider changes", async () => {
+    listModelEndpointsMock.mockResolvedValue([
+      {
+        name: "reranker",
+        model_type: "reranker",
+        endpoint: "http://reranker:8000",
+        model_name: "jina-reranker-v2",
+        batch_size: 32,
+        timeout: 30,
+        extra: { implementation: "infinity" },
+        has_api_key: false,
+        is_default: true,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("No embedder endpoints configured.");
+    await user.click(screen.getByRole("tab", { name: "reranker" }));
+    await screen.findByText("jina-reranker-v2");
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    const updateButton = within(dialog).getByRole("button", { name: "Update" }) as HTMLButtonElement;
+    await waitFor(() => expect(updateButton.disabled).toBe(false));
+    await user.click(within(dialog).getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /openai/i }));
+
+    await waitFor(() => expect(updateButton.disabled).toBe(true));
   });
 
   it("persists the STT API key used by draft validation", async () => {

--- a/ui/src/pages/admin/models.test.tsx
+++ b/ui/src/pages/admin/models.test.tsx
@@ -49,7 +49,7 @@ function renderPage() {
   );
 }
 
-describe("ModelsPage STT validation", () => {
+describe("ModelsPage validation", () => {
   beforeEach(() => {
     listModelEndpointsMock.mockReset().mockResolvedValue([]);
     updateModelEndpointMock.mockReset();
@@ -58,6 +58,30 @@ describe("ModelsPage STT validation", () => {
       model_found: true,
       transcription_supported: true,
     });
+  });
+
+  it("sends the selected reranker implementation during draft validation", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("No embedder endpoints configured.");
+    await user.click(screen.getByRole("tab", { name: "reranker" }));
+    await user.click(screen.getByRole("button", { name: /add endpoint/i }));
+
+    const dialog = screen.getByRole("dialog");
+    const textboxes = within(dialog).getAllByRole("textbox");
+    await user.type(textboxes[1], "http://reranker:8000");
+    await user.type(textboxes[2], "jina-reranker-v2");
+    await user.click(within(dialog).getByRole("button", { name: "Validate" }));
+
+    await waitFor(() =>
+      expect(validateModelEndpointMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model_type: "reranker",
+          extra: { implementation: "infinity" },
+        }),
+      ),
+    );
   });
 
   it("persists the STT API key used by draft validation", async () => {

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -474,6 +474,11 @@ function EndpointDialog({
         : { mossSpeakerAware: false, extra: editingSttExtra }
       : null;
     const editingMossExtra = editingMossFields?.extra ?? null;
+    const editingImplementation =
+      editingMossExtra && editing && editing.model_type !== "stt"
+        ? splitModelEndpointImplementation(editingMossExtra).implementation ||
+          DEFAULT_VENDOR_BY_TYPE[editing.model_type]
+        : "";
     const editingImplExtra = editingMossExtra
       ? editing?.model_type === "stt"
         ? editingMossExtra
@@ -498,6 +503,7 @@ function EndpointDialog({
       sttValidationMossSpeakerAware ===
         (editing.model_type === "stt" ? editingMossFields?.mossSpeakerAware || false : null) &&
       apiKey === editingExtra?.apiKey &&
+      (editing.model_type === "stt" || vendor === editingImplementation) &&
       extraJson === JSON.stringify(editingRawExtra, null, 2)
     ) {
       setValidated(true);
@@ -518,6 +524,7 @@ function EndpointDialog({
     sttValidationMossSpeakerAware,
     apiKey,
     extraJson,
+    vendor,
     editing,
   ]);
 

--- a/ui/src/pages/admin/models.tsx
+++ b/ui/src/pages/admin/models.tsx
@@ -362,6 +362,7 @@ function EndpointDialog({
     modelName,
     apiKey,
     extraJson,
+    vendor,
     sttValidationTimeout,
     sttValidationLanguageHint,
     sttValidationMossSpeakerAware,
@@ -594,24 +595,26 @@ function EndpointDialog({
       toast.error("Enter an endpoint URL first");
       return;
     }
-    let validationExtra: Record<string, unknown> | undefined;
-    if (isStt) {
-      try {
-        const parsedExtra: unknown = JSON.parse(extraJson);
-        if (typeof parsedExtra !== "object" || parsedExtra === null || Array.isArray(parsedExtra)) {
-          throw new Error("Extra must be a JSON object");
-        }
+    let validationExtra: Record<string, unknown>;
+    try {
+      const parsedExtra: unknown = JSON.parse(extraJson);
+      if (typeof parsedExtra !== "object" || parsedExtra === null || Array.isArray(parsedExtra)) {
+        throw new Error("Extra must be a JSON object");
+      }
+      if (isStt) {
         validationExtra = mergeModelEndpointMossSpeakerAware(
           mergeModelEndpointSttLanguage(parsedExtra as Record<string, unknown>, languageHint),
           mossSpeakerAware,
         );
-      } catch {
-        const msg = "Invalid JSON in extra field";
-        setValidated(false);
-        setValidationMsg(msg);
-        toast.error(msg);
-        return;
+      } else {
+        validationExtra = mergeModelEndpointImplementation(parsedExtra as Record<string, unknown>, vendor);
       }
+    } catch {
+      const msg = "Invalid JSON in extra field";
+      setValidated(false);
+      setValidationMsg(msg);
+      toast.error(msg);
+      return;
     }
     let apiKey: string | undefined;
     let submittedApiKey: string | undefined;


### PR DESCRIPTION
Kubernetes can route traffic to OpenRAG before its core dependencies are available. This adds a dedicated `/ready` endpoint and uses it for readiness, while startup and liveness remain on `/health_check` to avoid restart loops during slow dependency startup.

Readiness returns 503 when PostgreSQL, Milvus, or Ray is unavailable. Default model endpoint checks are reported for diagnosis but remain informational, so a model outage does not remove API routes that do not require inference. Checks use short timeouts and a two-second cache.

Model endpoint validation now uses the selected provider and requires revalidation when that provider changes. A stalled Ray actor lookup is shared across probes and isolated from the common executor so repeated readiness timeouts cannot starve unrelated work.

Validation: 3,053 Python unit tests and 299 UI tests passed. Ruff, formatting, the layer import guard, UI lint, and the production UI build also passed. The API and integration workflows will validate the updated branch in CI.

Closes #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an unauthenticated `/ready` endpoint reporting application and core dependency readiness.
  - Readiness responses include model status while gating availability on PostgreSQL, Milvus, and Ray.
  - Health and readiness probes bypass authentication, rate limiting, and metrics recording.
  - Startup and liveness probes use `/health_check`; readiness probes use `/ready`.
  - Improved model endpoint validation, including vendor, implementation, model availability, and health-only endpoint handling.
- **Documentation**
  - Documented probe behavior, Ray Serve overrides, model credentials, and HTTPS requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->