### PR TITLE
chore(release): bump version to 2.2.1

### DIFF
--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -3,8 +3,8 @@ name: openrag-stack
 description: A Helm chart for Kubernetes
 type: application
 
-version: 0.6.3
-appVersion: "2.2.0"
+version: 0.6.4
+appVersion: "2.2.1"
 
 maintainers:
   - name: linagora

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -99,7 +99,7 @@ ray:
     registry: "ghcr.io"
     repository: "linagora/openrag-ray"
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.2.0"
+    tag: "v2.2.1"
   resources:
     head:
       requests:
@@ -392,7 +392,7 @@ adminUi:
     repository: "linagoraai/openrag-admin-ui"
     # Pin to a release tag (ideally a digest) for reproducible deploys. Must be a
     # build from infra/docker/ui.Dockerfile (nginx-unprivileged, listens :8080).
-    tag: "v2.2.0"
+    tag: "v2.2.1"
     pullPolicy: IfNotPresent
   replicaCount: 1
   service:
@@ -449,7 +449,7 @@ openrag:
     registry: ""
     repository: "linagoraai/openrag"
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.2.0"
+    tag: "v2.2.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -18,7 +18,7 @@ x-openrag-env: &openrag_env
   FONT_PATH: ${FONT_PATH:-/app/data/fonts/GoNotoCurrent-Regular.ttf}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:v2.2.0
+  image: linagoraai/openrag:v2.2.1
   # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
   # writable dirs (data/, logs/, the HF cache) — which a non-root container
   # can't write when Docker auto-creates them root-owned — then it immediately
@@ -113,7 +113,7 @@ x-vllm: &vllm_template
 services:
   # ── Admin UI (React SPA + nginx, same-origin reverse proxy to the API) ──
   admin-ui:
-    image: linagoraai/openrag-admin-ui:v2.2.0
+    image: linagoraai/openrag-admin-ui:v2.2.1
     build:
       context: ../..
       dockerfile: infra/docker/ui.Dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "2.2.0"
+version = "2.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -18,10 +18,10 @@ export interface Release {
  * dialog content are derived from it.
  */
 export const releaseNotes: Release = {
-  version: "2.2.0",
-  date: "2026-09-03",
+  version: "2.2.1",
+  date: "2026-09-08",
   summary:
-    "OpenRAG 2.2.0 expands retrieval, indexing, chunking, and speech-to-text capabilities, while improving administration and release visibility.",
+    "OpenRAG 2.2.1 expands retrieval, indexing, chunking, and speech-to-text capabilities, while improving administration and release visibility.",
 
   newFeatures: [
     "Scope chat retrieval to specific indexed files by providing attachment file IDs, so answers can focus only on the selected documents.",
@@ -42,9 +42,9 @@ export const releaseNotes: Release = {
   breakingChange: {
     title: "Milvus 3.0 migration required",
     description:
-      "OpenRAG 2.2.0 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading. The BM25 analyzer has also changed to support case-insensitive lexical search and requires the corresponding vector database schema migration.",
+      "OpenRAG 2.2.1 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading. The BM25 analyzer has also changed to support case-insensitive lexical search and requires the corresponding vector database schema migration.",
     action:
-      "Back up your Milvus data and follow the Milvus migration guide, including the required schema migrations, before starting OpenRAG 2.2.0.",
+      "Back up your Milvus data and follow the Milvus migration guide, including the required schema migrations, before starting OpenRAG 2.2.1.",
   },
 };
 

--- a/uv.lock
+++ b/uv.lock
@@ -2762,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
Patch release for the Milvus v3.0.1 fix already merged to `main` (#919, empty-result hybrid searches).

Version-bump only — no code changes. Same file set as the 2.1.1 bump (3b056ecc), plus the release-notes header:

- `pyproject.toml` + `uv.lock` — 2.2.0 → 2.2.1 (this is what `/version` reports)
- `infra/charts/openrag-stack/Chart.yaml` — chart 0.6.3 → 0.6.4, appVersion 2.2.1
- `infra/charts/openrag-stack/values.yaml` — the three image tags → `v2.2.1`
- `infra/compose/docker-compose.yaml` — `openrag` and `openrag-admin-ui` images → `v2.2.1`
- `ui/src/lib/release-notes.ts` — `version` → 2.2.1, `date` → 2026-09-08 (`summary`/`newFeatures` intentionally kept from 2.2.0)

`ui/src/lib/whats-new.ts` has no pending `UNRELEASED` entries, so the `verify-tag` badge gate is clear.

After merge: tag `main` `v2.2.1` to trigger the GA build, then sync `main` into `develop`.

#906 is still open and is not in this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Released version 2.2.1.
  * Updated deployment configurations and container images to version 2.2.1.
  * Updated in-app release information, including the release date, summary, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->