### PR TITLE
feat(chunking): make structured_section the default chunker

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -307,7 +307,10 @@ ray:
 # Env: CHUNKER, CONTEXTUAL_RETRIEVAL, CONTEXTUALIZATION_TIMEOUT,
 #      MAX_CONCURRENT_CONTEXTUALIZATION, CHUNK_SIZE, CHUNK_OVERLAP_RATE
 chunker:
-  name: recursive_splitter
+  # structured_section cuts on the document's own structure (headings, leaf
+  # markers) and prepends the heading path to each chunk. Set
+  # CHUNKER=recursive_splitter for plain character-window splitting.
+  name: structured_section
   contextual_retrieval: true
   contextualization_timeout: 120
   max_concurrent_contextualization: 10

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -181,8 +181,8 @@ The default OpenRAG transcriber stack now ships with **vLLM v0.19.1**, which inc
 |------------------------|------|----------------------|-------------|
 | `CHUNKER`              | `str`  | structured_section   | Defines the chunking strategy: `structured_section` or `recursive_splitter`. |
 | `CONTEXTUAL_RETRIEVAL` | `bool` | true                 | Enables contextual retrieval to chunk context, a technique introduced by Anthropic to improve retrieval performance ([Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)) |
-| `CHUNK_SIZE`           | `int`  | 512                  | Maximum size (in characters) of each chunk. |
-| `CHUNK_OVERLAP_RATE`   | `float`| 0.2                  | Percentage of overlap between consecutive chunks. |
+| `CHUNK_SIZE`           | `int`  | 512                  | Target size of each chunk, in **tokens** — counted with the LLM tokenizer (`tiktoken` `cl100k_base` when the LLM is unreachable), not in characters. |
+| `CHUNK_OVERLAP_RATE`   | `float`| 0.2                  | Fraction of `CHUNK_SIZE` replayed between consecutive chunks. Applies to `recursive_splitter` only — `structured_section` forces overlap to 0. |
 | `CONTEXTUALIZATION_TIMEOUT` | `int` | 120 | Timeout in seconds for individual chunk contextualization LLM calls. Prevents long-running contextualization tasks from blocking the system. |
 | `MAX_CONCURRENT_CONTEXTUALIZATION` | `int` | 10 | Maximum number of concurrent chunk contextualization tasks. Limits parallel LLM requests to prevent CPU exhaustion during batch indexing. |
 
@@ -191,8 +191,8 @@ After files are converted to Markdown, only the **text content** is chunked.
 
 **Chunker strategies:**
 
-* **`structured_section`** *(default)*: Cuts on the document's own structure instead of on character separators. It detects headings (Markdown `#`, plus keyword headings such as `Titre` / `Chapitre` / `Section`) and leaf units (e.g. `Article L110-1`) by matching line content, keeps each leaf atomic, greedily packs consecutive short leaves up to `CHUNK_SIZE` tokens, and prepends the heading path so every chunk is self-describing at retrieval time. Overlap is always 0 — leaves are atomic, so replaying a tail would only duplicate whole sections, and `CHUNK_OVERLAP_RATE` is therefore ignored by this strategy. Best for structured documents (legal codes, standards, reports, technical manuals).
-* **`recursive_splitter`**: Uses hierarchical text structure (sections, paragraphs, sentences). Based on [RecursiveCharacterTextSplitter](https://docs.langchain.com/oss/python/integrations/splitters/index#text-structure-based), it preserves natural boundaries whenever possible while ensuring chunks never exceeding the `CHUNK_SIZE`. Set `CHUNKER=recursive_splitter` for unstructured prose, or to reproduce the chunking of earlier OpenRAG releases.
+* **`structured_section`** *(default)*: Cuts on the document's own structure instead of on character separators. It detects headings (Markdown `#`, plus keyword headings such as `Titre` / `Chapitre` / `Section`) and leaf units (e.g. `Article L110-1`) by matching line content, keeps each leaf atomic, greedily packs consecutive short leaves up to `CHUNK_SIZE`, and prepends the heading path so every chunk is self-describing at retrieval time. Overlap is always 0 — leaves are atomic, so replaying a tail would only duplicate whole sections, and `CHUNK_OVERLAP_RATE` is therefore ignored by this strategy. Best for structured documents (legal codes, standards, reports, technical manuals).
+* **`recursive_splitter`**: Uses hierarchical text structure (sections, paragraphs, sentences). Based on [RecursiveCharacterTextSplitter](https://docs.langchain.com/oss/python/integrations/splitters/index#text-structure-based), it preserves natural boundaries whenever possible while ensuring chunks never exceed `CHUNK_SIZE`, and replays `CHUNK_OVERLAP_RATE` of each chunk into the next. Set `CHUNKER=recursive_splitter` for unstructured prose, or to reproduce the chunking of earlier OpenRAG releases.
 
 ### Embedding
 Our embedder is **OpenAI-compatible** and runs on a **VLLM** instance configured with the following variables:

--- a/docs/content/docs/documentation/env_vars.md
+++ b/docs/content/docs/documentation/env_vars.md
@@ -179,7 +179,7 @@ The default OpenRAG transcriber stack now ships with **vLLM v0.19.1**, which inc
 
 | Variable               | Type | Default              | Description |
 |------------------------|------|----------------------|-------------|
-| `CHUNKER`              | `str`  | recursive_splitter   | Defines the chunking strategy: `recursive_splitter`. |
+| `CHUNKER`              | `str`  | structured_section   | Defines the chunking strategy: `structured_section` or `recursive_splitter`. |
 | `CONTEXTUAL_RETRIEVAL` | `bool` | true                 | Enables contextual retrieval to chunk context, a technique introduced by Anthropic to improve retrieval performance ([Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)) |
 | `CHUNK_SIZE`           | `int`  | 512                  | Maximum size (in characters) of each chunk. |
 | `CHUNK_OVERLAP_RATE`   | `float`| 0.2                  | Percentage of overlap between consecutive chunks. |
@@ -191,7 +191,8 @@ After files are converted to Markdown, only the **text content** is chunked.
 
 **Chunker strategies:**
 
-* **`recursive_splitter`**: Uses hierarchical text structure (sections, paragraphs, sentences). Based on [RecursiveCharacterTextSplitter](https://docs.langchain.com/oss/python/integrations/splitters/index#text-structure-based), it preserves natural boundaries whenever possible while ensuring chunks never exceeding the `CHUNK_SIZE`.
+* **`structured_section`** *(default)*: Cuts on the document's own structure instead of on character separators. It detects headings (Markdown `#`, plus keyword headings such as `Titre` / `Chapitre` / `Section`) and leaf units (e.g. `Article L110-1`) by matching line content, keeps each leaf atomic, greedily packs consecutive short leaves up to `CHUNK_SIZE` tokens, and prepends the heading path so every chunk is self-describing at retrieval time. Overlap is always 0 — leaves are atomic, so replaying a tail would only duplicate whole sections, and `CHUNK_OVERLAP_RATE` is therefore ignored by this strategy. Best for structured documents (legal codes, standards, reports, technical manuals).
+* **`recursive_splitter`**: Uses hierarchical text structure (sections, paragraphs, sentences). Based on [RecursiveCharacterTextSplitter](https://docs.langchain.com/oss/python/integrations/splitters/index#text-structure-based), it preserves natural boundaries whenever possible while ensuring chunks never exceeding the `CHUNK_SIZE`. Set `CHUNKER=recursive_splitter` for unstructured prose, or to reproduce the chunking of earlier OpenRAG releases.
 
 ### Embedding
 Our embedder is **OpenAI-compatible** and runs on a **VLLM** instance configured with the following variables:

--- a/openrag/core/config/chunking.py
+++ b/openrag/core/config/chunking.py
@@ -13,7 +13,12 @@ from .base import ConfigMixin
 class ChunkerConfig(ConfigMixin):
     """Chunking strategy settings."""
 
-    name: str = "recursive_splitter"
+    # ``structured_section`` is the default: it cuts on the document's own
+    # structure (headings, leaf markers) and prepends the heading path, so a
+    # chunk stays self-describing for retrieval instead of being an arbitrary
+    # character-window cut. ``recursive_splitter`` remains available for
+    # unstructured prose and for reproducing earlier releases' chunking.
+    name: str = "structured_section"
     contextual_retrieval: bool = True
     contextualization_timeout: int = 120
     max_concurrent_contextualization: int = 10

--- a/openrag/services/orchestrators/preset_service.py
+++ b/openrag/services/orchestrators/preset_service.py
@@ -45,7 +45,11 @@ _DEFAULT_SEEDS: dict[str, dict[str, dict[str, Any]]] = {
     # Named presets (legal/finance) keep their explicit choice.
     "indexation": {
         "default": {
-            "chunking": {"name": "recursive_splitter", "chunk_size": 512, "chunk_overlap_rate": 0.2},
+            # Kept in sync with ChunkerConfig's defaults, but note that
+            # _finalize_seed overwrites all three from the deployment's global
+            # chunker knobs (CHUNKER / CHUNK_SIZE / CHUNK_OVERLAP_RATE) before
+            # this seed is persisted — see #709.
+            "chunking": {"name": "structured_section", "chunk_size": 512, "chunk_overlap_rate": 0.2},
             # ``parsing_strategy`` is intentionally omitted so the default preset
             # inherits the deployment's global PDFLOADER (``file_loaders.pdf``)
             # rather than forcing one PDF backend on every partition. A hardcoded

--- a/tests/unit/core/config/test_pipeline_configs.py
+++ b/tests/unit/core/config/test_pipeline_configs.py
@@ -81,3 +81,33 @@ def test_indexation_pipeline_rejects_out_of_range_chunk_overlap_rate(rate: float
 def test_indexation_pipeline_accepts_in_range_chunk_overlap_rate(rate: float):
     cfg = IndexationPipelineConfig(chunking={"chunk_size": 512, "chunk_overlap_rate": rate})
     assert cfg.chunking.chunk_overlap_rate == rate
+
+
+def test_default_chunker_is_structured_section():
+    """The default chunking strategy is ``structured_section``.
+
+    Pinned because nothing else fails when the default flips: the name is a free
+    string, every registered strategy validates, and a silent revert would only
+    surface as a change in retrieval quality long after the fact. It is asserted
+    on three surfaces at once because they must not drift apart — the Pydantic
+    default, the ``conf/config.yaml`` shipped value, and the ``default``
+    indexation preset seed all have to name the same strategy.
+    """
+    from pathlib import Path
+
+    import core.chunking.factory  # noqa: F401  (registration side-effect)
+    import yaml
+    from core.chunking.registry import chunking_registry
+    from core.config.chunking import ChunkerConfig
+    from services.orchestrators.preset_service import _DEFAULT_SEEDS
+
+    assert ChunkerConfig().name == "structured_section"
+    assert IndexationPipelineConfig().chunking.name == "structured_section"
+    assert _DEFAULT_SEEDS["indexation"]["default"]["chunking"]["name"] == "structured_section"
+
+    shipped = yaml.safe_load(Path(__file__).parents[4].joinpath("conf/config.yaml").read_text())
+    assert shipped["chunker"]["name"] == "structured_section"
+
+    # A default that is not registered would fail every partition at chunker
+    # build time (create_chunker) rather than at config load.
+    assert ChunkerConfig().name in chunking_registry


### PR DESCRIPTION
## What

Makes `structured_section` the default chunking strategy, replacing `recursive_splitter`.

`recursive_splitter` cuts on character separators (paragraph → sentence → line → word) with a fixed overlap. The cut lands wherever the character budget runs out, and the resulting chunk carries no indication of where in the document it came from.

`structured_section` cuts on the document's own structure instead: it detects headings (Markdown `#`, plus keyword headings like `Titre` / `Chapitre` / `Section`) and leaf units (e.g. `Article L110-1`) by matching line content, keeps each leaf atomic, greedily packs consecutive short leaves up to the token target, and prepends the heading path so the chunk is self-describing at retrieval time. Overlap is forced to 0 — leaves are atomic, so replaying a tail would only duplicate whole sections.

It shipped in 2.2.0 as an opt-in choice on indexation presets. This promotes it to the default.

## Changes

| File | Change |
|---|---|
| `openrag/core/config/chunking.py` | `ChunkerConfig.name` default → `structured_section` |
| `conf/config.yaml` | shipped `chunker.name` → `structured_section` |
| `openrag/services/orchestrators/preset_service.py` | `default` indexation preset seed → `structured_section` |
| `docs/content/docs/documentation/env_vars.md` | `CHUNKER` default + a description of both strategies |
| `tests/unit/core/config/test_pipeline_configs.py` | new guard pinning all three surfaces together |

The three code surfaces have to name the same strategy or they drift, so the test asserts them together rather than one at a time.

## Why the test

Nothing failed when the default flipped — the full unit suite (2985 tests) passed unchanged before the guard was added. `ChunkerConfig.name` is a free string and every registered strategy validates, so a silent revert would surface only as degraded retrieval quality, long after the fact. `test_default_chunker_is_structured_section` was verified to fail on a reverted default.

## Scope / rollout notes

- **Existing deployments are unaffected.** `_DEFAULT_SEEDS` is a first-boot seed: once a `default` preset row exists it is the sole source of truth, so a running instance keeps whatever strategy is stored on it. Only fresh deployments (and deployments that set no `CHUNKER` and have no preset rows) pick up the new default.
- **Already-indexed documents are not re-chunked.** The new strategy applies to documents indexed after the change; existing chunks stay as they were until their file is re-indexed.
- **`recursive_splitter` remains registered and selectable** via `CHUNKER=recursive_splitter` or per-partition on an indexation preset.
- **The `legal` and `finance` presets are left alone** — they still carry an explicit `recursive_splitter` with deliberate per-domain chunk sizes (1024 / 768). Worth a follow-up: `legal` is arguably the strongest candidate for `structured_section`, since the strategy was designed against French legal codes. Left out here because changing a named preset's deliberate choice is a separate product decision from flipping the default.

## Verification

- `uv run pytest tests/unit/` → **2986 passed**
- `uv run ruff check openrag/ tests/` → clean; `ruff format --check` → clean
- End-to-end smoke: `load_config()` resolves `chunker.name = structured_section`, `create_chunker()` builds a `StructuredSectionChunker` (target 512 / max 768 / hard_max 1023 on a 2047-token embedder window), and chunking a headed document emits the `[Source | Page | Section]` heading-path header.
- Seeding with default `Settings()` produces `default → structured_section`, with `legal` and `finance` keeping `recursive_splitter`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured section chunking is now the default for document indexing.
  * Content is split using document headings and leaf sections, with heading paths included in each chunk.
  * Short sections may be grouped while preserving individual leaf sections.
  * The recursive splitter remains available for unstructured prose or previous chunking behavior.

* **Documentation**
  * Clarified that chunk size is measured in tokenizer tokens.
  * Documented that chunk overlap applies only to the recursive splitter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->