### PR TITLE
chore: sync main into develop after v2.2.1

### DIFF
--- a/docs/content/docs/documentation/milvus_migration.mdx
+++ b/docs/content/docs/documentation/milvus_migration.mdx
@@ -5,7 +5,7 @@ title: Milvus Migrations
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 # Milvus Upgrade
-OpenRAG now uses Milvus **3.0.0** with PyMilvus **3.0.1**. Existing Milvus 2.6 deployments can keep their data, but they must prepare the Milvus data directory before starting the new image because Milvus 3 runs as a non-root user.
+OpenRAG now uses Milvus **3.0.1** with PyMilvus **3.0.1**. Existing Milvus 2.6 deployments can keep their data, but they must prepare the Milvus data directory before starting the new image because Milvus 3 runs as a non-root user.
 
 Fresh installations need no manual ownership step. The Compose stack initializes empty bind mounts and named volumes before the server starts. If existing files are not already owned by the Milvus 3 user, startup stops with a migration error instead of risking a partially writable deployment. The procedure below remains mandatory for existing data in either storage mode because all files created by Milvus 2.6 must be transferred to the Milvus 3 user.
 
@@ -57,7 +57,7 @@ Do not skip this migration when upgrading an existing deployment:
 
 > For the full official reference, see the [Milvus upgrade guide](https://milvus.io/docs/upgrade_milvus_standalone-docker.md#Upgrade-process).
 
-### Upgrade from Milvus 2.6.x to 3.0.0
+### Upgrade from Milvus 2.6.x to 3.0.1
 
 Milvus 2.6 containers ran as root, so existing bind-mounted files and Docker named-volume contents are commonly owned by `root:root`. Milvus 3 runs as UID/GID `999:999` and cannot start until it owns the directory mounted at `/var/lib/milvus`.
 
@@ -122,7 +122,7 @@ Do not restart OpenRAG until Milvus is healthy and the logs contain no permissio
 docker compose ps milvus
 docker compose logs --tail 100 milvus
 docker inspect "$(docker compose ps -q milvus)" --format '{{.Config.Image}}'
-# Expected: milvusdb/milvus:v3.0.0
+# Expected: milvusdb/milvus:v3.0.1
 ```
 
 Once those checks pass, start the complete stack:
@@ -149,12 +149,12 @@ After the upgrade, confirm that every Milvus workload is ready and uses the expe
 kubectl get pods -n <namespace> -l app.kubernetes.io/name=milvus
 kubectl get pods -n <namespace> -l app.kubernetes.io/name=milvus \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}'
-# Expected Milvus image: milvusdb/milvus:v3.0.0
+# Expected Milvus image: milvusdb/milvus:v3.0.1
 ```
 
 ### Legacy path: upgrade Milvus 2.5.x to 2.6.11
 
-This intermediate path is only for deployments upgrading from **OpenRAG &lt;= 1.1.7 whose current Milvus server is 2.5.x**. Do not jump directly from Milvus 2.5.x to 3.0.0. Earlier Milvus versions can require additional intermediate or metadata migrations that are outside this procedure.
+This intermediate path is only for deployments upgrading from **OpenRAG &lt;= 1.1.7 whose current Milvus server is 2.5.x**. Do not jump directly from Milvus 2.5.x to 3.0.1. Earlier Milvus versions can require additional intermediate or metadata migrations that are outside this procedure.
 
 #### Step 1 — Upgrade Milvus to 2.5.16
 
@@ -189,7 +189,7 @@ docker inspect milvus-standalone --format '{{ .Config.Image }}'
 
 #### Preserve the message queue
 
-OpenRAG 2.5 standalone deployments normally use RocksMQ, but verify the effective source queue using the log check in the 2.6-to-3.0 procedure above. Keep that detected value in every Compose configuration used for the 2.6.11 and 3.0.0 steps.
+OpenRAG 2.5 standalone deployments normally use RocksMQ, but verify the effective source queue using the log check in the 2.6-to-3.0 procedure above. Keep that detected value in every Compose configuration used for the 2.6.11 and 3.0.1 steps.
 
 Before starting the intermediate OpenRAG release, add `MQ_TYPE: <detected-value>` to the Milvus service's environment. When moving to the current release, set the corresponding value in the Compose `.env` file and keep it until the upgrade is validated:
 

--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -3,8 +3,8 @@ name: openrag-stack
 description: A Helm chart for Kubernetes
 type: application
 
-version: 0.6.3
-appVersion: "2.2.0"
+version: 0.6.4
+appVersion: "2.2.1"
 
 maintainers:
   - name: linagora

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -99,7 +99,7 @@ ray:
     registry: "ghcr.io"
     repository: "linagora/openrag-ray"
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.2.0"
+    tag: "v2.2.1"
   resources:
     head:
       requests:
@@ -392,7 +392,7 @@ adminUi:
     repository: "linagoraai/openrag-admin-ui"
     # Pin to a release tag (ideally a digest) for reproducible deploys. Must be a
     # build from infra/docker/ui.Dockerfile (nginx-unprivileged, listens :8080).
-    tag: "v2.2.0"
+    tag: "v2.2.1"
     pullPolicy: IfNotPresent
   replicaCount: 1
   service:
@@ -449,7 +449,7 @@ openrag:
     registry: ""
     repository: "linagoraai/openrag"
     # Pin to a release tag (ideally a digest) for reproducible deploys.
-    tag: "v2.2.0"
+    tag: "v2.2.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -171,10 +171,10 @@ milvus:
   # note on it above. Without this, the milvus sub-chart names its own proxy
   # Service from the real Release.Name instead, which won't match VDB_HOST.
   fullnameOverride: "openrag-milvus"
-  # Chart 5.0.25 still defaults to Milvus 2.6.21. This override can be removed
-  # when the upstream 5.0.26 chart is available from its repository index.
+  # Chart 5.0.25 still defaults to Milvus 2.6.21. Keep this override until
+  # the chart defaults include the Milvus 3.0.1 empty-result search fix.
   image:
-    all: { tag: "v3.0.0" }
+    all: { tag: "v3.0.1" }
   # Milvus 3 runs as UID/GID 999. Applying this group on every mount lets
   # Kubernetes migrate supported existing volumes before the non-root process
   # starts. Storage drivers that do not support fsGroup require an

--- a/infra/compose/docker-compose.yaml
+++ b/infra/compose/docker-compose.yaml
@@ -18,7 +18,7 @@ x-openrag-env: &openrag_env
   FONT_PATH: ${FONT_PATH:-/app/data/fonts/GoNotoCurrent-Regular.ttf}
 
 x-openrag: &openrag_template
-  image: linagoraai/openrag:v2.2.0
+  image: linagoraai/openrag:v2.2.1
   # Start as root so entrypoint.sh can grant GID-0 write on the bind-mounted
   # writable dirs (data/, logs/, the HF cache) — which a non-root container
   # can't write when Docker auto-creates them root-owned — then it immediately
@@ -113,7 +113,7 @@ x-vllm: &vllm_template
 services:
   # ── Admin UI (React SPA + nginx, same-origin reverse proxy to the API) ──
   admin-ui:
-    image: linagoraai/openrag-admin-ui:v2.2.0
+    image: linagoraai/openrag-admin-ui:v2.2.1
     build:
       context: ../..
       dockerfile: infra/docker/ui.Dockerfile

--- a/infra/compose/milvus/milvus.named-volumes.yaml
+++ b/infra/compose/milvus/milvus.named-volumes.yaml
@@ -30,7 +30,7 @@ services:
       retries: 3
 
   milvus-init:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     user: "0:0"
     environment:
       LD_PRELOAD: ""
@@ -56,7 +56,7 @@ services:
     restart: "no"
 
   milvus:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     command: ["milvus", "run", "standalone"]
     # Run under Docker's default seccomp profile (do not disable syscall
     # filtering). If a specific kernel needs a wider profile, supply a vetted

--- a/infra/compose/milvus/milvus.yaml
+++ b/infra/compose/milvus/milvus.yaml
@@ -30,7 +30,7 @@ services:
       retries: 3
 
   milvus-init:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     user: "0:0"
     environment:
       LD_PRELOAD: ""
@@ -56,7 +56,7 @@ services:
     restart: "no"
 
   milvus:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     command: ["milvus", "run", "standalone"]
     # Run under Docker's default seccomp profile (do not disable syscall
     # filtering). If a specific kernel needs a wider profile, supply a vetted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag"
-version = "2.2.0"
+version = "2.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/api/api_run/docker-compose.yaml
+++ b/tests/integration/api/api_run/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       retries: 5
 
   milvus:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     command: ["milvus", "run", "standalone"]
     security_opt:
     - seccomp:unconfined

--- a/tests/integration/repos/docker-compose.yaml
+++ b/tests/integration/repos/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       retries: 5
 
   milvus:
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     command: ["milvus", "run", "standalone"]
     security_opt:
       - seccomp:unconfined

--- a/tests/load/workspace/README.md
+++ b/tests/load/workspace/README.md
@@ -27,7 +27,7 @@ docker compose down -v       # Remove everything (next run re-inserts data)
 
 | Service    | Image                       | Port  |
 |------------|-----------------------------|-------|
-| Milvus     | milvusdb/milvus:v3.0.0      | 19530 |
+| Milvus     | milvusdb/milvus:v3.0.1      | 19530 |
 | PostgreSQL | postgres:16                 | 5433  |
 | etcd       | quay.io/coreos/etcd:v3.5.25 | -     |
 | MinIO      | minio/minio                 | -     |

--- a/tests/load/workspace/docker-compose.yml
+++ b/tests/load/workspace/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   milvus:
     container_name: bench-milvus
-    image: milvusdb/milvus:v3.0.0
+    image: milvusdb/milvus:v3.0.1
     command: ["milvus", "run", "standalone"]
     security_opt:
       - seccomp:unconfined

--- a/tests/unit/infra/test_compose_storage.py
+++ b/tests/unit/infra/test_compose_storage.py
@@ -29,7 +29,7 @@ def _assert_milvus_initializer(services: dict) -> None:
     initializer = services["milvus-init"]
     milvus = services["milvus"]
 
-    assert initializer["image"] == milvus["image"] == "milvusdb/milvus:v3.0.0"
+    assert initializer["image"] == milvus["image"] == "milvusdb/milvus:v3.0.1"
     assert initializer["user"] == "0:0"
     assert initializer["environment"]["LD_PRELOAD"] == ""
     assert initializer["entrypoint"] == ["/bin/sh", "-ec"]
@@ -100,7 +100,7 @@ def test_named_volume_profile_is_opt_in() -> None:
     assert named_milvus["services"]["etcd"]["volumes"] == ["${ETCD_VOLUME:-etcd}:/etcd"]
     assert named_milvus["services"]["minio"]["volumes"] == ["${MINIO_VOLUME:-minio}:/minio_data"]
     assert named_milvus["services"]["milvus"]["volumes"] == ["${MILVUS_VOLUME:-milvus}:/var/lib/milvus"]
-    assert named_milvus["services"]["milvus"]["image"] == "milvusdb/milvus:v3.0.0"
+    assert named_milvus["services"]["milvus"]["image"] == "milvusdb/milvus:v3.0.1"
     assert named_milvus["services"]["milvus"]["environment"]["ETCD_AUTH_ENABLED"] == "false"
     assert named_milvus["services"]["milvus"]["environment"]["MQ_TYPE"] == "${MILVUS_MQ_TYPE:-default}"
     assert {"etcd", "minio", "milvus"} <= set(named_milvus["volumes"])

--- a/ui/src/lib/release-notes.ts
+++ b/ui/src/lib/release-notes.ts
@@ -18,10 +18,10 @@ export interface Release {
  * dialog content are derived from it.
  */
 export const releaseNotes: Release = {
-  version: "2.2.0",
-  date: "2026-09-03",
+  version: "2.2.1",
+  date: "2026-09-08",
   summary:
-    "OpenRAG 2.2.0 expands retrieval, indexing, chunking, and speech-to-text capabilities, while improving administration and release visibility.",
+    "OpenRAG 2.2.1 expands retrieval, indexing, chunking, and speech-to-text capabilities, while improving administration and release visibility.",
 
   newFeatures: [
     "Scope chat retrieval to specific indexed files by providing attachment file IDs, so answers can focus only on the selected documents.",
@@ -42,9 +42,9 @@ export const releaseNotes: Release = {
   breakingChange: {
     title: "Milvus 3.0 migration required",
     description:
-      "OpenRAG 2.2.0 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading. The BM25 analyzer has also changed to support case-insensitive lexical search and requires the corresponding vector database schema migration.",
+      "OpenRAG 2.2.1 requires Milvus 3.0. Existing Milvus 2.x deployments must be migrated before upgrading. The BM25 analyzer has also changed to support case-insensitive lexical search and requires the corresponding vector database schema migration.",
     action:
-      "Back up your Milvus data and follow the Milvus migration guide, including the required schema migrations, before starting OpenRAG 2.2.0.",
+      "Back up your Milvus data and follow the Milvus migration guide, including the required schema migrations, before starting OpenRAG 2.2.1.",
   },
 };
 

--- a/uv.lock
+++ b/uv.lock
@@ -2762,7 +2762,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
Back-carries the v2.2.1 hotfix release from `main` into `develop`, as required by the git-flow model in CONTRIBUTING.md (a hotfix merges into **both** `main` and `develop`).

Carries two things:

- **#919** — Milvus v3.0.1 for empty-result hybrid searches (the fix itself)
- **#922** — `chore(release): bump version to 2.2.1` (pyproject + uv.lock, chart 0.6.4 / appVersion 2.2.1, compose and values image tags, release-notes header)

Merged clean, no conflicts. The develop-side runtime Grafana link change in `infra/compose/docker-compose.yaml` survived the merge intact.

Merging via `main` rather than cherry-picking is deliberate: it brings the `v2.2.1` tag ancestry along, so the next release branch cut from `develop` cannot silently reintroduce the Milvus bug.

Supersedes #920, which carried only the fix half and can be closed once this lands.

After this, `develop` sits at 2.2.1 — the next feature release from it is 2.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the application release to version 2.2.1.
  * Upgraded bundled Milvus deployments to version 3.0.1, including installation, Compose, Helm, integration, and load-test configurations.
  * Updated migration guidance and in-app release notes for the latest versions.
* **Bug Fixes**
  * Includes the Milvus 3.0.1 fix for empty-result searches.
* **Chores**
  * Updated deployment image references and chart metadata to align with the 2.2.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->