### PR TITLE
chore(helm): track the Milvus 3 chart instead of overriding its image tag

### DIFF
--- a/infra/charts/openrag-stack/Chart.lock
+++ b/infra/charts/openrag-stack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.4.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.3
+  version: 18.10.0
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm/
-  version: 5.0.25
+  version: 5.0.27
 - name: vllm-stack
   repository: https://vllm-project.github.io/production-stack
-  version: 0.1.11
-digest: sha256:50f412b87a0f4b9fccb92b02a0ea0d21fa7d0343b86394077e4ac05cb7c16b61
-generated: "2026-08-25T13:53:27.648198879Z"
+  version: 0.1.12
+digest: sha256:e61a0ebcad0348811373bc5db2bc17a65948b11dccce74c43ff9cb8d33330eb1
+generated: "2026-09-10T10:14:02.697893304Z"

--- a/infra/charts/openrag-stack/Chart.yaml
+++ b/infra/charts/openrag-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: openrag-stack
 description: A Helm chart for Kubernetes
 type: application
 
-version: 0.6.4
+version: 0.6.5
 appVersion: "2.2.1"
 
 maintainers:
@@ -26,10 +26,11 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
   - name: milvus
-    # The Milvus 3 chart is 5.0.26, but that release is not yet present in the
-    # published repository index. Keep 5.0.25 and override its image tag in
-    # values.yaml until 5.0.26 can be resolved through helm dependency update.
-    version: "5.0.25"
+    # 5.0.26 declares Milvus 3.0.0 but was never added to the published index,
+    # so helm cannot resolve it. 5.0.27 is the first *indexed* chart with Milvus
+    # 3 defaults (appVersion and image.all.tag are both v3.0.1), so values.yaml
+    # no longer overrides the image tag.
+    version: "5.0.27"
     repository: "https://zilliztech.github.io/milvus-helm/"
     condition: milvus.enabled
   - name: vllm-stack

--- a/infra/charts/openrag-stack/values.yaml
+++ b/infra/charts/openrag-stack/values.yaml
@@ -171,10 +171,6 @@ milvus:
   # note on it above. Without this, the milvus sub-chart names its own proxy
   # Service from the real Release.Name instead, which won't match VDB_HOST.
   fullnameOverride: "openrag-milvus"
-  # Chart 5.0.25 still defaults to Milvus 2.6.21. Keep this override until
-  # the chart defaults include the Milvus 3.0.1 empty-result search fix.
-  image:
-    all: { tag: "v3.0.1" }
   # Milvus 3 runs as UID/GID 999. Applying this group on every mount lets
   # Kubernetes migrate supported existing volumes before the non-root process
   # starts. Storage drivers that do not support fsGroup require an


### PR DESCRIPTION
## Why

#919 pinned Milvus v3.0.1 by overriding the `milvus` sub-chart's `image.all.tag`, because at the
time the matching chart release (5.0.26) had never made it into the published repository index — the
comment on the dependency pin says exactly that. zilliztech/milvus-helm **5.0.27** is now published
(5.0.26 still isn't; 5.0.27 is the first 3.x chart in the index) and its defaults are Milvus 3:

```console
$ helm show values zilliztech/milvus --version 5.0.27
image:
  all:
    repository: milvusdb/milvus
    tag: v3.0.1
```

So the override has nothing left to do. Tracking the upstream chart means the sub-chart's own
manifests move with the image instead of us running 5.0.25's templates against a 3.x binary.

## What

- `Chart.yaml`: milvus dependency `5.0.25` → `5.0.27`, and the stale comment replaced.
- `values.yaml`: drop the `milvus.image.all.tag: "v3.0.1"` override.
- `Chart.lock`: regenerated with `helm dependency update`.
- Chart version `0.6.4` → `0.6.5` so the publish workflow pushes a new package
  (`oci://ghcr.io/linagora/openrag-stack` currently tops out at 0.6.4).

The `securityContext.fsGroup: 999` block below the removed override stays — that one is about UID 999
on pre-existing volumes, not about the tag.

## Verification

`helm template` rendered before and after (same values, `helm dependency build` on the locked
versions for the "before" side):

- Milvus image is `milvusdb/milvus:v3.0.1` in all 5 containers on both sides — the override and the
  new chart default agree, so the upgrade is a no-op for the running image.
- The only milvus-side delta is metadata: `helm.sh/chart: milvus-5.0.25 → 5.0.27` and
  `app.kubernetes.io/version: "2.6.21" → "3.0.1"` (the old label was wrong — it advertised the chart
  default rather than the image we were actually running).
- `helm lint` clean.

## Note on `Chart.lock`

`helm dependency update` also re-resolved the two range-pinned dependencies: postgresql
`18.7.3 → 18.10.0` (`>=17.6.0 <19.0.0`) and vllm-stack `0.1.11 → 0.1.12` (`>=0.1.7 <1.0.0`). That is
drift the lockfile had accumulated, not a deliberate bump here — and it does not change what we ship,
since `.github/workflows/helm.yaml` runs `helm dependency update` itself before packaging, so the
published chart has been floating to the newest in-range versions all along. The lockfile only
affects local `helm dependency build`.

Visible in the render diff: postgresql 18.10.0 adds `seccompProfile: RuntimeDefault` to the primary
pod and reshapes the `pg_isready` readiness command.

Correcting an offer made earlier in this PR: there is no hand-narrowed version of this lock diff.
`Chart.lock`'s digest covers the resolved versions as well as the constraints, so editing a version
in it by hand makes `helm dependency build` refuse with *"the lock file (Chart.lock) is out of sync
with the dependencies file (Chart.yaml)"*. Holding postgresql and vllm-stack still would mean pinning
them exactly in `Chart.yaml` instead of by range — a separate decision, not something this PR can
quietly do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the OpenRAG Stack deployment chart to version 0.6.5.
  * Updated the bundled Milvus chart to version 5.0.27.
  * Milvus deployments now use the image version provided by the bundled chart defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
