### PR TITLE
fix(indexing): keep enrichment stage failures from losing the file

### DIFF
--- a/openrag/services/workers/pipeline_builder.py
+++ b/openrag/services/workers/pipeline_builder.py
@@ -141,6 +141,36 @@ class IndexingPipeline:
             finally:
                 timings[name] = (time.perf_counter() - start) * 1000.0
 
+        async def _timed_enrichment(name: str, coro: Any) -> None:
+            """Run an enrichment stage best-effort (#702).
+
+            Captioning, contextualization and topic tagging improve a file's
+            index; they are not what makes it indexable. A failure here — a VLM
+            timeout, an unreachable LLM, a malformed response — used to abort
+            ``run()`` before chunk/embed/store, losing the whole file over an
+            enrichment step even though the base content was ready to store.
+            Skip the stage instead: warn, note it on the row, and index what we
+            have. This extends to *invocation* the reasoning ``_select_vlm`` /
+            ``_select_contextualizer`` / ``_select_topic_tagger`` already apply
+            to endpoint *resolution*.
+
+            Cancellation still propagates: ``CancelledError`` is a
+            ``BaseException``, so a cancelled task is never mistaken for a
+            degraded one. Each stage leaves the row's input intact on failure
+            (only successful stages overwrite ``processed_document``/``chunks``),
+            so the next stage runs on the un-enriched value.
+            """
+            try:
+                await _timed(name, coro)
+            except Exception as exc:  # noqa: BLE001 - enrichment must not fail the file
+                row.setdefault("degraded_stages", {})[name] = str(exc)
+                logger.bind(
+                    task_id=row.get("task_id"),
+                    filename=row.get("filename", ""),
+                    partition=row.get("partition"),
+                    stage=name,
+                ).warning(f"{name} stage failed; indexing the file without it: {exc}")
+
         try:
             await _timed("parse", parse_stage(row, parser, timeout=self.timeouts.parse))
             # The caption decision needs the parsed document (standalone images
@@ -168,7 +198,7 @@ class IndexingPipeline:
                 # per-row value win, so that migration is a one-line change.
                 if self.caption_prompt is not None:
                     row.setdefault("caption_prompt", self.caption_prompt)
-                await _timed(
+                await _timed_enrichment(
                     "caption",
                     caption_stage(
                         row,
@@ -179,7 +209,7 @@ class IndexingPipeline:
                 )
             await _timed("chunk", chunk_stage(row, chunker, timeout=self.timeouts.chunk))
             if contextualizer is not None:
-                await _timed(
+                await _timed_enrichment(
                     "contextualize",
                     contextualize_stage(
                         row,
@@ -194,7 +224,7 @@ class IndexingPipeline:
             self._warn_on_embedder_overflow(row, embedder_window, getattr(chunker, "length_function", None))
             if topic_tagger is not None:
                 max_tags = config.max_topic_tags if config is not None else 7
-                await _timed(
+                await _timed_enrichment(
                     "topic_tag",
                     topic_tag_stage(
                         row,

--- a/tests/unit/services/workers/test_pipeline_builder.py
+++ b/tests/unit/services/workers/test_pipeline_builder.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 
 import pytest
@@ -1084,3 +1085,94 @@ def test_overflow_warning_skips_chunks_far_below_the_limit():
         _logger.remove(sink_id)
     assert counted == [], "chunks far below the limit must not be re-tokenised"
     assert not messages
+
+
+class FailingVLM:
+    async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+        raise RuntimeError("vlm unreachable")
+
+
+class FailingContextualizer:
+    async def contextualize(self, chunks, *, filename="", lang="en", system_prompt=None):
+        raise RuntimeError("llm unreachable")
+
+
+class FailingTopicTagger:
+    async def tag(self, chunks, *, filename="", max_tags=7, lang="en", system_prompt=None):
+        raise RuntimeError("llm unreachable")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stage", "components", "config"),
+    [
+        ("caption", {"vlm": FailingVLM()}, {"enable_image_captioning": True}),
+        (
+            "contextualize",
+            {"contextualizer": FailingContextualizer()},
+            {"enable_contextualization": True},
+        ),
+        ("topic_tag", {"topic_tagger": FailingTopicTagger()}, {"enable_topic_tagging": True}),
+    ],
+)
+async def test_enrichment_stage_failure_does_not_lose_the_file(stage, components, config):
+    # #702: an enrichment failure (VLM/LLM timeout, unreachable endpoint, bad
+    # response) must not abort parse->chunk->embed->store. The file is still
+    # indexed from its base content, minus that enrichment.
+    document = Document(filename="note.txt", text="hello", partition="tenant-a")
+    processed = ProcessedDocument(
+        document_id=document.id,
+        text_blocks=[TextBlock(text="hello")],
+        images=[ImageBlock(image_bytes=b"png")],
+    )
+    vector_store = FakeVectorStore()
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([Chunk(id="c1", text="hello", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=vector_store,
+        **components,
+    )
+    row = {
+        "document": document,
+        "partition": "tenant-a",
+        "filename": "note.txt",
+        "indexation_config": config,
+    }
+
+    result = await pipeline.run(row)
+
+    assert result["stage"] == "stored"
+    assert result["stored_count"] == 1
+    assert vector_store.calls, "chunks were never stored"
+    assert stage in result["degraded_stages"]
+
+
+@pytest.mark.asyncio
+async def test_enrichment_cancellation_still_aborts_the_pipeline():
+    # Degrading on failure must not swallow cancellation: a cancelled task has
+    # to stop, not quietly index a half-enriched file.
+    class CancelledVLM:
+        async def caption_image(self, image_bytes: bytes, prompt: str | None = None) -> str:
+            raise asyncio.CancelledError
+
+    document = Document(filename="note.txt", text="hello", partition="tenant-a")
+    processed = ProcessedDocument(
+        document_id=document.id,
+        text_blocks=[TextBlock(text="hello")],
+        images=[ImageBlock(image_bytes=b"png")],
+    )
+    vector_store = FakeVectorStore()
+    pipeline = build_indexing_pipeline(
+        parser=FakeParser(processed),
+        chunker=FakeChunker([Chunk(id="c1", text="hello", partition="tenant-a")]),
+        embedder=FakeEmbedder([[1.0]]),
+        vector_store=vector_store,
+        vlm=CancelledVLM(),
+    )
+    row = {"document": document, "partition": "tenant-a", "filename": "note.txt"}
+
+    with pytest.raises(asyncio.CancelledError):
+        await pipeline.run(row)
+
+    assert vector_store.calls == []


### PR DESCRIPTION
Closes #702

If image captioning, contextualization or topic tagging failed, the whole
file was dropped. It was never indexed, even though parsing and chunking
had worked.

These three steps only improve the index, they are not needed to index a
file. So now a failure just skips that step. The pipeline logs a warning,
notes the failed step on the row, and stores the file with its base content.

Cancellation is not affected and still stops the job.

Tests: 3 new cases (one per step) plus one for cancellation. Full unit suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Indexing now continues when captioning, contextualization, or topic tagging encounters an error.
  - Content is stored without the failed enrichment, with the affected stage recorded for visibility.
  - Cancellation events still stop indexing as expected.

- **Tests**
  - Added coverage for successful storage after enrichment failures and for cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->